### PR TITLE
Fit responder error return value

### DIFF
--- a/library/spdm_requester_lib/encap_certificate.c
+++ b/library/spdm_requester_lib/encap_certificate.c
@@ -106,7 +106,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -138,7 +138,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_requester_lib/encap_challenge_auth.c
+++ b/library/spdm_requester_lib/encap_challenge_auth.c
@@ -76,7 +76,7 @@ return_status spdm_get_encap_response_challenge_auth(
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -139,7 +139,7 @@ return_status spdm_get_encap_response_challenge_auth(
 					   (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -147,8 +147,8 @@ return_status spdm_get_encap_response_challenge_auth(
 		spdm_generate_challenge_auth_signature(spdm_context, TRUE, ptr);
 	if (!result) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_CHALLENGE_AUTH, response_size, response);
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	ptr += signature_size;

--- a/library/spdm_requester_lib/encap_digests.c
+++ b/library/spdm_requester_lib/encap_digests.c
@@ -70,7 +70,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -109,7 +109,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/algorithms.c
+++ b/library/spdm_responder_lib/algorithms.c
@@ -291,7 +291,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -423,7 +423,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/capabilities.c
+++ b/library/spdm_responder_lib/capabilities.c
@@ -121,6 +121,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	uintn spdm_request_size;
 	spdm_capabilities_response *spdm_response;
 	spdm_context_t *spdm_context;
+	return_status status;
 
 	spdm_context = context;
 	spdm_request = request;
@@ -166,9 +167,14 @@ return_status spdm_get_response_capabilities(IN void *context,
 	//
 	// Cache
 	//
-	append_managed_buffer(&spdm_context->transcript.message_a, spdm_request,
+	status = append_managed_buffer(&spdm_context->transcript.message_a, spdm_request,
 			      spdm_request_size);
-
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+						SPDM_ERROR_CODE_UNSPECIFIED, 0,
+						response_size, response);
+		return RETURN_SUCCESS;
+	}
 	ASSERT(*response_size >= sizeof(spdm_capabilities_response));
 	*response_size = sizeof(spdm_capabilities_response);
 	zero_mem(response, *response_size);
@@ -188,9 +194,15 @@ return_status spdm_get_response_capabilities(IN void *context,
 	//
 	// Cache
 	//
-	append_managed_buffer(&spdm_context->transcript.message_a,
+	status = append_managed_buffer(&spdm_context->transcript.message_a,
 			      spdm_response, *response_size);
 
+	if (RETURN_ERROR(status)) {
+		spdm_generate_error_response(spdm_context,
+						SPDM_ERROR_CODE_UNSPECIFIED, 0,
+						response_size, response);
+		return RETURN_SUCCESS;
+	}
 	if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_11) {
 		spdm_context->connection_info.capability.ct_exponent =
 			spdm_request->ct_exponent;

--- a/library/spdm_responder_lib/certificate.c
+++ b/library/spdm_responder_lib/certificate.c
@@ -81,7 +81,7 @@ return_status spdm_get_response_certificate(IN void *context,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -155,7 +155,7 @@ return_status spdm_get_response_certificate(IN void *context,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -84,7 +84,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		return spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 	}
 
@@ -192,15 +192,15 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		return spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 	}
 	result = spdm_generate_challenge_auth_signature(spdm_context, FALSE,
 							ptr);
 	if (!result) {
 		return spdm_generate_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_CHALLENGE_AUTH, response_size, response);
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+			0, response_size, response);
 	}
 	ptr += signature_size;
 

--- a/library/spdm_responder_lib/digests.c
+++ b/library/spdm_responder_lib/digests.c
@@ -77,7 +77,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -137,7 +137,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/finish.c
+++ b/library/spdm_responder_lib/finish.c
@@ -158,7 +158,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -179,7 +179,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			signature_size);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
@@ -203,7 +203,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 				       hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -229,7 +229,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -244,8 +244,8 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		if (!result) {
 			spdm_generate_error_response(
 				spdm_context,
-				SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-				SPDM_FINISH_RSP, response_size, response);
+				SPDM_ERROR_CODE_UNSPECIFIED,
+				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
 
@@ -255,7 +255,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			hmac_size);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
@@ -266,7 +266,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -274,7 +274,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		session_info->secured_message_context, th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/key_exchange.c
+++ b/library/spdm_responder_lib/key_exchange.c
@@ -188,7 +188,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -246,7 +246,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -258,7 +258,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -282,7 +282,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -300,7 +300,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -312,7 +312,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -321,7 +321,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -338,15 +338,15 @@ return_status spdm_get_response_key_exchange(IN void *context,
 			spdm_free_session_id(spdm_context, session_id);
 			spdm_generate_error_response(
 				spdm_context,
-				SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-				SPDM_KEY_EXCHANGE_RSP, response_size, response);
+				SPDM_ERROR_CODE_UNSPECIFIED,
+				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
 		status = spdm_append_message_k(session_info, ptr, hmac_size);
 		if (RETURN_ERROR(status)) {
 			spdm_free_session_id(spdm_context, session_id);
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -259,7 +259,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		spdm_append_message_m(spdm_context, spdm_request, request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -535,8 +535,8 @@ return_status spdm_get_response_measurements(IN void *context,
 				if (RETURN_ERROR(status)) {
 					spdm_generate_error_response(
 						spdm_context,
-						SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-						SPDM_GET_MEASUREMENTS,
+						SPDM_ERROR_CODE_UNSPECIFIED,
+						0,
 						response_size, response);
 					reset_managed_buffer(
 						&spdm_context->transcript
@@ -571,7 +571,7 @@ return_status spdm_get_response_measurements(IN void *context,
 					       *response_size);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			reset_managed_buffer(
 				&spdm_context->transcript.message_m);

--- a/library/spdm_responder_lib/psk_exchange.c
+++ b/library/spdm_responder_lib/psk_exchange.c
@@ -225,7 +225,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -243,7 +243,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -264,7 +264,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -276,7 +276,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -285,7 +285,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -295,15 +295,15 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_PSK_EXCHANGE_RSP, response_size, response);
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	status = spdm_append_message_k(session_info, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -323,7 +323,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 						 FALSE, th2_hash_data);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
@@ -331,7 +331,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 			session_info->secured_message_context, th2_hash_data);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}

--- a/library/spdm_responder_lib/psk_finish.c
+++ b/library/spdm_responder_lib/psk_finish.c
@@ -105,7 +105,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 				       request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -135,7 +135,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -144,7 +144,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -154,7 +154,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -162,7 +162,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		session_info->secured_message_context, th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/library/spdm_responder_lib/version.c
+++ b/library/spdm_responder_lib/version.c
@@ -84,7 +84,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
@@ -116,7 +116,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
-					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -315,7 +315,7 @@ void test_spdm_responder_digests_case6(void **state)
 
 /**
   Test 7: receives a valid GET_DIGESTS request message from Requester, but the request message cannot be appended to the internal cache since the internal cache is full
-  Expected Behavior: produces an ERROR response message with error code = InvalidRequest
+  Expected Behavior: produces an ERROR response message with error code = Unspecified
 **/
 void test_spdm_responder_digests_case7(void **state)
 {
@@ -356,13 +356,13 @@ void test_spdm_responder_digests_case7(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
-			 SPDM_ERROR_CODE_INVALID_REQUEST);
+			 SPDM_ERROR_CODE_UNSPECIFIED);
 	assert_int_equal(spdm_response->header.param2, 0);
 }
 
 /**
   Test 8: receives a valid GET_DIGESTS request message from Requester, but the response message cannot be appended to the internal cache since the internal cache is full
-  Expected Behavior: produces an ERROR response message with error code = InvalidRequest
+  Expected Behavior: produces an ERROR response message with error code = Unspecified
 **/
 void test_spdm_responder_digests_case8(void **state)
 {
@@ -404,7 +404,7 @@ void test_spdm_responder_digests_case8(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
-			 SPDM_ERROR_CODE_INVALID_REQUEST);
+			 SPDM_ERROR_CODE_UNSPECIFIED);
 	assert_int_equal(spdm_response->header.param2, 0);
 }
 


### PR DESCRIPTION
Fix #23
1.Internal message appending error should return Unspecified.
2.Internal calculation error such as hash,signature... should return Unspecified.

Signed-off-by: yi1.li <yi1.li@intel.com>