### PR TITLE
Adding new test cases for the psk_finish message.

### DIFF
--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -68,6 +68,12 @@ return_status spdm_requester_psk_finish_test_send_message(IN void *spdm_context,
 		return RETURN_SUCCESS;
 	case 0xB:
 		return RETURN_SUCCESS;
+	case 0xC:
+		return RETURN_SUCCESS;
+	case 0xD:
+		return RETURN_SUCCESS;
+	case 0xE:
+		return RETURN_SUCCESS;
 	default:
 		return RETURN_DEVICE_ERROR;
 	}
@@ -461,11 +467,115 @@ return_status spdm_requester_psk_finish_test_receive_message(
 			->handshake_secret.response_handshake_sequence_number--;
 	}
 		return RETURN_SUCCESS;
+
+	case 0xC: {
+		spdm_psk_finish_response_t *spdm_response;
+		uint8 temp_buf[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn temp_buf_size;
+		uint32 session_id;
+		spdm_session_info_t *session_info;
+
+		session_id = 0xFFFFFFFF;
+		temp_buf_size = sizeof(spdm_psk_finish_response_t);
+		spdm_response = (void *)temp_buf;
+
+		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response->header.request_response_code =
+			SPDM_PSK_FINISH_RSP;
+		spdm_response->header.param1 = 0;
+		spdm_response->header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, temp_buf_size,
+						   temp_buf, response_size,
+						   response);
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		/* WALKAROUND: If just use single context to encode message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->handshake_secret.response_handshake_sequence_number--;
+	}
+		return RETURN_SUCCESS;
+
+	case 0xD: {
+		spdm_psk_finish_response_t *spdm_response;
+		uint8 temp_buf[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn temp_buf_size;
+		uint32 session_id;
+		spdm_session_info_t *session_info;
+
+		session_id = 0xFFFFFFFF;
+		temp_buf_size = sizeof(spdm_psk_finish_response_t);
+		spdm_response = (void *)temp_buf;
+
+		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response->header.request_response_code =
+			SPDM_FINISH_RSP; //wrong response code
+		spdm_response->header.param1 = 0;
+		spdm_response->header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, temp_buf_size,
+						   temp_buf, response_size,
+						   response);
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		/* WALKAROUND: If just use single context to encode message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->handshake_secret.response_handshake_sequence_number--;
+	}
+		return RETURN_SUCCESS;
+
+	case 0xE: {
+		spdm_psk_finish_response_t *spdm_response;
+		uint8 temp_buf[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn temp_buf_size;
+		uint32 session_id;
+		spdm_session_info_t *session_info;
+
+		session_id = 0xFFFFFFFF;
+		temp_buf_size = sizeof(spdm_psk_finish_response_t);
+		spdm_response = (void *)temp_buf;
+
+		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response->header.request_response_code =
+			SPDM_PSK_FINISH_RSP;
+		spdm_response->header.param1 = 0;
+		spdm_response->header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, temp_buf_size,
+						   temp_buf, response_size,
+						   response);
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		/* WALKAROUND: If just use single context to encode message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->handshake_secret.response_handshake_sequence_number--;
+	}
+		return RETURN_SUCCESS;
 	default:
 		return RETURN_DEVICE_ERROR;
 	}
 }
 
+/**
+  Test 1: when no PSK_FINISH_RSP message is received, and the client returns
+  a device error.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
+**/
 void test_spdm_requester_psk_finish_case1(void **state)
 {
 	return_status status;
@@ -530,6 +640,11 @@ void test_spdm_requester_psk_finish_case1(void **state)
 	free(data);
 }
 
+/**
+  Test 2: receiving a correct PSK_FINISH_RSP message.
+  Expected behavior: client returns a Status of RETURN_SUCCESS and
+  session is established.
+**/
 void test_spdm_requester_psk_finish_case2(void **state)
 {
 	return_status status;
@@ -621,6 +736,11 @@ void test_spdm_requester_psk_finish_case2(void **state)
 	free(data);
 }
 
+/**
+  Test 3: requester state has not been negotiated, as if GET_VERSION,
+  GET_CAPABILITIES and NEGOTIATE_ALGORITHMS had not been exchanged.
+  Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
+**/
 void test_spdm_requester_psk_finish_case3(void **state)
 {
 	return_status status;
@@ -708,6 +828,11 @@ void test_spdm_requester_psk_finish_case3(void **state)
 	free(data);
 }
 
+/**
+  Test 4: the requester is setup correctly, but receives an ERROR message
+  indicating InvalidParameters.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
+**/
 void test_spdm_requester_psk_finish_case4(void **state)
 {
 	return_status status;
@@ -795,6 +920,11 @@ void test_spdm_requester_psk_finish_case4(void **state)
 	free(data);
 }
 
+/**
+  Test 5: the requester is setup correctly, but receives an ERROR message
+  indicating the Busy status of the responder.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
+**/
 void test_spdm_requester_psk_finish_case5(void **state)
 {
 	return_status status;
@@ -882,6 +1012,13 @@ void test_spdm_requester_psk_finish_case5(void **state)
 	free(data);
 }
 
+/**
+  Test 6: the requester is setup correctly, but, on the first try, receiving
+  a Busy ERROR message, and, on retry, receiving a correct PSK_FINISH_RSP
+  message.
+  Expected behavior: client returns a Status of RETURN_SUCCESS and session
+  is established.
+**/
 void test_spdm_requester_psk_finish_case6(void **state)
 {
 	return_status status;
@@ -973,6 +1110,12 @@ void test_spdm_requester_psk_finish_case6(void **state)
 	free(data);
 }
 
+/**
+  Test 7: the requester is setup correctly, but receives an ERROR message
+  indicating the RequestResynch status of the responder.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the 
+  communication is reset to expect a new GET_VERSION message.
+**/
 void test_spdm_requester_psk_finish_case7(void **state)
 {
 	return_status status;
@@ -1062,6 +1205,11 @@ void test_spdm_requester_psk_finish_case7(void **state)
 	free(data);
 }
 
+/**
+  Test 8: the requester is setup correctly, but receives an ERROR message
+  indicating the ResponseNotReady status of the responder.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
+**/
 void test_spdm_requester_psk_finish_case8(void **state)
 {
 	return_status status;
@@ -1149,6 +1297,13 @@ void test_spdm_requester_psk_finish_case8(void **state)
 	free(data);
 }
 
+/**
+  Test 9: the requester is setup correctly, but, on the first try, receiving
+  a ResponseNotReady ERROR message, and, on retry, receiving a correct
+  PSK_FINISH_RSP message.
+  Expected behavior: client returns a Status of RETURN_SUCCESS and session
+  is established.
+**/
 void test_spdm_requester_psk_finish_case9(void **state)
 {
 	return_status status;
@@ -1240,6 +1395,14 @@ void test_spdm_requester_psk_finish_case9(void **state)
 	free(data);
 }
 
+/**
+  Test 10: receiving an unexpected ERROR message from the responder.
+  There are tests for all named codes, including some reserved ones
+  (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
+  However, for having specific test cases, it is excluded from this case:
+  Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
+  Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+**/
 void test_spdm_requester_psk_finish_case10(void **state) {
   return_status        status;
   spdm_test_context_t    *spdm_test_context;
@@ -1414,6 +1577,287 @@ void test_spdm_requester_psk_finish_case11(void **state)
 	free(data);
 }
 
+/**
+  Test 12: requester is not setup correctly to support pre-shared keys
+  (no capabilities). The responder would attempt to return a correct
+  PSK_FINISH_RSP message.
+  Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
+**/
+void test_spdm_requester_psk_finish_case12(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uint32 session_id;
+	void *data;
+	uintn data_size;
+	void *hash;
+	uintn hash_size;
+	spdm_session_info_t *session_info;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xC;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	//no PSK capabilities
+	spdm_context->connection_info.capability.flags &=
+		~(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP);
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data,
+						&data_size, &hash, &hash_size);
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+		data_size;
+	copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+		 data, data_size);
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+	set_mem(m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_encryption_key(
+		session_info->secured_message_context, m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size);
+	set_mem(m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_salt(
+		session_info->secured_message_context, m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size);
+	((spdm_secured_message_context_t *)(session_info
+						    ->secured_message_context))
+		->handshake_secret.response_handshake_sequence_number = 0;
+
+	status = spdm_send_receive_psk_finish(spdm_context, session_id);
+	assert_int_equal(status, RETURN_UNSUPPORTED);
+	free(data);
+}
+
+/**
+  Test 13: receiving an incorrect FINISH_RSP message, with wrong response
+  code, but all other field correct.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
+**/
+void test_spdm_requester_psk_finish_case13(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uint32 session_id;
+	void *data;
+	uintn data_size;
+	void *hash;
+	uintn hash_size;
+	spdm_session_info_t *session_info;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xD;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	//no PSK capabilities
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data,
+						&data_size, &hash, &hash_size);
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+		data_size;
+	copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+		 data, data_size);
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+	set_mem(m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_encryption_key(
+		session_info->secured_message_context, m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size);
+	set_mem(m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_salt(
+		session_info->secured_message_context, m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size);
+	((spdm_secured_message_context_t *)(session_info
+						    ->secured_message_context))
+		->handshake_secret.response_handshake_sequence_number = 0;
+
+	status = spdm_send_receive_psk_finish(spdm_context, session_id);
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	free(data);
+}
+
+/**
+  Test 14: requester is not setup correctly by not initializing a
+  session during PSK_EXCHANGE. The responder would attempt to 
+  return a correct PSK_FINISH_RSP message.
+  Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
+**/
+void test_spdm_requester_psk_finish_case14(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uint32 session_id;
+	void *data;
+	uintn data_size;
+	void *hash;
+	uintn hash_size;
+	spdm_session_info_t *session_info;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xE;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	//no PSK capabilities
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data,
+						&data_size, &hash, &hash_size);
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+		data_size;
+	copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+		 data, data_size);
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_NOT_STARTED);
+	set_mem(m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_encryption_key(
+		session_info->secured_message_context, m_dummy_key_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_key_size);
+	set_mem(m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size,
+		(uint8)(0xFF));
+	spdm_secured_message_set_response_handshake_salt(
+		session_info->secured_message_context, m_dummy_salt_buffer,
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->aead_iv_size);
+	((spdm_secured_message_context_t *)(session_info
+						    ->secured_message_context))
+		->handshake_secret.response_handshake_sequence_number = 0;
+
+	status = spdm_send_receive_psk_finish(spdm_context, session_id);
+	assert_int_equal(status, RETURN_UNSUPPORTED);
+	free(data);
+}
+
 spdm_test_context_t m_spdm_requester_psk_finish_test_context = {
 	SPDM_TEST_CONTEXT_SIGNATURE,
 	TRUE,
@@ -1446,6 +1890,12 @@ int spdm_requester_psk_finish_test_main(void)
 		cmocka_unit_test(test_spdm_requester_psk_finish_case10),
 		// Buffer reset
 		cmocka_unit_test(test_spdm_requester_psk_finish_case11),
+		// No correct setup
+		cmocka_unit_test(test_spdm_requester_psk_finish_case12),
+		// Wrong response code
+		cmocka_unit_test(test_spdm_requester_psk_finish_case13),
+		// Uninitialized session
+		cmocka_unit_test(test_spdm_requester_psk_finish_case14),
 	};
 
 	setup_spdm_test_context(&m_spdm_requester_psk_finish_test_context);

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -41,6 +41,12 @@ static void spdm_secured_message_set_request_finished_key(
 		 key, secured_message_context->hash_size);
 }
 
