### PR TITLE
Correcting argument description on spdm_bin_concat.

### DIFF
--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -309,7 +309,7 @@ boolean spdm_hmac_all_with_response_finished_key(
   This function concatenates binary data, which is used as info in HKDF expand later.
 
   @param  label                        An ascii string label for the spdm_bin_concat.
-  @param  label_size                    The size in bytes of the ASCII string label, including the NULL terminator.
+  @param  label_size                    The size in bytes of the ASCII string label, not including NULL terminator.
   @param  context                      A pre-defined hash value as the context for the spdm_bin_concat.
   @param  length                       16 bits length for the spdm_bin_concat.
   @param  hash_size                     The size in bytes of the context hash.

--- a/library/spdm_secured_message_lib/session.c
+++ b/library/spdm_secured_message_lib/session.c
@@ -36,7 +36,7 @@ void internal_dump_hex(IN uint8 *data, IN uintn size);
   This function concatenates binary data, which is used as info in HKDF expand later.
 
   @param  label                        An ascii string label for the spdm_bin_concat.
-  @param  label_size                    The size in bytes of the ASCII string label, including the NULL terminator.
+  @param  label_size                    The size in bytes of the ASCII string label, not including NULL terminator.
   @param  context                      A pre-defined hash value as the context for the spdm_bin_concat.
   @param  length                       16 bits length for the spdm_bin_concat.
   @param  hash_size                     The size in bytes of the context hash.


### PR DESCRIPTION
Fixes #57

Updates comment to provide accurate description on size of string expected for spdm_bin_concat.