### PR TITLE
Array compared to null bug

### DIFF
--- a/library/spdm_requester_lib/encap_certificate.c
+++ b/library/spdm_requester_lib/encap_certificate.c
@@ -57,19 +57,20 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
-		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_GET_CERTIFICATE, response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	slot_id = spdm_request->header.param1;
 
 	if (slot_id >= spdm_context->local_context.slot_count) {
 		spdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
+		return RETURN_SUCCESS;
+	}
+
+	if (spdm_context->local_context
+					  .local_cert_chain_provision[slot_id] == NULL) {
+		spdm_generate_encap_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 

--- a/library/spdm_requester_lib/encap_digests.c
+++ b/library/spdm_requester_lib/encap_digests.c
@@ -56,13 +56,6 @@ return_status spdm_get_encap_response_digest(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
-		spdm_generate_encap_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_GET_DIGESTS, response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	spdm_reset_message_buffer_via_request_code(spdm_context,
 						spdm_request->header.request_response_code);
 
@@ -89,6 +82,13 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	digest = (void *)(spdm_response + 1);
 	for (index = 0; index < spdm_context->local_context.slot_count;
 	     index++) {
+		if (spdm_context->local_context
+						  .local_cert_chain_provision[index] == NULL) {
+			spdm_generate_encap_error_response(
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+				0, response_size, response);
+			return RETURN_SUCCESS;
+		}
 		spdm_response->header.param2 |= (1 << index);
 		spdm_generate_cert_chain_hash(spdm_context, index,
 					      &digest[hash_size * index]);

--- a/library/spdm_responder_lib/certificate.c
+++ b/library/spdm_responder_lib/certificate.c
@@ -75,19 +75,20 @@ return_status spdm_get_response_certificate(IN void *context,
 	}
 	spdm_request_size = request_size;
 
-	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
-		spdm_generate_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_GET_CERTIFICATE, response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	slot_id = spdm_request->header.param1;
 
 	if (slot_id >= spdm_context->local_context.slot_count) {
 		spdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
+		return RETURN_SUCCESS;
+	}
+
+	if (spdm_context->local_context
+					  .local_cert_chain_provision[slot_id] == NULL) {
+		spdm_generate_error_response(
+			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 

--- a/library/spdm_responder_lib/digests.c
+++ b/library/spdm_responder_lib/digests.c
@@ -75,13 +75,6 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 
 	spdm_request_size = request_size;
 
-	if (spdm_context->local_context.local_cert_chain_provision == NULL) {
-		spdm_generate_error_response(
-			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-			SPDM_GET_DIGESTS, response_size, response);
-		return RETURN_SUCCESS;
-	}
-
 	no_local_cert_chain = TRUE;
 	for (index = 0; index < MAX_SPDM_SLOT_COUNT; index++) {
 		if (spdm_context->local_context
@@ -119,6 +112,13 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	digest = (void *)(spdm_response + 1);
 	for (index = 0; index < spdm_context->local_context.slot_count;
 	     index++) {
+		if (spdm_context->local_context
+						  .local_cert_chain_provision[index] == NULL) {
+			spdm_generate_error_response(
+				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+				0, response_size, response);
+			return RETURN_SUCCESS;
+		}
 		spdm_response->header.param2 |= (1 << index);
 		spdm_generate_cert_chain_hash(spdm_context, index,
 					      &digest[hash_size * index]);


### PR DESCRIPTION
local_cert_chain_provision is an array used to store cert chain pointers,
should compare the member of array instead of array-self.
If slot_id is valid but local_cert_chain_provision[slot_id] is NULL,
should report internal error with SPDM_ERROR_CODE_UNSPECIFIED.

Fix #51
Signed-off-by: yi1 li <yi1.li@intel.com>