+/**
+  Test 1: receiving a correct PSK_FINISH message from the requester with a 
+  correct MAC.
+  Expected behavior: the responder accepts the request and produces a valid
+  PSK_FINISH_RSP response message.
+**/
 void test_spdm_responder_psk_finish_case1(void **state)
 {
 	return_status status;
@@ -141,6 +147,11 @@ void test_spdm_responder_psk_finish_case1(void **state)
 	free(data1);
 }
 
+/**
+  Test 2: receiving a PSK_FINISH message larger than specified.
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the InvalidRequest.
+**/
 void test_spdm_responder_psk_finish_case2(void **state)
 {
 	return_status status;
@@ -240,6 +251,12 @@ void test_spdm_responder_psk_finish_case2(void **state)
 	free(data1);
 }
 
+/**
+  Test 3: receiving a correct PSK_FINISH from the requester, but the
+  responder is in a Busy state.
+  Expected behavior: the responder accepts the request, but produces an
+  ERROR message indicating the Busy state.
+**/
 void test_spdm_responder_psk_finish_case3(void **state)
 {
 	return_status status;
@@ -345,6 +362,12 @@ void test_spdm_responder_psk_finish_case3(void **state)
 	free(data1);
 }
 
+/**
+  Test 4: receiving a correct PSK_FINISH from the requester, but the
+  responder requires resynchronization with the requester.
+  Expected behavior: the responder accepts the request, but produces an
+  ERROR message indicating the NeedResynch state.
+**/
 void test_spdm_responder_psk_finish_case4(void **state)
 {
 	return_status status;
@@ -451,6 +474,12 @@ void test_spdm_responder_psk_finish_case4(void **state)
 	free(data1);
 }
 
