### PR TITLE
Adding new test cases for the key_update message (requester side)

### DIFF
--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(src_test_spdm_requester
     psk_exchange.c
     psk_finish.c
     heartbeat.c
+    key_update.c
     end_session.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -9,6 +9,9 @@
 #include <spdm_secured_message_lib_internal.h>
 
 static uint8 my_last_token;
+static uint8 my_last_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+static uint8 my_last_rsp_salt[MAX_AEAD_IV_SIZE];
+static uint64 my_last_rsp_sequence_number;
 
 static void spdm_set_standard_key_update_test_state(
 	IN OUT spdm_context_t *spdm_context, IN OUT uint32 *session_id)
@@ -542,6 +545,210 @@ return_status spdm_requester_key_update_test_send_message(
 		my_last_token = ((spdm_key_update_request_t 
 			  *) decoded_message)->header.param2;
 	}
+		return RETURN_SUCCESS;
+	case 0x1B: {
+		return_status       status;
+		uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn               decoded_message_size;
+		uint32              session_id;
+		uint32              *message_session_id;
+		boolean             is_app_message;
+		spdm_session_info_t *session_info;
+
+		message_session_id = NULL;
+		session_id = 0xFFFFFFFF;
+		decoded_message_size = sizeof(decoded_message);
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.request_data_sequence_number--;
+		status = spdm_transport_test_decode_message(spdm_context,
+		      &message_session_id, &is_app_message, TRUE, request_size,
+		      request, &decoded_message_size, decoded_message);
+		if (RETURN_ERROR(status)) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		my_last_token = ((spdm_key_update_request_t 
+			  *) decoded_message)->header.param2;
+	}
+		return RETURN_SUCCESS;
+	case 0x1C: {
+		static uintn sub_index = 0;
+
+		if(sub_index > 0) {
+			return_status       status;
+			uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn               decoded_message_size;
+			uint32              session_id;
+			uint32              *message_session_id;
+			boolean             is_app_message;
+			spdm_session_info_t *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x1D: {
+		static uintn sub_index = 0;
+
+		if(sub_index > 0) {
+			return_status       status;
+			uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn               decoded_message_size;
+			uint32              session_id;
+			uint32              *message_session_id;
+			boolean             is_app_message;
+			spdm_session_info_t *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x1E: {
+		static uintn sub_index = 0;
+
+		if(sub_index > 0) {
+			return_status       status;
+			uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn               decoded_message_size;
+			uint32              session_id;
+			uint32              *message_session_id;
+			boolean             is_app_message;
+			spdm_session_info_t *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x1F:
+	case 0x20:
+		return RETURN_SUCCESS;
+	case 0x21: {
+		static uintn sub_index = 0;
+
+		if(sub_index != 1) {
+			return_status          status;
+			uint8 decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn decoded_message_size;
+			uint32                 session_id;
+			uint32 *message_session_id;
+			boolean is_app_message;
+			spdm_session_info_t    *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x22:
 		return RETURN_SUCCESS;
 	default:
 		return RETURN_DEVICE_ERROR;
@@ -1801,6 +2008,574 @@ return_status spdm_requester_key_update_test_receive_message(
 			->application_secret.response_data_sequence_number--;
 
 		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1B: {
+		static uintn sub_index = 0;
+
+		spdm_key_update_response_t spdm_response;
+		uint32                     session_id;
+		spdm_session_info_t        *session_info;
+
+		session_id = 0xFFFFFFFF;
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = SPDM_KEY_UPDATE_ACK;
+		if (sub_index == 0) {
+			spdm_response.header.param1 =
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS;
+			spdm_response.header.param2 = my_last_token;
+		} else if (sub_index == 1) {
+			spdm_response.header.param1 =
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			/* as it is using single context, the keys were updated
+			   in the requester and do not need to be updated before
+			   sending the response */
+		}
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1C: {
+		spdm_error_response_t  spdm_response;
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+		uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+		uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+		uint64 curr_rsp_sequence_number;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		//use previous key to send
+		copy_mem(curr_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(curr_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+		curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, my_last_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, my_last_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = SPDM_ERROR;
+		spdm_response.header.param1 = SPDM_ERROR_CODE_INVALID_REQUEST;
+		spdm_response.header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+
+		//restore new key
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, curr_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, curr_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = curr_rsp_sequence_number;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1D: {
+		spdm_error_response_t  spdm_response;
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+		uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+		uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+		uint64 curr_rsp_sequence_number;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		//use previous key to send
+		copy_mem(curr_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(curr_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+		curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, my_last_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, my_last_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = SPDM_ERROR;
+		spdm_response.header.param1 = SPDM_ERROR_CODE_BUSY;
+		spdm_response.header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+
+		//restore new key
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, curr_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, curr_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = curr_rsp_sequence_number;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1E: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		if (sub_index == 0) {
+			spdm_error_response_t spdm_response;
+
+			uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+			uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+			uint64 curr_rsp_sequence_number;
+
+			//use previous key to send
+			copy_mem(curr_rsp_enc_key, secured_message_context
+				  ->application_secret.response_data_encryption_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(curr_rsp_salt, secured_message_context
+				  ->application_secret.response_data_salt,
+				  secured_message_context->aead_iv_size);
+			curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, my_last_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, my_last_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+			spdm_response.header.spdm_version =
+				SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = SPDM_ERROR_CODE_BUSY;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+
+			//restore new key
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, curr_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, curr_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = curr_rsp_sequence_number;
+		} else if (sub_index == 1) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			secured_message_context->application_secret
+				  .response_data_sequence_number--;
+		} else if (sub_index == 2) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+			  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			secured_message_context->application_secret
+				  .response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1F: {
+		spdm_error_response_t  spdm_response;
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+		uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+		uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+		uint64 curr_rsp_sequence_number;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		//use previous key to send
+		copy_mem(curr_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(curr_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+		curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, my_last_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, my_last_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = SPDM_ERROR;
+		spdm_response.header.param1 = SPDM_ERROR_CODE_REQUEST_RESYNCH;
+		spdm_response.header.param2 = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+
+		//restore new key
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, curr_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, curr_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = curr_rsp_sequence_number;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x20: {
+		spdm_error_response_data_response_not_ready_t spdm_response;
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+		uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+		uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+		uint64 curr_rsp_sequence_number;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		//use previous key to send
+		copy_mem(curr_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(curr_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+		curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, my_last_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, my_last_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = SPDM_ERROR;
+		spdm_response.header.param1 =
+			SPDM_ERROR_CODE_RESPONSE_NOT_READY;
+		spdm_response.header.param2 = 0;
+		spdm_response.extend_error_data.rd_exponent = 1;
+		spdm_response.extend_error_data.rd_tm = 1;
+		spdm_response.extend_error_data.request_code = SPDM_KEY_UPDATE;
+		spdm_response.extend_error_data.token = 0;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+
+		//restore new key
+		copy_mem(secured_message_context->application_secret
+			  .response_data_encryption_key, curr_rsp_enc_key,
+			  secured_message_context->aead_key_size);
+		copy_mem(secured_message_context->application_secret
+			  .response_data_salt, curr_rsp_salt,
+			  secured_message_context->aead_iv_size);
+		secured_message_context->application_secret
+			  .response_data_sequence_number = curr_rsp_sequence_number;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x21: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_secured_message_context_t *secured_message_context;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		if (sub_index == 0) {
+			spdm_error_response_data_response_not_ready_t
+				spdm_response;
+
+			uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+			uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+			uint64 curr_rsp_sequence_number;
+
+			//use previous key to send
+			copy_mem(curr_rsp_enc_key, secured_message_context
+				  ->application_secret.response_data_encryption_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(curr_rsp_salt, secured_message_context
+				  ->application_secret.response_data_salt,
+				  secured_message_context->aead_iv_size);
+			curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, my_last_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, my_last_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+			spdm_response.header.spdm_version =
+				SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 =
+				SPDM_ERROR_CODE_RESPONSE_NOT_READY;
+			spdm_response.header.param2 = 0;
+			spdm_response.extend_error_data.rd_exponent = 1;
+			spdm_response.extend_error_data.rd_tm = 1;
+			spdm_response.extend_error_data.request_code =
+				SPDM_KEY_UPDATE;
+			spdm_response.extend_error_data.token = 1;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+
+			//restore new key
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, curr_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, curr_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = curr_rsp_sequence_number;
+		} else if (sub_index == 1) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			secured_message_context->application_secret
+				  .response_data_sequence_number--;
+		} else if (sub_index == 2) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+			  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			secured_message_context->application_secret
+				  .response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x22: {
+		static uint16 error_code = SPDM_ERROR_CODE_RESERVED_00;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		spdm_error_response_t    spdm_response;
+
+		spdm_secured_message_context_t *secured_message_context;
+		uint8 curr_rsp_enc_key[MAX_AEAD_KEY_SIZE];
+		uint8 curr_rsp_salt[MAX_AEAD_IV_SIZE];
+		uint64 curr_rsp_sequence_number;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		secured_message_context = session_info->secured_message_context;
+
+		if(error_code <= 0xff) {
+			//use previous key to send
+			copy_mem(curr_rsp_enc_key, secured_message_context
+				  ->application_secret.response_data_encryption_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(curr_rsp_salt, secured_message_context
+				  ->application_secret.response_data_salt,
+				  secured_message_context->aead_iv_size);
+			curr_rsp_sequence_number = my_last_rsp_sequence_number;
+
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, my_last_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, my_last_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = my_last_rsp_sequence_number;
+
+			zero_mem (&spdm_response, sizeof(spdm_response));
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = (uint8) error_code;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+
+			//restore new key
+			copy_mem(secured_message_context->application_secret
+				  .response_data_encryption_key, curr_rsp_enc_key,
+				  secured_message_context->aead_key_size);
+			copy_mem(secured_message_context->application_secret
+				  .response_data_salt, curr_rsp_salt,
+				  secured_message_context->aead_iv_size);
+			secured_message_context->application_secret
+				  .response_data_sequence_number = curr_rsp_sequence_number;
+		}
+
+		error_code++;
+		//busy is treated in cases 5 and 6
+		if(error_code == SPDM_ERROR_CODE_BUSY) {
+			error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+		}
+		//skip some reserved error codes (0d to 3e)
+		if(error_code == SPDM_ERROR_CODE_RESERVED_0D) {
+			error_code = SPDM_ERROR_CODE_RESERVED_3F;
+		}
+		//skip response not ready, request resync, and some reserved codes (44 to fc)
+		if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) { 
+			error_code = SPDM_ERROR_CODE_RESERVED_FD;
+		}
 	}
 		return RETURN_SUCCESS;
 
@@ -3192,6 +3967,536 @@ void test_spdm_requester_key_update_case26(void **state)
 		  *)(session_info->secured_message_context))->hash_size);
 }
 
+/**
+  Test 27: receiving a correct UPDATE_KEY_ACK message for updating
+  both the request data key and the response data key.
+  Expected behavior: client returns a Status of RETURN_SUCCESS, and
+  the request data key and response data key are updated.
+**/
+void test_spdm_requester_key_update_case27(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1B;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_rsp_secret_buffer, m_rsp_secret_buffer,
+		  sizeof(m_rsp_secret_buffer));
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 28: the requester is setup correctly (see Test 27), but receives an
+  ERROR message indicating InvalidParameters when updating all keys.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
+  no keys should be updated.
+**/
+void test_spdm_requester_key_update_case28(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1C;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	//no keys are updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 29: the requester is setup correctly (see Test 27), but receives an
+  ERROR message indicating the Busy status of the responder, when updating
+  all keys.
+  Expected behavior: client returns a Status of RETURN_NO_RESPONSE, and
+  no keys should be updated.
+**/
+void test_spdm_requester_key_update_case29(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1D;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	//no keys are updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_NO_RESPONSE);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 30: the requester is setup correctly (see Test 27), but, when updating
+  all keys, on the first try, receiving a Busy ERROR message, and on retry,
+  receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY behavior is
+  not altered.
+  Expected behavior: client returns a Status of RETURN_SUCCESS, and
+  the request data key and response data key are updated.
+**/
+void test_spdm_requester_key_update_case30(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1E;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_rsp_secret_buffer, m_rsp_secret_buffer,
+		  sizeof(m_rsp_secret_buffer));
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 31: the requester is setup correctly (see Test 27), but receives an
+  ERROR message indicating the RequestResynch status of the responder, when
+  updating all keys.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the 
+  communication is reset to expect a new GET_VERSION message.
+**/
+void test_spdm_requester_key_update_case31(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1F;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_int_equal(spdm_context->connection_info.connection_state,
+			 SPDM_CONNECTION_STATE_NOT_STARTED);
+}
+
+/**
+  Test 32: the requester is setup correctly (see Test 27), but receives an
+  ERROR message indicating the ResponseNotReady status of the responder, when
+  updating all keys.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
+  no keys should be updated.
+**/
+void test_spdm_requester_key_update_case32(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x20;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	//no keys are updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 33: the requester is setup correctly (see Test 27), but, when updating
+  all keys, on the first try, receiving a ResponseNotReady ERROR message, and
+  on retry, receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY
+  behavior is not altered.
+  Expected behavior: client returns a Status of RETURN_SUCCESS, and
+  the request data key and response data key are updated.
+**/
+void test_spdm_requester_key_update_case33(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x21;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//store previous encryption state
+	copy_mem(my_last_rsp_enc_key, secured_message_context
+			  ->application_secret.response_data_encryption_key,
+			  secured_message_context->aead_key_size);
+	copy_mem(my_last_rsp_salt, secured_message_context
+			  ->application_secret.response_data_salt,
+			  secured_message_context->aead_iv_size);
+	my_last_rsp_sequence_number = secured_message_context
+			  ->application_secret.response_data_sequence_number;
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_rsp_secret_buffer, m_rsp_secret_buffer,
+		  sizeof(m_rsp_secret_buffer));
+
+	status = spdm_key_update(
+		spdm_context, session_id, FALSE);
+
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 34: receiving an unexpected ERROR message from the responder,
+  when updating all keys.
+  There are tests for all named codes, including some reserved ones
+  (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
+  However, for having specific test cases, it is excluded from this case:
+  Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
+  Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and
+  no keys should be updated.
+**/
+void test_spdm_requester_key_update_case34(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+	uint16                 error_code;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_secured_message_context_t *secured_message_context;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x22;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+	secured_message_context = session_info->secured_message_context;
+
+	error_code = SPDM_ERROR_CODE_RESERVED_00;
+	while(error_code <= 0xff) {
+		spdm_set_standard_key_update_test_secrets(
+			  session_info->secured_message_context,
+			  m_rsp_secret_buffer, (uint8)(0xFF),
+			  m_req_secret_buffer, (uint8)(0xEE));
+
+		//store previous encryption state
+		copy_mem(my_last_rsp_enc_key, secured_message_context
+				  ->application_secret.response_data_encryption_key,
+				  secured_message_context->aead_key_size);
+		copy_mem(my_last_rsp_salt, secured_message_context
+				  ->application_secret.response_data_salt,
+				  secured_message_context->aead_iv_size);
+		my_last_rsp_sequence_number = secured_message_context
+				  ->application_secret.response_data_sequence_number;
+
+		//no keys are updated
+
+		status = spdm_key_update(
+			spdm_context, session_id, FALSE);
+
+		// assert_int_equal (status, RETURN_DEVICE_ERROR);
+		ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+		assert_memory_equal(((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				  ->application_secret.request_data_secret,
+			  m_req_secret_buffer, ((spdm_secured_message_context_t 
+			  *)(session_info->secured_message_context))->hash_size);
+		assert_memory_equal(((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				  ->application_secret.response_data_secret,
+			  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+			  *)(session_info->secured_message_context))->hash_size);
+
+		error_code++;
+		//busy is treated in cases 5 and 6
+		if(error_code == SPDM_ERROR_CODE_BUSY) {
+			error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+		}
+		//skip some reserved error codes (0d to 3e)
+		if(error_code == SPDM_ERROR_CODE_RESERVED_0D) {
+			error_code = SPDM_ERROR_CODE_RESERVED_3F;
+		}
+		//skip response not ready, request resync, and some reserved codes (44 to fc)
+		if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
+			error_code = SPDM_ERROR_CODE_RESERVED_FD;
+		}
+	}
+}
+
 spdm_test_context_t m_spdm_requester_key_update_test_context = {
 	SPDM_TEST_CONTEXT_SIGNATURE,
 	TRUE,
@@ -3252,6 +4557,23 @@ int spdm_requester_key_update_test_main(void)
 		// Wrong parameters
 		cmocka_unit_test(test_spdm_requester_key_update_case25),
 		cmocka_unit_test(test_spdm_requester_key_update_case26),
+		//// update all keys
+		// Sucessful response
+		cmocka_unit_test(test_spdm_requester_key_update_case27),
+		// Error response: SPDM_ERROR_CODE_INVALID_REQUEST
+		cmocka_unit_test(test_spdm_requester_key_update_case28),
+		// Always SPDM_ERROR_CODE_BUSY
+		cmocka_unit_test(test_spdm_requester_key_update_case29),
+		// SPDM_ERROR_CODE_BUSY + Successful response
+		cmocka_unit_test(test_spdm_requester_key_update_case30),
+		// Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH
+		cmocka_unit_test(test_spdm_requester_key_update_case31),
+		// Always SPDM_ERROR_CODE_RESPONSE_NOT_READY
+		cmocka_unit_test(test_spdm_requester_key_update_case32),
+		// SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response
+		cmocka_unit_test(test_spdm_requester_key_update_case33),
+		// Unexpected errors
+		cmocka_unit_test(test_spdm_requester_key_update_case34),
 	};
 
 	setup_spdm_test_context(&m_spdm_requester_key_update_test_context);

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -380,7 +380,135 @@ return_status spdm_requester_key_update_test_send_message(
 	case 0xD:
 	case 0xE:
 	case 0xF:
-	case 0x10: {
+	case 0x10:
+	case 0x11:
+	case 0x12:
+	case 0x13:
+	case 0x14:
+	case 0x15: {
+		return_status       status;
+		uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn               decoded_message_size;
+		uint32              session_id;
+		uint32              *message_session_id;
+		boolean             is_app_message;
+		spdm_session_info_t *session_info;
+
+		message_session_id = NULL;
+		session_id = 0xFFFFFFFF;
+		decoded_message_size = sizeof(decoded_message);
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.request_data_sequence_number--;
+		status = spdm_transport_test_decode_message(spdm_context,
+		      &message_session_id, &is_app_message, TRUE, request_size,
+		      request, &decoded_message_size, decoded_message);
+		if (RETURN_ERROR(status)) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		my_last_token = ((spdm_key_update_request_t 
+			  *) decoded_message)->header.param2;
+	}
+		return RETURN_SUCCESS;
+	case 0x16: {
+		static uintn sub_index = 0;
+
+		if(sub_index < 2) {
+			return_status          status;
+			uint8 decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn decoded_message_size;
+			uint32                 session_id;
+			uint32 *message_session_id;
+			boolean is_app_message;
+			spdm_session_info_t    *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x17: {
+		static uintn sub_index = 0;
+
+		DEBUG((DEBUG_INFO, "send message: %d\n", sub_index));
+
+		if(sub_index%2 == 0) {
+			return_status          status;
+			uint8 decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+			uintn decoded_message_size;
+			uint32                 session_id;
+			uint32 *message_session_id;
+			boolean is_app_message;
+			spdm_session_info_t    *session_info;
+
+			message_session_id = NULL;
+			session_id = 0xFFFFFFFF;
+			decoded_message_size = sizeof(decoded_message);
+
+			session_info = spdm_get_session_info_via_session_id(
+				spdm_context, session_id);
+			if (session_info == NULL) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.request_data_sequence_number--;
+			status = spdm_transport_test_decode_message(spdm_context,
+			      &message_session_id, &is_app_message, TRUE, request_size,
+			      request, &decoded_message_size, decoded_message);
+			if (RETURN_ERROR(status)) {
+				return RETURN_DEVICE_ERROR;
+			}
+
+			my_last_token = ((spdm_key_update_request_t 
+				  *) decoded_message)->header.param2;
+
+			DEBUG((DEBUG_INFO, "last token: %x\n", my_last_token));
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+	case 0x18:
+	case 0x19:
+	case 0x1A: {
 		return_status       status;
 		uint8               decoded_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 		uintn               decoded_message_size;
@@ -1069,6 +1197,597 @@ return_status spdm_requester_key_update_test_receive_message(
 		} else if (sub_index == 1) {
 			spdm_response.header.param1 = 
 				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+		}
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x11: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 1) {
+			spdm_error_response_t  spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = SPDM_ERROR_CODE_INVALID_REQUEST;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x12: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else {
+			spdm_error_response_t  spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = SPDM_ERROR_CODE_BUSY;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x13: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 1) {
+			spdm_error_response_t spdm_response;
+
+			spdm_response.header.spdm_version =
+				SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = SPDM_ERROR_CODE_BUSY;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 2) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x14: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 1) {
+			spdm_error_response_t  spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 = SPDM_ERROR_CODE_REQUEST_RESYNCH;
+			spdm_response.header.param2 = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x15: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else {
+			spdm_error_response_data_response_not_ready_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 =
+				SPDM_ERROR_CODE_RESPONSE_NOT_READY;
+			spdm_response.header.param2 = 0;
+			spdm_response.extend_error_data.rd_exponent = 1;
+			spdm_response.extend_error_data.rd_tm = 1;
+			spdm_response.extend_error_data.request_code = SPDM_KEY_UPDATE;
+			spdm_response.extend_error_data.token = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x16: {
+		static uintn sub_index = 0;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if (sub_index == 0) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 1) {
+			spdm_error_response_data_response_not_ready_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = SPDM_ERROR;
+			spdm_response.header.param1 =
+				SPDM_ERROR_CODE_RESPONSE_NOT_READY;
+			spdm_response.header.param2 = 0;
+			spdm_response.extend_error_data.rd_exponent = 1;
+			spdm_response.extend_error_data.rd_tm = 1;
+			spdm_response.extend_error_data.request_code = SPDM_KEY_UPDATE;
+			spdm_response.extend_error_data.token = 0;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+		else if (sub_index == 2) {
+			spdm_key_update_response_t spdm_response;
+
+			spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+
+			spdm_transport_test_encode_message(spdm_context,
+						   &session_id, FALSE, FALSE, 
+						   sizeof(spdm_response), &spdm_response,
+						   response_size, response);
+			/* WALKAROUND: If just use single context to encode
+			   message and then decode message */
+			((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				->application_secret.response_data_sequence_number--;
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x17: {
+		static uintn sub_index = 0;
+		static uint16 error_code = SPDM_ERROR_CODE_RESERVED_00;
+
+		uint32                 session_id;
+		spdm_session_info_t    *session_info;
+
+		session_id = 0xFFFFFFFF;
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		if(error_code <= 0xff) {
+			if (sub_index%2 == 0) {
+				spdm_key_update_response_t spdm_response;
+
+				spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+				spdm_response.header.request_response_code = 
+					  SPDM_KEY_UPDATE_ACK;
+				spdm_response.header.param1 = 
+					  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+				spdm_response.header.param2 = my_last_token;
+
+				spdm_transport_test_encode_message(spdm_context,
+							   &session_id, FALSE, FALSE, 
+							   sizeof(spdm_response), &spdm_response,
+							   response_size, response);
+				/* WALKAROUND: If just use single context to encode
+				   message and then decode message */
+				((spdm_secured_message_context_t
+					  *)(session_info->secured_message_context))
+					->application_secret.response_data_sequence_number--;
+			}
+			else {
+				spdm_error_response_t    spdm_response;
+
+				zero_mem (&spdm_response, sizeof(spdm_response));
+				spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+				spdm_response.header.request_response_code = SPDM_ERROR;
+				spdm_response.header.param1 = (uint8) error_code;
+				spdm_response.header.param2 = 0;
+
+				spdm_transport_test_encode_message(spdm_context,
+							   &session_id, FALSE, FALSE, 
+							   sizeof(spdm_response), &spdm_response,
+							   response_size, response);
+				/* WALKAROUND: If just use single context to encode
+				   message and then decode message */
+				((spdm_secured_message_context_t
+					  *)(session_info->secured_message_context))
+					->application_secret.response_data_sequence_number--;
+
+				error_code++;
+				//busy is treated in cases 5 and 6
+				if(error_code == SPDM_ERROR_CODE_BUSY) {
+					error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+				}
+				//skip some reserved error codes (0d to 3e)
+				if(error_code == SPDM_ERROR_CODE_RESERVED_0D) {
+					error_code = SPDM_ERROR_CODE_RESERVED_3F;
+				}
+				//skip response not ready, request resync, and some reserved codes (44 to fc)
+				if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) { 
+					error_code = SPDM_ERROR_CODE_RESERVED_FD;
+				}
+			}
+		}
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x18: {
+		static uintn sub_index = 0;
+
+		spdm_key_update_response_t spdm_response;
+		uint32                     session_id;
+		spdm_session_info_t        *session_info;
+
+		session_id = 0xFFFFFFFF;
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = 
+			  SPDM_KEY_UPDATE_ACK;
+		if (sub_index == 0) {
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE_ACK;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+		} else if (sub_index == 1) {
+			//wrong response code
+			spdm_response.header.request_response_code = 
+				  SPDM_KEY_UPDATE;
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			spdm_response.header.param2 = my_last_token;
+		}
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x19: {
+		static uintn sub_index = 0;
+
+		spdm_key_update_response_t spdm_response;
+		uint32                     session_id;
+		spdm_session_info_t        *session_info;
+
+		session_id = 0xFFFFFFFF;
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = 
+			  SPDM_KEY_UPDATE_ACK;
+		if (sub_index == 0) {
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+		} else if (sub_index == 1) {
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY;
+			//wrong token
+			spdm_response.header.param2 = my_last_token + 1;
+		}
+
+		spdm_transport_test_encode_message(spdm_context, &session_id,
+						   FALSE, FALSE, sizeof(spdm_response),
+						   &spdm_response, response_size, response);
+		/* WALKAROUND: If just use single context to encode
+		   message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+
+		sub_index++;
+	}
+		return RETURN_SUCCESS;
+
+	case 0x1A: {
+		static uintn sub_index = 0;
+
+		spdm_key_update_response_t spdm_response;
+		uint32                     session_id;
+		spdm_session_info_t        *session_info;
+
+		session_id = 0xFFFFFFFF;
+
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+
+		spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+		spdm_response.header.request_response_code = 
+			  SPDM_KEY_UPDATE_ACK;
+		if (sub_index == 0) {
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
+			spdm_response.header.param2 = my_last_token;
+		} else if (sub_index == 1) {
+			//wrong operation code
+			spdm_response.header.param1 = 
+				  SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY;
 			spdm_response.header.param2 = my_last_token;
 		}
 
@@ -1917,6 +2636,562 @@ void test_spdm_requester_key_update_case16(void **state)
 		  *)(session_info->secured_message_context))->hash_size);
 }
 
+/**
+  Test 17: the requester is setup correctly (see Test 2), but receives an
+  ERROR message indicating InvalidParameters when verifying key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case17(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x11;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 18: the requester is setup correctly (see Test 2), but receives an
+  ERROR message indicating the Busy status of the responder, when verifying
+  key.
+  Expected behavior: client returns a Status of RETURN_NO_RESPONSE, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case18(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x12;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_NO_RESPONSE);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 19: the requester is setup correctly (see Test 2), but, when
+  verifying key, on the first try, receiving a Busy ERROR message,
+  and on retry, receiving a correct KEY_UPDATE_ACK message. The
+  VERIFY_KEY behavior is not altered.
+  Expected behavior: client returns a Status of RETURN_SUCCESS, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case19(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x13;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 20: the requester is setup correctly (see Test 2), but receives an
+  ERROR message indicating the RequestResynch status of the responder, when
+  verifying key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the 
+  communication is reset to expect a new GET_VERSION message.
+**/
+void test_spdm_requester_key_update_case20(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x14;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_int_equal(spdm_context->connection_info.connection_state,
+			 SPDM_CONNECTION_STATE_NOT_STARTED);
+}
+
+/**
+  Test 21: the requester is setup correctly (see Test 2), but receives an
+  ERROR message indicating the ResponseNotReady status of the responder, when
+  verifying key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case21(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x15;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 22: the requester is setup correctly (see Test 2), but, when verifying
+  key, on the first try, receiving a ResponseNotReady ERROR message, and on
+  retry, receiving a correct KEY_UPDATE_ACK message.
+  Expected behavior: client returns a Status of RETURN_SUCCESS, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case22(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x16;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_SUCCESS);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 23: receiving an unexpected ERROR message from the responder,
+  when verifying key.
+  There are tests for all named codes, including some reserved ones
+  (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
+  However, for having specific test cases, it is excluded from this case:
+  Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
+  Expected behavior: client returns a status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case23(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+	uint16                 error_code;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x17;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	error_code = SPDM_ERROR_CODE_RESERVED_00;
+	while(error_code <= 0xff) {
+		spdm_set_standard_key_update_test_secrets(
+			  session_info->secured_message_context,
+			  m_rsp_secret_buffer, (uint8)(0xFF),
+			  m_req_secret_buffer, (uint8)(0xEE));
+
+		//request side updated
+		spdm_compute_secret_update(((spdm_secured_message_context_t 
+				 *)(session_info->secured_message_context))->hash_size,
+			  m_req_secret_buffer, m_req_secret_buffer,
+			  sizeof(m_req_secret_buffer));
+		//response side *not* updated
+
+		status = spdm_key_update(
+			spdm_context, session_id, TRUE);
+
+		// assert_int_equal (status, RETURN_DEVICE_ERROR);
+		ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+		assert_memory_equal(((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				  ->application_secret.request_data_secret,
+			  m_req_secret_buffer, ((spdm_secured_message_context_t 
+			  *)(session_info->secured_message_context))->hash_size);
+		assert_memory_equal(((spdm_secured_message_context_t
+				  *)(session_info->secured_message_context))
+				  ->application_secret.response_data_secret,
+			  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+			  *)(session_info->secured_message_context))->hash_size);
+
+		error_code++;
+		//busy is treated in cases 5 and 6
+		if(error_code == SPDM_ERROR_CODE_BUSY) {
+			error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+		}
+		//skip some reserved error codes (0d to 3e)
+		if(error_code == SPDM_ERROR_CODE_RESERVED_0D) {
+			error_code = SPDM_ERROR_CODE_RESERVED_3F;
+		}
+		//skip response not ready, request resync, and some reserved codes (44 to fc)
+		if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
+			error_code = SPDM_ERROR_CODE_RESERVED_FD;
+		}
+	}
+}
+
+/**
+  Test 24: receiving an incorrect KEY_UPDATE_ACK message, with wrong
+  response code, but all other field correct, when verifying key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case24(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x18;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 25: the requester is setup correctly (see Test 2), and receives a
+  correct KEY_UPDATE_ACK to update key. However, it receives a 
+  KEY_UPDATE_ACK response with the wrong token to verify the key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case25(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x19;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
+/**
+  Test 26: the requester is setup correctly (see Test 2) and receives a
+  correct KEY_UPDATE_ACK to update key. However, it receives a 
+  KEY_UPDATE_ACK response with the wrong operation code to verify the key.
+  Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
+  request data key is not rollbacked.
+**/
+void test_spdm_requester_key_update_case26(void **state)
+{
+	return_status          status;
+	spdm_test_context_t    *spdm_test_context;
+	spdm_context_t         *spdm_context;
+	uint32                 session_id;
+	spdm_session_info_t    *session_info;
+
+	uint8    m_req_secret_buffer[MAX_HASH_SIZE];
+	uint8    m_rsp_secret_buffer[MAX_HASH_SIZE];
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x1A;
+
+	spdm_set_standard_key_update_test_state(
+		  spdm_context, &session_id);
+
+	session_info = &spdm_context->session_info[0];
+
+	spdm_set_standard_key_update_test_secrets(
+		  session_info->secured_message_context,
+		  m_rsp_secret_buffer, (uint8)(0xFF),
+		  m_req_secret_buffer, (uint8)(0xEE));
+
+	//request side updated
+	spdm_compute_secret_update(((spdm_secured_message_context_t 
+			 *)(session_info->secured_message_context))->hash_size,
+		  m_req_secret_buffer, m_req_secret_buffer,
+		  sizeof(m_req_secret_buffer));
+	//response side *not* updated
+
+	status = spdm_key_update(
+		spdm_context, session_id, TRUE);
+
+	assert_int_equal(status, RETURN_DEVICE_ERROR);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.request_data_secret,
+		  m_req_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+	assert_memory_equal(((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			  ->application_secret.response_data_secret,
+		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
+		  *)(session_info->secured_message_context))->hash_size);
+}
+
 spdm_test_context_t m_spdm_requester_key_update_test_context = {
 	SPDM_TEST_CONTEXT_SIGNATURE,
 	TRUE,
@@ -1957,6 +3232,26 @@ int spdm_requester_key_update_test_main(void)
 		// Wrong parameters
 		cmocka_unit_test(test_spdm_requester_key_update_case15),
 		cmocka_unit_test(test_spdm_requester_key_update_case16),
+		//// verify key
+		// Error response: SPDM_ERROR_CODE_INVALID_REQUEST
+		cmocka_unit_test(test_spdm_requester_key_update_case17),
+		// Always SPDM_ERROR_CODE_BUSY
+		cmocka_unit_test(test_spdm_requester_key_update_case18),
+		// SPDM_ERROR_CODE_BUSY + Successful response
+		cmocka_unit_test(test_spdm_requester_key_update_case19),
+		// Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH
+		cmocka_unit_test(test_spdm_requester_key_update_case20),
+		// Always SPDM_ERROR_CODE_RESPONSE_NOT_READY
+		cmocka_unit_test(test_spdm_requester_key_update_case21),
+		// SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response
+		cmocka_unit_test(test_spdm_requester_key_update_case22),
+		// Unexpected errors
+		cmocka_unit_test(test_spdm_requester_key_update_case23),
+		// No correct setup
+		cmocka_unit_test(test_spdm_requester_key_update_case24),
+		// Wrong parameters
+		cmocka_unit_test(test_spdm_requester_key_update_case25),
+		cmocka_unit_test(test_spdm_requester_key_update_case26),
 	};
 
 	setup_spdm_test_context(&m_spdm_requester_key_update_test_context);

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -19,6 +19,7 @@ int spdm_requester_finish_test_main(void);
 int spdm_requester_psk_exchange_test_main(void);
 int spdm_requester_psk_finish_test_main(void);
 int spdm_requester_heartbeat_test_main(void);
+int spdm_requester_key_update_test_main(void);
 int spdm_requester_end_session_test_main(void);
 
 int main(void)
@@ -70,6 +71,10 @@ int main(void)
 	}
 
 	if (spdm_requester_heartbeat_test_main() != 0) {
+		return_value = 1;
+	}
+
+	if (spdm_requester_key_update_test_main() != 0) {
 		return_value = 1;
 	}
 


### PR DESCRIPTION
We add unit test cases on the requester side for the key_update message. Including the standard tests from previous messages.
These tests verify the output of the requester side of the key update, and whether the major secret was updated.
We also include the handling of retries and received ERROR responses, as in previous messages.

It includes 4 commits:

1) when receiving an ERROR response, we call the "spdm_handle_error_response_main()" function to handle it, both in the UpdateKey/UpdateAllKeys and VerifyNewKey operations.
The major secret is rolled back in most "failed" cases for UpdateKey/UpdateAllKeys, but not for VerifyNewKey.
Additionally, it can successfully retry when receiving a Busy or ResponseNotReady ERROR response.

2) new test cases for the UpdateKey operation:
- send request failed
- success case
- invalid state
- standard errors (InvalidParameters, Busy, RequestResync, ResponseNotReady)
- errors with retry (Busy, ResponseNotReady)
- unexpected errors
- buffer reset
- wrong setup (capabilities, session)
- wrong response parameters (response code, operation, token)

3) new test cases for the VerifyNewKey operation:
- standard errors (InvalidParameters, Busy, RequestResync, ResponseNotReady)
- errors with retry (Busy, ResponseNotReady)
- unexpected errors
- wrong response parameters (response code, operation, token)

4) new test cases for the UpdateAllKeys operation:
- success case
- standard errors (InvalidParameters, Busy, RequestResync, ResponseNotReady)
- errors with retry (Busy, ResponseNotReady)
- unexpected errors

We note here that there are some test cases in commit 4 that are not successful, beginning at case 28, because the library still lacks management of decryption keys in the requester when receiving ERROR messages.
Cases 28, 32, and 34 are "false success" cases, which have the same output behavior, but they are not using the correct keys.
We include a detailed explanation in issue #165.
Commits 1, 2 and 3 can be tested separately and added to the repo independently of commit 4. 