### PR TITLE
Add application specific opaque data into spdm context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,7 @@ endif()
     ADD_SUBDIRECTORY(unit_test/test_size/cryptstublib_dummy)
     ADD_SUBDIRECTORY(unit_test/test_size/intrinsiclib)
     ADD_SUBDIRECTORY(unit_test/test_size/malloclib_null)
+    ADD_SUBDIRECTORY(unit_test/test_spdm_common)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     if(ARCH STREQUAL "x64")

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -106,7 +106,11 @@ typedef enum {
 	SPDM_DATA_SESSION_USE_PSK,
 	SPDM_DATA_SESSION_MUT_AUTH_REQUESTED,
 	SPDM_DATA_SESSION_END_SESSION_ATTRIBUTES,
-
+	//
+	// Opaque data that can be used by the application
+	// during callback functions such spdm_device_send_message_func.
+	//
+	SPDM_DATA_OPAQUE_CONTEXT_DATA,
 	//
 	// MAX
 	//

--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -51,6 +51,10 @@ return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
 	uint8 slot_id;
 	uint8 mut_auth_requested;
 
+	if (!context || !data || data_type >= SPDM_DATA_MAX) {
+		return RETURN_INVALID_PARAMETER;
+	}
+
 	spdm_context = context;
 
 	if (need_session_info_for_data(data_type)) {
@@ -361,6 +365,12 @@ return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
 		}
 		session_info->end_session_attributes = *(uint8 *)data;
 		break;
+	case SPDM_DATA_OPAQUE_CONTEXT_DATA:
+		if (data_size != sizeof(void *) || *(void **)data == NULL) {
+			return RETURN_INVALID_PARAMETER;
+		}
+		spdm_context->opaque_context_data_ptr = *(void **)data;
+		break;
 	default:
 		return RETURN_UNSUPPORTED;
 		break;
@@ -397,6 +407,10 @@ return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 	void *target_data;
 	uint32 session_id;
 	spdm_session_info_t *session_info;
+
+	if (!context || !data || !data_size || data_type >= SPDM_DATA_MAX) {
+		return RETURN_INVALID_PARAMETER;
+	}
 
 	spdm_context = context;
 
@@ -540,6 +554,10 @@ return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 	case SPDM_DATA_SESSION_END_SESSION_ATTRIBUTES:
 		target_data_size = sizeof(uint8);
 		target_data = &session_info->end_session_attributes;
+		break;
+	case SPDM_DATA_OPAQUE_CONTEXT_DATA:
+		target_data_size = sizeof(void *);
+		target_data = &spdm_context->opaque_context_data_ptr;
 		break;
 	default:
 		return RETURN_UNSUPPORTED;

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -310,6 +310,11 @@ typedef struct {
 	// Register for the retry times when receive "BUSY" Error response (requester only)
 	//
 	uint8 retry_times;
+
+	//
+	// Opaque context data for use by application
+	//
+	void *opaque_context_data_ptr;
 } spdm_context_t;
 
 /**

--- a/unit_test/test_spdm_common/CMakeLists.txt
+++ b/unit_test/test_spdm_common/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 2.6)
+
+INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/test_spdm_requester
+                    ${LIBSPDM_DIR}/include
+                    ${LIBSPDM_DIR}/include/hal
+                    ${LIBSPDM_DIR}/include/hal/${ARCH}
+                    ${LIBSPDM_DIR}/unit_test/include
+                    ${LIBSPDM_DIR}/library/spdm_common_lib
+                    ${LIBSPDM_DIR}/library/spdm_requester_lib
+                    ${LIBSPDM_DIR}/library/spdm_secured_message_lib
+                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
+                    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common
+)
+
+SET(src_test_spdm_common
+    test_spdm_common.c
+    context_data.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c
+)
+
+SET(test_spdm_common_LIBRARY
+    memlib
+    debuglib
+    spdm_requester_lib
+    spdm_common_lib
+    ${CRYPTO_LIB_PATHS}
+    rnglib
+    cryptlib_${CRYPTO}
+    malloclib
+    spdm_crypt_lib
+    spdm_secured_message_lib
+    spdm_device_secret_lib
+    spdm_transport_test_lib
+    cmockalib
+)
+
+if(NOT ((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC")))
+    ADD_EXECUTABLE(test_spdm_common ${src_test_spdm_common})
+    TARGET_LINK_LIBRARIES(test_spdm_common ${test_spdm_common_LIBRARY})
+endif()
+
+

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1,0 +1,208 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+#include "spdm_unit_test.h"
+#include <spdm_requester_lib_internal.h>
+
+static const uint32_t opaque_data = 0xDEADBEEF;
+
+/**
+  Test 1: Basic test - tests happy path of setting and getting opaque data from
+  context successfully.
+**/
+static void test_spdm_common_context_data_case1(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	void *data = (void *)&opaque_data;
+	void *return_data = NULL;
+	uintn data_return_size = 0;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1;
+
+	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &data, sizeof(data));
+	assert_int_equal(status, RETURN_SUCCESS);
+
+	data_return_size = sizeof(return_data);
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &return_data, &data_return_size);
+	assert_int_equal(status, RETURN_SUCCESS);
+
+	assert_memory_equal(data, return_data, sizeof(data));
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* check that nothing changed at the data location */
+	assert_int_equal(opaque_data, 0xDEADBEEF);
+}
+
+/**
+  Test 2: Test failure paths of setting opaque data in context. spdm_set_data
+  should fail when an invalid size is passed.
+**/
+static void test_spdm_common_context_data_case2(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	void *data = (void *)&opaque_data;
+	void *return_data = NULL;
+	void *current_return_data = NULL;
+	uintn data_return_size = 0;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1;
+
+	/**
+	 * Get current opaque data in context. May have been set in previous
+	 * tests. This will be used to compare later to ensure the value hasn't
+	 * changed after a failed set data.
+	 */
+	data_return_size = sizeof(current_return_data);
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &current_return_data, &data_return_size);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* Ensure nothing has changed between subsequent calls to get data */
+	assert_ptr_equal(current_return_data, &opaque_data);
+
+	/*
+	 * Set data with invalid size, it should fail. Read back to ensure that
+	 * no data was set.
+	 */
+	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &data, 500);
+	assert_int_equal(status, RETURN_INVALID_PARAMETER);
+
+	data_return_size = sizeof(return_data);
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &return_data, &data_return_size);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_ptr_equal(return_data, current_return_data);
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* check that nothing changed at the data location */
+	assert_int_equal(opaque_data, 0xDEADBEEF);
+}
+
+/**
+  Test 3: Test failure paths of setting opaque data in context. spdm_set_data
+  should fail when data contains NULL value.
+**/
+static void test_spdm_common_context_data_case3(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	void *data = NULL;
+	void *return_data = NULL;
+	void *current_return_data = NULL;
+	uintn data_return_size = 0;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1;
+
+	/**
+	 * Get current opaque data in context. May have been set in previous
+	 * tests. This will be used to compare later to ensure the value hasn't
+	 * changed after a failed set data.
+	 */
+	data_return_size = sizeof(current_return_data);
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &current_return_data, &data_return_size);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* Ensure nothing has changed between subsequent calls to get data */
+	assert_ptr_equal(current_return_data, &opaque_data);
+
+
+	/*
+	 * Set data with NULL data, it should fail. Read back to ensure that
+	 * no data was set.
+	 */
+	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &data, sizeof(void *));
+	assert_int_equal(status, RETURN_INVALID_PARAMETER);
+
+	data_return_size = sizeof(return_data);
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &return_data, &data_return_size);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_ptr_equal(return_data, current_return_data);
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* check that nothing changed at the data location */
+	assert_int_equal(opaque_data, 0xDEADBEEF);
+
+}
+
+/**
+  Test 4: Test failure paths of getting opaque data in context. spdm_get_data
+  should fail when the size of buffer to get is too small.
+**/
+static void test_spdm_common_context_data_case4(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	void *data = (void *)&opaque_data;
+	void *return_data = NULL;
+	uintn data_return_size = 0;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1;
+
+	/*
+	 * Set data successfully.
+	 */
+	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &data, sizeof(void *));
+	assert_int_equal(status, RETURN_SUCCESS);
+
+	/*
+	 * Fail get data due to insufficient buffer for return value. returned
+	 * data size must return required buffer size.
+	 */
+	data_return_size = 4;
+	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+			       NULL, &return_data, &data_return_size);
+	assert_int_equal(status, RETURN_BUFFER_TOO_SMALL);
+	assert_int_equal(data_return_size, sizeof(void*));
+
+	/* check that nothing changed at the data location */
+	assert_int_equal(opaque_data, 0xDEADBEEF);
+}
+
+static spdm_test_context_t m_spdm_common_context_data_test_context = {
+	SPDM_TEST_CONTEXT_SIGNATURE,
+	TRUE,
+	NULL,
+	NULL,
+};
+
+int spdm_common_context_data_test_main(void)
+{
+	const struct CMUnitTest spdm_common_context_data_tests[] = {
+		cmocka_unit_test(test_spdm_common_context_data_case1),
+		cmocka_unit_test(test_spdm_common_context_data_case2),
+		cmocka_unit_test(test_spdm_common_context_data_case3),
+		cmocka_unit_test(test_spdm_common_context_data_case4),
+	};
+
+	setup_spdm_test_context(&m_spdm_common_context_data_test_context);
+
+	return cmocka_run_group_tests(spdm_common_context_data_tests,
+				      spdm_unit_test_group_setup,
+				      spdm_unit_test_group_teardown);
+}

--- a/unit_test/test_spdm_common/test_spdm_common.c
+++ b/unit_test/test_spdm_common/test_spdm_common.c
@@ -1,0 +1,19 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+
+extern int spdm_common_context_data_test_main(void);
+
+int main(void)
+{
+	int return_value = 0;
+
+	if (spdm_common_context_data_test_main() != 0) {
+		return_value = 1;
+	}
+
+	return return_value;
+}


### PR DESCRIPTION
Fix DMTF#66
Added opaque data pointer to spdm context. This is useful to pass
pointers to application specific data through the context to callback
functions such as spdm_device_send_message_func.

Signed-off-by: Raghu Krishnamurthy raghupathyk@nvidia.com