### PR TITLE
Adjust message appending flow

### DIFF
--- a/library/spdm_requester_lib/challenge.c
+++ b/library/spdm_requester_lib/challenge.c
@@ -99,15 +99,6 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache data
-	//
-	status = spdm_append_message_c(spdm_context, &spdm_request,
-				       sizeof(spdm_request));
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
 	status = spdm_receive_spdm_response(
@@ -123,8 +114,8 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_error_response_main(
-			spdm_context, NULL, &spdm_context->transcript.message_c,
-			sizeof(spdm_request), &spdm_response_size,
+			spdm_context, NULL, 
+			NULL, 0, &spdm_response_size,
 			&spdm_response, SPDM_CHALLENGE, SPDM_CHALLENGE_AUTH,
 			sizeof(spdm_challenge_auth_response_max_t));
 		if (RETURN_ERROR(status)) {
@@ -213,7 +204,14 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 		return RETURN_SECURITY_VIOLATION;
 	}
 	ptr += sizeof(uint16);
-
+	//
+	// Cache data
+	//
+	status = spdm_append_message_c(spdm_context, &spdm_request,
+				       sizeof(spdm_request));
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
 	if (spdm_response_size <
 	    sizeof(spdm_challenge_auth_response_t) + hash_size +
 		    SPDM_NONCE_SIZE + measurement_summary_hash_size +

--- a/library/spdm_requester_lib/encap_certificate.c
+++ b/library/spdm_requester_lib/encap_certificate.c
@@ -99,18 +99,6 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 				   .local_cert_chain_provision_size[slot_id] -
 			   (length + offset);
 
-	//
-	// Cache
-	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
-					   request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
-			response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	ASSERT(*response_size >= sizeof(spdm_certificate_response_t) + length);
 	*response_size = sizeof(spdm_certificate_response_t) + length;
 	zero_mem(response, *response_size);
@@ -134,6 +122,15 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	//
 	// Cache
 	//
+	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+					   request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_encap_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
+			response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/encap_challenge_auth.c
+++ b/library/spdm_requester_lib/encap_challenge_auth.c
@@ -69,18 +69,6 @@ return_status spdm_get_encap_response_challenge_auth(
 		return RETURN_SUCCESS;
 	}
 
-	//
-	// Cache
-	//
-	status = spdm_append_message_mut_c(spdm_context, spdm_request,
-					   request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
-			response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	signature_size = spdm_get_req_asym_signature_size(
 		spdm_context->connection_info.algorithm.req_base_asym_alg);
 	hash_size = spdm_get_hash_size(
@@ -135,9 +123,19 @@ return_status spdm_get_encap_response_challenge_auth(
 	//
 	// Calc Sign
 	//
+	status = spdm_append_message_mut_c(spdm_context, spdm_request,
+					   request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_encap_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
+			response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_mut_c(spdm_context, spdm_response,
 					   (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
+		reset_managed_buffer(&spdm_context->transcript.message_mut_c);
 		spdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);

--- a/library/spdm_requester_lib/encap_digests.c
+++ b/library/spdm_requester_lib/encap_digests.c
@@ -63,18 +63,6 @@ return_status spdm_get_encap_response_digest(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	//
-	// Cache
-	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
-					   request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
-			response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
@@ -105,6 +93,15 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	//
 	// Cache
 	//
+	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+					   request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_encap_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
+			response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/get_capabilities.c
+++ b/library/spdm_requester_lib/get_capabilities.c
@@ -129,15 +129,6 @@ return_status try_spdm_get_capabilities(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache data
-	//
-	status = spdm_append_message_a(spdm_context, &spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
 	status = spdm_receive_spdm_response(
@@ -149,8 +140,6 @@ return_status try_spdm_get_capabilities(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
-		shrink_managed_buffer(&spdm_context->transcript.message_a,
-				      spdm_request_size);
 		status = spdm_handle_simple_error_response(
 			spdm_context, spdm_response.header.param1);
 		if (RETURN_ERROR(status)) {
@@ -181,6 +170,12 @@ return_status try_spdm_get_capabilities(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
+	status = spdm_append_message_a(spdm_context, &spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
+
 	status = spdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/get_certificate.c
+++ b/library/spdm_requester_lib/get_certificate.c
@@ -103,16 +103,6 @@ return_status try_spdm_get_certificate(IN void *context, IN uint8 slot_id,
 			goto done;
 		}
 
-		//
-		// Cache data
-		//
-		status = spdm_append_message_b(spdm_context, &spdm_request,
-					       sizeof(spdm_request));
-		if (RETURN_ERROR(status)) {
-			status = RETURN_SECURITY_VIOLATION;
-			goto done;
-		}
-
 		spdm_response_size = sizeof(spdm_response);
 		zero_mem(&spdm_response, sizeof(spdm_response));
 		status = spdm_receive_spdm_response(spdm_context, NULL,
@@ -129,8 +119,7 @@ return_status try_spdm_get_certificate(IN void *context, IN uint8 slot_id,
 		if (spdm_response.header.request_response_code == SPDM_ERROR) {
 			status = spdm_handle_error_response_main(
 				spdm_context, NULL,
-				&spdm_context->transcript.message_b,
-				sizeof(spdm_request), &spdm_response_size,
+				NULL, 0, &spdm_response_size,
 				&spdm_response, SPDM_GET_CERTIFICATE,
 				SPDM_CERTIFICATE,
 				sizeof(spdm_certificate_response_max_t));
@@ -169,6 +158,12 @@ return_status try_spdm_get_certificate(IN void *context, IN uint8 slot_id,
 		//
 		// Cache data
 		//
+		status = spdm_append_message_b(spdm_context, &spdm_request,
+					       sizeof(spdm_request));
+		if (RETURN_ERROR(status)) {
+			status = RETURN_SECURITY_VIOLATION;
+			goto done;
+		}
 		status = spdm_append_message_b(spdm_context, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/get_digests.c
+++ b/library/spdm_requester_lib/get_digests.c
@@ -66,22 +66,11 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 	spdm_request.header.request_response_code = SPDM_GET_DIGESTS;
 	spdm_request.header.param1 = 0;
 	spdm_request.header.param2 = 0;
-
 	status = spdm_send_spdm_request(spdm_context, NULL,
 					sizeof(spdm_request), &spdm_request);
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
-
-	//
-	// Cache data
-	//
-	status = spdm_append_message_b(spdm_context, &spdm_request,
-				       sizeof(spdm_request));
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
 	status = spdm_receive_spdm_response(
@@ -94,8 +83,8 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_error_response_main(
-			spdm_context, NULL, &spdm_context->transcript.message_b,
-			sizeof(spdm_request), &spdm_response_size,
+			spdm_context, NULL, NULL,
+			0, &spdm_response_size,
 			&spdm_response, SPDM_GET_DIGESTS, SPDM_DIGESTS,
 			sizeof(spdm_digests_response_max_t));
 		if (RETURN_ERROR(status)) {
@@ -134,6 +123,12 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 	//
 	// Cache data
 	//
+	status = spdm_append_message_b(spdm_context, &spdm_request,
+				       sizeof(spdm_request));
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
+
 	status = spdm_append_message_b(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/get_measurements.c
+++ b/library/spdm_requester_lib/get_measurements.c
@@ -158,15 +158,6 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache data
-	//
-	status = spdm_append_message_m(spdm_context, &spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
 	status = spdm_receive_spdm_response(
@@ -180,7 +171,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_error_response_main(
 			spdm_context, session_id,
-			&spdm_context->transcript.message_m, spdm_request_size,
+			NULL, 0,
 			&spdm_response_size, &spdm_response,
 			SPDM_GET_MEASUREMENTS, SPDM_MEASUREMENTS,
 			sizeof(spdm_measurements_response_max_t));
@@ -282,6 +273,15 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 				     measurement_record_data_length +
 				     SPDM_NONCE_SIZE + sizeof(uint16) +
 				     opaque_length + signature_size;
+		//
+		// Cache data
+		//
+		status = spdm_append_message_m(spdm_context, &spdm_request,
+						spdm_request_size);
+		if (RETURN_ERROR(status)) {
+			return RETURN_SECURITY_VIOLATION;
+		}
+
 		status = spdm_append_message_m(spdm_context, &spdm_response,
 					       spdm_response_size -
 						       signature_size);
@@ -341,6 +341,15 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 				     measurement_record_data_length +
 					 SPDM_NONCE_SIZE + sizeof(uint16) +
 				     opaque_length;
+		//
+		// Cache data
+		//
+		status = spdm_append_message_m(spdm_context, &spdm_request,
+						spdm_request_size);
+		if (RETURN_ERROR(status)) {
+			return RETURN_SECURITY_VIOLATION;
+		}
+
 		status = spdm_append_message_m(spdm_context, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/get_version.c
+++ b/library/spdm_requester_lib/get_version.c
@@ -48,17 +48,9 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache data
-	//
 	reset_managed_buffer(&spdm_context->transcript.message_a);
 	reset_managed_buffer(&spdm_context->transcript.message_b);
 	reset_managed_buffer(&spdm_context->transcript.message_c);
-	status = spdm_append_message_a(spdm_context, &spdm_request,
-				       sizeof(spdm_request));
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
@@ -74,8 +66,6 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
-		shrink_managed_buffer(&spdm_context->transcript.message_a,
-				      sizeof(spdm_request));
 		status = spdm_handle_simple_error_response(
 			spdm_context, spdm_response.header.param1);
 		if (RETURN_ERROR(status)) {
@@ -108,9 +98,15 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
+	status = spdm_append_message_a(spdm_context, &spdm_request,
+				       sizeof(spdm_request));
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
 	status = spdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
+		reset_managed_buffer(&spdm_context->transcript.message_a);
 		return RETURN_SECURITY_VIOLATION;
 	}
 	compatible_version_count = 0;

--- a/library/spdm_requester_lib/key_exchange.c
+++ b/library/spdm_requester_lib/key_exchange.c
@@ -223,19 +223,6 @@ return_status try_spdm_send_receive_key_exchange(
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache session data
-	//
-	status = spdm_append_message_k(session_info, &spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
-		spdm_secured_message_dhe_free(
-			spdm_context->connection_info.algorithm.dhe_named_group,
-			dhe_context);
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	signature_size = spdm_get_asym_signature_size(
 		spdm_context->connection_info.algorithm.base_asym_algo);
 	measurement_summary_hash_size = spdm_get_measurement_summary_hash_size(
@@ -312,6 +299,19 @@ return_status try_spdm_send_receive_key_exchange(
 			     dhe_key_size + measurement_summary_hash_size +
 			     sizeof(uint16) + opaque_length + signature_size +
 			     hmac_size;
+
+	//
+	// Cache session data
+	//
+	status = spdm_append_message_k(session_info, &spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_free_session_id(spdm_context, *session_id);
+		spdm_secured_message_dhe_free(
+			spdm_context->connection_info.algorithm.dhe_named_group,
+			dhe_context);
+		return RETURN_SECURITY_VIOLATION;
+	}
 
 	status = spdm_append_message_k(session_info, &spdm_response,
 				       spdm_response_size - signature_size -

--- a/library/spdm_requester_lib/negotiate_algorithms.c
+++ b/library/spdm_requester_lib/negotiate_algorithms.c
@@ -112,15 +112,6 @@ return_status try_spdm_negotiate_algorithms(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache data
-	//
-	status = spdm_append_message_a(spdm_context, &spdm_request,
-				       spdm_request.length);
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
 	status = spdm_receive_spdm_response(
@@ -132,8 +123,6 @@ return_status try_spdm_negotiate_algorithms(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
-		shrink_managed_buffer(&spdm_context->transcript.message_a,
-				      spdm_request.length);
 		status = spdm_handle_simple_error_response(
 			spdm_context, spdm_response.header.param1);
 		if (RETURN_ERROR(status)) {
@@ -210,6 +199,12 @@ return_status try_spdm_negotiate_algorithms(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
+	status = spdm_append_message_a(spdm_context, &spdm_request,
+				       spdm_request.length);
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
+
 	status = spdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/psk_exchange.c
+++ b/library/spdm_requester_lib/psk_exchange.c
@@ -192,15 +192,6 @@ return_status try_spdm_send_receive_psk_exchange(
 		return RETURN_DEVICE_ERROR;
 	}
 
-	//
-	// Cache session data
-	//
-	status = spdm_append_message_k(session_info, &spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		return RETURN_SECURITY_VIOLATION;
-	}
-
 	measurement_summary_hash_size = spdm_get_measurement_summary_hash_size(
 		spdm_context, TRUE, measurement_hash_type);
 	hmac_size = spdm_get_hash_size(
@@ -246,6 +237,15 @@ return_status try_spdm_send_receive_psk_exchange(
 	ptr += spdm_response.context_length;
 
 	ptr += spdm_response.opaque_length;
+
+	//
+	// Cache session data
+	//
+	status = spdm_append_message_k(session_info, &spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		return RETURN_SECURITY_VIOLATION;
+	}
 
 	status = spdm_append_message_k(session_info, &spdm_response,
 				       spdm_response_size - hmac_size);

--- a/library/spdm_responder_lib/algorithms.c
+++ b/library/spdm_responder_lib/algorithms.c
@@ -284,18 +284,6 @@ return_status spdm_get_response_algorithms(IN void *context,
 	}
 	spdm_request_size = request_size;
 
-	//
-	// Cache
-	//
-	status = spdm_append_message_a(spdm_context, spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	ASSERT(*response_size >= sizeof(spdm_algorithms_response_mine_t));
 	*response_size = sizeof(spdm_algorithms_response_mine_t);
 	zero_mem(response, *response_size);
@@ -416,17 +404,6 @@ return_status spdm_get_response_algorithms(IN void *context,
 			ARRAY_SIZE(m_key_schedule_priority_table),
 			spdm_context->local_context.algorithm.key_schedule,
 			spdm_context->connection_info.algorithm.key_schedule);
-	//
-	// Cache
-	//
-	status = spdm_append_message_a(spdm_context, spdm_response,
-				       *response_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
 
 	spdm_context->connection_info.algorithm.measurement_spec =
 		spdm_response->measurement_specification_sel;
@@ -557,6 +534,24 @@ return_status spdm_get_response_algorithms(IN void *context,
 		spdm_context->connection_info.algorithm.req_base_asym_alg = 0;
 		spdm_context->connection_info.algorithm.key_schedule = 0;
 	}
+	status = spdm_append_message_a(spdm_context, spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
+	status = spdm_append_message_a(spdm_context, spdm_response,
+				       *response_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	spdm_set_connection_state(spdm_context,
 				  SPDM_CONNECTION_STATE_NEGOTIATED);
 

--- a/library/spdm_responder_lib/capabilities.c
+++ b/library/spdm_responder_lib/capabilities.c
@@ -164,17 +164,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	spdm_request_size = request_size;
-	//
-	// Cache
-	//
-	status = append_managed_buffer(&spdm_context->transcript.message_a, spdm_request,
-			      spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-						SPDM_ERROR_CODE_UNSPECIFIED, 0,
-						response_size, response);
-		return RETURN_SUCCESS;
-	}
+
 	ASSERT(*response_size >= sizeof(spdm_capabilities_response));
 	*response_size = sizeof(spdm_capabilities_response);
 	zero_mem(response, *response_size);
@@ -194,6 +184,14 @@ return_status spdm_get_response_capabilities(IN void *context,
 	//
 	// Cache
 	//
+	status = append_managed_buffer(&spdm_context->transcript.message_a, spdm_request,
+			      spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+						SPDM_ERROR_CODE_UNSPECIFIED, 0,
+						response_size, response);
+		return RETURN_SUCCESS;
+	}
 	status = append_managed_buffer(&spdm_context->transcript.message_a,
 			      spdm_response, *response_size);
 

--- a/library/spdm_responder_lib/certificate.c
+++ b/library/spdm_responder_lib/certificate.c
@@ -74,17 +74,6 @@ return_status spdm_get_response_certificate(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	spdm_request_size = request_size;
-	//
-	// Cache
-	//
-	status = spdm_append_message_b(spdm_context, spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
 
 	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
 		spdm_generate_error_response(
@@ -151,6 +140,15 @@ return_status spdm_get_response_certificate(IN void *context,
 	//
 	// Cache
 	//
+	status = spdm_append_message_b(spdm_context, spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -77,16 +77,6 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	}
 
 	spdm_request_size = request_size;
-	//
-	// Cache
-	//
-	status = spdm_append_message_c(spdm_context, spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		return spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-	}
 
 	slot_id = spdm_request->header.param1;
 
@@ -173,7 +163,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 		spdm_context, FALSE, spdm_request->header.param2, ptr);
 	if (!result) {
 		return spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 	}
 	ptr += measurement_summary_hash_size;
@@ -188,9 +178,19 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	//
 	// Calc Sign
 	//
+	status = spdm_append_message_c(spdm_context, spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_c(spdm_context, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
+		reset_managed_buffer(&spdm_context->transcript.message_c);
 		return spdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);

--- a/library/spdm_responder_lib/digests.c
+++ b/library/spdm_responder_lib/digests.c
@@ -70,17 +70,6 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 	spdm_request_size = request_size;
-	//
-	// Cache
-	//
-	status = spdm_append_message_b(spdm_context, spdm_request,
-				       spdm_request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
 
 	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
 		spdm_generate_error_response(
@@ -133,6 +122,15 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	//
 	// Cache
 	//
+	status = spdm_append_message_b(spdm_context, spdm_request,
+				       spdm_request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	status = spdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/key_exchange.c
+++ b/library/spdm_responder_lib/key_exchange.c
@@ -184,15 +184,6 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(session_info, request, request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	spdm_response->rsp_session_id = rsp_session_id;
 
 	spdm_response->mut_auth_requested = 0;
@@ -276,6 +267,15 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		spdm_context->local_context
 			.local_cert_chain_provision_size[slot_id];
+
+	status = spdm_append_message_k(session_info, request, request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_free_session_id(spdm_context, session_id);
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
 
 	status = spdm_append_message_k(session_info, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -252,18 +252,6 @@ return_status spdm_get_response_measurements(IN void *context,
 	}
 	ASSERT(device_measurement_count <= MAX_SPDM_MEASUREMENT_BLOCK_COUNT);
 
-	//
-	// Cache
-	//
-	status =
-		spdm_append_message_m(spdm_context, spdm_request, request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	signature_size = spdm_get_asym_signature_size(
 		spdm_context->connection_info.algorithm.base_asym_algo);
 	measurment_sig_size =
@@ -317,25 +305,9 @@ return_status spdm_get_response_measurements(IN void *context,
 						spdm_context,
 						SPDM_ERROR_CODE_INVALID_REQUEST,
 						0, response_size, response);
-					reset_managed_buffer(
-						&spdm_context->transcript
-							 .message_m);
 					return RETURN_SUCCESS;
 				}
 				spdm_response->header.param2 = slot_id_param;
-			}
-			status = spdm_create_measurement_signature(
-				spdm_context, spdm_response,
-				spdm_response_size);
-			if (RETURN_ERROR(status)) {
-				spdm_generate_error_response(
-					spdm_context,
-					SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-					SPDM_GET_MEASUREMENTS, response_size,
-					response);
-				reset_managed_buffer(
-					&spdm_context->transcript.message_m);
-				return RETURN_SUCCESS;
 			}
 		} else {
 			spdm_create_measurement_opaque(spdm_context,
@@ -419,25 +391,9 @@ return_status spdm_get_response_measurements(IN void *context,
 						spdm_context,
 						SPDM_ERROR_CODE_INVALID_REQUEST,
 						0, response_size, response);
-					reset_managed_buffer(
-						&spdm_context->transcript
-							 .message_m);
 					return RETURN_SUCCESS;
 				}
 				spdm_response->header.param2 = slot_id_param;
-			}
-			status = spdm_create_measurement_signature(
-				spdm_context, spdm_response,
-				spdm_response_size);
-			if (RETURN_ERROR(status)) {
-				spdm_generate_error_response(
-					spdm_context,
-					SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-					SPDM_GET_MEASUREMENTS, response_size,
-					response);
-				reset_managed_buffer(
-					&spdm_context->transcript.message_m);
-				return RETURN_SUCCESS;
 			}
 		} else {
 			spdm_create_measurement_opaque(spdm_context,
@@ -521,27 +477,10 @@ return_status spdm_get_response_measurements(IN void *context,
 							SPDM_ERROR_CODE_INVALID_REQUEST,
 							0, response_size,
 							response);
-						reset_managed_buffer(
-							&spdm_context->transcript
-								 .message_m);
 						return RETURN_SUCCESS;
 					}
 					spdm_response->header.param2 =
 						slot_id_param;
-				}
-				status = spdm_create_measurement_signature(
-					spdm_context, spdm_response,
-					spdm_response_size);
-				if (RETURN_ERROR(status)) {
-					spdm_generate_error_response(
-						spdm_context,
-						SPDM_ERROR_CODE_UNSPECIFIED,
-						0,
-						response_size, response);
-					reset_managed_buffer(
-						&spdm_context->transcript
-							 .message_m);
-					return RETURN_SUCCESS;
 				}
 			} else {
 				spdm_create_measurement_opaque(
@@ -553,19 +492,42 @@ return_status spdm_get_response_measurements(IN void *context,
 			spdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
 			return RETURN_SUCCESS;
 		}
 		break;
 	}
+
+	status = spdm_append_message_m(
+			spdm_context, spdm_request,
+			request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+						SPDM_ERROR_CODE_UNSPECIFIED, 0,
+						response_size, response);
+		return RETURN_SUCCESS;
+	}
+
 	if ((spdm_request->header.param1 &
 	     SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE) !=
 	    0) {
-		//
-		// Reset
-		//
-		reset_managed_buffer(&spdm_context->transcript.message_m);
+
+		status = spdm_create_measurement_signature(
+			spdm_context, spdm_response,
+			spdm_response_size);
+		if (RETURN_ERROR(status)) {
+			spdm_generate_error_response(
+				spdm_context,
+				SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+				SPDM_GET_MEASUREMENTS,
+				response_size, response);
+			reset_managed_buffer(
+				&spdm_context->transcript
+						.message_m);
+			return RETURN_SUCCESS;
+		}
+		//reset
+		reset_managed_buffer(
+			&spdm_context->transcript.message_m);
 	} else {
 		status = spdm_append_message_m(spdm_context, spdm_response,
 					       *response_size);

--- a/library/spdm_responder_lib/psk_exchange.c
+++ b/library/spdm_responder_lib/psk_exchange.c
@@ -221,15 +221,6 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(session_info, request, request_size);
-	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
-					     response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	spdm_response->rsp_session_id = rsp_session_id;
 	spdm_response->reserved = 0;
 
@@ -259,6 +250,16 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	ASSERT_RETURN_ERROR(status);
 	ptr += opaque_psk_exchange_rsp_size;
 
+
+	status = spdm_append_message_k(session_info, request, request_size);
+	if (RETURN_ERROR(status)) {
+		spdm_free_session_id(spdm_context, session_id);
+		spdm_generate_error_response(spdm_context,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
+					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+	
 	status = spdm_append_message_k(session_info, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/version.c
+++ b/library/spdm_responder_lib/version.c
@@ -115,6 +115,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	status = spdm_append_message_a(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
+		reset_managed_buffer(&spdm_context->transcript.message_a);
 		spdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1343,7 +1343,7 @@ void test_spdm_requester_challenge_case7(void **state)
   Test 8: the requester is setup correctly (see Test 2), but receives an ERROR
   message indicating the ResponseNotReady status of the responder.
   Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
-  buffer stores only the request.
+  buffer stores nothing.
 **/
 void test_spdm_requester_challenge_case8(void **state)
 {
@@ -1388,7 +1388,7 @@ void test_spdm_requester_challenge_case8(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-	assert_int_equal (spdm_context->transcript.message_c.buffer_size, 4 + SPDM_NONCE_SIZE);
+	assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
 	free(data);
 }
 

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1015,7 +1015,7 @@ void test_spdm_requester_get_digests_case10(void **state)
 
 /**
   Test 11: a request message is successfully sent but a failure occurs during the receiving of the response message
-  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received (managed buffer not shrinked)
+  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
 **/
 void test_spdm_requester_get_digests_case11(void **state)
 {
@@ -1047,7 +1047,7 @@ void test_spdm_requester_get_digests_case11(void **state)
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-			 sizeof(spdm_get_digest_request_t));
+			 0);
 }
 
 /**
@@ -1090,7 +1090,7 @@ void test_spdm_requester_get_digests_case12(void **state)
 
 /**
   Test 13: a request message is successfully sent but the request_response_code from the response message is different than the code of SPDM_DIGESTS
-  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received (managed buffer not shrinked)
+  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received 
 **/
 void test_spdm_requester_get_digests_case13(void **state)
 {
@@ -1122,12 +1122,12 @@ void test_spdm_requester_get_digests_case13(void **state)
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-			 sizeof(spdm_get_digest_request_t));
+			 0);
 }
 
 /**
   Test 14: a request message is successfully sent but the number of digests in the response message is equal to zero
-  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received
 **/
 void test_spdm_requester_get_digests_case14(void **state)
 {
@@ -1159,12 +1159,12 @@ void test_spdm_requester_get_digests_case14(void **state)
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-			 sizeof(spdm_get_digest_request_t));
+			 0);
 }
 
 /**
   Test 15: a request message is successfully sent but it cannot be appended to the internal cache since the internal cache is full
-  Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION
+  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR
 **/
 void test_spdm_requester_get_digests_case15(void **state)
 {
@@ -1174,6 +1174,7 @@ void test_spdm_requester_get_digests_case15(void **state)
 	uint8 slot_mask;
 	uint8 total_digest_buffer[MAX_HASH_SIZE * MAX_SPDM_SLOT_COUNT];
 
+	
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0xF;
@@ -1195,7 +1196,7 @@ void test_spdm_requester_get_digests_case15(void **state)
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
 /**
@@ -1307,7 +1308,7 @@ void test_spdm_requester_get_digests_case18(void **state)
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-			 sizeof(spdm_get_digest_request_t));
+			 0);
 }
 
 /**
@@ -1512,7 +1513,9 @@ int spdm_requester_get_digests_test_main(void)
 		// Zero digests received
 		cmocka_unit_test(test_spdm_requester_get_digests_case14),
 		// Internal cache full (request message)
-		cmocka_unit_test(test_spdm_requester_get_digests_case15),
+		// If request text is appending when reponse successfully instead of request,
+		// case15 will useless and will cause a bug
+		// cmocka_unit_test(test_spdm_requester_get_digests_case15),
 		// Internal cache full (response message)
 		cmocka_unit_test(test_spdm_requester_get_digests_case16),
 		// Invalid digest

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -3770,7 +3770,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-			 sizeof(spdm_message_header_t));
+			 0);
 	free(data);
 }
 
@@ -3885,7 +3885,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-			 sizeof(spdm_get_measurements_request_t));
+			 0);
 	free(data);
 }
 
@@ -3943,7 +3943,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-			 sizeof(spdm_get_measurements_request_t));
+			 0);
 	free(data);
 }
 


### PR DESCRIPTION
Fix #24
And fix derivation issues of bug24:
1. Remove useless shrink function using.
2. Unit-test should not assume there is any data in meesage buffer if response fail.

Signed-off-by: yi1 li <yi1.li@intel.com>