### PR TITLE
Add check for PSK_CAP_RESPONDER_WITH_CONTEXT in FINISH.

### DIFF
--- a/library/spdm_requester_lib/psk_finish.c
+++ b/library/spdm_requester_lib/psk_finish.c
@@ -45,7 +45,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
-		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
+		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
 		return RETURN_UNSUPPORTED;
 	}
 	if (spdm_context->connection_info.connection_state <

--- a/library/spdm_responder_lib/psk_finish.c
+++ b/library/spdm_responder_lib/psk_finish.c
@@ -52,7 +52,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
-		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
+		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
 		spdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_PSK_EXCHANGE, response_size, response);


### PR DESCRIPTION
This is to prevent responder returning response in NO_CONTEXT case.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>