### PR TITLE
Skip the first cert when verifying integrity

### DIFF
--- a/library/spdm_crypt_lib/crypt.c
+++ b/library/spdm_crypt_lib/crypt.c
@@ -2579,11 +2579,16 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32 base_hash_algo,
 				"!!! VerifyCertificateChainBuffer - PASS (cert root hash match) !!!\n"));
 	}
 
-	if (!x509_verify_cert_chain(first_cert_buffer, first_cert_buffer_size,
-				    cert_chain_data, cert_chain_data_size)) {
-		DEBUG((DEBUG_INFO,
-		       "!!! VerifyCertificateChainBuffer - FAIL (cert chain verify failed)!!!\n"));
-		return FALSE;
+	//If the number of certificates in the certificate chain is more than 1,
+	//other certificates need to be verified. 
+	if (cert_chain_data_size > first_cert_buffer_size) {
+		if (!x509_verify_cert_chain(first_cert_buffer, first_cert_buffer_size,
+						cert_chain_data + first_cert_buffer_size,
+						cert_chain_data_size - first_cert_buffer_size)) {
+			DEBUG((DEBUG_INFO,
+				"!!! VerifyCertificateChainBuffer - FAIL (cert chain verify failed)!!!\n"));
+			return FALSE;
+		}
 	}
 
 	if (!x509_get_cert_from_cert_chain(

--- a/library/spdm_crypt_lib/crypt.c
+++ b/library/spdm_crypt_lib/crypt.c
@@ -2533,8 +2533,8 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32 base_hash_algo,
 {
 	uint8 *cert_chain_data;
 	uintn cert_chain_data_size;
-	uint8 *root_cert_buffer;
-	uintn root_cert_buffer_size;
+	uint8 *first_cert_buffer;
+	uintn first_cert_buffer_size;
 	uintn hash_size;
 	uint8 calc_root_cert_hash[MAX_HASH_SIZE];
 	uint8 *leaf_cert_buffer;
@@ -2559,15 +2559,15 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32 base_hash_algo,
 	cert_chain_data_size =
 		cert_chain_buffer_size - sizeof(spdm_cert_chain_t) - hash_size;
 	if (!x509_get_cert_from_cert_chain(
-		    cert_chain_data, cert_chain_data_size, 0, &root_cert_buffer,
-		    &root_cert_buffer_size)) {
+		    cert_chain_data, cert_chain_data_size, 0, &first_cert_buffer,
+		    &first_cert_buffer_size)) {
 		DEBUG((DEBUG_INFO,
 		       "!!! VerifyCertificateChainBuffer - FAIL (get root certificate failed)!!!\n"));
 		return FALSE;
 	}
 
-	if (spdm_is_root_certificate(root_cert_buffer, root_cert_buffer_size)) {
-		spdm_hash_all(base_hash_algo, root_cert_buffer, root_cert_buffer_size,
+	if (spdm_is_root_certificate(first_cert_buffer, first_cert_buffer_size)) {
+		spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
 				calc_root_cert_hash);
 		if (const_compare_mem((uint8 *)cert_chain_buffer + sizeof(spdm_cert_chain_t),
 				calc_root_cert_hash, hash_size) != 0) {
@@ -2579,7 +2579,7 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32 base_hash_algo,
 				"!!! VerifyCertificateChainBuffer - PASS (cert root hash match) !!!\n"));
 	}
 
-	if (!x509_verify_cert_chain(root_cert_buffer, root_cert_buffer_size,
+	if (!x509_verify_cert_chain(first_cert_buffer, first_cert_buffer_size,
 				    cert_chain_data, cert_chain_data_size)) {
 		DEBUG((DEBUG_INFO,
 		       "!!! VerifyCertificateChainBuffer - FAIL (cert chain verify failed)!!!\n"));


### PR DESCRIPTION
REF: #124
Skip the first certificate of a certificate chain without root certificate when verifying integrity.

Signed-off-by: yi1 li <yi1.li@intel.com>