### PR TITLE
Fix warnings when compiling with clang-10

### DIFF
--- a/unit_test/test_size/cryptlib_dummy/hmac/hmac_sha.c
+++ b/unit_test/test_size/cryptlib_dummy/hmac/hmac_sha.c
@@ -164,7 +164,7 @@ boolean hmac_sha256_all(IN const void *data, IN uintn data_size,
 void *hmac_sha384_new(void)
 {
 	ASSERT(FALSE);
-	return FALSE;
+	return NULL;
 }
 
 /**
@@ -316,7 +316,7 @@ boolean hmac_sha384_all(IN const void *data, IN uintn data_size,
 void *hmac_sha512_new(void)
 {
 	ASSERT(FALSE);
-	return FALSE;
+	return NULL;
 }
 
 /**

--- a/unit_test/test_size/cryptlib_dummy/pk/dh.c
+++ b/unit_test/test_size/cryptlib_dummy/pk/dh.c
@@ -25,7 +25,7 @@
 void *dh_new_by_nid(IN uintn nid)
 {
 	ASSERT(FALSE);
-	return FALSE;
+	return NULL;
 }
 
 /**

--- a/unit_test/test_size/intrinsiclib/CMakeLists.txt
+++ b/unit_test/test_size/intrinsiclib/CMakeLists.txt
@@ -4,6 +4,10 @@ if(TOOLCHAIN MATCHES "VS")
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /GL-")
 endif()
 
+if(TOOLCHAIN MATCHES "CLANG")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-library-redeclaration")
+endif()
+
 INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal 
                     ${LIBSPDM_DIR}/include/hal/${ARCH}


### PR DESCRIPTION
Fixes couple of warnings thrown by clang-10 in test code. Also adds
-Wno-incompatible-library-redeclaration for the test instrinsic lib
since it is defining standard lib functions.

Signed-off-by: Raghu Krishnamurthy <raghupathyk@nvidia.com>