### PR TITLE
need return trust anchor in GetCertificate to the caller

### DIFF
--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -123,6 +123,34 @@ return_status spdm_get_certificate(IN void *spdm_context, IN uint8 slot_id,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  cert_chain_size                On input, indicate the size in bytes of the destination buffer to store the digest buffer.
+                                       On output, indicate the size in bytes of the certificate chain.
+  @param  cert_chain                    A pointer to a destination buffer to store the certificate chain.
+  @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+  @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
+
+  @retval RETURN_SUCCESS               The certificate chain is got successfully.
+  @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+  @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+**/
+return_status spdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
+				   IN OUT uintn *cert_chain_size,
+				   OUT void *cert_chain,
+				   OUT void **trust_anchor OPTIONAL,
+				   OUT uintn *trust_anchor_size OPTIONAL);
+
+/**
+  This function sends GET_CERTIFICATE
+  to get certificate chain in one slot from device.
+
+  This function verify the integrity of the certificate chain.
+  root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
+
+  If the peer root certificate hash is deployed,
+  this function also verifies the digest with the root hash in the certificate chain.
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  slot_id                      The number of slot for the certificate chain.
   @param  length                       MAX_SPDM_CERT_CHAIN_BLOCK_LEN.
   @param  cert_chain_size                On input, indicate the size in bytes of the destination buffer to store the digest buffer.
                                        On output, indicate the size in bytes of the certificate chain.
@@ -137,6 +165,37 @@ return_status spdm_get_certificate_choose_length(IN void *spdm_context,
 						 IN uint16 length,
 						 IN OUT uintn *cert_chain_size,
 						 OUT void *cert_chain);
+
+/**
+  This function sends GET_CERTIFICATE
+  to get certificate chain in one slot from device.
+
+  This function verify the integrity of the certificate chain.
+  root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
+
+  If the peer root certificate hash is deployed,
+  this function also verifies the digest with the root hash in the certificate chain.
+
+  @param  spdm_context                  A pointer to the SPDM context.
+  @param  slot_id                      The number of slot for the certificate chain.
+  @param  length                       MAX_SPDM_CERT_CHAIN_BLOCK_LEN.
+  @param  cert_chain_size                On input, indicate the size in bytes of the destination buffer to store the digest buffer.
+                                       On output, indicate the size in bytes of the certificate chain.
+  @param  cert_chain                    A pointer to a destination buffer to store the certificate chain.
+  @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+  @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
+
+  @retval RETURN_SUCCESS               The certificate chain is got successfully.
+  @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+  @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+**/
+return_status spdm_get_certificate_choose_length_ex(IN void *context,
+						 IN uint8 slot_id,
+						 IN uint16 length,
+						 IN OUT uintn *cert_chain_size,
+						 OUT void *cert_chain,
+						 OUT void **trust_anchor OPTIONAL,
+						 OUT uintn *trust_anchor_size OPTIONAL);
 
 /**
   This function sends CHALLENGE

--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -398,13 +398,17 @@ boolean spdm_verify_peer_digests(IN spdm_context_t *spdm_context,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  cert_chain_buffer              Certitiface chain buffer including spdm_cert_chain_t header.
   @param  cert_chain_buffer_size          size in bytes of the certitiface chain buffer.
+  @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+  @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
 
   @retval TRUE  Peer certificate chain buffer verification passed.
   @retval FALSE Peer certificate chain buffer verification failed.
 **/
 boolean spdm_verify_peer_cert_chain_buffer(IN spdm_context_t *spdm_context,
 					   IN void *cert_chain_buffer,
-					   IN uintn cert_chain_buffer_size)
+					   IN uintn cert_chain_buffer_size,
+					   OUT void **trust_anchor OPTIONAL,
+					   OUT uintn *trust_anchor_size OPTIONAL)
 {
 	uint8 *cert_chain_data;
 	uintn cert_chain_data_size;
@@ -462,6 +466,12 @@ boolean spdm_verify_peer_cert_chain_buffer(IN spdm_context_t *spdm_context,
 				return FALSE;
 			}
 		}
+		if (trust_anchor != NULL) {
+			*trust_anchor = root_cert;
+		}
+		if (trust_anchor_size != NULL) {
+			*trust_anchor_size = root_cert_size;
+		}
 	} else if ((cert_chain_data != NULL) && (cert_chain_data_size != 0)) {
 		// Whether it contains the root certificate or not,
 		// it should be equal to the one provisioned in trusted environment
@@ -475,6 +485,13 @@ boolean spdm_verify_peer_cert_chain_buffer(IN spdm_context_t *spdm_context,
 			DEBUG((DEBUG_INFO,
 			       "!!! verify_peer_cert_chain_buffer - FAIL !!!\n"));
 			return FALSE;
+		}
+		if (trust_anchor != NULL) {
+			*trust_anchor = cert_chain_data + sizeof(spdm_cert_chain_t) +
+				spdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+		}
+		if (trust_anchor_size != NULL) {
+			*trust_anchor_size = cert_chain_data_size;
 		}
 	}
 

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -520,13 +520,17 @@ boolean spdm_verify_peer_digests(IN spdm_context_t *spdm_context,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  cert_chain_buffer              Certitiface chain buffer including spdm_cert_chain_t header.
   @param  cert_chain_buffer_size          size in bytes of the certitiface chain buffer.
+  @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+  @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
 
   @retval TRUE  Peer certificate chain buffer verification passed.
   @retval FALSE Peer certificate chain buffer verification failed.
 **/
 boolean spdm_verify_peer_cert_chain_buffer(IN spdm_context_t *spdm_context,
 					   IN void *cert_chain_buffer,
-					   IN uintn cert_chain_buffer_size);
+					   IN uintn cert_chain_buffer_size,
+					   OUT void **trust_anchor OPTIONAL,
+					   OUT uintn *trust_anchor_size OPTIONAL);
 
 /**
   This function generates the challenge signature based upon m1m2 for authentication.

--- a/library/spdm_responder_lib/encap_get_certificate.c
+++ b/library/spdm_responder_lib/encap_get_certificate.c
@@ -166,7 +166,8 @@ return_status spdm_process_encap_response_certificate(
 		get_managed_buffer(
 			&spdm_context->encap_context.certificate_chain_buffer),
 		get_managed_buffer_size(
-			&spdm_context->encap_context.certificate_chain_buffer));
+			&spdm_context->encap_context.certificate_chain_buffer),
+		NULL, NULL);
 	if (!result) {
 		spdm_context->encap_context.error_state =
 			SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;


### PR DESCRIPTION
The caller may need to know which trust anchor is used to pass the certificate verification.

REF: https://github.com/DMTF/libspdm/issues/138

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>