### PR TITLE
Fix error handling for CHALLENGE_AUTH signature generation

### DIFF
--- a/library/spdm_requester_lib/challenge.c
+++ b/library/spdm_requester_lib/challenge.c
@@ -227,6 +227,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	status = spdm_append_message_c(spdm_context, &spdm_response,
 				       spdm_response_size - signature_size);
 	if (RETURN_ERROR(status)) {
+		reset_managed_buffer(&spdm_context->transcript.message_c);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -241,6 +242,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	result = spdm_verify_challenge_auth_signature(
 		spdm_context, TRUE, signature, signature_size);
 	if (!result) {
+		reset_managed_buffer(&spdm_context->transcript.message_c);
 		spdm_context->error_state =
 			SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;
 		return RETURN_SECURITY_VIOLATION;
@@ -260,6 +262,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 		       "spdm_challenge - spdm_encapsulated_request - %p\n",
 		       status));
 		if (RETURN_ERROR(status)) {
+			reset_managed_buffer(&spdm_context->transcript.message_c);
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;
 			return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -202,6 +202,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	result = spdm_generate_challenge_auth_signature(spdm_context, FALSE,
 							ptr);
 	if (!result) {
+		reset_managed_buffer(&spdm_context->transcript.message_c);
 		return spdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);


### PR DESCRIPTION
Fix #99
Should reset message_c before return error.
Signed-off-by: yi1 li <yi1.li@intel.com>