### PR TITLE
fix get_digests verification

### DIFF
--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -499,13 +499,13 @@ boolean spdm_generate_cert_chain_hash(IN spdm_context_t *spdm_context,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  digest                       The digest data buffer.
-  @param  digest_size                   size in bytes of the digest data buffer.
+  @param  digest_count                   size of the digest data buffer.
 
   @retval TRUE  digest verification pass.
   @retval FALSE digest verification fail.
 **/
 boolean spdm_verify_peer_digests(IN spdm_context_t *spdm_context,
-				 IN void *digest, IN uintn digest_size);
+				 IN void *digest, IN uintn digest_count);
 
 /**
   This function verifies peer certificate chain buffer including spdm_cert_chain_t header.

--- a/library/spdm_requester_lib/get_digests.c
+++ b/library/spdm_requester_lib/get_digests.c
@@ -145,8 +145,7 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 	}
 
 	result = spdm_verify_peer_digests(
-		spdm_context, spdm_response.digest,
-		spdm_response_size - sizeof(spdm_digest_response_t));
+		spdm_context, spdm_response.digest, digest_count);
 	if (!result) {
 		spdm_context->error_state =
 			SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;

--- a/library/spdm_responder_lib/encap_get_digests.c
+++ b/library/spdm_responder_lib/encap_get_digests.c
@@ -146,7 +146,7 @@ return_status spdm_process_encap_response_digest(
 	}
 
 	result = spdm_verify_peer_digests(spdm_context, digest,
-					  digest_count * digest_size);
+					  digest_count);
 	if (!result) {
 		return RETURN_SECURITY_VIOLATION;
 	}

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -87,7 +87,7 @@ return_status spdm_requester_get_digests_test_receive_message(
 			->connection_info.algorithm.base_hash_algo =
 			m_use_hash_algo;
 		temp_buf_size = sizeof(spdm_digest_response_t) +
-				spdm_get_hash_size(m_use_hash_algo);
+				spdm_get_hash_size(m_use_hash_algo) * MAX_SPDM_SLOT_COUNT;
 		spdm_response = (void *)temp_buf;
 
 		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
@@ -98,9 +98,12 @@ return_status spdm_requester_get_digests_test_receive_message(
 			(uint8)(0xFF));
 
 		digest = (void *)(spdm_response + 1);
+		//send all eight certchains digest
+		//but only No.7 is right
+		digest += spdm_get_hash_size(m_use_hash_algo) * (MAX_SPDM_SLOT_COUNT - 2);
 		spdm_hash_all(m_use_hash_algo, m_local_certificate_chain,
 			      MAX_SPDM_MESSAGE_BUFFER_SIZE, &digest[0]);
-		spdm_response->header.param2 |= (1 << 0);
+		spdm_response->header.param2 |= (0xFF << 0);
 
 		spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
 						   FALSE, temp_buf_size,
@@ -708,7 +711,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 		sizeof(spdm_get_digest_request_t) +
 			sizeof(spdm_digest_response_t) +
 			spdm_get_hash_size(spdm_context->connection_info
-						   .algorithm.base_hash_algo));
+						   .algorithm.base_hash_algo) * MAX_SPDM_SLOT_COUNT);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 }
 


### PR DESCRIPTION
Fix #64
Requester should compare digests in response to local cached digests one by one.
Signed-off-by: yi1 li <yi1.li@intel.com>