### PR TITLE
Fix for uninitialized variables error on warning

### DIFF
--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -67,6 +67,8 @@ return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
 		if (session_info == NULL) {
 			return RETURN_INVALID_PARAMETER;
 		}
+	} else {
+		session_info = NULL;
 	}
 
 	switch (data_type) {
@@ -423,6 +425,8 @@ return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 		if (session_info == NULL) {
 			return RETURN_INVALID_PARAMETER;
 		}
+	} else {
+		session_info = NULL;
 	}
 
 	switch (data_type) {

--- a/library/spdm_responder_lib/receive_send.c
+++ b/library/spdm_responder_lib/receive_send.c
@@ -283,6 +283,7 @@ return_status spdm_build_response(IN void *context, IN uint32 *session_id,
 	spdm_message_header_t *spdm_response;
 
 	spdm_context = context;
+	status = RETURN_UNSUPPORTED;
 
 	if (spdm_context->last_spdm_error.error_code != 0) {
 		//


### PR DESCRIPTION
When compiling with more restrictive options, such as force error on warning, the compiler will think these two variables (session_info and return_status) may be used before initialized.  Fix this issue by always initializing the variables.