### PR TITLE
record transcript hash instead of data.

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -675,7 +675,7 @@ void *spdm_assign_session_id(IN void *spdm_context, IN uint32 session_id,
 **/
 void *spdm_free_session_id(IN void *spdm_context, IN uint32 session_id);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates current TH data with message A and message K.
 
@@ -722,7 +722,7 @@ boolean spdm_calculate_th_hmac_for_exchange_rsp(
 	OPTIONAL IN OUT uintn *th_hmac_buffer_size, OUT void *th_hmac_buffer);
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates current TH data with message A, message K and message F.
 

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -120,6 +120,21 @@ typedef boolean (*hash_all_func)(IN const void *data, IN uintn data_size,
 				 OUT uint8 *hash_value);
 
 /**
+  Allocates and initializes one HMAC context for subsequent hash use.
+
+  @return  Pointer to the HMAC context that has been initialized.
+           If the allocations fails, hmac_new_func() returns NULL.
+**/
+typedef void * (*hmac_new_func)();
+
+/**
+  Release the specified HMAC context.
+
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+typedef void (*hmac_free_func)(IN void *hmac_ctx);
+
+/**
   Set user-supplied key for subsequent use. It must be done before any
   calling to hmac_update().
 
@@ -185,7 +200,7 @@ typedef boolean (*hmac_update_func)(IN OUT void *hmac_ctx, IN const void *data,
 
   @param[in, out]  hmac_ctx  Pointer to the HMAC context.
   @param[out]      hmac_value          Pointer to a buffer that receives the HMAC digest
-                                      value (32 bytes).
+                                      value.
 
   @retval TRUE   HMAC digest computation succeeded.
   @retval FALSE  HMAC digest computation failed.
@@ -514,6 +529,24 @@ boolean spdm_hash_update(IN uint32 base_hash_algo, IN OUT void *hash_context,
 boolean spdm_hash_final(IN uint32 base_hash_algo, IN OUT void *hash_context, OUT uint8 *hash_value);
 
 /**
+  Allocates and initializes one HMAC context for subsequent use.
+
+  @param  base_hash_algo                 SPDM base_hash_algo
+
+  @return  Pointer to the HMAC context that has been initialized.
+           If the allocations fails, spdm_hash_new() returns NULL.
+**/
+void *spdm_hmac_new(IN uint32 base_hash_algo);
+
+/**
+  Release the specified HMAC context.
+
+  @param  base_hash_algo                 SPDM base_hash_algo
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+void spdm_hmac_free(IN uint32 base_hash_algo, IN void *hmac_ctx);
+
+/**
   Set user-supplied key for subsequent use. It must be done before any
   calling to hmac_update().
 
@@ -579,7 +612,7 @@ boolean spdm_hmac_update(IN uint32 base_hash_algo,
 
   @param[in, out]  hmac_ctx  Pointer to the HMAC context.
   @param[out]      hmac_value          Pointer to a buffer that receives the HMAC digest
-                                      value (32 bytes).
+                                      value.
 
   @retval TRUE   HMAC digest computation succeeded.
   @retval FALSE  HMAC digest computation failed.

--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -121,7 +121,8 @@ boolean spdm_measurement_collection(IN uint8 measurement_specification,
 
   @param  req_base_asym_alg               Indicates the signing algorithm.
   @param  base_hash_algo                 Indicates the hash algorithm.
-  @param  message                      A pointer to a message to be signed (before hash).
+  @param  is_data_hash                   Indicate the message type. TRUE: raw message before hash, FALSE: message hash.
+  @param  message                      A pointer to a message to be signed.
   @param  message_size                  The size in bytes of the message to be signed.
   @param  signature                    A pointer to a destination buffer to store the signature.
   @param  sig_size                      On input, indicates the size in bytes of the destination buffer to store the signature.
@@ -131,7 +132,7 @@ boolean spdm_measurement_collection(IN uint8 measurement_specification,
   @retval FALSE signing fail.
 **/
 boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size);
 
@@ -140,7 +141,8 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
 
   @param  base_asym_algo                 Indicates the signing algorithm.
   @param  base_hash_algo                 Indicates the hash algorithm.
-  @param  message                      A pointer to a message to be signed (before hash).
+  @param  is_data_hash                   Indicate the message type. TRUE: raw message before hash, FALSE: message hash.
+  @param  message                      A pointer to a message to be signed.
   @param  message_size                  The size in bytes of the message to be signed.
   @param  signature                    A pointer to a destination buffer to store the signature.
   @param  sig_size                      On input, indicates the size in bytes of the destination buffer to store the signature.
@@ -150,7 +152,7 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
   @retval FALSE signing fail.
 **/
 boolean spdm_responder_data_sign(IN uint32 base_asym_algo,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size);
 

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -27,7 +27,7 @@
 #define MAX_SPDM_CONNECTION_STATE_CALLBACK_NUM 4
 
 // If cache transcript data or transcript hash
-//#define RECORD_TRANSCRIPT_DATA 1
+#define LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT 0
 
 //
 // Crypto Configuation

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -25,6 +25,9 @@
 #define MAX_SPDM_SESSION_STATE_CALLBACK_NUM 4
 #define MAX_SPDM_CONNECTION_STATE_CALLBACK_NUM 4
 
+// If cache transcript data or transcript hash
+//#define RECORD_TRANSCRIPT_DATA 1
+
 //
 // Crypto Configuation
 // In each category, at least one should be selected.

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -19,7 +19,8 @@
 #define MAX_SPDM_CERT_CHAIN_BLOCK_LEN 1024
 
 #define MAX_SPDM_MESSAGE_BUFFER_SIZE 0x1200
