### PR TITLE
Fixing incorrect return value check in measurements.c

### DIFF
--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -514,10 +514,10 @@ return_status spdm_get_response_measurements(IN void *context,
 	     SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE) !=
 	    0) {
 
-		status = spdm_create_measurement_signature(
+		ret = spdm_create_measurement_signature(
 			spdm_context, spdm_response,
 			spdm_response_size);
-		if (RETURN_ERROR(status)) {
+		if (!ret) {
 			spdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSPECIFIED,


### PR DESCRIPTION
Fixes #80

spdm_create_measurement_signature returns boolean, while the existing code checks for negative value as failure return status. This check will never be true, so we can quietly fail spdm_create_measurement_signature and continue on.

Fixing return value check to ensure we catch failure.