+/**
+  Test 5: receiving a correct PSK_FINISH from the requester, but the
+  responder could not produce the response in time.
+  Expected behavior: the responder accepts the request, but produces an
+  ERROR message indicating the ResponseNotReady state.
+**/
 void test_spdm_responder_psk_finish_case5(void **state)
 {
 	return_status status;
@@ -563,6 +592,14 @@ void test_spdm_responder_psk_finish_case5(void **state)
 	free(data1);
 }
 
+/**
+  Test 6: receiving a correct PSK_FINISH from the requester, but the
+  responder is not set no receive a PSK-FINISH message because previous
+  messages (namely, GET_CAPABILITIES, NEGOTIATE_ALGORITHMS or
+  GET_DIGESTS) have not been received.
+  Expected behavior: the responder rejects the request, and produces an
+  ERROR message indicating the UnexpectedRequest.
+**/
 void test_spdm_responder_psk_finish_case6(void **state)
 {
 	return_status status;
@@ -785,6 +822,649 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	free(data1);
 }
 
+/**
+  Test 8: receiving a correct PSK_FINISH message from the requester, but
+  the responder has no capabilities for pre-shared keys.
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the UnsupportedRequest.
+**/
+void test_spdm_responder_psk_finish_case8(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	large_managed_buffer_t th_curr;
+	uint8 request_finished_key[MAX_HASH_SIZE];
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x8;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags &=
+		~(SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP);
+	spdm_context->local_context.capability.flags &=
+		~(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP);
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
+	// transcript.message_a size is 0
+	// session_transcript.message_k is 0
+	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
+			      sizeof(spdm_psk_finish_request_t));
+	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
+	spdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
+		      get_managed_buffer_size(&th_curr), request_finished_key,
+		      hash_size, ptr);
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + hmac_size;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+	assert_int_equal(spdm_response->header.param2, SPDM_PSK_EXCHANGE);
+	free(data1);
+}
+
+/**
+  Test 9: receiving a correct PSK_FINISH message from the requester, but
+  the responder is not correctly setup by not initializing a session during
+  PSK_EXCHANGE.
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the InvalidRequest.
+**/
+void test_spdm_responder_psk_finish_case9(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	large_managed_buffer_t th_curr;
+	uint8 request_finished_key[MAX_HASH_SIZE];
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x9;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_NOT_STARTED);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
+	// transcript.message_a size is 0
+	// session_transcript.message_k is 0
+	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
+			      sizeof(spdm_psk_finish_request_t));
+	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
+	spdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
+		      get_managed_buffer_size(&th_curr), request_finished_key,
+		      hash_size, ptr);
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + hmac_size;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_INVALID_REQUEST);
+	assert_int_equal(spdm_response->header.param2, 0);
+	free(data1);
+}
+
+/**
+  Test 10: receiving a PSK_FINISH message from the requester with an
+  incorrect MAC (all-zero).
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the DecryptError.
+**/
+void test_spdm_responder_psk_finish_case10(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xA;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	set_mem(ptr, hmac_size, (uint8)(0x00)); //all-zero MAC
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + hmac_size;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_DECRYPT_ERROR);
+	assert_int_equal(spdm_response->header.param2, 0);
+	free(data1);
+}
+
+/**
+  Test 11: receiving a PSK_FINISH message from the requester with an
+  incorrect MAC (arbitrary).
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the DecryptError.
+**/
+void test_spdm_responder_psk_finish_case11(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	uint8 request_finished_key[MAX_HASH_SIZE];
+	uint8 zero_data[MAX_HASH_SIZE];
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xB;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	//arbitrary MAC
+	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
+	set_mem(zero_data, hash_size, (uint8)(0x00));
+	spdm_hmac_all(m_use_hash_algo, zero_data, hash_size,
+		      request_finished_key, hash_size, ptr);
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + hmac_size;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_DECRYPT_ERROR);
+	assert_int_equal(spdm_response->header.param2, 0);
+	free(data1);
+}
+
+/**
+  Test 12: receiving a PSK_FINISH message from the requester with an
+  incorrect MAC size (a correct MAC repeated twice).
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the InvalidRequest.
+**/
+void test_spdm_responder_psk_finish_case12(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	large_managed_buffer_t th_curr;
+	uint8 request_finished_key[MAX_HASH_SIZE];
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xC;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
+	// transcript.message_a size is 0
+	// session_transcript.message_k is 0
+	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
+			      sizeof(spdm_psk_finish_request_t));
+	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
+	spdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
+		      get_managed_buffer_size(&th_curr), request_finished_key,
+		      hash_size, ptr);
+	copy_mem(ptr, ptr + hmac_size, hmac_size); // 2x HMAC size
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + 2*hmac_size;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_INVALID_REQUEST);
+	assert_int_equal(spdm_response->header.param2, 0);
+	free(data1);
+}
+
+/**
+  Test 13: receiving a PSK_FINISH message from the requester with an
+  incorrect MAC size (only the correct first half of the MAC).
+  Expected behavior: the responder refuses the PSK_FINISH message and
+  produces an ERROR message indicating the InvalidRequest.
+**/
+void test_spdm_responder_psk_finish_case13(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uintn response_size;
+	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	spdm_psk_finish_response_t *spdm_response;
+	void *data1;
+	uintn data_size1;
+	uint8 *ptr;
+	large_managed_buffer_t th_curr;
+	uint8 request_finished_key[MAX_HASH_SIZE];
+	spdm_session_info_t *session_info;
+	uint32 session_id;
+	uint32 hash_size;
+	uint32 hmac_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0xD;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_NEGOTIATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data1,
+						&data_size1, NULL, NULL);
+	spdm_context->local_context.local_cert_chain_provision[0] = data1;
+	spdm_context->local_context.local_cert_chain_provision_size[0] =
+		data_size1;
+	spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+	spdm_context->connection_info.local_used_cert_chain_buffer_size =
+		data_size1;
+	spdm_context->local_context.slot_count = 1;
+	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_context->local_context.mut_auth_requested = 0;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+	session_id = 0xFFFFFFFF;
+	spdm_context->latest_session_id = session_id;
+	spdm_context->last_spdm_request_session_id_valid = TRUE;
+	spdm_context->last_spdm_request_session_id = session_id;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	set_mem(m_dummy_buffer, hash_size, (uint8)(0xFF));
+	spdm_secured_message_set_request_finished_key(
+		session_info->secured_message_context, m_dummy_buffer,
+		hash_size);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_HANDSHAKING);
+
+	hash_size = spdm_get_hash_size(m_use_hash_algo);
+	hmac_size = spdm_get_hash_size(m_use_hash_algo);
+	ptr = m_spdm_psk_finish_request1.verify_data;
+	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
+	// transcript.message_a size is 0
+	// session_transcript.message_k is 0
+	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
+			      sizeof(spdm_psk_finish_request_t));
+	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
+	spdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
+		      get_managed_buffer_size(&th_curr), request_finished_key,
+		      hash_size, ptr);
+	set_mem(ptr + hmac_size/2, hmac_size/2, (uint8) 0x00); // half HMAC size
+	m_spdm_psk_finish_request1_size =
+		sizeof(spdm_psk_finish_request_t) + hmac_size/2;
+	response_size = sizeof(response);
+	status = spdm_get_response_psk_finish(spdm_context,
+					      m_spdm_psk_finish_request1_size,
+					      &m_spdm_psk_finish_request1,
+					      &response_size, response);
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+	spdm_response = (void *)response;
+	assert_int_equal(spdm_response->header.request_response_code,
+			 SPDM_ERROR);
+	assert_int_equal(spdm_response->header.param1,
+			 SPDM_ERROR_CODE_INVALID_REQUEST);
+	assert_int_equal(spdm_response->header.param2, 0);
+	free(data1);
+}
+
 spdm_test_context_t m_spdm_responder_psk_finish_test_context = {
 	SPDM_TEST_CONTEXT_SIGNATURE,
 	FALSE,
@@ -807,6 +1487,16 @@ int spdm_responder_psk_finish_test_main(void)
 		cmocka_unit_test(test_spdm_responder_psk_finish_case6),
 		// Buffer reset
 		cmocka_unit_test(test_spdm_responder_psk_finish_case7),
+		// Unsupported PSK capabilities
+		cmocka_unit_test(test_spdm_responder_psk_finish_case8),
+		// Uninitialized session
+		cmocka_unit_test(test_spdm_responder_psk_finish_case9),
+		// Incorrect MAC
+		cmocka_unit_test(test_spdm_responder_psk_finish_case10),
+		cmocka_unit_test(test_spdm_responder_psk_finish_case11),
+		// Incorrect MAC size
+		cmocka_unit_test(test_spdm_responder_psk_finish_case12),
+		cmocka_unit_test(test_spdm_responder_psk_finish_case13),
 	};
 
 	setup_spdm_test_context(&m_spdm_responder_psk_finish_test_context);


### PR DESCRIPTION
This commit adds new unit test cases for the PSK_FINISH/PSK_FINISH_RSP messages.

On the requester side:
* no capabilities for PSK
* wrong response code
* session not initiated

On the responder side:
* with mutual authentication (success case)
* no capabilities for PSK
* session not initiated
* incorrect MAC (all-zero and arbitrary)
* wrong MAC size (double and half sizes)

Signed-off-by: Marcos Vinicius Maciel da Silva <vinicius_ceth@yahoo.com.br>