-#define MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE 0x100
+#define MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE 0x100  // to hold message_a before negotiate
+#define MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE 0x300 // to hold message_k before finished_key is ready
 
 #define MAX_SPDM_REQUEST_RETRY_TIMES 3
 #define MAX_SPDM_SESSION_STATE_CALLBACK_NUM 4

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -83,6 +83,17 @@ void spdm_secured_message_set_use_psk(IN void *spdm_secured_message_context,
 				      IN boolean use_psk);
 
 /**
+  Return if finished_key is ready.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @retval TRUE  finished_key is ready.
+  @retval FALSE finished_key is not ready.
+*/
+boolean
+spdm_secured_message_is_finished_key_ready(IN void *spdm_secured_message_context);
+
+/**
   Set session_state to an SPDM secured message context.
 
   @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
@@ -282,6 +293,83 @@ boolean spdm_secured_message_dhe_compute_key(
 void spdm_clear_handshake_secret(IN void *spdm_secured_message_context);
 
 /**
+  Allocates and initializes one HMAC context for subsequent use, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @return Pointer to the HMAC context that has been initialized.
+**/
+void *
+spdm_hmac_new_with_request_finished_key(
+	IN void *spdm_secured_message_context);
+
+/**
+  Release the specified HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+void spdm_hmac_free_with_request_finished_key(
+	IN void *spdm_secured_message_context, IN void *hmac_ctx);
+
+/**
+  Set request_finished_key for subsequent use. It must be done before any
+  calling to hmac_update().
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx  Pointer to HMAC context.
+
+  @retval TRUE   The key is set successfully.
+  @retval FALSE  The key is set unsuccessfully.
+**/
+boolean spdm_hmac_init_with_request_finished_key(
+	IN void *spdm_secured_message_context, OUT void *hmac_ctx);
+
+/**
+  Makes a copy of an existing HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  new_hmac_ctx  Pointer to new HMAC context.
+
+  @retval TRUE   HMAC context copy succeeded.
+  @retval FALSE  HMAC context copy failed.
+**/
+boolean spdm_hmac_duplicate_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	IN const void *hmac_ctx, OUT void *new_hmac_ctx);
+
+/**
+  Digests the input data and updates HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  data              Pointer to the buffer containing the data to be digested.
+  @param  data_size          size of data buffer in bytes.
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_update_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx, IN const void *data,
+	IN uintn data_size);
+
+/**
+  Completes computation of the HMAC digest value, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_final_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx,  OUT uint8 *hmac_value);
+
+/**
   Computes the HMAC of a input data buffer, with request_finished_key.
 
   @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
@@ -296,6 +384,83 @@ boolean
 spdm_hmac_all_with_request_finished_key(IN void *spdm_secured_message_context,
 					IN const void *data, IN uintn data_size,
 					OUT uint8 *hmac_value);
+
+/**
+  Allocates and initializes one HMAC context for subsequent use, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @return Pointer to the HMAC context that has been initialized.
+**/
+void *
+spdm_hmac_new_with_response_finished_key(
+	IN void *spdm_secured_message_context);
+
+/**
+  Release the specified HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+void spdm_hmac_free_with_response_finished_key(
+	IN void *spdm_secured_message_context, IN void *hmac_ctx);
+
+/**
+  Set response_finished_key for subsequent use. It must be done before any
+  calling to hmac_update().
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx  Pointer to HMAC context.
+
+  @retval TRUE   The key is set successfully.
+  @retval FALSE  The key is set unsuccessfully.
+**/
+boolean spdm_hmac_init_with_response_finished_key(
+	IN void *spdm_secured_message_context, OUT void *hmac_ctx);
+
+/**
+  Makes a copy of an existing HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  new_hmac_ctx  Pointer to new HMAC context.
+
+  @retval TRUE   HMAC context copy succeeded.
+  @retval FALSE  HMAC context copy failed.
+**/
+boolean spdm_hmac_duplicate_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	IN const void *hmac_ctx, OUT void *new_hmac_ctx);
+
+/**
+  Digests the input data and updates HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  data              Pointer to the buffer containing the data to be digested.
+  @param  data_size          size of data buffer in bytes.
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_update_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx, IN const void *data,
+	IN uintn data_size);
+
+/**
+  Completes computation of the HMAC digest value, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_final_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx,  OUT uint8 *hmac_value);
 
 /**
   Computes the HMAC of a input data buffer, with response_finished_key.

--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -1122,12 +1122,19 @@ return_status spdm_append_message_k(IN void *context, IN void *session_info,
 		spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
 			spdm_session_info->session_transcript.digest_context_th, message, message_size);
 		if (!finished_key_ready) {
+			//
+			// append message only if finished_key is NOT ready.
+			//
 			append_managed_buffer(
 				&spdm_session_info->session_transcript.temp_message_k, message, message_size);
 		}
 
 		//
-		// append message only if finished_key is NOT ready.
+		// Above action is to calculate HASH for message_k.
+		// However, we cannot use similar way to calculate HMAC. (chicken-egg problem)
+		// HMAC need finished_key, and finished_key calculation need message_k.
+		// If the finished_key is NOT ready, then we cannot calculate HMAC. We have to cache to temp_message_k and stop here.
+		// If the finished_key is ready, then we can start calculating HMAC. No need to cache temp_message_k.
 		//
 		if (!finished_key_ready) {
 			return RETURN_SUCCESS;

--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -598,7 +598,7 @@ void spdm_reset_message_b(IN void *context)
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_context->transcript.message_b);
 #else
 	if (spdm_context->transcript.digest_context_m1m2 != NULL) {
@@ -619,7 +619,7 @@ void spdm_reset_message_c(IN void *context)
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_context->transcript.message_c);
 #else
 	if (spdm_context->transcript.digest_context_m1m2 != NULL) {
@@ -640,7 +640,7 @@ void spdm_reset_message_mut_b(IN void *context)
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_context->transcript.message_mut_b);
 #else
 	if (spdm_context->transcript.digest_context_mut_m1m2 != NULL) {
@@ -661,7 +661,7 @@ void spdm_reset_message_mut_c(IN void *context)
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_context->transcript.message_mut_c);
 #else
 	if (spdm_context->transcript.digest_context_mut_m1m2 != NULL) {
@@ -682,7 +682,7 @@ void spdm_reset_message_m(IN void *context)
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_context->transcript.message_m);
 #else
 	if (spdm_context->transcript.digest_context_l1l2 != NULL) {
@@ -704,7 +704,7 @@ void spdm_reset_message_k(IN void *context, IN void *session_info)
 	spdm_session_info_t *spdm_session_info;
 
 	spdm_session_info = session_info;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_session_info->session_transcript.message_k);
 #else
 	{
@@ -762,7 +762,7 @@ void spdm_reset_message_f(IN void *context, IN void *session_info)
 	spdm_session_info_t *spdm_session_info;
 
 	spdm_session_info = session_info;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	reset_managed_buffer(&spdm_session_info->session_transcript.message_f);
 #else
 	{
@@ -884,7 +884,7 @@ return_status spdm_append_message_b(IN void *context, IN void *message,
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(&spdm_context->transcript.message_b,
 				     message, message_size);
 #else
@@ -920,7 +920,7 @@ return_status spdm_append_message_c(IN void *context, IN void *message,
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(&spdm_context->transcript.message_c,
 				     message, message_size);
 #else
@@ -956,7 +956,7 @@ return_status spdm_append_message_mut_b(IN void *context, IN void *message,
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(&spdm_context->transcript.message_mut_b,
 				     message, message_size);
 #else
@@ -988,7 +988,7 @@ return_status spdm_append_message_mut_c(IN void *context, IN void *message,
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(&spdm_context->transcript.message_mut_c,
 				     message, message_size);
 #else
@@ -1020,7 +1020,7 @@ return_status spdm_append_message_m(IN void *context, IN void *message,
 	spdm_context_t *spdm_context;
 
 	spdm_context = context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(&spdm_context->transcript.message_m,
 				     message, message_size);
 #else
@@ -1054,7 +1054,7 @@ return_status spdm_append_message_k(IN void *context, IN void *session_info,
 	spdm_session_info_t *spdm_session_info;
 
 	spdm_session_info = session_info;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(
 		&spdm_session_info->session_transcript.message_k, message,
 		message_size);
@@ -1187,7 +1187,7 @@ return_status spdm_append_message_f(IN void *context, IN void *session_info,
 	spdm_session_info_t *spdm_session_info;
 
 	spdm_session_info = session_info;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return append_managed_buffer(
 		&spdm_session_info->session_transcript.message_f, message,
 		message_size);
@@ -1490,7 +1490,7 @@ void spdm_init_context(IN void *context)
 	spdm_context->version = spdm_context_struct_VERSION;
 	spdm_context->transcript.message_a.max_buffer_size =
 		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.max_buffer_size =
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	spdm_context->transcript.message_c.max_buffer_size =

--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -1489,18 +1489,18 @@ void spdm_init_context(IN void *context)
 	zero_mem(spdm_context, sizeof(spdm_context_t));
 	spdm_context->version = spdm_context_struct_VERSION;
 	spdm_context->transcript.message_a.max_buffer_size =
-		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_a.buffer);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_b.buffer);
 	spdm_context->transcript.message_c.max_buffer_size =
-		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_c.buffer);
 	spdm_context->transcript.message_mut_b.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_mut_b.buffer);
 	spdm_context->transcript.message_mut_c.max_buffer_size =
-		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_mut_c.buffer);
 	spdm_context->transcript.message_m.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(spdm_context->transcript.message_m.buffer);
 #endif
 	spdm_context->retry_times = MAX_SPDM_REQUEST_RETRY_TIMES;
 	spdm_context->response_state = SPDM_RESPONSE_STATE_NORMAL;
@@ -1527,7 +1527,7 @@ void spdm_init_context(IN void *context)
 	spdm_context->local_context.secured_message_version.spdm_version[0]
 		.update_version_number = 0;
 	spdm_context->encap_context.certificate_chain_buffer.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(spdm_context->encap_context.certificate_chain_buffer.buffer);
 
 	secured_message_context = (void *)((uintn)(spdm_context + 1));
 	SecuredMessageContextSize = spdm_secured_message_get_context_size();
@@ -1571,7 +1571,8 @@ void spdm_reset_context(IN void *context)
 	spdm_context->last_spdm_request_session_id = INVALID_SESSION_ID;
 	spdm_context->last_spdm_request_session_id_valid = FALSE;
 	spdm_context->last_spdm_request_size = 0;
-	spdm_context->encap_context.certificate_chain_buffer.max_buffer_size = MAX_SPDM_MESSAGE_BUFFER_SIZE;
+	spdm_context->encap_context.certificate_chain_buffer.max_buffer_size =
+		sizeof(spdm_context->encap_context.certificate_chain_buffer.buffer);
 	for (index = 0; index < MAX_SPDM_SESSION_COUNT; index++)
 	{
 		spdm_session_info_init(spdm_context,

--- a/library/spdm_common_lib/context_data_session.c
+++ b/library/spdm_common_lib/context_data_session.c
@@ -62,12 +62,12 @@ void spdm_session_info_init(IN spdm_context_t *spdm_context,
 		spdm_context->local_context.psk_hint_size);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	session_info->session_transcript.message_k.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(session_info->session_transcript.message_k.buffer);
 	session_info->session_transcript.message_f.max_buffer_size =
-		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+		sizeof(session_info->session_transcript.message_f.buffer);
 #else
 	session_info->session_transcript.temp_message_k.max_buffer_size =
-		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE;
+		sizeof(session_info->session_transcript.temp_message_k.buffer);
 #endif
 }
 

--- a/library/spdm_common_lib/context_data_session.c
+++ b/library/spdm_common_lib/context_data_session.c
@@ -60,10 +60,15 @@ void spdm_session_info_init(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context,
 		spdm_context->local_context.psk_hint,
 		spdm_context->local_context.psk_hint_size);
+#if RECORD_TRANSCRIPT_DATA
 	session_info->session_transcript.message_k.max_buffer_size =
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	session_info->session_transcript.message_f.max_buffer_size =
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
+#else
+	session_info->session_transcript.temp_message_k.max_buffer_size =
+		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE;
+#endif
 }
 
 /**

--- a/library/spdm_common_lib/context_data_session.c
+++ b/library/spdm_common_lib/context_data_session.c
@@ -60,7 +60,7 @@ void spdm_session_info_init(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context,
 		spdm_context->local_context.psk_hint,
 		spdm_context->local_context.psk_hint_size);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	session_info->session_transcript.message_k.max_buffer_size =
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	session_info->session_transcript.message_f.max_buffer_size =

--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -144,7 +144,7 @@ boolean spdm_get_local_cert_chain_data(IN void *context,
 	return TRUE;
 }
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates m1m2.
 
@@ -316,7 +316,7 @@ boolean spdm_calculate_m1m2_hash(IN void *context, IN boolean is_mut,
 }
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates l1l2.
 
@@ -576,7 +576,7 @@ boolean spdm_generate_challenge_auth_signature(IN spdm_context_t *spdm_context,
 {
 	boolean result;
 	uintn signature_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 m1m2_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn m1m2_buffer_size;
 #else
@@ -584,7 +584,7 @@ boolean spdm_generate_challenge_auth_signature(IN spdm_context_t *spdm_context,
 	uintn m1m2_hash_size;
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	m1m2_buffer_size = sizeof(m1m2_buffer);
 	result = spdm_calculate_m1m2(spdm_context, is_requester,
 				     &m1m2_buffer_size, &m1m2_buffer);
@@ -601,7 +601,7 @@ boolean spdm_generate_challenge_auth_signature(IN spdm_context_t *spdm_context,
 		signature_size = spdm_get_req_asym_signature_size(
 			spdm_context->connection_info.algorithm
 				.req_base_asym_alg);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		result = spdm_requester_data_sign(
 			spdm_context->connection_info.algorithm
 				.req_base_asym_alg,
@@ -619,7 +619,7 @@ boolean spdm_generate_challenge_auth_signature(IN spdm_context_t *spdm_context,
 	} else {
 		signature_size = spdm_get_asym_signature_size(
 			spdm_context->connection_info.algorithm.base_asym_algo);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		result = spdm_responder_data_sign(
 			spdm_context->connection_info.algorithm.base_asym_algo,
 			spdm_context->connection_info.algorithm.base_hash_algo,
@@ -708,7 +708,7 @@ boolean spdm_verify_challenge_auth_signature(IN spdm_context_t *spdm_context,
 	void *context;
 	uint8 *cert_chain_data;
 	uintn cert_chain_data_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 m1m2_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn m1m2_buffer_size;
 #else
@@ -716,7 +716,7 @@ boolean spdm_verify_challenge_auth_signature(IN spdm_context_t *spdm_context,
 	uintn m1m2_hash_size;
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	m1m2_buffer_size = sizeof(m1m2_buffer);
 	result = spdm_calculate_m1m2(spdm_context, !is_requester,
 				     &m1m2_buffer_size, &m1m2_buffer);
@@ -753,7 +753,7 @@ boolean spdm_verify_challenge_auth_signature(IN spdm_context_t *spdm_context,
 			return FALSE;
 		}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		result = spdm_asym_verify(
 			spdm_context->connection_info.algorithm.base_asym_algo,
 			spdm_context->connection_info.algorithm.base_hash_algo,
@@ -778,7 +778,7 @@ boolean spdm_verify_challenge_auth_signature(IN spdm_context_t *spdm_context,
 			return FALSE;
 		}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		result = spdm_req_asym_verify(
 			spdm_context->connection_info.algorithm
 				.req_base_asym_alg,
@@ -990,7 +990,7 @@ boolean spdm_generate_measurement_signature(IN spdm_context_t *spdm_context,
 {
 	uintn signature_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 l1l2_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn l1l2_buffer_size;
 #else
@@ -998,7 +998,7 @@ boolean spdm_generate_measurement_signature(IN spdm_context_t *spdm_context,
 	uintn l1l2_hash_size;
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	l1l2_buffer_size = sizeof(l1l2_buffer);
 	result = spdm_calculate_l1l2(spdm_context, &l1l2_buffer_size,
 				     l1l2_buffer);
@@ -1013,7 +1013,7 @@ boolean spdm_generate_measurement_signature(IN spdm_context_t *spdm_context,
 
 	signature_size = spdm_get_asym_signature_size(
 		spdm_context->connection_info.algorithm.base_asym_algo);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_responder_data_sign(
 		spdm_context->connection_info.algorithm.base_asym_algo,
 		spdm_context->connection_info.algorithm.base_hash_algo,
@@ -1047,7 +1047,7 @@ boolean spdm_verify_measurement_signature(IN spdm_context_t *spdm_context,
 	void *context;
 	uint8 *cert_chain_data;
 	uintn cert_chain_data_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 l1l2_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn l1l2_buffer_size;
 #else
@@ -1055,7 +1055,7 @@ boolean spdm_verify_measurement_signature(IN spdm_context_t *spdm_context,
 	uintn l1l2_hash_size;
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	l1l2_buffer_size = sizeof(l1l2_buffer);
 	result = spdm_calculate_l1l2(spdm_context, &l1l2_buffer_size,
 				     l1l2_buffer);
@@ -1091,7 +1091,7 @@ boolean spdm_verify_measurement_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_asym_verify(
 		spdm_context->connection_info.algorithm.base_asym_algo,
 		spdm_context->connection_info.algorithm.base_hash_algo, context,

--- a/library/spdm_common_lib/crypto_service_session.c
+++ b/library/spdm_common_lib/crypto_service_session.c
@@ -6,7 +6,7 @@
 
 #include "spdm_common_lib_internal.h"
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates current TH data with message A and message K.
 
@@ -177,7 +177,7 @@ boolean spdm_calculate_th_hmac_for_exchange_rsp(
 }
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates current TH data with message A, message K and message F.
 
@@ -448,7 +448,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	boolean result;
 	uintn signature_size;
 	uintn hash_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -464,7 +464,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
@@ -487,7 +487,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_responder_data_sign(
 		spdm_context->connection_info.algorithm.base_asym_algo,
 		spdm_context->connection_info.algorithm.base_hash_algo,
@@ -525,7 +525,7 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	uint8 *cert_chain_buffer;
 	uintn cert_chain_buffer_size;
 	uintn hash_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -540,7 +540,7 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
@@ -592,7 +592,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 	uint8 *cert_buffer;
 	uintn cert_buffer_size;
 	void *context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -606,7 +606,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
@@ -655,7 +655,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_asym_verify(
 		spdm_context->connection_info.algorithm.base_asym_algo,
 		spdm_context->connection_info.algorithm.base_hash_algo, context,
@@ -699,7 +699,7 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	uint8 *cert_chain_buffer;
 	uintn cert_chain_buffer_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -714,7 +714,7 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
@@ -769,7 +769,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	boolean result;
 	uintn signature_size;
 	uintn hash_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -792,7 +792,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -816,7 +816,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	internal_dump_data(hash_data, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_requester_data_sign(
 		spdm_context->connection_info.algorithm.req_base_asym_alg,
 		spdm_context->connection_info.algorithm.base_hash_algo,
@@ -857,7 +857,7 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
 	uint8 *mut_cert_chain_buffer;
 	uintn mut_cert_chain_buffer_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -883,7 +883,7 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
 		mut_cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -940,7 +940,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 	uint8 *mut_cert_buffer;
 	uintn mut_cert_buffer_size;
 	void *context;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -961,7 +961,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -1013,7 +1013,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	result = spdm_req_asym_verify(
 		spdm_context->connection_info.algorithm.req_base_asym_alg,
 		spdm_context->connection_info.algorithm.base_hash_algo, context,
@@ -1058,7 +1058,7 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
 	uintn mut_cert_chain_buffer_size;
 	uintn hash_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1085,7 +1085,7 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
 		mut_cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -1138,7 +1138,7 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 	uintn mut_cert_chain_buffer_size;
 	uintn hash_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1164,7 +1164,7 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 		mut_cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -1215,7 +1215,7 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 	uint8 *mut_cert_chain_buffer;
 	uintn mut_cert_chain_buffer_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1242,7 +1242,7 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 		mut_cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
@@ -1293,7 +1293,7 @@ spdm_generate_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	uint8 hmac_data[MAX_HASH_SIZE];
 	uintn hash_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1301,7 +1301,7 @@ spdm_generate_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(spdm_context, session_info,
 						NULL, 0, &th_curr_data_size,
@@ -1348,7 +1348,7 @@ boolean spdm_verify_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	uintn hash_size;
 	uint8 calc_hmac_data[MAX_HASH_SIZE];
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1357,7 +1357,7 @@ boolean spdm_verify_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	ASSERT(hash_size == hmac_data_size);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(spdm_context, session_info,
 						NULL, 0, &th_curr_data_size,
@@ -1408,7 +1408,7 @@ spdm_generate_psk_exchange_req_hmac(IN spdm_context_t *spdm_context,
 	uintn hash_size;
 	uint8 calc_hmac_data[MAX_HASH_SIZE];
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1416,7 +1416,7 @@ spdm_generate_psk_exchange_req_hmac(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(spdm_context, session_info, NULL,
 					      0, NULL, 0, &th_curr_data_size,
@@ -1462,7 +1462,7 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
 	uint8 hmac_data[MAX_HASH_SIZE];
 	uintn hash_size;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1471,7 +1471,7 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	ASSERT(hmac_size == hash_size);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(spdm_context, session_info, NULL,
 					      0, NULL, 0, &th_curr_data_size,
@@ -1524,7 +1524,7 @@ return_status spdm_calculate_th1_hash(IN void *context,
 	uintn cert_chain_buffer_size;
 	spdm_session_info_t *session_info;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1556,7 +1556,7 @@ return_status spdm_calculate_th1_hash(IN void *context,
 		cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
@@ -1604,7 +1604,7 @@ return_status spdm_calculate_th2_hash(IN void *context,
 	uintn mut_cert_chain_buffer_size;
 	spdm_session_info_t *session_info;
 	boolean result;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uint8 th_curr_data[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn th_curr_data_size;
 #endif
@@ -1657,7 +1657,7 @@ return_status spdm_calculate_th2_hash(IN void *context,
 		mut_cert_chain_buffer_size = 0;
 	}
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
 	result = spdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,

--- a/library/spdm_common_lib/crypto_service_session.c
+++ b/library/spdm_common_lib/crypto_service_session.c
@@ -255,7 +255,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	result = spdm_responder_data_sign(
 		spdm_context->connection_info.algorithm.base_asym_algo,
 		spdm_context->connection_info.algorithm.base_hash_algo,
-		th_curr_data, th_curr_data_size, signature, &signature_size);
+		FALSE, th_curr_data, th_curr_data_size, signature, &signature_size);
 	if (result) {
 		DEBUG((DEBUG_INFO, "signature - "));
 		internal_dump_data(signature, signature_size);
@@ -531,7 +531,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	result = spdm_requester_data_sign(
 		spdm_context->connection_info.algorithm.req_base_asym_alg,
 		spdm_context->connection_info.algorithm.base_hash_algo,
-		th_curr_data, th_curr_data_size, signature, &signature_size);
+		FALSE, th_curr_data, th_curr_data_size, signature, &signature_size);
 	if (result) {
 		DEBUG((DEBUG_INFO, "signature - "));
 		internal_dump_data(signature, signature_size);

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -119,6 +119,12 @@ typedef struct {
 typedef struct {
 	uintn max_buffer_size;
 	uintn buffer_size;
+	uint8 buffer[MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE];
+} medium_managed_buffer_t;
+
+typedef struct {
+	uintn max_buffer_size;
+	uintn buffer_size;
 	uint8 buffer[MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE];
 } small_managed_buffer_t;
 
@@ -157,7 +163,6 @@ typedef struct {
 #endif
 } spdm_transcript_t;
 
-typedef struct {
 	//
 	// TH for KEY_EXCHANGE response signature: Concatenate (A, Ct, K)
 	// Ct = certificate chain
@@ -189,8 +194,6 @@ typedef struct {
 	// CM = mutual certificate chain *
 	// F  = Concatenate (FINISH request, FINISH response)
 	//
-	large_managed_buffer_t message_k;
-	large_managed_buffer_t message_f;
 	//
 	// TH for PSK_EXCHANGE response HMAC: Concatenate (A, K)
 	// K  = Concatenate (PSK_EXCHANGE request, PSK_EXCHANGE response\verify_data)
@@ -210,6 +213,23 @@ typedef struct {
 	// K  = Concatenate (PSK_EXCHANGE request, PSK_EXCHANGE response)
 	// F  = Concatenate (PSK_FINISH request, PSK_FINISH response)
 	//
+typedef struct {
+#if RECORD_TRANSCRIPT_DATA
+	large_managed_buffer_t message_k;
+	large_managed_buffer_t message_f;
+#else
+	// the message_k must be plan text because we do not know the finished_key yet.
+	medium_managed_buffer_t temp_message_k;
+	boolean                message_f_initialized;
+	boolean                finished_key_ready;
+	void                   *digest_context_th;
+	void                   *hmac_rsp_context_th;
+	void                   *hmac_req_context_th;
+	// this is back up for message F reset.
+	void                   *digest_context_th_backup;
+	void                   *hmac_rsp_context_th_backup;
+	void                   *hmac_req_context_th_backup;
+#endif
 } spdm_session_transcript_t;
 
 typedef struct {

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -150,7 +150,7 @@ typedef struct {
 typedef struct {
 	// the message_a must be plan text because we do not know the algorithm yet.
 	small_managed_buffer_t message_a;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	large_managed_buffer_t message_b;
 	small_managed_buffer_t message_c;
 	large_managed_buffer_t message_mut_b;
@@ -214,7 +214,7 @@ typedef struct {
 	// F  = Concatenate (PSK_FINISH request, PSK_FINISH response)
 	//
 typedef struct {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	large_managed_buffer_t message_k;
 	large_managed_buffer_t message_f;
 #else
@@ -476,7 +476,7 @@ spdm_is_capabilities_flag_supported(IN spdm_context_t *spdm_context,
 				    IN uint32 requester_capabilities_flag,
 				    IN uint32 responder_capabilities_flag);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates m1m2.
 
@@ -506,7 +506,7 @@ boolean spdm_calculate_m1m2_hash(IN void *context, IN boolean is_mut,
 			    OUT void *m1m2_hash);
 #endif
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates l1l2.
 

--- a/library/spdm_common_lib/support.c
+++ b/library/spdm_common_lib/support.c
@@ -119,6 +119,8 @@ return_status append_managed_buffer(IN OUT void *m_buffer, IN void *buffer,
 	ASSERT((managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_BUFFER_SIZE) ||
 	       (managed_buffer->max_buffer_size ==
+		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE) ||
+	       (managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE));
 	ASSERT(managed_buffer->max_buffer_size >= managed_buffer->buffer_size);
 	if (buffer_size >
@@ -157,6 +159,8 @@ void reset_managed_buffer(IN OUT void *m_buffer)
 	ASSERT((managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_BUFFER_SIZE) ||
 	       (managed_buffer->max_buffer_size ==
+		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE) ||
+	       (managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE));
 	managed_buffer->buffer_size = 0;
 	zero_mem(managed_buffer + 1, managed_buffer->max_buffer_size);
@@ -178,6 +182,8 @@ uintn get_managed_buffer_size(IN OUT void *m_buffer)
 	ASSERT((managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_BUFFER_SIZE) ||
 	       (managed_buffer->max_buffer_size ==
+		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE) ||
+	       (managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE));
 	return managed_buffer->buffer_size;
 }
@@ -198,6 +204,8 @@ void *get_managed_buffer(IN OUT void *m_buffer)
 	ASSERT((managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_BUFFER_SIZE) ||
 	       (managed_buffer->max_buffer_size ==
+		MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE) ||
+	       (managed_buffer->max_buffer_size ==
 		MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE));
 	return (managed_buffer + 1);
 }
@@ -215,6 +223,7 @@ void init_managed_buffer(IN OUT void *m_buffer, IN uintn max_buffer_size)
 	managed_buffer = m_buffer;
 
 	ASSERT((max_buffer_size == MAX_SPDM_MESSAGE_BUFFER_SIZE) ||
+	       (max_buffer_size == MAX_SPDM_MESSAGE_MEDIUM_BUFFER_SIZE) ||
 	       (max_buffer_size == MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE));
 
 	managed_buffer->max_buffer_size = max_buffer_size;

--- a/library/spdm_requester_lib/encap_challenge_auth.c
+++ b/library/spdm_requester_lib/encap_challenge_auth.c
@@ -138,7 +138,7 @@ return_status spdm_get_encap_response_challenge_auth(
 	status = spdm_append_message_mut_c(spdm_context, spdm_response,
 					   (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		reset_managed_buffer(&spdm_context->transcript.message_mut_c);
+		spdm_reset_message_mut_c(spdm_context);
 		spdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);

--- a/library/spdm_requester_lib/encap_request.c
+++ b/library/spdm_requester_lib/encap_request.c
@@ -186,8 +186,8 @@ return_status spdm_encapsulated_request(IN spdm_context_t *spdm_context,
 	//
 	// Cache
 	//
-	reset_managed_buffer(&spdm_context->transcript.message_mut_b);
-	reset_managed_buffer(&spdm_context->transcript.message_mut_c);
+	spdm_reset_message_mut_b(spdm_context);
+	spdm_reset_message_mut_c(spdm_context);
 
 	if (session_id == NULL) {
 		spdm_context->last_spdm_request_session_id_valid = FALSE;

--- a/library/spdm_requester_lib/finish.c
+++ b/library/spdm_requester_lib/finish.c
@@ -174,8 +174,8 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		}
 		status = spdm_handle_error_response_main(
 			spdm_context, &session_id,
-			&session_info->session_transcript.message_f,
-			spdm_request_size, &spdm_response_size, &spdm_response,
+			NULL,
+			0, &spdm_response_size, &spdm_response,
 			SPDM_FINISH, SPDM_FINISH_RSP,
 			sizeof(spdm_finish_response_mine_t));
 		if (RETURN_ERROR(status)) {

--- a/library/spdm_requester_lib/finish.c
+++ b/library/spdm_requester_lib/finish.c
@@ -123,7 +123,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		sizeof(spdm_finish_request_t) + signature_size + hmac_size;
 	ptr = spdm_request.signature;
 
-	status = spdm_append_message_f(session_info, (uint8 *)&spdm_request,
+	status = spdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -134,7 +134,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		if (!result) {
 			return RETURN_SECURITY_VIOLATION;
 		}
-		status = spdm_append_message_f(session_info, ptr,
+		status = spdm_append_message_f(spdm_context, session_info, TRUE, ptr,
 					       signature_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
@@ -147,7 +147,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_f(session_info, ptr, hmac_size);
+	status = spdm_append_message_f(spdm_context, session_info, TRUE, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
@@ -170,7 +170,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		if (spdm_response.header.param1 != SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
-			spdm_reset_message_f (session_info);
+			spdm_reset_message_f (spdm_context, session_info);
 		}
 		status = spdm_handle_error_response_main(
 			spdm_context, &session_id,
@@ -197,7 +197,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	status = spdm_append_message_f(session_info, &spdm_response,
+	status = spdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -217,7 +217,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		}
 
 		status = spdm_append_message_f(
-			session_info,
+			spdm_context, session_info, TRUE,
 			(uint8 *)&spdm_response +
 				sizeof(spdm_finish_response_t),
 			hmac_size);

--- a/library/spdm_requester_lib/get_measurements.c
+++ b/library/spdm_requester_lib/get_measurements.c
@@ -183,7 +183,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		}
 	} else if (spdm_response.header.request_response_code !=
 		   SPDM_MEASUREMENTS) {
-		reset_managed_buffer(&spdm_context->transcript.message_m);
+		spdm_reset_message_m(spdm_context);
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response_size < sizeof(spdm_measurements_response_t)) {
@@ -196,8 +196,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (spdm_response.number_of_blocks != 0) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else if (measurement_operation ==
@@ -216,8 +215,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (measurement_record_data_length != 0) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else {
@@ -242,15 +240,13 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    sizeof(spdm_measurements_response_t) +
 			    measurement_record_data_length + SPDM_NONCE_SIZE +
 			    sizeof(uint16)) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_DEVICE_ERROR;
 		}
 		if (spdm_is_version_supported(spdm_context,
 					      SPDM_MESSAGE_VERSION_11) &&
 		    spdm_response.header.param2 != slot_id_param) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SECURITY_VIOLATION;
 		}
 		ptr = measurement_record_data + measurement_record_data_length;
@@ -289,8 +285,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 					       spdm_response_size -
 						       signature_size);
 		if (RETURN_ERROR(status)) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
@@ -308,12 +303,11 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		if (!result) {
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_MEASUREMENT_AUTH_FAILURE;
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		reset_managed_buffer(&spdm_context->transcript.message_m);
+		spdm_reset_message_m(spdm_context);
 	} else {
 		if (spdm_response_size <
 		    sizeof(spdm_measurements_response_t) +
@@ -356,8 +350,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		status = spdm_append_message_m(spdm_context, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SECURITY_VIOLATION;
 		}
 	}

--- a/library/spdm_requester_lib/get_version.c
+++ b/library/spdm_requester_lib/get_version.c
@@ -166,9 +166,9 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 
-	reset_managed_buffer(&spdm_context->transcript.message_a);
-	reset_managed_buffer(&spdm_context->transcript.message_b);
-	reset_managed_buffer(&spdm_context->transcript.message_c);
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
@@ -225,7 +225,7 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 	status = spdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
-		reset_managed_buffer(&spdm_context->transcript.message_a);
+		spdm_reset_message_a(spdm_context);
 		return RETURN_SECURITY_VIOLATION;
 	}
 

--- a/library/spdm_requester_lib/key_exchange.c
+++ b/library/spdm_requester_lib/key_exchange.c
@@ -305,7 +305,7 @@ return_status try_spdm_send_receive_key_exchange(
 	//
 	// Cache session data
 	//
-	status = spdm_append_message_k(session_info, &spdm_request,
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, *session_id);
@@ -315,7 +315,7 @@ return_status try_spdm_send_receive_key_exchange(
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(session_info, &spdm_response,
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size - signature_size -
 					       hmac_size);
 	if (RETURN_ERROR(status)) {
@@ -342,7 +342,7 @@ return_status try_spdm_send_receive_key_exchange(
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(session_info, signature, signature_size);
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, signature, signature_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
@@ -398,7 +398,7 @@ return_status try_spdm_send_receive_key_exchange(
 		}
 		ptr += hmac_size;
 
-		status = spdm_append_message_k(session_info, verify_data,
+		status = spdm_append_message_k(spdm_context, session_info, TRUE, verify_data,
 					       hmac_size);
 		if (RETURN_ERROR(status)) {
 			spdm_free_session_id(spdm_context, *session_id);

--- a/library/spdm_requester_lib/psk_exchange.c
+++ b/library/spdm_requester_lib/psk_exchange.c
@@ -243,13 +243,13 @@ return_status try_spdm_send_receive_psk_exchange(
 	//
 	// Cache session data
 	//
-	status = spdm_append_message_k(session_info, &spdm_request,
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(session_info, &spdm_response,
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, *session_id);
@@ -283,7 +283,7 @@ return_status try_spdm_send_receive_psk_exchange(
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(session_info, verify_data, hmac_size);
+	status = spdm_append_message_k(spdm_context, session_info, TRUE, verify_data, hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/psk_finish.c
+++ b/library/spdm_requester_lib/psk_finish.c
@@ -78,7 +78,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	spdm_request_size = sizeof(spdm_finish_request_t) + hmac_size;
 
-	status = spdm_append_message_f(session_info, (uint8 *)&spdm_request,
+	status = spdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
 				       spdm_request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -87,7 +87,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	spdm_generate_psk_exchange_req_hmac(spdm_context, session_info,
 					    spdm_request.verify_data);
 
-	status = spdm_append_message_f(session_info,
+	status = spdm_append_message_f(spdm_context, session_info, TRUE,
 				       (uint8 *)&spdm_request +
 					       spdm_request_size - hmac_size,
 				       hmac_size);
@@ -114,8 +114,8 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_error_response_main(
 			spdm_context, &session_id,
-			&session_info->session_transcript.message_f,
-			spdm_request_size, &spdm_response_size, &spdm_response,
+			NULL,
+			0, &spdm_response_size, &spdm_response,
 			SPDM_PSK_FINISH, SPDM_PSK_FINISH_RSP,
 			sizeof(spdm_psk_finish_response_max_t));
 		if (RETURN_ERROR(status)) {
@@ -129,7 +129,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	status = spdm_append_message_f(session_info, &spdm_response,
+	status = spdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_responder_lib/capabilities.c
+++ b/library/spdm_responder_lib/capabilities.c
@@ -225,7 +225,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	//
 	// Cache
 	//
-	status = append_managed_buffer(&spdm_context->transcript.message_a, spdm_request,
+	status = spdm_append_message_a(spdm_context, spdm_request,
 			      spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -233,7 +233,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 						response_size, response);
 		return RETURN_SUCCESS;
 	}
-	status = append_managed_buffer(&spdm_context->transcript.message_a,
+	status = spdm_append_message_a(spdm_context,
 			      spdm_response, *response_size);
 
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -194,7 +194,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	status = spdm_append_message_c(spdm_context, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		reset_managed_buffer(&spdm_context->transcript.message_c);
+		spdm_reset_message_c(spdm_context);
 		return spdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);

--- a/library/spdm_responder_lib/encap_challenge.c
+++ b/library/spdm_responder_lib/encap_challenge.c
@@ -116,8 +116,8 @@ return_status spdm_process_encap_response_challenge_auth(
 	}
 	if (spdm_response->header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_encap_error_response_main(
-			spdm_context, &spdm_context->transcript.message_mut_c,
-			spdm_context->encap_context.last_encap_request_size,
+			spdm_context, NULL,
+			0,
 			spdm_response->header.param1);
 		if (RETURN_ERROR(status)) {
 			return status;

--- a/library/spdm_responder_lib/encap_get_certificate.c
+++ b/library/spdm_responder_lib/encap_get_certificate.c
@@ -106,8 +106,8 @@ return_status spdm_process_encap_response_certificate(
 	}
 	if (spdm_response->header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_encap_error_response_main(
-			spdm_context, &spdm_context->transcript.message_mut_b,
-			spdm_context->encap_context.last_encap_request_size,
+			spdm_context, NULL,
+			0,
 			spdm_response->header.param1);
 		if (RETURN_ERROR(status)) {
 			return status;

--- a/library/spdm_responder_lib/encap_get_digests.c
+++ b/library/spdm_responder_lib/encap_get_digests.c
@@ -102,8 +102,8 @@ return_status spdm_process_encap_response_digest(
 	}
 	if (spdm_response->header.request_response_code == SPDM_ERROR) {
 		status = spdm_handle_encap_error_response_main(
-			spdm_context, &spdm_context->transcript.message_mut_b,
-			spdm_context->encap_context.last_encap_request_size,
+			spdm_context, NULL,
+			0,
 			spdm_response->header.param1);
 		if (RETURN_ERROR(status)) {
 			return status;

--- a/library/spdm_responder_lib/encap_response.c
+++ b/library/spdm_responder_lib/encap_response.c
@@ -198,8 +198,8 @@ void spdm_init_mut_auth_encap_state(IN spdm_context_t *spdm_context,
 	//
 	// Clear Cache
 	//
-	reset_managed_buffer(&spdm_context->transcript.message_mut_b);
-	reset_managed_buffer(&spdm_context->transcript.message_mut_c);
+	spdm_reset_message_mut_b(spdm_context);
+	spdm_reset_message_mut_c(spdm_context);
 
 	//
 	// Possible Sequence:
@@ -252,8 +252,8 @@ void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
 	//
 	// Clear Cache
 	//
-	reset_managed_buffer(&spdm_context->transcript.message_mut_b);
-	reset_managed_buffer(&spdm_context->transcript.message_mut_c);
+	spdm_reset_message_mut_b(spdm_context);
+	spdm_reset_message_mut_c(spdm_context);
 
 	//
 	// Possible Sequence:
@@ -308,8 +308,8 @@ void spdm_init_key_update_encap_state(IN void *context)
 	spdm_context->encap_context.certificate_chain_buffer.buffer_size = 0;
 	spdm_context->response_state = SPDM_RESPONSE_STATE_PROCESSING_ENCAP;
 
-	reset_managed_buffer(&spdm_context->transcript.message_mut_b);
-	reset_managed_buffer(&spdm_context->transcript.message_mut_c);
+	spdm_reset_message_mut_b(spdm_context);
+	spdm_reset_message_mut_c(spdm_context);
 
 	zero_mem(spdm_context->encap_context.request_op_code_sequence,
 		 sizeof(spdm_context->encap_context.request_op_code_sequence));

--- a/library/spdm_responder_lib/finish.c
+++ b/library/spdm_responder_lib/finish.c
@@ -157,7 +157,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	spdm_reset_message_buffer_via_request_code(spdm_context,
 						spdm_request->header.request_response_code);
 
-	status = spdm_append_message_f(session_info, request,
+	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -177,7 +177,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			return RETURN_SUCCESS;
 		}
 		status = spdm_append_message_f(
-			session_info,
+			spdm_context, session_info, FALSE,
 			(uint8 *)request + sizeof(spdm_finish_request_t),
 			signature_size);
 		if (RETURN_ERROR(status)) {
@@ -200,7 +200,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_f(session_info,
+	status = spdm_append_message_f(spdm_context, session_info, FALSE,
 				       (uint8 *)request + signature_size +
 					       sizeof(spdm_finish_request_t),
 				       hmac_size);
@@ -228,7 +228,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	spdm_response->header.param1 = 0;
 	spdm_response->header.param2 = 0;
 
-	status = spdm_append_message_f(session_info, spdm_response,
+	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -253,7 +253,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		}
 
 		status = spdm_append_message_f(
-			session_info,
+			spdm_context, session_info, FALSE,
 			(uint8 *)spdm_response + sizeof(spdm_finish_request_t),
 			hmac_size);
 		if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/key_exchange.c
+++ b/library/spdm_responder_lib/key_exchange.c
@@ -271,7 +271,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		spdm_context->local_context
 			.local_cert_chain_provision_size[slot_id];
 
-	status = spdm_append_message_k(session_info, request, request_size);
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
@@ -280,7 +280,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(session_info, spdm_response,
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
@@ -299,7 +299,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(session_info, ptr, signature_size);
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, signature_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
@@ -345,7 +345,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
-		status = spdm_append_message_k(session_info, ptr, hmac_size);
+		status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 		if (RETURN_ERROR(status)) {
 			spdm_free_session_id(spdm_context, session_id);
 			spdm_generate_error_response(

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -523,14 +523,11 @@ return_status spdm_get_response_measurements(IN void *context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				SPDM_GET_MEASUREMENTS,
 				response_size, response);
-			reset_managed_buffer(
-				&spdm_context->transcript
-						.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SUCCESS;
 		}
 		//reset
-		reset_managed_buffer(
-			&spdm_context->transcript.message_m);
+		spdm_reset_message_m(spdm_context);
 	} else {
 		status = spdm_append_message_m(spdm_context, spdm_response,
 					       *response_size);
@@ -538,8 +535,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			spdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
-			reset_managed_buffer(
-				&spdm_context->transcript.message_m);
+			spdm_reset_message_m(spdm_context);
 			return RETURN_SUCCESS;
 		}
 	}

--- a/library/spdm_responder_lib/psk_exchange.c
+++ b/library/spdm_responder_lib/psk_exchange.c
@@ -254,7 +254,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	ptr += opaque_psk_exchange_rsp_size;
 
 
-	status = spdm_append_message_k(session_info, request, request_size);
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,
@@ -263,7 +263,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	
-	status = spdm_append_message_k(session_info, spdm_response,
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
@@ -303,7 +303,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
-	status = spdm_append_message_k(session_info, ptr, hmac_size);
+	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
 		spdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/psk_finish.c
+++ b/library/spdm_responder_lib/psk_finish.c
@@ -104,7 +104,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	spdm_reset_message_buffer_via_request_code(spdm_context,
 						spdm_request->header.request_response_code);
 
-	status = spdm_append_message_f(session_info, request,
+	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -134,7 +134,8 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	status = spdm_append_message_f(
-		session_info, (uint8 *)request + request_size - hmac_size,
+		spdm_context, session_info, FALSE,
+		(uint8 *)request + request_size - hmac_size,
 		hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -143,7 +144,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_f(session_info, spdm_response,
+	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/version.c
+++ b/library/spdm_responder_lib/version.c
@@ -81,9 +81,9 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	//
 	// Cache
 	//
-	reset_managed_buffer(&spdm_context->transcript.message_a);
-	reset_managed_buffer(&spdm_context->transcript.message_b);
-	reset_managed_buffer(&spdm_context->transcript.message_c);
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	status = spdm_append_message_a(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
@@ -121,7 +121,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	status = spdm_append_message_a(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		reset_managed_buffer(&spdm_context->transcript.message_a);
+		spdm_reset_message_a(spdm_context);
 		spdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);

--- a/library/spdm_secured_message_lib/context_data.c
+++ b/library/spdm_secured_message_lib/context_data.c
@@ -50,6 +50,23 @@ void spdm_secured_message_set_use_psk(IN void *spdm_secured_message_context,
 }
 
 /**
+  Return if finished_key is ready.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @retval TRUE  finished_key is ready.
+  @retval FALSE finished_key is not ready.
+*/
+boolean
+spdm_secured_message_is_finished_key_ready(IN void *spdm_secured_message_context)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return secured_message_context->finished_key_ready;
+}
+
+/**
   Set session_state to an SPDM secured message context.
 
   @param  spdm_secured_message_context    A pointer to the SPDM secured message context.

--- a/library/spdm_secured_message_lib/session.c
+++ b/library/spdm_secured_message_lib/session.c
@@ -140,17 +140,17 @@ return_status spdm_generate_aead_key_and_iv(
 }
 
 /**
-  This function generates SPDM FinishedKey for a session.
+  This function generates SPDM finished_key for a session.
 
   @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
   @param  handshake_secret              The handshake secret.
-  @param  FinishedKey                  The buffer to store the finished key.
+  @param  finished_key                  The buffer to store the finished key.
 
-  @retval RETURN_SUCCESS  SPDM FinishedKey for a session is generated.
+  @retval RETURN_SUCCESS  SPDM finished_key for a session is generated.
 **/
 return_status spdm_generate_finished_key(
 	IN spdm_secured_message_context_t *secured_message_context,
-	IN uint8 *handshake_secret, OUT uint8 *FinishedKey)
+	IN uint8 *handshake_secret, OUT uint8 *finished_key)
 {
 	return_status status;
 	boolean ret_val;
@@ -169,10 +169,10 @@ return_status spdm_generate_finished_key(
 	internal_dump_hex(bin_str7, bin_str7_size);
 	ret_val = spdm_hkdf_expand(secured_message_context->base_hash_algo,
 				   handshake_secret, hash_size, bin_str7,
-				   bin_str7_size, FinishedKey, hash_size);
+				   bin_str7_size, finished_key, hash_size);
 	ASSERT(ret_val);
-	DEBUG((DEBUG_INFO, "FinishedKey (0x%x) - ", hash_size));
-	internal_dump_data(FinishedKey, hash_size);
+	DEBUG((DEBUG_INFO, "finished_key (0x%x) - ", hash_size));
+	internal_dump_data(finished_key, hash_size);
 	DEBUG((DEBUG_INFO, "\n"));
 
 	return RETURN_SUCCESS;
@@ -339,6 +339,8 @@ spdm_generate_session_handshake_key(IN void *spdm_secured_message_context,
 
 	zero_mem(secured_message_context->master_secret.dhe_secret,
 		MAX_DHE_KEY_SIZE);
+	
+	secured_message_context->finished_key_ready = TRUE;
 	return RETURN_SUCCESS;
 }
 
@@ -776,6 +778,128 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
 }
 
 /**
+  Allocates and initializes one HMAC context for subsequent use, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @return Pointer to the HMAC context that has been initialized.
+**/
+void *
+spdm_hmac_new_with_request_finished_key(
+	IN void *spdm_secured_message_context)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_new(secured_message_context->base_hash_algo);
+}
+
+/**
+  Release the specified HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+void spdm_hmac_free_with_request_finished_key(
+	IN void *spdm_secured_message_context, IN void *hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	spdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
+}
+
+/**
+  Set request_finished_key for subsequent use. It must be done before any
+  calling to hmac_update().
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx  Pointer to HMAC context.
+
+  @retval TRUE   The key is set successfully.
+  @retval FALSE  The key is set unsuccessfully.
+**/
+boolean spdm_hmac_init_with_request_finished_key(
+	IN void *spdm_secured_message_context, OUT void *hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_init(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		secured_message_context->handshake_secret.request_finished_key,
+		secured_message_context->hash_size);
+}
+
+/**
+  Makes a copy of an existing HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  new_hmac_ctx  Pointer to new HMAC context.
+
+  @retval TRUE   HMAC context copy succeeded.
+  @retval FALSE  HMAC context copy failed.
+**/
+boolean spdm_hmac_duplicate_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	IN const void *hmac_ctx, OUT void *new_hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_duplicate(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		new_hmac_ctx);
+}
+
+/**
+  Digests the input data and updates HMAC context, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  data              Pointer to the buffer containing the data to be digested.
+  @param  data_size          size of data buffer in bytes.
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_update_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx, IN const void *data,
+	IN uintn data_size)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_update(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		data, data_size);
+}
+
+/**
+  Completes computation of the HMAC digest value, with request_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_final_with_request_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx,  OUT uint8 *hmac_value)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_final(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		hmac_value);
+}
+
+/**
   Computes the HMAC of a input data buffer, with request_finished_key.
 
   @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
@@ -798,6 +922,128 @@ spdm_hmac_all_with_request_finished_key(IN void *spdm_secured_message_context,
 		secured_message_context->base_hash_algo, data, data_size,
 		secured_message_context->handshake_secret.request_finished_key,
 		secured_message_context->hash_size, hmac_value);
+}
+
+/**
+  Allocates and initializes one HMAC context for subsequent use, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+
+  @return Pointer to the HMAC context that has been initialized.
+**/
+void *
+spdm_hmac_new_with_response_finished_key(
+	IN void *spdm_secured_message_context)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_new(secured_message_context->base_hash_algo);
+}
+
+/**
+  Release the specified HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx                   Pointer to the HMAC context to be released.
+**/
+void spdm_hmac_free_with_response_finished_key(
+	IN void *spdm_secured_message_context, IN void *hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	spdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
+}
+
+/**
+  Set response_finished_key for subsequent use. It must be done before any
+  calling to hmac_update().
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx  Pointer to HMAC context.
+
+  @retval TRUE   The key is set successfully.
+  @retval FALSE  The key is set unsuccessfully.
+**/
+boolean spdm_hmac_init_with_response_finished_key(
+	IN void *spdm_secured_message_context, OUT void *hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_init(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		secured_message_context->handshake_secret.response_finished_key,
+		secured_message_context->hash_size);
+}
+
+/**
+  Makes a copy of an existing HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  new_hmac_ctx  Pointer to new HMAC context.
+
+  @retval TRUE   HMAC context copy succeeded.
+  @retval FALSE  HMAC context copy failed.
+**/
+boolean spdm_hmac_duplicate_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	IN const void *hmac_ctx, OUT void *new_hmac_ctx)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_duplicate(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		new_hmac_ctx);
+}
+
+/**
+  Digests the input data and updates HMAC context, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  data              Pointer to the buffer containing the data to be digested.
+  @param  data_size          size of data buffer in bytes.
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_update_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx, IN const void *data,
+	IN uintn data_size)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_update(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		data, data_size);
+}
+
+/**
+  Completes computation of the HMAC digest value, with response_finished_key.
+
+  @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+  @param  hmac_ctx     Pointer to HMAC context being copied.
+  @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+
+  @retval TRUE   HMAC data digest succeeded.
+  @retval FALSE  HMAC data digest failed.
+**/
+boolean spdm_hmac_final_with_response_finished_key(
+	IN void *spdm_secured_message_context,
+	OUT void *hmac_ctx,  OUT uint8 *hmac_value)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	return spdm_hmac_final(
+		secured_message_context->base_hash_algo, hmac_ctx,
+		hmac_value);
 }
 
 /**

--- a/library/spdm_secured_message_lib/spdm_secured_message_lib_internal.h
+++ b/library/spdm_secured_message_lib/spdm_secured_message_lib_internal.h
@@ -52,6 +52,7 @@ typedef struct {
 	uintn aead_iv_size;
 	uintn aead_tag_size;
 	boolean use_psk;
+	boolean finished_key_ready;
 	spdm_session_state_t session_state;
 	spdm_session_info_struct_master_secret_t master_secret;
 	spdm_session_info_struct_handshake_secret_t handshake_secret;

--- a/os_stub/spdm_device_secret_lib/lib.c
+++ b/os_stub/spdm_device_secret_lib/lib.c
@@ -199,7 +199,7 @@ boolean spdm_measurement_collection(IN uint8 measurement_specification,
   @retval FALSE signing fail.
 **/
 boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size)
 {
@@ -221,8 +221,13 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
 	if (!result) {
 		return FALSE;
 	}
-	result = spdm_req_asym_sign(req_base_asym_alg, base_hash_algo, context,
-				    message, message_size, signature, sig_size);
+	if (is_data_hash) {
+		result = spdm_req_asym_sign_hash(req_base_asym_alg, base_hash_algo, context,
+						message, message_size, signature, sig_size);
+	} else {
+		result = spdm_req_asym_sign(req_base_asym_alg, base_hash_algo, context,
+						message, message_size, signature, sig_size);
+	}
 	spdm_req_asym_free(req_base_asym_alg, context);
 	free(private_pem);
 
@@ -244,7 +249,7 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
   @retval FALSE signing fail.
 **/
 boolean spdm_responder_data_sign(IN uint32 base_asym_algo,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size)
 {
@@ -264,8 +269,13 @@ boolean spdm_responder_data_sign(IN uint32 base_asym_algo,
 	if (!result) {
 		return FALSE;
 	}
-	result = spdm_asym_sign(base_asym_algo, base_hash_algo, context,
-				message, message_size, signature, sig_size);
+	if (is_data_hash) {
+		result = spdm_asym_sign_hash(base_asym_algo, base_hash_algo, context,
+					message, message_size, signature, sig_size);
+	} else {
+		result = spdm_asym_sign(base_asym_algo, base_hash_algo, context,
+					message, message_size, signature, sig_size);
+	}
 	spdm_asym_free(base_asym_algo, context);
 	free(private_pem);
 

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -40,7 +40,8 @@ boolean spdm_measurement_collection(IN uint8 measurement_specification,
 
   @param  req_base_asym_alg               Indicates the signing algorithm.
   @param  base_hash_algo                 Indicates the hash algorithm.
-  @param  message                      A pointer to a message to be signed (before hash).
+  @param  is_data_hash                   Indicate the message type. TRUE: raw message before hash, FALSE: message hash.
+  @param  message                      A pointer to a message to be signed.
   @param  message_size                  The size in bytes of the message to be signed.
   @param  signature                    A pointer to a destination buffer to store the signature.
   @param  sig_size                      On input, indicates the size in bytes of the destination buffer to store the signature.
@@ -50,7 +51,7 @@ boolean spdm_measurement_collection(IN uint8 measurement_specification,
   @retval FALSE signing fail.
 **/
 boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size)
 {
@@ -62,7 +63,8 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
 
   @param  base_asym_algo                 Indicates the signing algorithm.
   @param  base_hash_algo                 Indicates the hash algorithm.
-  @param  message                      A pointer to a message to be signed (before hash).
+  @param  is_data_hash                   Indicate the message type. TRUE: raw message before hash, FALSE: message hash.
+  @param  message                      A pointer to a message to be signed.
   @param  message_size                  The size in bytes of the message to be signed.
   @param  signature                    A pointer to a destination buffer to store the signature.
   @param  sig_size                      On input, indicates the size in bytes of the destination buffer to store the signature.
@@ -72,7 +74,7 @@ boolean spdm_requester_data_sign(IN uint16 req_base_asym_alg,
   @retval FALSE signing fail.
 **/
 boolean spdm_responder_data_sign(IN uint32 base_asym_algo,
-				 IN uint32 base_hash_algo,
+				 IN uint32 base_hash_algo, IN boolean is_data_hash,
 				 IN const uint8 *message, IN uintn message_size,
 				 OUT uint8 *signature, IN OUT uintn *sig_size)
 {

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1001,7 +1001,7 @@ void test_spdm_requester_challenge_case1(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1123,7 +1123,7 @@ void test_spdm_requester_challenge_case3(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1178,7 +1178,7 @@ void test_spdm_requester_challenge_case4(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1233,7 +1233,7 @@ void test_spdm_requester_challenge_case5(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1343,7 +1343,7 @@ void test_spdm_requester_challenge_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1398,7 +1398,7 @@ void test_spdm_requester_challenge_case8(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
 #endif
 	free(data);
@@ -1496,7 +1496,7 @@ void test_spdm_requester_challenge_case10(void **state) {
   zero_mem (measurement_hash, sizeof(measurement_hash));
   status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
   assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
 #endif
   free(data);
@@ -1935,7 +1935,7 @@ void test_spdm_requester_challenge_case20(void **state) {
     status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     // assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_c.buffer_size, 0, error_code);
 #endif

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -164,7 +164,7 @@ return_status spdm_requester_challenge_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -234,7 +234,7 @@ return_status spdm_requester_challenge_test_receive_message(
 			      m_local_buffer_size, hash_data);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -358,7 +358,7 @@ return_status spdm_requester_challenge_test_receive_message(
 				spdm_get_asym_signature_size(m_use_asym_algo);
 			spdm_responder_data_sign(m_use_asym_algo,
 						 m_use_hash_algo,
-						 m_local_buffer,
+						 FALSE, m_local_buffer,
 						 m_local_buffer_size, ptr,
 						 &sig_size);
 			ptr += sig_size;
@@ -495,7 +495,7 @@ return_status spdm_requester_challenge_test_receive_message(
 				spdm_get_asym_signature_size(m_use_asym_algo);
 			spdm_responder_data_sign(m_use_asym_algo,
 						 m_use_hash_algo,
-						 m_local_buffer,
+						 FALSE, m_local_buffer,
 						 m_local_buffer_size, ptr,
 						 &sig_size);
 			ptr += sig_size;
@@ -549,7 +549,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -615,7 +615,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -664,7 +664,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -713,7 +713,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -762,7 +762,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -813,7 +813,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -863,7 +863,7 @@ return_status spdm_requester_challenge_test_receive_message(
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     spdm_hash_all (m_use_hash_algo, hash_data, spdm_get_hash_size (m_use_hash_algo), hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, hash_data, spdm_get_hash_size (m_use_hash_algo), Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, hash_data, spdm_get_hash_size (m_use_hash_algo), Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -912,7 +912,7 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     spdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = spdm_get_asym_signature_size (m_use_asym_algo);
-    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
+    spdm_responder_data_sign (m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -980,9 +980,9 @@ void test_spdm_requester_challenge_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1001,7 +1001,9 @@ void test_spdm_requester_challenge_case1(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1040,9 +1042,9 @@ void test_spdm_requester_challenge_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1100,9 +1102,9 @@ void test_spdm_requester_challenge_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1121,7 +1123,9 @@ void test_spdm_requester_challenge_case3(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1153,9 +1157,9 @@ void test_spdm_requester_challenge_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1174,7 +1178,9 @@ void test_spdm_requester_challenge_case4(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1206,9 +1212,9 @@ void test_spdm_requester_challenge_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1227,7 +1233,9 @@ void test_spdm_requester_challenge_case5(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1259,9 +1267,9 @@ void test_spdm_requester_challenge_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1312,9 +1320,9 @@ void test_spdm_requester_challenge_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1335,7 +1343,9 @@ void test_spdm_requester_challenge_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1367,9 +1377,9 @@ void test_spdm_requester_challenge_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1388,7 +1398,9 @@ void test_spdm_requester_challenge_case8(void **state)
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1421,9 +1433,9 @@ void test_spdm_requester_challenge_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+	spdm_reset_message_b(spdm_context);
+	spdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1470,9 +1482,9 @@ void test_spdm_requester_challenge_case10(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   // spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1484,7 +1496,9 @@ void test_spdm_requester_challenge_case10(void **state) {
   zero_mem (measurement_hash, sizeof(measurement_hash));
   status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
   assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
+#endif
   free(data);
 }
 
@@ -1510,9 +1524,9 @@ void test_spdm_requester_challenge_case11(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1550,9 +1564,9 @@ void test_spdm_requester_challenge_case12(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1591,9 +1605,9 @@ void test_spdm_requester_challenge_case13(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1631,9 +1645,9 @@ void test_spdm_requester_challenge_case14(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1672,9 +1686,9 @@ void test_spdm_requester_challenge_case15(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1719,9 +1733,9 @@ void test_spdm_requester_challenge_case16(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1766,9 +1780,9 @@ void test_spdm_requester_challenge_case17(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1814,9 +1828,9 @@ void test_spdm_requester_challenge_case18(void **state) {
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP; //additional measurement capability
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1861,9 +1875,9 @@ void test_spdm_requester_challenge_case19(void **state) {
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP; //additional measurement capability
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_context->transcript.message_a.buffer_size = 0;
-  spdm_context->transcript.message_b.buffer_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
+  spdm_reset_message_b(spdm_context);
+  spdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1913,16 +1927,18 @@ void test_spdm_requester_challenge_case20(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
-    spdm_context->transcript.message_b.buffer_size = 0;
-    spdm_context->transcript.message_c.buffer_size = 0;
+    spdm_reset_message_a(spdm_context);
+    spdm_reset_message_b(spdm_context);
+    spdm_reset_message_c(spdm_context);
 
     zero_mem (measurement_hash, sizeof(measurement_hash));
     status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
-    // assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+#if RECORD_TRANSCRIPT_DATA
+    // assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_c.buffer_size, 0, error_code);
+#endif
 
     error_code++;
     if(error_code == SPDM_ERROR_CODE_BUSY) { //busy is treated in cases 5 and 6

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -496,7 +496,7 @@ void test_spdm_requester_end_session_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -560,7 +560,7 @@ void test_spdm_requester_end_session_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -651,7 +651,7 @@ void test_spdm_requester_end_session_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -738,7 +738,7 @@ void test_spdm_requester_end_session_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -825,7 +825,7 @@ void test_spdm_requester_end_session_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -912,7 +912,7 @@ void test_spdm_requester_end_session_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1003,7 +1003,7 @@ void test_spdm_requester_end_session_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1092,7 +1092,7 @@ void test_spdm_requester_end_session_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1179,7 +1179,7 @@ void test_spdm_requester_end_session_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1274,7 +1274,7 @@ void test_spdm_requester_end_session_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+    spdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1337,7 +1337,7 @@ void test_spdm_requester_end_session_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1386,6 +1386,7 @@ void test_spdm_requester_end_session_case11(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1396,6 +1397,7 @@ void test_spdm_requester_end_session_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	status = spdm_send_receive_end_session(spdm_context, session_id, 0);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1403,11 +1405,13 @@ void test_spdm_requester_end_session_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	free(data);
 }
 

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -1386,7 +1386,7 @@ void test_spdm_requester_end_session_case11(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1405,7 +1405,7 @@ void test_spdm_requester_end_session_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -2077,7 +2077,7 @@ void test_spdm_requester_finish_case11(void **state)
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
 	req_slot_id_param = 0;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -2097,7 +2097,7 @@ void test_spdm_requester_finish_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -1283,7 +1283,7 @@ void test_spdm_requester_finish_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1359,7 +1359,7 @@ void test_spdm_requester_finish_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1438,7 +1438,7 @@ void test_spdm_requester_finish_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1513,7 +1513,7 @@ void test_spdm_requester_finish_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1588,7 +1588,7 @@ void test_spdm_requester_finish_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1664,7 +1664,7 @@ void test_spdm_requester_finish_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1744,7 +1744,7 @@ void test_spdm_requester_finish_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1821,7 +1821,7 @@ void test_spdm_requester_finish_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1897,7 +1897,7 @@ void test_spdm_requester_finish_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1984,7 +1984,7 @@ void test_spdm_requester_finish_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
     session_info = &spdm_context->session_info[0];
     spdm_session_info_init (spdm_context, session_info, session_id, FALSE);
@@ -2045,7 +2045,7 @@ void test_spdm_requester_finish_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2076,6 +2076,7 @@ void test_spdm_requester_finish_case11(void **state)
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
 	req_slot_id_param = 0;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -2086,6 +2087,7 @@ void test_spdm_requester_finish_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	status = spdm_send_receive_finish(spdm_context, session_id,
 					  req_slot_id_param);
@@ -2094,12 +2096,14 @@ void test_spdm_requester_finish_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2143,7 +2147,7 @@ void test_spdm_requester_finish_case12(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2220,7 +2224,7 @@ void test_spdm_requester_finish_case13(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2295,7 +2299,7 @@ void test_spdm_requester_finish_case14(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2371,7 +2375,7 @@ void test_spdm_requester_finish_case15(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2447,7 +2451,7 @@ void test_spdm_requester_finish_case16(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2538,7 +2542,7 @@ void test_spdm_requester_finish_case17(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2625,7 +2629,7 @@ void test_spdm_requester_finish_case18(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2713,7 +2717,7 @@ void test_spdm_requester_finish_case19(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2801,7 +2805,7 @@ void test_spdm_requester_finish_case20(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -23,6 +23,7 @@ void spdm_secured_message_set_response_finished_key(
 	copy_mem(
 		secured_message_context->handshake_secret.response_finished_key,
 		key, secured_message_context->hash_size);
+	secured_message_context->finished_key_ready = TRUE;
 }
 
 return_status spdm_requester_finish_test_send_message(IN void *spdm_context,

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -772,7 +772,7 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 	spdm_test_context->case_id = 0x2;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 						spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -785,7 +785,7 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 			 0);
 	assert_int_equal(spdm_context->connection_info.capability.flags,
 			 DEFAULT_CAPABILITY_FLAG);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -772,9 +772,10 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 	spdm_test_context->case_id = 0x2;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 						spdm_context->transcript.message_m.max_buffer_size;
-
+#endif
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
@@ -784,7 +785,9 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 			 0);
 	assert_int_equal(spdm_context->connection_info.capability.flags,
 			 DEFAULT_CAPABILITY_FLAG);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_get_capabilities_case3(void **state)
@@ -1134,7 +1137,7 @@ void test_spdm_requester_get_capabilities_case19(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1158,7 +1161,7 @@ void test_spdm_requester_get_capabilities_case20(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1182,7 +1185,7 @@ void test_spdm_requester_get_capabilities_case21(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1206,7 +1209,7 @@ void test_spdm_requester_get_capabilities_case22(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1230,7 +1233,7 @@ void test_spdm_requester_get_capabilities_case23(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1254,7 +1257,7 @@ void test_spdm_requester_get_capabilities_case24(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1278,7 +1281,7 @@ void test_spdm_requester_get_capabilities_case25(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1302,7 +1305,7 @@ void test_spdm_requester_get_capabilities_case26(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1326,7 +1329,7 @@ void test_spdm_requester_get_capabilities_case27(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1348,7 +1351,7 @@ void test_spdm_requester_get_capabilities_case28(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1374,7 +1377,7 @@ void test_spdm_requester_get_capabilities_case29(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AFTER_VERSION;
-    reset_managed_buffer(&spdm_context->transcript.message_a);
+    spdm_reset_message_a(spdm_context);
 
     status = spdm_get_capabilities (spdm_context);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1138,7 +1138,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1147,7 +1147,9 @@ void test_spdm_requester_get_certificate_case1(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1186,8 +1188,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
 		DEBUG((DEBUG_INFO, "root cert data :\n"));
 		internal_dump_hex(
 			root_cert,
-			get_managed_buffer_size(
-				&spdm_context->transcript.message_mut_b));
+			root_cert_size);
 	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
 		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	spdm_context->local_context.peer_root_cert_provision_size =
@@ -1195,22 +1196,26 @@ void test_spdm_requester_get_certificate_case2(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
+#endif
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1250,7 +1255,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1259,7 +1264,9 @@ void test_spdm_requester_get_certificate_case3(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1299,7 +1306,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1308,7 +1315,9 @@ void test_spdm_requester_get_certificate_case4(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1348,7 +1357,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1357,7 +1366,9 @@ void test_spdm_requester_get_certificate_case5(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1400,7 +1411,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1409,10 +1420,12 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1452,7 +1465,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1463,7 +1476,9 @@ void test_spdm_requester_get_certificate_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -1503,7 +1518,7 @@ void test_spdm_requester_get_certificate_case8(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1554,7 +1569,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1563,10 +1578,12 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1608,7 +1625,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	spdm_context->local_context.peer_root_cert_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision = data;
 	spdm_context->local_context.peer_cert_chain_provision_size = data_size;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1617,10 +1634,12 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1666,7 +1685,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
 		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
@@ -1676,10 +1695,12 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1728,7 +1749,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
 		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
@@ -1738,10 +1759,12 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1787,7 +1810,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
 		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
@@ -1797,10 +1820,12 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
 				 data_size);
+#endif
 	free(data);
 }
 
@@ -1850,7 +1875,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 	count = (data_size + get_cert_length - 1) / get_cert_length;
 
@@ -1861,11 +1886,13 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	// It may fail because the spdm does not support too many messages.
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
+#if RECORD_TRANSCRIPT_DATA
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +
 				sizeof(spdm_certificate_response_t) * count +
 				data_size);
+#endif
 	}
 	free(data);
 }
@@ -1912,7 +1939,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
 		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
@@ -1924,11 +1951,13 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	// It may fail because the spdm does not support too long message.
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
+#if RECORD_TRANSCRIPT_DATA
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +
 				sizeof(spdm_certificate_response_t) * count +
 				data_size);
+#endif
 	}
 	free(data);
 }
@@ -1972,15 +2001,17 @@ void test_spdm_requester_get_certificate_case16(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AFTER_DIGESTS;
-    spdm_context->transcript.message_b.buffer_size = 0;
+    spdm_reset_message_b(spdm_context);
 
     cert_chain_size = sizeof(cert_chain);
     zero_mem (cert_chain, sizeof(cert_chain));
     status = spdm_get_certificate (spdm_context, 0, &cert_chain_size, cert_chain);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
-    // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+#if RECORD_TRANSCRIPT_DATA
+    // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0, error_code);
+#endif
 
     error_code++;
     if(error_code == SPDM_ERROR_CODE_BUSY) { //busy is treated in cases 5 and 6
@@ -2033,7 +2064,7 @@ void test_spdm_requester_get_certificate_case17(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -2081,7 +2112,7 @@ void test_spdm_requester_get_certificate_case18(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1147,7 +1147,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 	free(data);
@@ -1200,7 +1200,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -1209,7 +1209,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1264,7 +1264,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 	free(data);
@@ -1315,7 +1315,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 	free(data);
@@ -1366,7 +1366,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 	free(data);
@@ -1420,7 +1420,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1476,7 +1476,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 	free(data);
@@ -1578,7 +1578,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1634,7 +1634,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1695,7 +1695,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1759,7 +1759,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1820,7 +1820,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1886,7 +1886,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	// It may fail because the spdm does not support too many messages.
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +
@@ -1951,7 +1951,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	// It may fail because the spdm does not support too long message.
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +
@@ -2008,7 +2008,7 @@ void test_spdm_requester_get_certificate_case16(void **state) {
     status = spdm_get_certificate (spdm_context, 0, &cert_chain_size, cert_chain);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0, error_code);
 #endif

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -662,13 +662,15 @@ void test_spdm_requester_get_digests_case1(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -698,14 +700,17 @@ void test_spdm_requester_get_digests_case2(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
+#endif
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
@@ -713,6 +718,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 			spdm_get_hash_size(spdm_context->connection_info
 						   .algorithm.base_hash_algo) * MAX_SPDM_SLOT_COUNT);
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -743,13 +749,15 @@ void test_spdm_requester_get_digests_case3(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -779,13 +787,15 @@ void test_spdm_requester_get_digests_case4(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -815,13 +825,15 @@ void test_spdm_requester_get_digests_case5(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -852,18 +864,20 @@ void test_spdm_requester_get_digests_case6(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
 			sizeof(spdm_digest_response_t) +
 			spdm_get_hash_size(spdm_context->connection_info
 						   .algorithm.base_hash_algo));
+#endif
 }
 
 /**
@@ -894,7 +908,7 @@ void test_spdm_requester_get_digests_case7(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -902,7 +916,9 @@ void test_spdm_requester_get_digests_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -933,7 +949,7 @@ void test_spdm_requester_get_digests_case8(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -969,18 +985,20 @@ void test_spdm_requester_get_digests_case9(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
 			sizeof(spdm_digest_response_t) +
 			spdm_get_hash_size(spdm_context->connection_info
 						   .algorithm.base_hash_algo));
+#endif
 }
 
 /**
@@ -1010,13 +1028,15 @@ void test_spdm_requester_get_digests_case10(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1046,14 +1066,16 @@ void test_spdm_requester_get_digests_case11(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
+#endif
 }
 
 /**
@@ -1084,14 +1106,16 @@ void test_spdm_requester_get_digests_case12(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
+#endif
 }
 
 /**
@@ -1121,14 +1145,16 @@ void test_spdm_requester_get_digests_case13(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
+#endif
 }
 
 /**
@@ -1158,14 +1184,16 @@ void test_spdm_requester_get_digests_case14(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
+#endif
 }
 
 /**
@@ -1196,8 +1224,10 @@ void test_spdm_requester_get_digests_case15(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size;
+#endif
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1232,14 +1262,18 @@ void test_spdm_requester_get_digests_case16(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size -
 		(sizeof(spdm_digest_response_t));
+#endif
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#endif
 }
 
 /**
@@ -1269,7 +1303,7 @@ void test_spdm_requester_get_digests_case17(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1307,14 +1341,16 @@ void test_spdm_requester_get_digests_case18(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
+#endif
 }
 
 /**
@@ -1344,7 +1380,7 @@ void test_spdm_requester_get_digests_case19(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1382,14 +1418,16 @@ void test_spdm_requester_get_digests_case20(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
+#endif
 }
 
 /**
@@ -1420,14 +1458,16 @@ void test_spdm_requester_get_digests_case21(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
+#endif
 }
 
 /**
@@ -1458,14 +1498,16 @@ void test_spdm_requester_get_digests_case22(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_b.buffer_size = 0;
+    spdm_reset_message_b(spdm_context);
     
     zero_mem (total_digest_buffer, sizeof(total_digest_buffer));
     status = spdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+#if RECORD_TRANSCRIPT_DATA
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0, error_code);
+#endif
 
     error_code++;
     if(error_code == SPDM_ERROR_CODE_BUSY) { //busy is treated in cases 5 and 6

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -668,7 +668,7 @@ void test_spdm_requester_get_digests_case1(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -702,7 +702,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 		(uint8)(0xFF));
 	spdm_reset_message_b(spdm_context);
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -710,7 +710,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
@@ -755,7 +755,7 @@ void test_spdm_requester_get_digests_case3(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -793,7 +793,7 @@ void test_spdm_requester_get_digests_case4(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -831,7 +831,7 @@ void test_spdm_requester_get_digests_case5(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -870,7 +870,7 @@ void test_spdm_requester_get_digests_case6(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
@@ -916,7 +916,7 @@ void test_spdm_requester_get_digests_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -991,7 +991,7 @@ void test_spdm_requester_get_digests_case9(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
 		spdm_context->transcript.message_b.buffer_size,
 		sizeof(spdm_get_digest_request_t) +
@@ -1034,7 +1034,7 @@ void test_spdm_requester_get_digests_case10(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 #endif
 }
@@ -1072,7 +1072,7 @@ void test_spdm_requester_get_digests_case11(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
 #endif
@@ -1112,7 +1112,7 @@ void test_spdm_requester_get_digests_case12(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
 #endif
@@ -1151,7 +1151,7 @@ void test_spdm_requester_get_digests_case13(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
 #endif
@@ -1190,7 +1190,7 @@ void test_spdm_requester_get_digests_case14(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
 #endif
@@ -1224,7 +1224,7 @@ void test_spdm_requester_get_digests_case15(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size;
 #endif
@@ -1262,7 +1262,7 @@ void test_spdm_requester_get_digests_case16(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size -
 		(sizeof(spdm_digest_response_t));
@@ -1271,7 +1271,7 @@ void test_spdm_requester_get_digests_case16(void **state)
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #endif
 }
@@ -1347,7 +1347,7 @@ void test_spdm_requester_get_digests_case18(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 0);
 #endif
@@ -1424,7 +1424,7 @@ void test_spdm_requester_get_digests_case20(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
 #endif
@@ -1464,7 +1464,7 @@ void test_spdm_requester_get_digests_case21(void **state)
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_digest_request_t));
 #endif
@@ -1505,7 +1505,7 @@ void test_spdm_requester_get_digests_case22(void **state) {
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0, error_code);
 #endif
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -2440,7 +2440,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2496,7 +2496,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2552,7 +2552,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2608,7 +2608,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2664,7 +2664,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2720,7 +2720,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2778,7 +2778,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2887,7 +2887,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -2940,7 +2940,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
 		0, &number_of_blocks, NULL, NULL);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(number_of_blocks, 4);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -2998,7 +2998,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -3063,7 +3063,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -3122,7 +3122,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -3181,7 +3181,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -3240,7 +3240,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -3303,7 +3303,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 					      measurement_record);
 		if (SlotIDs[i] == ALTERNATIVE_DEFAULT_SLOT_ID) {
 			assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
@@ -3312,7 +3312,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 			assert_int_equal(status, RETURN_INVALID_PARAMETER);
 		} else {
 			assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
@@ -3375,7 +3375,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
 			SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
 			0, &number_of_blocks, NULL, NULL);
 		assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
 #endif
@@ -3435,7 +3435,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -3496,7 +3496,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-// #if RECORD_TRANSCRIPT_DATA
+// #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
 // #endif
 	free(data);
@@ -3554,7 +3554,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-// #if RECORD_TRANSCRIPT_DATA
+// #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
 // #endif
 	free(data);
@@ -3612,7 +3612,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-// #if RECORD_TRANSCRIPT_DATA
+// #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
 // #endif
 	free(data);
@@ -3676,7 +3676,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 					      measurement_record);
 		// It may fail due to transcript.message_m overflow
 		if (status == RETURN_SUCCESS) {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				NumberOfMessages *
@@ -3689,7 +3689,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 					 sizeof(uint16)));
 #endif
 		} else {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
@@ -3752,7 +3752,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -3817,7 +3817,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
 #endif
@@ -3877,7 +3877,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	free(data);
@@ -3936,7 +3936,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
 #endif
@@ -3996,7 +3996,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
 #endif
@@ -4058,7 +4058,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 ExpectedBufferSize);
 #endif
@@ -4117,7 +4117,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4180,7 +4180,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4245,7 +4245,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4307,7 +4307,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 		0, &number_of_block, &measurement_record_length,
 		measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4363,7 +4363,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
     status = spdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     // assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_m.buffer_size, 0, error_code);
 #endif

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -453,7 +453,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -536,7 +536,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -672,7 +672,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 				spdm_get_asym_signature_size(m_use_asym_algo);
 			spdm_responder_data_sign(m_use_asym_algo,
 						 m_use_hash_algo,
-						 m_local_buffer,
+						 FALSE, m_local_buffer,
 						 m_local_buffer_size, ptr,
 						 &sig_size);
 			ptr += sig_size;
@@ -822,7 +822,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 				spdm_get_asym_signature_size(m_use_asym_algo);
 			spdm_responder_data_sign(m_use_asym_algo,
 						 m_use_hash_algo,
-						 m_local_buffer,
+						 FALSE, m_local_buffer,
 						 m_local_buffer_size, ptr,
 						 &sig_size);
 			ptr += sig_size;
@@ -1196,7 +1196,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -1279,7 +1279,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -1818,7 +1818,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -1910,7 +1910,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		       spdm_get_hash_size(m_use_hash_algo)));
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -2002,7 +2002,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		       spdm_get_hash_size(m_use_hash_algo)));
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -2092,7 +2092,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		       spdm_get_hash_size(m_use_hash_algo)));
 		internal_dump_hex(m_local_buffer, m_local_buffer_size);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 m_local_buffer, m_local_buffer_size,
+					 FALSE, m_local_buffer, m_local_buffer_size,
 					 ptr, &sig_size);
 		ptr += sig_size;
 
@@ -2418,7 +2418,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2440,7 +2440,9 @@ void test_spdm_requester_get_measurements_case1(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2472,7 +2474,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2494,7 +2496,9 @@ void test_spdm_requester_get_measurements_case2(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2526,7 +2530,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2548,7 +2552,9 @@ void test_spdm_requester_get_measurements_case3(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2580,7 +2586,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2602,7 +2608,9 @@ void test_spdm_requester_get_measurements_case4(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2634,7 +2642,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2656,7 +2664,9 @@ void test_spdm_requester_get_measurements_case5(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2688,7 +2698,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2710,7 +2720,9 @@ void test_spdm_requester_get_measurements_case6(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2742,7 +2754,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2766,7 +2778,9 @@ void test_spdm_requester_get_measurements_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2798,7 +2812,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2851,7 +2865,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2873,7 +2887,9 @@ void test_spdm_requester_get_measurements_case9(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -2903,7 +2919,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2924,10 +2940,12 @@ void test_spdm_requester_get_measurements_case10(void **state)
 		0, &number_of_blocks, NULL, NULL);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(number_of_blocks, 4);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
 				 SPDM_NONCE_SIZE + sizeof(uint16));
+#endif
 	free(data);
 }
 
@@ -2959,7 +2977,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2980,6 +2998,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -2987,6 +3006,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 				 spdm_get_measurement_hash_size(
 					 m_use_measurement_hash_algo) +
 				 SPDM_NONCE_SIZE + sizeof(uint16));
+#endif
 	free(data);
 }
 
@@ -3021,7 +3041,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3043,7 +3063,9 @@ void test_spdm_requester_get_measurements_case12(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -3078,7 +3100,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3100,7 +3122,9 @@ void test_spdm_requester_get_measurements_case13(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -3135,7 +3159,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3157,7 +3181,9 @@ void test_spdm_requester_get_measurements_case14(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -3192,7 +3218,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3214,7 +3240,9 @@ void test_spdm_requester_get_measurements_case15(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -3267,7 +3295,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 
 	for (int i = 0; i < sizeof(SlotIDs) / sizeof(SlotIDs[0]); i++) {
 		measurement_record_length = sizeof(measurement_record);
-		spdm_context->transcript.message_m.buffer_size = 0;
+		spdm_reset_message_m(spdm_context);
 		status = spdm_get_measurement(spdm_context, NULL,
 					      request_attribute, 1, SlotIDs[i],
 					      &number_of_block,
@@ -3275,16 +3303,20 @@ void test_spdm_requester_get_measurements_case16(void **state)
 					      measurement_record);
 		if (SlotIDs[i] == ALTERNATIVE_DEFAULT_SLOT_ID) {
 			assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
+#endif
 		} else if (SlotIDs[i] == 0xF) {
 			assert_int_equal(status, RETURN_INVALID_PARAMETER);
 		} else {
 			assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
+#endif
 		}
 	}
 	free(data);
@@ -3319,7 +3351,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3343,8 +3375,10 @@ void test_spdm_requester_get_measurements_case17(void **state)
 			SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
 			0, &number_of_blocks, NULL, NULL);
 		assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
+#endif
 	}
 	free(data);
 }
@@ -3380,7 +3414,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3401,10 +3435,12 @@ void test_spdm_requester_get_measurements_case18(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
 				 LARGE_MEASUREMENT_SIZE);
+#endif
 	free(data);
 }
 
@@ -3439,7 +3475,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3460,7 +3496,9 @@ void test_spdm_requester_get_measurements_case19(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+// #if RECORD_TRANSCRIPT_DATA
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
+// #endif
 	free(data);
 }
 
@@ -3495,7 +3533,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3516,7 +3554,9 @@ void test_spdm_requester_get_measurements_case20(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+// #if RECORD_TRANSCRIPT_DATA
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
+// #endif
 	free(data);
 }
 
@@ -3551,7 +3591,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3572,7 +3612,9 @@ void test_spdm_requester_get_measurements_case21(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+// #if RECORD_TRANSCRIPT_DATA
 	// assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
+// #endif
 	free(data);
 }
 
@@ -3609,7 +3651,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3634,6 +3676,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 					      measurement_record);
 		// It may fail due to transcript.message_m overflow
 		if (status == RETURN_SUCCESS) {
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				NumberOfMessages *
@@ -3644,10 +3687,13 @@ void test_spdm_requester_get_measurements_case22(void **state)
 						 m_use_measurement_hash_algo) +
 					 SPDM_NONCE_SIZE +
 					 sizeof(uint16)));
+#endif
 		} else {
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
+#endif
 			break;
 		}
 	}
@@ -3685,7 +3731,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3706,6 +3752,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -3714,6 +3761,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 					 m_use_measurement_hash_algo) +
 				 SPDM_NONCE_SIZE + 
 				 sizeof(uint16) + MAX_SPDM_OPAQUE_DATA_SIZE);
+#endif
 	free(data);
 }
 
@@ -3748,7 +3796,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3769,8 +3817,10 @@ void test_spdm_requester_get_measurements_case24(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
+#endif
 	free(data);
 }
 
@@ -3805,7 +3855,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3827,7 +3877,9 @@ void test_spdm_requester_get_measurements_case25(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	free(data);
 }
 
@@ -3862,7 +3914,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3884,8 +3936,10 @@ void test_spdm_requester_get_measurements_case26(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
+#endif
 	free(data);
 }
 
@@ -3920,7 +3974,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3942,8 +3996,10 @@ void test_spdm_requester_get_measurements_case27(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 0);
+#endif
 	free(data);
 }
 
@@ -3979,7 +4035,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4002,8 +4058,10 @@ void test_spdm_requester_get_measurements_case28(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 ExpectedBufferSize);
+#endif
 	free(data);
 }
 
@@ -4038,7 +4096,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4059,6 +4117,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4068,6 +4127,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 				 SPDM_NONCE_SIZE +
 				 sizeof(uint16) +
 				 MAX_SPDM_OPAQUE_DATA_SIZE / 2 - 1);
+#endif
 	free(data);
 }
 
@@ -4099,7 +4159,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4120,6 +4180,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4128,6 +4189,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 					 m_use_measurement_hash_algo) +
 				 sizeof(uint16) +
 				 MAX_SPDM_OPAQUE_DATA_SIZE / 2);
+#endif
 	free(data);
 }
 
@@ -4162,7 +4224,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4183,6 +4245,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 				      &measurement_record_length,
 				      measurement_record);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4190,6 +4253,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 				 spdm_get_measurement_hash_size(
 					 m_use_measurement_hash_algo) +
 				 sizeof(uint16) + MAX_UINT16);
+#endif
 	free(data);
 }
 
@@ -4221,7 +4285,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4243,6 +4307,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 		0, &number_of_block, &measurement_record_length,
 		measurement_record);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 sizeof(spdm_message_header_t) +
 				 sizeof(spdm_measurements_response_t) +
@@ -4250,6 +4315,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 				      spdm_get_measurement_hash_size(
 					      m_use_measurement_hash_algo)) +
 				 sizeof(uint16) + SPDM_NONCE_SIZE);
+#endif
 	free(data);
 }
 
@@ -4291,14 +4357,16 @@ void test_spdm_requester_get_measurements_case33(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AUTHENTICATED;
-    spdm_context->transcript.message_m.buffer_size = 0;
+    spdm_reset_message_m(spdm_context);
 
     measurement_record_length = sizeof(measurement_record);
     status = spdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
-    // assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+#if RECORD_TRANSCRIPT_DATA
+    // assert_int_equal (spdm_context->transcript.message_m.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_m.buffer_size, 0, error_code);
+#endif
 
     error_code++;
     if(error_code == SPDM_ERROR_CODE_BUSY) { //busy is treated in cases 5 and 6

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -1375,7 +1375,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1390,7 +1390,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 
 	status = spdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -497,7 +497,7 @@ void test_spdm_requester_heartbeat_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -561,7 +561,7 @@ void test_spdm_requester_heartbeat_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -648,7 +648,7 @@ void test_spdm_requester_heartbeat_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -735,7 +735,7 @@ void test_spdm_requester_heartbeat_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -822,7 +822,7 @@ void test_spdm_requester_heartbeat_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -909,7 +909,7 @@ void test_spdm_requester_heartbeat_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -996,7 +996,7 @@ void test_spdm_requester_heartbeat_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1085,7 +1085,7 @@ void test_spdm_requester_heartbeat_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1172,7 +1172,7 @@ void test_spdm_requester_heartbeat_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1263,7 +1263,7 @@ void test_spdm_requester_heartbeat_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1326,7 +1326,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1375,6 +1375,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1385,14 +1386,17 @@ void test_spdm_requester_heartbeat_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	status = spdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	free(data);
 }
 

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -289,7 +289,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
 			      get_managed_buffer_size(&th_curr), hash_data);
 		free(data);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 get_managed_buffer(&th_curr),
+					 FALSE, get_managed_buffer(&th_curr),
 					 get_managed_buffer_size(&th_curr), ptr,
 					 &signature_size);
 		copy_mem(&m_local_buffer[m_local_buffer_size], ptr,
@@ -439,7 +439,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
 			      get_managed_buffer_size(&th_curr), hash_data);
 		free(data);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 get_managed_buffer(&th_curr),
+					 FALSE, get_managed_buffer(&th_curr),
 					 get_managed_buffer_size(&th_curr), ptr,
 					 &signature_size);
 		copy_mem(&m_local_buffer[m_local_buffer_size], ptr,
@@ -647,7 +647,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
 			free(data);
 			spdm_responder_data_sign(
 				m_use_asym_algo, m_use_hash_algo,
-				get_managed_buffer(&th_curr),
+				FALSE, get_managed_buffer(&th_curr),
 				get_managed_buffer_size(&th_curr), ptr,
 				&signature_size);
 			copy_mem(&m_local_buffer[m_local_buffer_size], ptr,
@@ -875,7 +875,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
 			free(data);
 			spdm_responder_data_sign(
 				m_use_asym_algo, m_use_hash_algo,
-				get_managed_buffer(&th_curr),
+				FALSE, get_managed_buffer(&th_curr),
 				get_managed_buffer_size(&th_curr), ptr,
 				&signature_size);
 			copy_mem(&m_local_buffer[m_local_buffer_size], ptr,
@@ -1060,7 +1060,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
 			      get_managed_buffer_size(&th_curr), hash_data);
 		free(data);
 		spdm_responder_data_sign(m_use_asym_algo, m_use_hash_algo,
-					 get_managed_buffer(&th_curr),
+					 FALSE, get_managed_buffer(&th_curr),
 					 get_managed_buffer_size(&th_curr), ptr,
 					 &signature_size);
 		copy_mem(&m_local_buffer[m_local_buffer_size], ptr,
@@ -1131,7 +1131,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1182,7 +1182,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1238,7 +1238,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1289,7 +1289,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1340,7 +1340,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1391,7 +1391,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1447,7 +1447,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1500,7 +1500,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1551,7 +1551,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1611,7 +1611,7 @@ void test_spdm_requester_key_exchange_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+    spdm_reset_message_a(spdm_context);
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
@@ -1661,7 +1661,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1672,6 +1672,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 		m_use_aead_algo;
 	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
 		data_size;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1682,7 +1683,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
-
+#endif
 	copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
 		 data, data_size);
 
@@ -1698,11 +1699,13 @@ void test_spdm_requester_key_exchange_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_HANDSHAKING);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	free(data);
 }
 

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -1672,7 +1672,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 		m_use_aead_algo;
 	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
 		data_size;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1699,7 +1699,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_HANDSHAKING);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -968,7 +968,7 @@ void test_spdm_requester_negotiate_algorithms_case1(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
@@ -992,7 +992,7 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size,
 			 sizeof(spdm_negotiate_algorithms_request_t) +
 				 sizeof(spdm_algorithms_response_t));
@@ -1018,7 +1018,7 @@ void test_spdm_requester_negotiate_algorithms_case3(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
@@ -1042,7 +1042,7 @@ void test_spdm_requester_negotiate_algorithms_case4(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
@@ -1066,7 +1066,7 @@ void test_spdm_requester_negotiate_algorithms_case5(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
@@ -1090,7 +1090,7 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size,
 			 sizeof(spdm_negotiate_algorithms_request_t) +
 				 sizeof(spdm_algorithms_response_t));
@@ -1118,7 +1118,7 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
@@ -1163,7 +1163,7 @@ void test_spdm_requester_negotiate_algorithms_case9(void **state)
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
-// #if RECORD_TRANSCRIPT_DATA
+// #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	//  assert_int_equal (spdm_context->transcript.message_a.buffer_size, sizeof(spdm_negotiate_algorithms_request_t) + sizeof(spdm_algorithms_response_t));
 // #endif
 }
@@ -1489,7 +1489,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
   assert_int_equal (spdm_context->transcript.message_a.buffer_size, sizeof(spdm_negotiate_algorithms_request_t) + 4*sizeof(spdm_negotiate_algorithms_common_struct_table_t) + sizeof(spdm_algorithms_response_spdm11_t));
 #endif
 }

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -964,11 +964,13 @@ void test_spdm_requester_negotiate_algorithms_case1(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case2(void **state)
@@ -986,13 +988,15 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size,
 			 sizeof(spdm_negotiate_algorithms_request_t) +
 				 sizeof(spdm_algorithms_response_t));
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case3(void **state)
@@ -1010,11 +1014,13 @@ void test_spdm_requester_negotiate_algorithms_case3(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case4(void **state)
@@ -1032,11 +1038,13 @@ void test_spdm_requester_negotiate_algorithms_case4(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case5(void **state)
@@ -1054,11 +1062,13 @@ void test_spdm_requester_negotiate_algorithms_case5(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case6(void **state)
@@ -1076,13 +1086,15 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size,
 			 sizeof(spdm_negotiate_algorithms_request_t) +
 				 sizeof(spdm_algorithms_response_t));
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case7(void **state)
@@ -1100,13 +1112,15 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case8(void **state)
@@ -1124,7 +1138,7 @@ void test_spdm_requester_negotiate_algorithms_case8(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1145,11 +1159,13 @@ void test_spdm_requester_negotiate_algorithms_case9(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
+// #if RECORD_TRANSCRIPT_DATA
 	//  assert_int_equal (spdm_context->transcript.message_a.buffer_size, sizeof(spdm_negotiate_algorithms_request_t) + sizeof(spdm_algorithms_response_t));
+// #endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case10(void **state)
@@ -1172,7 +1188,7 @@ void test_spdm_requester_negotiate_algorithms_case10(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo = 0;
 	spdm_context->connection_info.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1203,7 +1219,7 @@ void test_spdm_requester_negotiate_algorithms_case11(void **state)
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1229,7 +1245,7 @@ void test_spdm_requester_negotiate_algorithms_case12(void **state)
 	spdm_context->connection_info.algorithm.measurement_hash_algo = 0;
 	spdm_context->connection_info.algorithm.base_asym_algo = 0;
 	spdm_context->connection_info.algorithm.base_hash_algo = 0;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1249,7 +1265,7 @@ void test_spdm_requester_negotiate_algorithms_case13(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1267,7 +1283,7 @@ void test_spdm_requester_negotiate_algorithms_case14(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1285,7 +1301,7 @@ void test_spdm_requester_negotiate_algorithms_case15(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1303,7 +1319,7 @@ void test_spdm_requester_negotiate_algorithms_case16(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1321,7 +1337,7 @@ void test_spdm_requester_negotiate_algorithms_case16(void **state) {
 //   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 //   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 //   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-//   spdm_context->transcript.message_a.buffer_size = 0;
+//   spdm_reset_message_a(spdm_context);
 //
 //   status = spdm_negotiate_algorithms (spdm_context);
 //   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1339,7 +1355,7 @@ void test_spdm_requester_negotiate_algorithms_case17(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1357,7 +1373,7 @@ void test_spdm_requester_negotiate_algorithms_case18(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1375,7 +1391,7 @@ void test_spdm_requester_negotiate_algorithms_case19(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1393,7 +1409,7 @@ void test_spdm_requester_negotiate_algorithms_case20(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1411,7 +1427,7 @@ void test_spdm_requester_negotiate_algorithms_case21(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1429,7 +1445,7 @@ void test_spdm_requester_negotiate_algorithms_case22(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1450,7 +1466,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1473,7 +1489,9 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
   assert_int_equal (spdm_context->transcript.message_a.buffer_size, sizeof(spdm_negotiate_algorithms_request_t) + 4*sizeof(spdm_negotiate_algorithms_common_struct_table_t) + sizeof(spdm_algorithms_response_spdm11_t));
+#endif
 }
 
 void test_spdm_requester_negotiate_algorithms_case24(void **state) {
@@ -1491,7 +1509,7 @@ void test_spdm_requester_negotiate_algorithms_case24(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1531,7 +1549,7 @@ void test_spdm_requester_negotiate_algorithms_case25(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1571,7 +1589,7 @@ void test_spdm_requester_negotiate_algorithms_case26(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1611,7 +1629,7 @@ void test_spdm_requester_negotiate_algorithms_case27(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1651,7 +1669,7 @@ void test_spdm_requester_negotiate_algorithms_case28(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1691,7 +1709,7 @@ void test_spdm_requester_negotiate_algorithms_case29(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1731,7 +1749,7 @@ void test_spdm_requester_negotiate_algorithms_case30(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1771,7 +1789,7 @@ void test_spdm_requester_negotiate_algorithms_case31(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -1528,7 +1528,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 	spdm_context->local_context.psk_hint_size =
 		sizeof(TEST_PSK_HINT_STRING);
 	spdm_context->local_context.psk_hint = m_local_psk_hint;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1553,7 +1553,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_HANDSHAKING);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -940,7 +940,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -995,7 +995,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1055,7 +1055,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1110,7 +1110,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1165,7 +1165,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1220,7 +1220,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1280,7 +1280,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1337,7 +1337,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1392,7 +1392,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1460,7 +1460,7 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+    spdm_reset_message_a(spdm_context);
   
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
@@ -1509,7 +1509,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1528,6 +1528,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 	spdm_context->local_context.psk_hint_size =
 		sizeof(TEST_PSK_HINT_STRING);
 	spdm_context->local_context.psk_hint = m_local_psk_hint;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1538,6 +1539,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	heartbeat_period = 0;
 	zero_mem(measurement_hash, sizeof(measurement_hash));
@@ -1551,11 +1553,13 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_HANDSHAKING);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	
 	free(data);
 }

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -608,7 +608,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -677,7 +677,7 @@ void test_spdm_requester_psk_finish_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -773,7 +773,7 @@ void test_spdm_requester_psk_finish_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -865,7 +865,7 @@ void test_spdm_requester_psk_finish_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -957,7 +957,7 @@ void test_spdm_requester_psk_finish_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1051,7 +1051,7 @@ void test_spdm_requester_psk_finish_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1148,7 +1148,7 @@ void test_spdm_requester_psk_finish_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1242,7 +1242,7 @@ void test_spdm_requester_psk_finish_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1336,7 +1336,7 @@ void test_spdm_requester_psk_finish_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1439,7 +1439,7 @@ void test_spdm_requester_psk_finish_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1502,7 +1502,8 @@ void test_spdm_requester_psk_finish_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1513,6 +1514,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
@@ -1569,11 +1571,13 @@ void test_spdm_requester_psk_finish_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	free(data);
 }
 

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -12,6 +12,15 @@ static uint8 m_local_psk_hint[32];
 static uint8 m_dummy_key_buffer[MAX_AEAD_KEY_SIZE];
 static uint8 m_dummy_salt_buffer[MAX_AEAD_IV_SIZE];
 
+static void spdm_secured_message_set_dummy_finished_key(
+	IN void *spdm_secured_message_context)
+{
+	spdm_secured_message_context_t *secured_message_context;
+
+	secured_message_context = spdm_secured_message_context;
+	secured_message_context->finished_key_ready = TRUE;
+}
+
 void spdm_secured_message_set_response_handshake_encryption_key(
 	IN void *spdm_secured_message_context, IN void *key, IN uintn key_size)
 {
@@ -634,6 +643,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
 	spdm_secured_message_set_session_state(
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_HANDSHAKING);
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -726,6 +736,7 @@ void test_spdm_requester_psk_finish_case2(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -822,6 +833,7 @@ void test_spdm_requester_psk_finish_case3(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -914,6 +926,7 @@ void test_spdm_requester_psk_finish_case4(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1006,6 +1019,7 @@ void test_spdm_requester_psk_finish_case5(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -1100,6 +1114,7 @@ void test_spdm_requester_psk_finish_case6(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1197,6 +1212,7 @@ void test_spdm_requester_psk_finish_case7(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1291,6 +1307,7 @@ void test_spdm_requester_psk_finish_case8(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1385,6 +1402,7 @@ void test_spdm_requester_psk_finish_case9(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1450,7 +1468,8 @@ void test_spdm_requester_psk_finish_case10(void **state) {
     set_mem (m_dummy_salt_buffer, ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size, (uint8)(0xFF));
     spdm_secured_message_set_response_handshake_salt (session_info->secured_message_context, m_dummy_salt_buffer, ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size);
     ((spdm_secured_message_context_t*)(session_info->secured_message_context))->handshake_secret.response_handshake_sequence_number = 0;
-    
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
+
     status = spdm_send_receive_psk_finish (spdm_context, session_id); 
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
@@ -1564,6 +1583,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1669,6 +1689,7 @@ void test_spdm_requester_psk_finish_case12(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -1762,6 +1783,7 @@ void test_spdm_requester_psk_finish_case13(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1856,6 +1878,7 @@ void test_spdm_requester_psk_finish_case14(void **state)
 	((spdm_secured_message_context_t *)(session_info
 						    ->secured_message_context))
 		->handshake_secret.response_handshake_sequence_number = 0;
+	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_UNSUPPORTED);

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -1522,7 +1522,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
 	spdm_reset_message_a(spdm_context);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -1591,7 +1591,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 		spdm_secured_message_get_session_state(
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -912,7 +912,7 @@ void test_spdm_responder_algorithms_case7(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -967,7 +967,7 @@ void test_spdm_responder_algorithms_case8(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1021,7 +1021,7 @@ void test_spdm_responder_algorithms_case9(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1075,7 +1075,7 @@ void test_spdm_responder_algorithms_case10(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1129,7 +1129,7 @@ void test_spdm_responder_algorithms_case11(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1183,7 +1183,7 @@ void test_spdm_responder_algorithms_case12(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1236,7 +1236,7 @@ void test_spdm_responder_algorithms_case13(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1280,7 +1280,7 @@ void test_spdm_responder_algorithms_case14(void **state) {
   spdm_context->local_context.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   response_size = sizeof(response);
   status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request10_size, &m_spdm_negotiate_algorithm_request10, &response_size, response);
@@ -1310,7 +1310,7 @@ void test_spdm_responder_algorithms_case15(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1356,7 +1356,7 @@ void test_spdm_responder_algorithms_case16(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1411,7 +1411,7 @@ void test_spdm_responder_algorithms_case17(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1466,7 +1466,7 @@ void test_spdm_responder_algorithms_case18(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1517,7 +1517,7 @@ void test_spdm_responder_algorithms_case19(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->transcript.message_a.buffer_size = 0;
+  spdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -406,7 +406,7 @@ void test_spdm_responder_capabilities_case1(void **state)
 	spdm_test_context->case_id = 0x1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -422,7 +422,7 @@ void test_spdm_responder_capabilities_case1(void **state)
 			 spdm_response->header.spdm_version);
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_CAPABILITIES);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 #endif

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -406,8 +406,10 @@ void test_spdm_responder_capabilities_case1(void **state)
 	spdm_test_context->case_id = 0x1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	status = spdm_get_response_capabilities(
@@ -420,8 +422,10 @@ void test_spdm_responder_capabilities_case1(void **state)
 			 spdm_response->header.spdm_version);
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_CAPABILITIES);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
+#endif
 }
 
 void test_spdm_responder_capabilities_case2(void **state)
@@ -948,7 +952,7 @@ void test_spdm_responder_capabilities_case18(void **state)
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
 
-	reset_managed_buffer(&spdm_context->transcript.message_a);
+	spdm_reset_message_a(spdm_context);
 
 	response_size = sizeof(response);
 	status = spdm_get_response_capabilities(

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -68,7 +68,7 @@ void test_spdm_responder_certificate_case1(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size;
 	spdm_context->local_context.slot_count = 1;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -88,7 +88,7 @@ void test_spdm_responder_certificate_case1(void **state)
 			 MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
 	assert_int_equal(spdm_response->remainder_length,
 			 data_size - MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 #endif
@@ -953,7 +953,7 @@ void test_spdm_responder_certificate_case12(void **state)
 	if (spdm_response != NULL) {
 		if (spdm_response->header.request_response_code ==
 		    SPDM_CERTIFICATE) {
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_b.buffer_size,
 				sizeof(spdm_get_certificate_request_t) * count +

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -59,6 +59,8 @@ void test_spdm_responder_certificate_case1(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -66,8 +68,10 @@ void test_spdm_responder_certificate_case1(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size;
 	spdm_context->local_context.slot_count = 1;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	status = spdm_get_response_certificate(
@@ -84,8 +88,10 @@ void test_spdm_responder_certificate_case1(void **state)
 			 MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
 	assert_int_equal(spdm_response->remainder_length,
 			 data_size - MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
+#endif
 	free(data);
 }
 
@@ -111,6 +117,8 @@ void test_spdm_responder_certificate_case2(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -157,6 +165,8 @@ void test_spdm_responder_certificate_case3(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -204,6 +214,8 @@ void test_spdm_responder_certificate_case4(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -253,6 +265,8 @@ void test_spdm_responder_certificate_case5(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -306,6 +320,8 @@ void test_spdm_responder_certificate_case6(void **state)
 		SPDM_CONNECTION_STATE_NOT_STARTED;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -360,6 +376,8 @@ void test_spdm_responder_certificate_case7(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -379,7 +397,7 @@ void test_spdm_responder_certificate_case7(void **state)
 					MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		reset_managed_buffer(&spdm_context->transcript.message_b);
+		spdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -438,6 +456,8 @@ void test_spdm_responder_certificate_case8(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -458,7 +478,7 @@ void test_spdm_responder_certificate_case8(void **state)
 		m_spdm_get_certificate_request3.offset = test_offsets[i];
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		reset_managed_buffer(&spdm_context->transcript.message_b);
+		spdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -541,6 +561,8 @@ void test_spdm_responder_certificate_case9(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -565,8 +587,7 @@ void test_spdm_responder_certificate_case9(void **state)
 			m_spdm_get_certificate_request3.offset = test_sizes[j];
 
 			// reseting an internal buffer to avoid overflow and prevent tests to succeed
-			reset_managed_buffer(
-				&spdm_context->transcript.message_b);
+			spdm_reset_message_b(spdm_context);
 			response_size = sizeof(response);
 			status = spdm_get_response_certificate(
 				spdm_context,
@@ -653,6 +674,8 @@ void test_spdm_responder_certificate_case10(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 
 	m_spdm_get_certificate_request3.length = MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 
@@ -680,7 +703,7 @@ void test_spdm_responder_certificate_case10(void **state)
 				m_spdm_get_certificate_request3.length);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		reset_managed_buffer(&spdm_context->transcript.message_b);
+		spdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -764,6 +787,8 @@ void test_spdm_responder_certificate_case11(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 
 	m_spdm_get_certificate_request3.length = MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	m_spdm_get_certificate_request3.offset = 0;
@@ -789,7 +814,7 @@ void test_spdm_responder_certificate_case11(void **state)
 				m_spdm_get_certificate_request3.length);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		reset_managed_buffer(&spdm_context->transcript.message_b);
+		spdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -866,6 +891,8 @@ void test_spdm_responder_certificate_case12(void **state)
 		SPDM_CONNECTION_STATE_AFTER_DIGESTS;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, NULL, NULL);
@@ -882,7 +909,7 @@ void test_spdm_responder_certificate_case12(void **state)
 		m_spdm_get_certificate_request3.length;
 
 	// reseting an internal buffer to avoid overflow and prevent tests to succeed
-	reset_managed_buffer(&spdm_context->transcript.message_b);
+	spdm_reset_message_b(spdm_context);
 
 	spdm_response = NULL;
 	for (uintn offset = 0; offset < data_size; offset++) {
@@ -926,12 +953,14 @@ void test_spdm_responder_certificate_case12(void **state)
 	if (spdm_response != NULL) {
 		if (spdm_response->header.request_response_code ==
 		    SPDM_CERTIFICATE) {
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_b.buffer_size,
 				sizeof(spdm_get_certificate_request_t) * count +
 					sizeof(spdm_certificate_response_t) *
 						count +
 					data_size);
+#endif
 		}
 	}
 	free(data);

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -89,9 +89,11 @@ void test_spdm_responder_challenge_auth_case1(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -110,8 +112,10 @@ void test_spdm_responder_challenge_auth_case1(void **state)
 			 SPDM_CHALLENGE_AUTH);
 	assert_int_equal(spdm_response->header.param1, 0);
 	assert_int_equal(spdm_response->header.param2, 1 << 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
+#endif
 	free(data1);
 }
 
@@ -158,7 +162,7 @@ void test_spdm_responder_challenge_auth_case2(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -222,7 +226,7 @@ void test_spdm_responder_challenge_auth_case3(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -287,7 +291,7 @@ void test_spdm_responder_challenge_auth_case4(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -354,7 +358,7 @@ void test_spdm_responder_challenge_auth_case5(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -426,7 +430,7 @@ void test_spdm_responder_challenge_auth_case6(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_context->transcript.message_c.buffer_size = 0;
+	spdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -479,7 +483,7 @@ void test_spdm_responder_challenge_auth_case7(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -527,7 +531,7 @@ void test_spdm_responder_challenge_auth_case8(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -575,7 +579,7 @@ void test_spdm_responder_challenge_auth_case9(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[1] = data_size1;
   spdm_context->local_context.slot_count = 2;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -623,7 +627,7 @@ void test_spdm_responder_challenge_auth_case10(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -672,7 +676,7 @@ void test_spdm_responder_challenge_auth_case11(void **state) {
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 8;
   spdm_context->local_context.opaque_challenge_auth_rsp = m_opaque_challenge_auth_rsp;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -721,7 +725,7 @@ void test_spdm_responder_challenge_auth_case12(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -770,7 +774,7 @@ void test_spdm_responder_challenge_auth_case13(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -820,7 +824,7 @@ void test_spdm_responder_challenge_auth_case14(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_context->transcript.message_c.buffer_size = 0;
+  spdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -90,7 +90,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
 	spdm_reset_message_c(spdm_context);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -112,7 +112,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
 			 SPDM_CHALLENGE_AUTH);
 	assert_int_equal(spdm_response->header.param1, 0);
 	assert_int_equal(spdm_response->header.param2, 1 << 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 #endif

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -54,8 +54,10 @@ void test_spdm_responder_digests_case1(void **state)
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
 	spdm_context->local_context.slot_count = 1;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	status = spdm_get_response_digests(spdm_context,
@@ -71,8 +73,10 @@ void test_spdm_responder_digests_case1(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_DIGESTS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
+#endif
 }
 
 /**
@@ -348,20 +352,26 @@ void test_spdm_responder_digests_case7(void **state)
 	spdm_context->local_context.slot_count = 1;
 
 	response_size = sizeof(response);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size;
+#endif
 	status = spdm_get_response_digests(spdm_context,
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,
 					   &response_size, response);
 	assert_int_equal(status, RETURN_SUCCESS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+#endif
 	spdm_response = (void *)response;
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_UNSPECIFIED);
 	assert_int_equal(spdm_response->header.param2, 0);
+#endif
 }
 
 /**
@@ -395,21 +405,27 @@ void test_spdm_responder_digests_case8(void **state)
 	spdm_context->local_context.slot_count = 1;
 
 	response_size = sizeof(response);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size -
 		sizeof(spdm_get_digest_request_t);
+#endif
 	status = spdm_get_response_digests(spdm_context,
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,
 					   &response_size, response);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
+#endif
 	spdm_response = (void *)response;
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_UNSPECIFIED);
 	assert_int_equal(spdm_response->header.param2, 0);
+#endif
 }
 
 /**
@@ -445,7 +461,7 @@ void test_spdm_responder_digests_case9(void **state)
 	spdm_context->local_context.slot_count = 0;
 
 	response_size = sizeof(response);
-	spdm_context->transcript.message_b.buffer_size = 0;
+	spdm_reset_message_b(spdm_context);
 	status = spdm_get_response_digests(spdm_context,
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -54,7 +54,7 @@ void test_spdm_responder_digests_case1(void **state)
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
 	spdm_context->local_context.slot_count = 1;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -73,7 +73,7 @@ void test_spdm_responder_digests_case1(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_DIGESTS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 #endif
@@ -352,7 +352,7 @@ void test_spdm_responder_digests_case7(void **state)
 	spdm_context->local_context.slot_count = 1;
 
 	response_size = sizeof(response);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size;
 #endif
@@ -361,11 +361,11 @@ void test_spdm_responder_digests_case7(void **state)
 					   &m_spdm_get_digests_request1,
 					   &response_size, response);
 	assert_int_equal(status, RETURN_SUCCESS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
 #endif
 	spdm_response = (void *)response;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
@@ -405,7 +405,7 @@ void test_spdm_responder_digests_case8(void **state)
 	spdm_context->local_context.slot_count = 1;
 
 	response_size = sizeof(response);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size -
 		sizeof(spdm_get_digest_request_t);
@@ -414,12 +414,12 @@ void test_spdm_responder_digests_case8(void **state)
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,
 					   &response_size, response);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
 #endif
 	spdm_response = (void *)response;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -64,7 +64,7 @@ void test_spdm_responder_end_session_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -140,7 +140,7 @@ void test_spdm_responder_end_session_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -220,7 +220,7 @@ void test_spdm_responder_end_session_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -301,7 +301,7 @@ void test_spdm_responder_end_session_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -384,7 +384,7 @@ void test_spdm_responder_end_session_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -471,7 +471,7 @@ void test_spdm_responder_end_session_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -550,7 +550,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -568,6 +568,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_secured_message_set_session_state(
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_ESTABLISHED);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -578,6 +579,7 @@ void test_spdm_responder_end_session_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	status = spdm_get_response_end_session(spdm_context,
@@ -589,11 +591,13 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_END_SESSION_ACK);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 
 	free(data1);
 }

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -568,7 +568,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_secured_message_set_session_state(
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_ESTABLISHED);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -591,7 +591,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_END_SESSION_ACK);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -44,6 +44,7 @@ void spdm_secured_message_set_request_finished_key(
 	ASSERT(key_size == secured_message_context->hash_size);
 	copy_mem(secured_message_context->handshake_secret.request_finished_key,
 		 key, secured_message_context->hash_size);
+	secured_message_context->finished_key_ready = TRUE;
 }
 
 /**

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -809,7 +809,7 @@ void test_spdm_responder_finish_case7(void **state)
 	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
 	cert_buffer = (uint8 *)data1;
 	cert_buffer_size = data_size1;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -845,7 +845,7 @@ void test_spdm_responder_finish_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_FINISH_RSP);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -105,7 +105,7 @@ void test_spdm_responder_finish_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -213,7 +213,7 @@ void test_spdm_responder_finish_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -324,7 +324,7 @@ void test_spdm_responder_finish_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -438,7 +438,7 @@ void test_spdm_responder_finish_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -554,7 +554,7 @@ void test_spdm_responder_finish_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -676,7 +676,7 @@ void test_spdm_responder_finish_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -782,7 +782,7 @@ void test_spdm_responder_finish_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -808,6 +808,7 @@ void test_spdm_responder_finish_case7(void **state)
 	init_managed_buffer(&th_curr, MAX_SPDM_MESSAGE_BUFFER_SIZE);
 	cert_buffer = (uint8 *)data1;
 	cert_buffer_size = data_size1;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -818,6 +819,7 @@ void test_spdm_responder_finish_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	spdm_hash_all(m_use_hash_algo, cert_buffer, cert_buffer_size,
 		      cert_buffer_hash);
@@ -842,11 +844,13 @@ void test_spdm_responder_finish_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_FINISH_RSP);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 
 	free(data1);
 }
@@ -916,7 +920,7 @@ void test_spdm_responder_finish_case8(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,
@@ -968,7 +972,7 @@ void test_spdm_responder_finish_case8(void **state)
 	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_finish_request3,
 			      sizeof(spdm_finish_request_t));
 	spdm_requester_data_sign(m_use_req_asym_algo, m_use_hash_algo,
-		get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
+		FALSE, get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
 		ptr, &req_asym_signature_size);
 	append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
 	ptr += req_asym_signature_size;
@@ -1052,7 +1056,7 @@ void test_spdm_responder_finish_case9(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1165,7 +1169,7 @@ void test_spdm_responder_finish_case10(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1272,7 +1276,7 @@ void test_spdm_responder_finish_case11(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1368,7 +1372,7 @@ void test_spdm_responder_finish_case12(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1471,7 +1475,7 @@ void test_spdm_responder_finish_case13(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1584,7 +1588,7 @@ void test_spdm_responder_finish_case14(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1703,7 +1707,7 @@ void test_spdm_responder_finish_case15(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,
@@ -1755,7 +1759,7 @@ void test_spdm_responder_finish_case15(void **state)
 	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_finish_request3,
 			      sizeof(spdm_finish_request_t));
 	spdm_requester_data_sign(m_use_req_asym_algo, m_use_hash_algo,
-		get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
+		FALSE, get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
 		ptr, &req_asym_signature_size);
 	append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
 	ptr += req_asym_signature_size;
@@ -1849,7 +1853,7 @@ void test_spdm_responder_finish_case16(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,
@@ -1904,7 +1908,7 @@ void test_spdm_responder_finish_case16(void **state)
 	spdm_hash_all(m_use_hash_algo, get_managed_buffer(&th_curr),
 		      get_managed_buffer_size(&th_curr), random_buffer);
 	spdm_requester_data_sign(m_use_req_asym_algo, m_use_hash_algo,
-		random_buffer, hash_size, ptr, &req_asym_signature_size);
+		FALSE, random_buffer, hash_size, ptr, &req_asym_signature_size);
 	append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
 	ptr += req_asym_signature_size;
 	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -64,7 +64,7 @@ void test_spdm_responder_heartbeat_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -140,7 +140,7 @@ void test_spdm_responder_heartbeat_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -220,7 +220,7 @@ void test_spdm_responder_heartbeat_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -301,7 +301,7 @@ void test_spdm_responder_heartbeat_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -384,7 +384,7 @@ void test_spdm_responder_heartbeat_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -471,7 +471,7 @@ void test_spdm_responder_heartbeat_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -550,7 +550,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -558,6 +558,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_context->local_context.psk_hint_size =
 		sizeof(TEST_PSK_HINT_STRING);
 	spdm_context->local_context.psk_hint = m_local_psk_hint;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -568,6 +569,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	session_id = 0xFFFFFFFF;
 	spdm_context->latest_session_id = session_id;
@@ -589,11 +591,13 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_HEARTBEAT_ACK);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 
 	free(data1);
 }

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -558,7 +558,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_context->local_context.psk_hint_size =
 		sizeof(TEST_PSK_HINT_STRING);
 	spdm_context->local_context.psk_hint = m_local_psk_hint;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -591,7 +591,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_HEARTBEAT_ACK);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -562,7 +562,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
 	spdm_context->local_context.slot_count = 1;
 	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -604,7 +604,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_KEY_EXCHANGE_RSP);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -76,7 +76,7 @@ void test_spdm_responder_key_exchange_case1(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -155,7 +155,7 @@ void test_spdm_responder_key_exchange_case2(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -234,7 +234,7 @@ void test_spdm_responder_key_exchange_case3(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -314,7 +314,7 @@ void test_spdm_responder_key_exchange_case4(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -396,7 +396,7 @@ void test_spdm_responder_key_exchange_case5(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -482,7 +482,7 @@ void test_spdm_responder_key_exchange_case6(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -560,8 +560,9 @@ void test_spdm_responder_key_exchange_case7(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -572,6 +573,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
 			       m_spdm_key_exchange_request1.random_data);
@@ -602,11 +604,13 @@ void test_spdm_responder_key_exchange_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_KEY_EXCHANGE_RSP);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 
 	free(data1);
 }

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -122,7 +122,7 @@ void test_spdm_responder_measurements_case1(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -140,11 +140,13 @@ void test_spdm_responder_measurements_case1(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->header.param1,
 			 MEASUREMENT_BLOCK_NUMBER);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request1_size +
 				 sizeof(spdm_measurements_response_t) +
 				 SPDM_NONCE_SIZE +
 				 sizeof(uint16));
+#endif
 }
 
 /**
@@ -175,7 +177,7 @@ void test_spdm_responder_measurements_case2(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -193,7 +195,9 @@ void test_spdm_responder_measurements_case2(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -225,7 +229,7 @@ void test_spdm_responder_measurements_case3(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -244,7 +248,9 @@ void test_spdm_responder_measurements_case3(void **state)
 	assert_int_equal(spdm_response->header.param2, 0);
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_BUSY);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -276,7 +282,7 @@ void test_spdm_responder_measurements_case4(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -296,7 +302,9 @@ void test_spdm_responder_measurements_case4(void **state)
 	assert_int_equal(spdm_response->header.param2, 0);
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_NEED_RESYNC);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -329,7 +337,7 @@ void test_spdm_responder_measurements_case5(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -354,7 +362,9 @@ void test_spdm_responder_measurements_case5(void **state)
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_NOT_READY);
 	assert_int_equal(error_data->request_code, SPDM_GET_MEASUREMENTS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -387,7 +397,7 @@ void test_spdm_responder_measurements_case6(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -405,7 +415,9 @@ void test_spdm_responder_measurements_case6(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -437,7 +449,7 @@ void test_spdm_responder_measurements_case7(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -457,7 +469,9 @@ void test_spdm_responder_measurements_case7(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->header.param1,
 			 MEASUREMENT_BLOCK_NUMBER);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -489,7 +503,7 @@ void test_spdm_responder_measurements_case8(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -510,7 +524,9 @@ void test_spdm_responder_measurements_case8(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -541,7 +557,7 @@ void test_spdm_responder_measurements_case9(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -559,7 +575,9 @@ void test_spdm_responder_measurements_case9(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -590,7 +608,7 @@ void test_spdm_responder_measurements_case10(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -610,6 +628,7 @@ void test_spdm_responder_measurements_case10(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request6_size +
 				 sizeof(spdm_measurements_response_t) +
@@ -617,6 +636,7 @@ void test_spdm_responder_measurements_case10(void **state)
 				 spdm_get_measurement_hash_size(
 					 m_use_measurement_hash_algo) + SPDM_NONCE_SIZE +
 				 sizeof(uint16));
+#endif
 }
 
 /**
@@ -648,7 +668,7 @@ void test_spdm_responder_measurements_case11(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -675,7 +695,9 @@ void test_spdm_responder_measurements_case11(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->number_of_blocks,
 			 MEASUREMENT_BLOCK_NUMBER);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -706,7 +728,7 @@ void test_spdm_responder_measurements_case12(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -731,6 +753,7 @@ void test_spdm_responder_measurements_case12(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->number_of_blocks,
 			 MEASUREMENT_BLOCK_NUMBER);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request7_size +
 				 sizeof(spdm_measurements_response_t) +
@@ -741,6 +764,7 @@ void test_spdm_responder_measurements_case12(void **state)
 				 (sizeof(spdm_measurement_block_dmtf_t) +
 				  MEASUREMENT_MANIFEST_SIZE) + SPDM_NONCE_SIZE +
 				 sizeof(uint16));
+#endif
 }
 
 /**
@@ -785,7 +809,7 @@ void test_spdm_responder_measurements_case13(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -806,8 +830,10 @@ void test_spdm_responder_measurements_case13(void **state)
 		assert_int_equal(spdm_response->header.param1,
 				 SPDM_ERROR_CODE_INVALID_REQUEST);
 		assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
+#endif
 	}
 }
 
@@ -853,7 +879,7 @@ void test_spdm_responder_measurements_case14(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -874,8 +900,10 @@ void test_spdm_responder_measurements_case14(void **state)
 		assert_int_equal(spdm_response->header.param1,
 				 SPDM_ERROR_CODE_INVALID_REQUEST);
 		assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
+#endif
 	}
 }
 
@@ -910,7 +938,7 @@ void test_spdm_responder_measurements_case15(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -929,7 +957,9 @@ void test_spdm_responder_measurements_case15(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -963,7 +993,7 @@ void test_spdm_responder_measurements_case16(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -980,7 +1010,9 @@ void test_spdm_responder_measurements_case16(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1012,7 +1044,7 @@ void test_spdm_responder_measurements_case17(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	;
@@ -1034,7 +1066,9 @@ void test_spdm_responder_measurements_case17(void **state)
 	assert_int_equal(
 		spdm_response->header.param2,
 		m_spdm_get_measurements_request10.header.request_response_code);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1069,7 +1103,7 @@ void test_spdm_responder_measurements_case18(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	read_responder_public_certificate_chain(m_use_hash_algo,
@@ -1101,7 +1135,9 @@ void test_spdm_responder_measurements_case18(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 	assert_int_equal(m_spdm_get_measurements_request11.SlotIDParam,
 			 spdm_response->header.param2);
 
@@ -1139,7 +1175,7 @@ void test_spdm_responder_measurements_case19(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1158,7 +1194,9 @@ void test_spdm_responder_measurements_case19(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1191,7 +1229,7 @@ void test_spdm_responder_measurements_case20(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1210,7 +1248,9 @@ void test_spdm_responder_measurements_case20(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1242,7 +1282,7 @@ void test_spdm_responder_measurements_case21(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -1260,7 +1300,9 @@ void test_spdm_responder_measurements_case21(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+#endif
 }
 
 /**
@@ -1295,7 +1337,7 @@ void test_spdm_responder_measurements_case22(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_context->transcript.message_m.buffer_size = 0;
+	spdm_reset_message_m(spdm_context);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -1322,6 +1364,7 @@ void test_spdm_responder_measurements_case22(void **state)
 					spdm_get_measurement_hash_size(
 						m_use_measurement_hash_algo) + SPDM_NONCE_SIZE +
 					sizeof(uint16));
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				NumberOfMessages *
@@ -1331,13 +1374,16 @@ void test_spdm_responder_measurements_case22(void **state)
 					 spdm_get_measurement_hash_size(
 						 m_use_measurement_hash_algo) + SPDM_NONCE_SIZE +
 					 sizeof(uint16)));
+#endif
 		} else {
 			assert_int_equal(
 				spdm_response->header.request_response_code,
 				SPDM_ERROR);
+#if RECORD_TRANSCRIPT_DATA
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);
+#endif
 			break;
 		}
 	}

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -140,7 +140,7 @@ void test_spdm_responder_measurements_case1(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->header.param1,
 			 MEASUREMENT_BLOCK_NUMBER);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request1_size +
 				 sizeof(spdm_measurements_response_t) +
@@ -195,7 +195,7 @@ void test_spdm_responder_measurements_case2(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -248,7 +248,7 @@ void test_spdm_responder_measurements_case3(void **state)
 	assert_int_equal(spdm_response->header.param2, 0);
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_BUSY);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -302,7 +302,7 @@ void test_spdm_responder_measurements_case4(void **state)
 	assert_int_equal(spdm_response->header.param2, 0);
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_NEED_RESYNC);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -362,7 +362,7 @@ void test_spdm_responder_measurements_case5(void **state)
 	assert_int_equal(spdm_context->response_state,
 			 SPDM_RESPONSE_STATE_NOT_READY);
 	assert_int_equal(error_data->request_code, SPDM_GET_MEASUREMENTS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -415,7 +415,7 @@ void test_spdm_responder_measurements_case6(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -469,7 +469,7 @@ void test_spdm_responder_measurements_case7(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->header.param1,
 			 MEASUREMENT_BLOCK_NUMBER);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -524,7 +524,7 @@ void test_spdm_responder_measurements_case8(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -575,7 +575,7 @@ void test_spdm_responder_measurements_case9(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -628,7 +628,7 @@ void test_spdm_responder_measurements_case10(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request6_size +
 				 sizeof(spdm_measurements_response_t) +
@@ -695,7 +695,7 @@ void test_spdm_responder_measurements_case11(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->number_of_blocks,
 			 MEASUREMENT_BLOCK_NUMBER);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -753,7 +753,7 @@ void test_spdm_responder_measurements_case12(void **state)
 			 SPDM_MEASUREMENTS);
 	assert_int_equal(spdm_response->number_of_blocks,
 			 MEASUREMENT_BLOCK_NUMBER);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 m_spdm_get_measurements_request7_size +
 				 sizeof(spdm_measurements_response_t) +
@@ -830,7 +830,7 @@ void test_spdm_responder_measurements_case13(void **state)
 		assert_int_equal(spdm_response->header.param1,
 				 SPDM_ERROR_CODE_INVALID_REQUEST);
 		assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
 #endif
@@ -900,7 +900,7 @@ void test_spdm_responder_measurements_case14(void **state)
 		assert_int_equal(spdm_response->header.param1,
 				 SPDM_ERROR_CODE_INVALID_REQUEST);
 		assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 		assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 				 0);
 #endif
@@ -957,7 +957,7 @@ void test_spdm_responder_measurements_case15(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1010,7 +1010,7 @@ void test_spdm_responder_measurements_case16(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1066,7 +1066,7 @@ void test_spdm_responder_measurements_case17(void **state)
 	assert_int_equal(
 		spdm_response->header.param2,
 		m_spdm_get_measurements_request10.header.request_response_code);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1135,7 +1135,7 @@ void test_spdm_responder_measurements_case18(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_MEASUREMENTS);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 	assert_int_equal(m_spdm_get_measurements_request11.SlotIDParam,
@@ -1194,7 +1194,7 @@ void test_spdm_responder_measurements_case19(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1248,7 +1248,7 @@ void test_spdm_responder_measurements_case20(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1300,7 +1300,7 @@ void test_spdm_responder_measurements_case21(void **state)
 	assert_int_equal(spdm_response->header.param1,
 			 SPDM_ERROR_CODE_INVALID_REQUEST);
 	assert_int_equal(spdm_response->header.param2, 0);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
 }
@@ -1364,7 +1364,7 @@ void test_spdm_responder_measurements_case22(void **state)
 					spdm_get_measurement_hash_size(
 						m_use_measurement_hash_algo) + SPDM_NONCE_SIZE +
 					sizeof(uint16));
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				NumberOfMessages *
@@ -1379,7 +1379,7 @@ void test_spdm_responder_measurements_case22(void **state)
 			assert_int_equal(
 				spdm_response->header.request_response_code,
 				SPDM_ERROR);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 			assert_int_equal(
 				spdm_context->transcript.message_m.buffer_size,
 				0);

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -80,7 +80,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -104,8 +104,10 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	ptr += m_spdm_psk_exchange_request1.context_length;
 	spdm_build_opaque_data_supported_version_data(
 		spdm_context, &opaque_psk_exchange_req_size, ptr);
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
+#endif
 	ptr += opaque_psk_exchange_req_size;
 	response_size = sizeof(response);
 	status = spdm_get_response_psk_exchange(
@@ -120,8 +122,10 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_EXCHANGE_RSP);
 	assert_int_equal(spdm_response->rsp_session_id, 0xFFFF);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
+#endif
 	free(data1);
 }
 
@@ -169,7 +173,7 @@ void test_spdm_responder_psk_exchange_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -254,7 +258,7 @@ void test_spdm_responder_psk_exchange_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -340,7 +344,7 @@ void test_spdm_responder_psk_exchange_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -428,7 +432,7 @@ void test_spdm_responder_psk_exchange_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -520,7 +524,7 @@ void test_spdm_responder_psk_exchange_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -604,7 +608,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -628,10 +632,9 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 	ptr += m_spdm_psk_exchange_request1.context_length;
 	spdm_build_opaque_data_supported_version_data(
 		spdm_context, &opaque_psk_exchange_req_size, ptr);
-	spdm_context->transcript.message_m.buffer_size =
-		spdm_context->transcript.message_m.max_buffer_size;
 	ptr += opaque_psk_exchange_req_size;
 
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -642,6 +645,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	response_size = sizeof(response);
 	status = spdm_get_response_psk_exchange(
@@ -655,13 +659,13 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_EXCHANGE_RSP);
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-					0);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 
 	free(data1);
 }

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -104,7 +104,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	ptr += m_spdm_psk_exchange_request1.context_length;
 	spdm_build_opaque_data_supported_version_data(
 		spdm_context, &opaque_psk_exchange_req_size, ptr);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
 #endif
@@ -122,7 +122,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_EXCHANGE_RSP);
 	assert_int_equal(spdm_response->rsp_session_id, 0xFFFF);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 					0);
 #endif
@@ -634,7 +634,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 		spdm_context, &opaque_psk_exchange_req_size, ptr);
 	ptr += opaque_psk_exchange_req_size;
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -659,7 +659,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_EXCHANGE_RSP);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -787,7 +787,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
 			      sizeof(spdm_psk_finish_request_t));
 
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -816,7 +816,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_FINISH_RSP);
-#if RECORD_TRANSCRIPT_DATA
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -39,6 +39,7 @@ static void spdm_secured_message_set_request_finished_key(
 	ASSERT(key_size == secured_message_context->hash_size);
 	copy_mem(secured_message_context->handshake_secret.request_finished_key,
 		 key, secured_message_context->hash_size);
+	secured_message_context->finished_key_ready = TRUE;
 }
 
 /**

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -96,7 +96,7 @@ void test_spdm_responder_psk_finish_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -200,7 +200,7 @@ void test_spdm_responder_psk_finish_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -307,7 +307,7 @@ void test_spdm_responder_psk_finish_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -418,7 +418,7 @@ void test_spdm_responder_psk_finish_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -531,7 +531,7 @@ void test_spdm_responder_psk_finish_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -650,7 +650,7 @@ void test_spdm_responder_psk_finish_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -753,7 +753,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_context->transcript.message_a.buffer_size = 0;
+	spdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -786,6 +786,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	append_managed_buffer(&th_curr, (uint8 *)&m_spdm_psk_finish_request1,
 			      sizeof(spdm_psk_finish_request_t));
 
+#if RECORD_TRANSCRIPT_DATA
 	spdm_context->transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
@@ -796,6 +797,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 							spdm_context->transcript.message_mut_b.max_buffer_size;
 	spdm_context->transcript.message_mut_c.buffer_size =
 							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 
 	set_mem(request_finished_key, MAX_HASH_SIZE, (uint8)(0xFF));
 	spdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
@@ -813,11 +815,13 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_FINISH_RSP);
+#if RECORD_TRANSCRIPT_DATA
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_c.buffer_size, 0);
+#endif
 	 
 	free(data1);
 }

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -263,6 +263,7 @@ static void spdm_secured_message_set_request_finished_key(
 	ASSERT(key_size == secured_message_context->hash_size);
 	copy_mem(secured_message_context->handshake_secret.request_finished_key,
 		 key, secured_message_context->hash_size);
+	secured_message_context->finished_key_ready = TRUE;
 }
 
 /**
@@ -831,7 +832,7 @@ void test_spdm_responder_respond_if_ready_case8(void **state) {
   spdm_context->last_spdm_request_session_id_valid = TRUE;
   spdm_context->last_spdm_request_session_id = session_id;
   session_info = &spdm_context->session_info[0];
-  spdm_session_info_init (spdm_context, session_info, session_id, FALSE);
+  spdm_session_info_init (spdm_context, session_info, session_id, TRUE);
   hash_size = spdm_get_hash_size (m_use_hash_algo);
   set_mem (dummy_buffer, hash_size, (uint8)(0xFF));
   spdm_secured_message_set_request_finished_key (session_info->secured_message_context, dummy_buffer, hash_size);


### PR DESCRIPTION
REF: https://github.com/DMTF/libspdm/issues/22

The context size is reduced from 0x12c10 (76K) to 0x7078 (29K).

The scope is message_b/c/mut_b/mut_c, message_m(measurement),
and message_k/f(key_exchange/finish).

We cannot do for message_a, because the algo is not negotiated yet.
We still need cache partial message_k, before finished_key is ready.

Test:
1) Pass unit test with RECORD_TRANSCRIPT_DATA on/off
2) Pass emu test with responder (data) + requester (hash)
3) Pass emu test with responder (hash) + requester (data)

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
