### PR TITLE
Enable unit testing in workflow.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,15 +4,10 @@ on:
   workflow_dispatch
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +15,20 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Build with Cmake
+      - name: Build
         run: |
           mkdir build
           cd build
           cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=openssl ..
           make copy_sample_key
           make -j2
+
+      - name: Test Requester
+        run: |
+          cd build/bin
+          ./test_spdm_requester
+
+      - name: Test Responder
+        run: |
+          cd build/bin
+          ./test_spdm_responder

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -1,7 +1,7 @@
 /**
-    Copyright Notice:
-    Copyright 2021 DMTF. All rights reserved.
-    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+	Copyright Notice:
+	Copyright 2021 DMTF. All rights reserved.
+	License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
 #include "spdm_unit_test.h"
@@ -23,30 +23,59 @@ int spdm_requester_end_session_test_main(void);
 
 int main(void)
 {
-	spdm_requester_get_version_test_main();
+	int return_value = 0;
 
-	spdm_requester_get_capabilities_test_main();
+	if (spdm_requester_get_version_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_negotiate_algorithms_test_main();
+	if (spdm_requester_get_capabilities_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_get_digests_test_main();
+	if (spdm_requester_negotiate_algorithms_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_get_certificate_test_main();
+	if (spdm_requester_get_digests_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_challenge_test_main();
+	if (spdm_requester_get_certificate_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_get_measurements_test_main();
+	if (spdm_requester_challenge_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_key_exchange_test_main();
+	if (spdm_requester_get_measurements_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_finish_test_main();
+	if (spdm_requester_key_exchange_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_psk_exchange_test_main();
+	if (spdm_requester_finish_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_psk_finish_test_main();
+	if (spdm_requester_psk_exchange_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_heartbeat_test_main();
+	if (spdm_requester_psk_finish_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_requester_end_session_test_main();
-	return 0;
+	if (spdm_requester_heartbeat_test_main() != 0) {
+		return_value = 1;
+	}
+
+	if (spdm_requester_end_session_test_main() != 0) {
+		return_value = 1;
+	}
+
+	return return_value;
 }

--- a/unit_test/test_spdm_responder/test_spdm_responder.c
+++ b/unit_test/test_spdm_responder/test_spdm_responder.c
@@ -1,7 +1,7 @@
 /**
-    Copyright Notice:
-    Copyright 2021 DMTF. All rights reserved.
-    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+	Copyright Notice:
+	Copyright 2021 DMTF. All rights reserved.
+	License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
 #include "spdm_unit_test.h"
@@ -24,32 +24,63 @@ int spdm_responder_end_session_test_main(void);
 
 int main(void)
 {
-	spdm_responder_version_test_main();
+	int return_value = 0;
 
-	spdm_responder_capabilities_test_main();
+	if (spdm_responder_version_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_algorithms_test_main();
+	if (spdm_responder_capabilities_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_digests_test_main();
+	if (spdm_responder_algorithms_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_certificate_test_main();
+	if (spdm_responder_digests_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_challenge_auth_test_main();
+	if (spdm_responder_certificate_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_measurements_test_main();
+	if (spdm_responder_challenge_auth_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_respond_if_ready_test_main ();
+	if (spdm_responder_measurements_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_key_exchange_test_main();
+	if (spdm_responder_respond_if_ready_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_finish_test_main();
+	if (spdm_responder_key_exchange_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_psk_exchange_test_main();
+	if (spdm_responder_finish_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_psk_finish_test_main();
+	if (spdm_responder_psk_exchange_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_heartbeat_test_main();
+	if (spdm_responder_psk_finish_test_main() != 0) {
+		return_value = 1;
+	}
 
-	spdm_responder_end_session_test_main();
-	return 0;
+	if (spdm_responder_heartbeat_test_main() != 0) {
+		return_value = 1;
+	}
+
+	if (spdm_responder_end_session_test_main() != 0) {
+		return_value = 1;
+	}
+
+	return return_value;
 }


### PR DESCRIPTION
test_spdm_requester and test_spdm_responder now return the test status as an exit code. cmake.yml runs the two tests as part of the build process.