### PR TITLE
Fix91 Measurement transcript hash shall be calculated per session

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -531,10 +531,13 @@ void spdm_reset_message_mut_c(IN void *spdm_context);
 
 /**
   Reset message M cache in SPDM context.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
 **/
-void spdm_reset_message_m(IN void *spdm_context);
+void spdm_reset_message_m(IN void *context, IN void *session_info);
 
 /**
   Reset message K cache in SPDM context.
@@ -619,16 +622,19 @@ return_status spdm_append_message_mut_c(IN void *spdm_context, IN void *message,
 
 /**
   Append message M cache in SPDM context.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  message                      message buffer.
   @param  message_size                  size in bytes of message buffer.
 
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_m(IN void *spdm_context, IN void *message,
-				    IN uintn message_size);
+return_status spdm_append_message_m(IN void *context, IN void *session_info,
+					IN void *message, IN uintn message_size);
 
 /**
   Append message K cache in SPDM context.

--- a/library/spdm_common_lib/context_data.c
+++ b/library/spdm_common_lib/context_data.c
@@ -682,21 +682,38 @@ void spdm_reset_message_mut_c(IN void *context)
 
 /**
   Reset message M cache in SPDM context.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
 **/
-void spdm_reset_message_m(IN void *context)
+void spdm_reset_message_m(IN void *context, IN void *session_info)
 {
 	spdm_context_t *spdm_context;
+	spdm_session_info_t *spdm_session_info;
 
 	spdm_context = context;
+	spdm_session_info = session_info;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	reset_managed_buffer(&spdm_context->transcript.message_m);
+	if (spdm_session_info == NULL) {
+		reset_managed_buffer(&spdm_context->transcript.message_m);
+	} else {
+		reset_managed_buffer(&spdm_session_info->session_transcript.message_m);
+	}
 #else
-	if (spdm_context->transcript.digest_context_l1l2 != NULL) {
-		spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
-			spdm_context->transcript.digest_context_l1l2);
-		spdm_context->transcript.digest_context_l1l2 = NULL;
+	if (spdm_session_info == NULL) {
+		if (spdm_context->transcript.digest_context_l1l2 != NULL) {
+			spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+				spdm_context->transcript.digest_context_l1l2);
+			spdm_context->transcript.digest_context_l1l2 = NULL;
+	}
+	} else {
+		if (spdm_session_info->session_transcript.digest_context_l1l2 != NULL) {
+			spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+				spdm_session_info->session_transcript.digest_context_l1l2);
+			spdm_session_info->session_transcript.digest_context_l1l2 = NULL;
+		}
 	}
 #endif
 }
@@ -807,9 +824,10 @@ void spdm_reset_message_f(IN void *context, IN void *session_info)
   Reset message buffer in SPDM context according to request code.
 
   @param  spdm_context               	A pointer to the SPDM context.
+  @param  spdm_session_info             A pointer to the SPDM session context.
   @param  spdm_request               	The SPDM request code.
 */
-void spdm_reset_message_buffer_via_request_code(IN void *context,
+void spdm_reset_message_buffer_via_request_code(IN void *context, IN void *session_info,
 			       IN uint8 request_code)
 {
 	spdm_context_t *spdm_context;
@@ -819,7 +837,7 @@ void spdm_reset_message_buffer_via_request_code(IN void *context,
 	  Any request other than SPDM_GET_MEASUREMENTS resets L1/L2
 	*/
 	if (request_code != SPDM_GET_MEASUREMENTS) {
-		spdm_reset_message_m(spdm_context);
+		spdm_reset_message_m(spdm_context, session_info);
 	}
 	/**
 	  If the Requester issued GET_MEASUREMENTS or KEY_EXCHANGE or FINISH or PSK_EXCHANGE 
@@ -1014,33 +1032,55 @@ return_status spdm_append_message_mut_c(IN void *context, IN void *message,
 
 /**
   Append message M cache in SPDM context.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  message                      message buffer.
   @param  message_size                  size in bytes of message buffer.
 
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_m(IN void *context, IN void *message,
-				    IN uintn message_size)
+return_status spdm_append_message_m(IN void *context, IN void *session_info,
+					IN void *message, IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
+	spdm_session_info_t *spdm_session_info;
 
 	spdm_context = context;
+	spdm_session_info = session_info;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	return append_managed_buffer(&spdm_context->transcript.message_m,
-				     message, message_size);
-#else
-	if (spdm_context->transcript.digest_context_l1l2 == NULL) {
-		spdm_context->transcript.digest_context_l1l2 = spdm_hash_new (
-			spdm_context->connection_info.algorithm.base_hash_algo);
-		spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-			spdm_context->transcript.digest_context_l1l2);
+	if (spdm_session_info == NULL) {
+		return append_managed_buffer(&spdm_context->transcript.message_m,
+								message, message_size);
+	} else {
+		return append_managed_buffer(&spdm_session_info->session_transcript.message_m,
+								message, message_size);
 	}
-	return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-		spdm_context->transcript.digest_context_l1l2, message, message_size) ?
-		RETURN_SUCCESS : RETURN_DEVICE_ERROR;
+#else
+	if (spdm_session_info == NULL) {
+		if (spdm_context->transcript.digest_context_l1l2 == NULL) {
+			spdm_context->transcript.digest_context_l1l2 = spdm_hash_new (
+				spdm_context->connection_info.algorithm.base_hash_algo);
+			spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+				spdm_context->transcript.digest_context_l1l2);
+		}
+		return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+			spdm_context->transcript.digest_context_l1l2, message, message_size) ?
+			RETURN_SUCCESS : RETURN_DEVICE_ERROR;
+	} else {
+		if (spdm_session_info->session_transcript.digest_context_l1l2 == NULL) {
+			spdm_session_info->session_transcript.digest_context_l1l2 = spdm_hash_new (
+				spdm_context->connection_info.algorithm.base_hash_algo);
+			spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+				spdm_session_info->session_transcript.digest_context_l1l2);
+		}
+		return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+			spdm_session_info->session_transcript.digest_context_l1l2, message, message_size) ?
+			RETURN_SUCCESS : RETURN_DEVICE_ERROR;
+	}
 #endif
 }
 

--- a/library/spdm_common_lib/context_data_session.c
+++ b/library/spdm_common_lib/context_data_session.c
@@ -67,6 +67,8 @@ void spdm_session_info_init(IN spdm_context_t *spdm_context,
 		sizeof(session_info->session_transcript.message_k.buffer);
 	session_info->session_transcript.message_f.max_buffer_size =
 		sizeof(session_info->session_transcript.message_f.buffer);
+	session_info->session_transcript.message_m.max_buffer_size =
+		sizeof(session_info->session_transcript.message_m.buffer);
 #else
 	session_info->session_transcript.temp_message_k.max_buffer_size =
 		sizeof(session_info->session_transcript.temp_message_k.buffer);

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -523,27 +523,33 @@ boolean spdm_calculate_m1m2_hash(IN void *context, IN boolean is_mut,
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
   This function calculates l1l2.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  l1l2_buffer_size               size in bytes of the l1l2
   @param  l1l2_buffer                   The buffer to store the l1l2
 
   @retval RETURN_SUCCESS  l1l2 is calculated.
 */
-boolean spdm_calculate_l1l2(IN void *context, IN OUT uintn *l1l2_buffer_size,
-			    OUT void *l1l2_buffer);
+boolean spdm_calculate_l1l2(IN void *context, IN void *session_info,
+				IN OUT uintn *l1l2_buffer_size, OUT void *l1l2_buffer);
 #else
 /*
   This function calculates l1l2 hash.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  l1l2_hash_size               size in bytes of the l1l2 hash
   @param  l1l2_hash                   The buffer to store the l1l2 hash
 
   @retval RETURN_SUCCESS  l1l2 is calculated.
 */
-boolean spdm_calculate_l1l2_hash(IN void *context, IN OUT uintn *l1l2_hash_size,
-			    OUT void *l1l2_hash);
+boolean spdm_calculate_l1l2_hash(IN void *context, IN void *session_info,
+				IN OUT uintn *l1l2_hash_size, OUT void *l1l2_hash);
 #endif
 
 /**
@@ -669,20 +675,27 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 
 /**
   This function generates the measurement signature to response message based upon l1l2.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  signature                    The buffer to store the signature.
 
-  @retval TRUE  measurement signature is created.
-  @retval FALSE measurement signature is not created.
+  @retval TRUE  measurement signature is generated.
+  @retval FALSE measurement signature is not generated.
 **/
 boolean spdm_generate_measurement_signature(IN spdm_context_t *spdm_context,
+						IN spdm_session_info_t *session_info,
 					    OUT uint8 *signature);
 
 /**
   This function verifies the measurement signature based upon l1l2.
+  If session_info is NULL, this function will use M cache of SPDM context,
+  else will use M cache of SPDM session context.
 
   @param  spdm_context                  A pointer to the SPDM context.
+  @param  session_info                  A pointer to the SPDM session context.
   @param  sign_data                     The signature data buffer.
   @param  sign_data_size                 size in bytes of the signature data buffer.
 
@@ -690,6 +703,7 @@ boolean spdm_generate_measurement_signature(IN spdm_context_t *spdm_context,
   @retval FALSE signature verification fail.
 **/
 boolean spdm_verify_measurement_signature(IN spdm_context_t *spdm_context,
+					  IN spdm_session_info_t *session_info,
 					  IN void *sign_data,
 					  IN uintn sign_data_size);
 

--- a/library/spdm_common_lib/spdm_common_lib_internal.h
+++ b/library/spdm_common_lib/spdm_common_lib_internal.h
@@ -219,12 +219,14 @@ typedef struct {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	large_managed_buffer_t message_k;
 	large_managed_buffer_t message_f;
+	large_managed_buffer_t message_m;
 #else
 	// the message_k must be plan text because we do not know the finished_key yet.
 	medium_managed_buffer_t temp_message_k;
 	boolean                message_f_initialized;
 	boolean                finished_key_ready;
 	void                   *digest_context_th;
+	void                   *digest_context_l1l2;
 	void                   *hmac_rsp_context_th;
 	void                   *hmac_req_context_th;
 	// this is back up for message F reset.
@@ -424,10 +426,11 @@ void init_managed_buffer(IN OUT void *managed_buffer_t,
 /**
   Reset message buffer in SPDM context according to request code.
 
-  @param  spdm_context                A pointer to the SPDM context.
-  @param  spdm_request                The SPDM request code.
+  @param  spdm_context               	A pointer to the SPDM context.
+  @param  spdm_session_info             A pointer to the SPDM session context.
+  @param  spdm_request               	The SPDM request code.
 */
-void spdm_reset_message_buffer_via_request_code(IN void *context,
+void spdm_reset_message_buffer_via_request_code(IN void *context, IN void *session_info,
 			       IN uint8 request_code);
 
 /**

--- a/library/spdm_requester_lib/challenge.c
+++ b/library/spdm_requester_lib/challenge.c
@@ -69,7 +69,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	spdm_challenge_auth_response_attribute_t auth_attribute;
 
 	spdm_context = context;
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 									SPDM_CHALLENGE);
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, TRUE, 0,

--- a/library/spdm_requester_lib/encap_certificate.c
+++ b/library/spdm_requester_lib/encap_certificate.c
@@ -102,7 +102,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 				   .local_cert_chain_provision_size[slot_id] -
 			   (length + offset);
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_certificate_response_t) + length);

--- a/library/spdm_requester_lib/encap_challenge_auth.c
+++ b/library/spdm_requester_lib/encap_challenge_auth.c
@@ -71,7 +71,7 @@ return_status spdm_get_encap_response_challenge_auth(
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	signature_size = spdm_get_req_asym_signature_size(

--- a/library/spdm_requester_lib/encap_digests.c
+++ b/library/spdm_requester_lib/encap_digests.c
@@ -58,7 +58,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	hash_size = spdm_get_hash_size(

--- a/library/spdm_requester_lib/encap_key_update.c
+++ b/library/spdm_requester_lib/encap_key_update.c
@@ -109,7 +109,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_key_update_response_t));

--- a/library/spdm_requester_lib/encap_key_update.c
+++ b/library/spdm_requester_lib/encap_key_update.c
@@ -109,7 +109,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_key_update_response_t));

--- a/library/spdm_requester_lib/encap_request.c
+++ b/library/spdm_requester_lib/encap_request.c
@@ -233,7 +233,7 @@ return_status spdm_encapsulated_request(IN spdm_context_t *spdm_context,
 		spdm_get_encapsulated_request_request->header.param2 = 0;
 		spdm_request_size =
 			sizeof(spdm_get_encapsulated_request_request_t);
-		spdm_reset_message_buffer_via_request_code(spdm_context,
+		spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 							spdm_get_encapsulated_request_request->header.request_response_code);
 		status = spdm_send_spdm_request(
 			spdm_context, session_id, spdm_request_size,

--- a/library/spdm_requester_lib/end_session.c
+++ b/library/spdm_requester_lib/end_session.c
@@ -37,7 +37,7 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
 	spdm_session_info_t *session_info;
 	spdm_session_state_t session_state;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						SPDM_END_SESSION);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/end_session.c
+++ b/library/spdm_requester_lib/end_session.c
@@ -37,8 +37,6 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
 	spdm_session_info_t *session_info;
 	spdm_session_state_t session_state;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
-						SPDM_END_SESSION);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
 		return RETURN_UNSUPPORTED;
@@ -74,6 +72,9 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
+
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+						SPDM_END_SESSION);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));

--- a/library/spdm_requester_lib/finish.c
+++ b/library/spdm_requester_lib/finish.c
@@ -54,7 +54,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						SPDM_FINISH);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/finish.c
+++ b/library/spdm_requester_lib/finish.c
@@ -54,8 +54,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
-						SPDM_FINISH);
+
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
 		return RETURN_UNSUPPORTED;
@@ -157,6 +156,9 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
+
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+						SPDM_FINISH);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));

--- a/library/spdm_requester_lib/get_capabilities.c
+++ b/library/spdm_requester_lib/get_capabilities.c
@@ -104,7 +104,7 @@ return_status try_spdm_get_capabilities(IN spdm_context_t *spdm_context)
 	spdm_capabilities_response spdm_response;
 	uintn spdm_response_size;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 								SPDM_GET_CAPABILITIES);
 	if (spdm_context->connection_info.connection_state !=
 	    SPDM_CONNECTION_STATE_AFTER_VERSION) {

--- a/library/spdm_requester_lib/get_certificate.c
+++ b/library/spdm_requester_lib/get_certificate.c
@@ -63,7 +63,7 @@ return_status try_spdm_get_certificate(IN void *context, IN uint8 slot_id,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 							SPDM_GET_CERTIFICATE);
 	if ((spdm_context->connection_info.connection_state !=
 	     SPDM_CONNECTION_STATE_NEGOTIATED) &&

--- a/library/spdm_requester_lib/get_digests.c
+++ b/library/spdm_requester_lib/get_digests.c
@@ -53,7 +53,7 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 										SPDM_GET_DIGESTS);
 	if (spdm_context->connection_info.connection_state !=
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/get_measurements.c
+++ b/library/spdm_requester_lib/get_measurements.c
@@ -91,6 +91,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    SPDM_CONNECTION_STATE_AUTHENTICATED) {
 			return RETURN_UNSUPPORTED;
 		}
+		session_info = NULL;
 	} else {
 		if (spdm_context->connection_info.connection_state <
 		    SPDM_CONNECTION_STATE_NEGOTIATED) {
@@ -199,7 +200,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		}
 	} else if (spdm_response.header.request_response_code !=
 		   SPDM_MEASUREMENTS) {
-		spdm_reset_message_m(spdm_context, NULL);
+		spdm_reset_message_m(spdm_context, session_info);
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response_size < sizeof(spdm_measurements_response_t)) {
@@ -212,7 +213,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (spdm_response.number_of_blocks != 0) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else if (measurement_operation ==
@@ -231,7 +232,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (measurement_record_data_length != 0) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else {
@@ -256,13 +257,13 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    sizeof(spdm_measurements_response_t) +
 			    measurement_record_data_length + SPDM_NONCE_SIZE +
 			    sizeof(uint16)) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 		if (spdm_is_version_supported(spdm_context,
 					      SPDM_MESSAGE_VERSION_11) &&
 		    spdm_response.header.param2 != slot_id_param) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 		ptr = measurement_record_data + measurement_record_data_length;
@@ -294,17 +295,17 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, NULL, &spdm_request,
+		status = spdm_append_message_m(spdm_context, session_info, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, NULL, &spdm_response,
+		status = spdm_append_message_m(spdm_context, session_info, &spdm_response,
 					       spdm_response_size -
 						       signature_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
@@ -318,15 +319,15 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		internal_dump_hex(signature, signature_size);
 
 		result = spdm_verify_measurement_signature(
-			spdm_context, signature, signature_size);
+			spdm_context, session_info, signature, signature_size);
 		if (!result) {
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_MEASUREMENT_AUTH_FAILURE;
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		spdm_reset_message_m(spdm_context, NULL);
+		spdm_reset_message_m(spdm_context, session_info);
 	} else {
 		if (spdm_response_size <
 		    sizeof(spdm_measurements_response_t) +
@@ -363,16 +364,16 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, NULL, &spdm_request,
+		status = spdm_append_message_m(spdm_context, session_info, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, NULL, &spdm_response,
+		status = spdm_append_message_m(spdm_context, session_info, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context, NULL);
+			spdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 	}

--- a/library/spdm_requester_lib/get_measurements.c
+++ b/library/spdm_requester_lib/get_measurements.c
@@ -84,7 +84,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 									SPDM_GET_MEASUREMENTS);
 	if (session_id == NULL) {
 		if (spdm_context->connection_info.connection_state <
@@ -199,7 +199,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		}
 	} else if (spdm_response.header.request_response_code !=
 		   SPDM_MEASUREMENTS) {
-		spdm_reset_message_m(spdm_context);
+		spdm_reset_message_m(spdm_context, NULL);
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response_size < sizeof(spdm_measurements_response_t)) {
@@ -212,7 +212,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (spdm_response.number_of_blocks != 0) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else if (measurement_operation ==
@@ -231,7 +231,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (measurement_record_data_length != 0) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else {
@@ -256,13 +256,13 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    sizeof(spdm_measurements_response_t) +
 			    measurement_record_data_length + SPDM_NONCE_SIZE +
 			    sizeof(uint16)) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_DEVICE_ERROR;
 		}
 		if (spdm_is_version_supported(spdm_context,
 					      SPDM_MESSAGE_VERSION_11) &&
 		    spdm_response.header.param2 != slot_id_param) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SECURITY_VIOLATION;
 		}
 		ptr = measurement_record_data + measurement_record_data_length;
@@ -294,17 +294,17 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, &spdm_request,
+		status = spdm_append_message_m(spdm_context, NULL, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, &spdm_response,
+		status = spdm_append_message_m(spdm_context, NULL, &spdm_response,
 					       spdm_response_size -
 						       signature_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
@@ -322,11 +322,11 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		if (!result) {
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_MEASUREMENT_AUTH_FAILURE;
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		spdm_reset_message_m(spdm_context);
+		spdm_reset_message_m(spdm_context, NULL);
 	} else {
 		if (spdm_response_size <
 		    sizeof(spdm_measurements_response_t) +
@@ -363,16 +363,16 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, &spdm_request,
+		status = spdm_append_message_m(spdm_context, NULL, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, &spdm_response,
+		status = spdm_append_message_m(spdm_context, NULL, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SECURITY_VIOLATION;
 		}
 	}

--- a/library/spdm_requester_lib/get_version.c
+++ b/library/spdm_requester_lib/get_version.c
@@ -157,7 +157,7 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 
 	spdm_reset_context(spdm_context);
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request.header.request_response_code);
 
 	status = spdm_send_spdm_request(spdm_context, NULL,

--- a/library/spdm_requester_lib/heartbeat.c
+++ b/library/spdm_requester_lib/heartbeat.c
@@ -43,8 +43,7 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32 session_id)
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
-											SPDM_HEARTBEAT);
+
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
 		return RETURN_UNSUPPORTED;
@@ -70,6 +69,9 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32 session_id)
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
+
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+											SPDM_HEARTBEAT);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));

--- a/library/spdm_requester_lib/heartbeat.c
+++ b/library/spdm_requester_lib/heartbeat.c
@@ -43,7 +43,7 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32 session_id)
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 											SPDM_HEARTBEAT);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/key_exchange.c
+++ b/library/spdm_requester_lib/key_exchange.c
@@ -87,7 +87,7 @@ return_status try_spdm_send_receive_key_exchange(
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 									SPDM_KEY_EXCHANGE);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/key_update.c
+++ b/library/spdm_requester_lib/key_update.c
@@ -51,8 +51,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32 session_id,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
-										SPDM_KEY_UPDATE);
+
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
 		return RETURN_UNSUPPORTED;
@@ -74,6 +73,9 @@ return_status try_spdm_key_update(IN void *context, IN uint32 session_id,
 	} else {
 		action = SPDM_KEY_UPDATE_ACTION_ALL;
 	}
+
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+										SPDM_KEY_UPDATE);
 
 	if(!(*key_updated)) {
 		//

--- a/library/spdm_requester_lib/key_update.c
+++ b/library/spdm_requester_lib/key_update.c
@@ -51,7 +51,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32 session_id,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 										SPDM_KEY_UPDATE);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/negotiate_algorithms.c
+++ b/library/spdm_requester_lib/negotiate_algorithms.c
@@ -59,7 +59,7 @@ return_status try_spdm_negotiate_algorithms(IN spdm_context_t *spdm_context)
 	uint8 fixed_alg_size;
 	uint8 ext_alg_count;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 									SPDM_NEGOTIATE_ALGORITHMS);
 	
 	if (spdm_context->connection_info.connection_state !=

--- a/library/spdm_requester_lib/psk_exchange.c
+++ b/library/spdm_requester_lib/psk_exchange.c
@@ -94,7 +94,7 @@ return_status try_spdm_send_receive_psk_exchange(
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 								SPDM_PSK_EXCHANGE);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/psk_finish.c
+++ b/library/spdm_requester_lib/psk_finish.c
@@ -48,7 +48,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 										SPDM_PSK_FINISH);
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {

--- a/library/spdm_requester_lib/psk_finish.c
+++ b/library/spdm_requester_lib/psk_finish.c
@@ -48,8 +48,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
 		return RETURN_UNSUPPORTED;
 	}
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
-										SPDM_PSK_FINISH);
+
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
 		return RETURN_UNSUPPORTED;
@@ -100,6 +99,9 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
+
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+										SPDM_PSK_FINISH);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));

--- a/library/spdm_responder_lib/algorithms.c
+++ b/library/spdm_responder_lib/algorithms.c
@@ -285,7 +285,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 	}
 	spdm_request_size = request_size;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_algorithms_response_mine_t));

--- a/library/spdm_responder_lib/capabilities.c
+++ b/library/spdm_responder_lib/capabilities.c
@@ -203,7 +203,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	}
 	spdm_request_size = request_size;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_capabilities_response));

--- a/library/spdm_responder_lib/certificate.c
+++ b/library/spdm_responder_lib/certificate.c
@@ -108,7 +108,7 @@ return_status spdm_get_response_certificate(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	if ((uintn)(offset + length) >

--- a/library/spdm_responder_lib/challenge_auth.c
+++ b/library/spdm_responder_lib/challenge_auth.c
@@ -127,7 +127,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 					     response_size, response);
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	spdm_response->header.request_response_code = SPDM_CHALLENGE_AUTH;

--- a/library/spdm_responder_lib/digests.c
+++ b/library/spdm_responder_lib/digests.c
@@ -72,7 +72,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	spdm_request_size = request_size;

--- a/library/spdm_responder_lib/encap_challenge.c
+++ b/library/spdm_responder_lib/encap_challenge.c
@@ -55,7 +55,7 @@ return_status spdm_get_encap_request_challenge(IN spdm_context_t *spdm_context,
 	internal_dump_data(spdm_request->nonce, SPDM_NONCE_SIZE);
 	DEBUG((DEBUG_INFO, "\n"));
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	//

--- a/library/spdm_responder_lib/encap_get_certificate.c
+++ b/library/spdm_responder_lib/encap_get_certificate.c
@@ -56,7 +56,7 @@ spdm_get_encap_request_get_certificate(IN spdm_context_t *spdm_context,
 	DEBUG((DEBUG_INFO, "request (offset 0x%x, size 0x%x):\n",
 	       spdm_request->offset, spdm_request->length));
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	//

--- a/library/spdm_responder_lib/encap_get_digests.c
+++ b/library/spdm_responder_lib/encap_get_digests.c
@@ -42,7 +42,7 @@ spdm_get_encap_request_get_digest(IN spdm_context_t *spdm_context,
 
 	spdm_request = encap_request;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	if (spdm_is_version_supported(spdm_context, SPDM_MESSAGE_VERSION_11)) {

--- a/library/spdm_responder_lib/encap_key_update.c
+++ b/library/spdm_responder_lib/encap_key_update.c
@@ -61,7 +61,7 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
 	spdm_request->header.spdm_version = SPDM_MESSAGE_VERSION_11;
 	spdm_request->header.request_response_code = SPDM_KEY_UPDATE;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	if (spdm_context->encap_context.last_encap_request_header

--- a/library/spdm_responder_lib/encap_key_update.c
+++ b/library/spdm_responder_lib/encap_key_update.c
@@ -61,7 +61,7 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
 	spdm_request->header.spdm_version = SPDM_MESSAGE_VERSION_11;
 	spdm_request->header.request_response_code = SPDM_KEY_UPDATE;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	if (spdm_context->encap_context.last_encap_request_header

--- a/library/spdm_responder_lib/encap_response.c
+++ b/library/spdm_responder_lib/encap_response.c
@@ -388,7 +388,7 @@ return_status spdm_get_response_encapsulated_request(
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size > sizeof(spdm_encapsulated_request_response_t));
@@ -529,7 +529,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	status = spdm_process_encapsulated_response(

--- a/library/spdm_responder_lib/end_session.c
+++ b/library/spdm_responder_lib/end_session.c
@@ -82,7 +82,7 @@ return_status spdm_get_response_end_session(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	session_info->end_session_attributes = spdm_request->header.param1;

--- a/library/spdm_responder_lib/end_session.c
+++ b/library/spdm_responder_lib/end_session.c
@@ -82,7 +82,7 @@ return_status spdm_get_response_end_session(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	session_info->end_session_attributes = spdm_request->header.param1;

--- a/library/spdm_responder_lib/finish.c
+++ b/library/spdm_responder_lib/finish.c
@@ -154,7 +154,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,

--- a/library/spdm_responder_lib/finish.c
+++ b/library/spdm_responder_lib/finish.c
@@ -154,7 +154,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,

--- a/library/spdm_responder_lib/heartbeat.c
+++ b/library/spdm_responder_lib/heartbeat.c
@@ -91,7 +91,7 @@ return_status spdm_get_response_heartbeat(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_heartbeat_response_t));

--- a/library/spdm_responder_lib/heartbeat.c
+++ b/library/spdm_responder_lib/heartbeat.c
@@ -91,7 +91,7 @@ return_status spdm_get_response_heartbeat(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_heartbeat_response_t));

--- a/library/spdm_responder_lib/key_exchange.c
+++ b/library/spdm_responder_lib/key_exchange.c
@@ -163,7 +163,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	opaque_key_exchange_rsp_size =
 		spdm_get_opaque_data_version_selection_data_size(spdm_context);
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	if (spdm_is_capabilities_flag_supported(

--- a/library/spdm_responder_lib/key_update.c
+++ b/library/spdm_responder_lib/key_update.c
@@ -138,7 +138,7 @@ return_status spdm_get_response_key_update(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_key_update_response_t));

--- a/library/spdm_responder_lib/key_update.c
+++ b/library/spdm_responder_lib/key_update.c
@@ -138,7 +138,7 @@ return_status spdm_get_response_key_update(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	ASSERT(*response_size >= sizeof(spdm_key_update_response_t));

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -45,7 +45,7 @@ boolean spdm_create_measurement_signature(IN spdm_context_t *spdm_context,
 		 spdm_context->local_context.opaque_measurement_rsp_size);
 	ptr += spdm_context->local_context.opaque_measurement_rsp_size;
 
-	status = spdm_append_message_m(spdm_context, response_message,
+	status = spdm_append_message_m(spdm_context, NULL, response_message,
 				       response_message_size - signature_size);
 	if (RETURN_ERROR(status)) {
 		return FALSE;
@@ -498,11 +498,11 @@ return_status spdm_get_response_measurements(IN void *context,
 		break;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_m(
-			spdm_context, spdm_request,
+			spdm_context, NULL, spdm_request,
 			request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_generate_error_response(spdm_context,
@@ -524,19 +524,19 @@ return_status spdm_get_response_measurements(IN void *context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				SPDM_GET_MEASUREMENTS,
 				response_size, response);
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SUCCESS;
 		}
 		//reset
-		spdm_reset_message_m(spdm_context);
+		spdm_reset_message_m(spdm_context, NULL);
 	} else {
-		status = spdm_append_message_m(spdm_context, spdm_response,
+		status = spdm_append_message_m(spdm_context, NULL, spdm_response,
 					       *response_size);
 		if (RETURN_ERROR(status)) {
 			spdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
-			spdm_reset_message_m(spdm_context);
+			spdm_reset_message_m(spdm_context, NULL);
 			return RETURN_SUCCESS;
 		}
 	}

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -498,7 +498,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		break;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_m(

--- a/library/spdm_responder_lib/psk_exchange.c
+++ b/library/spdm_responder_lib/psk_exchange.c
@@ -236,7 +236,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	spdm_response->rsp_session_id = rsp_session_id;

--- a/library/spdm_responder_lib/psk_finish.c
+++ b/library/spdm_responder_lib/psk_finish.c
@@ -101,7 +101,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,

--- a/library/spdm_responder_lib/psk_finish.c
+++ b/library/spdm_responder_lib/psk_finish.c
@@ -101,7 +101,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,

--- a/library/spdm_responder_lib/version.c
+++ b/library/spdm_responder_lib/version.c
@@ -75,7 +75,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	}
 	spdm_request_size = request_size;
 
-	spdm_reset_message_buffer_via_request_code(spdm_context,
+	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request->header.request_response_code);
 
 	//

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -1387,7 +1387,7 @@ void test_spdm_requester_end_session_case11(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
+	session_info->session_transcript.message_m.buffer_size =
 							spdm_context->transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
@@ -1406,7 +1406,7 @@ void test_spdm_requester_end_session_case11(void **state)
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_NOT_STARTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -2078,8 +2078,8 @@ void test_spdm_requester_finish_case11(void **state)
 		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
 	req_slot_id_param = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-		spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+		session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -2098,7 +2098,7 @@ void test_spdm_requester_finish_case11(void **state)
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size,
 					0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -2429,7 +2429,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2485,7 +2485,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2541,7 +2541,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2597,7 +2597,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2653,7 +2653,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2709,7 +2709,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2765,7 +2765,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2823,7 +2823,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2876,7 +2876,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2930,7 +2930,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2988,7 +2988,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3052,7 +3052,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3111,7 +3111,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3170,7 +3170,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3229,7 +3229,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3306,7 +3306,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 
 	for (int i = 0; i < sizeof(SlotIDs) / sizeof(SlotIDs[0]); i++) {
 		measurement_record_length = sizeof(measurement_record);
-		spdm_reset_message_m(spdm_context);
+		spdm_reset_message_m(spdm_context, NULL);
 		status = spdm_get_measurement(spdm_context, NULL,
 					      request_attribute, 1, SlotIDs[i],
 					      &number_of_block,
@@ -3362,7 +3362,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3425,7 +3425,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3486,7 +3486,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3544,7 +3544,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3602,7 +3602,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3662,7 +3662,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3742,7 +3742,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3807,7 +3807,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3866,7 +3866,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3925,7 +3925,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3985,7 +3985,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4046,7 +4046,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4107,7 +4107,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4170,7 +4170,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4235,7 +4235,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4296,7 +4296,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4368,7 +4368,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AUTHENTICATED;
-    spdm_reset_message_m(spdm_context);
+    spdm_reset_message_m(spdm_context, NULL);
 
     measurement_record_length = sizeof(measurement_record);
     status = spdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -6,12 +6,14 @@
 
 #include "spdm_unit_test.h"
 #include <spdm_requester_lib_internal.h>
+#include <spdm_secured_message_lib_internal.h>
 
 #define ALTERNATIVE_DEFAULT_SLOT_ID 2
 #define LARGE_MEASUREMENT_SIZE ((1 << 24) - 1)
 
 static uintn m_local_buffer_size;
 static uint8 m_local_buffer[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+static uint8 m_local_psk_hint[32];
 
 uintn spdm_test_get_measurement_request_size(IN void *spdm_context,
 					     IN void *buffer,
@@ -65,7 +67,19 @@ return_status spdm_requester_get_measurements_test_send_message(
 	spdm_test_context_t *spdm_test_context;
 	uintn header_size;
 	uintn message_size;
+	uint32 *session_id;
+	spdm_session_info_t *session_info;
+	boolean is_app_message;
+	uint8 app_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	uintn app_message_size;
+	spdm_secured_message_callbacks_t spdm_secured_message_callbacks_t;
 
+	spdm_secured_message_callbacks_t.version =
+		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
+	spdm_secured_message_callbacks_t.get_sequence_number =
+		test_get_sequence_number;
+	spdm_secured_message_callbacks_t.get_max_random_number_count =
+		test_get_max_random_number_count;
 	spdm_test_context = get_spdm_test_context();
 	header_size = sizeof(test_message_header_t);
 	switch (spdm_test_context->case_id) {
@@ -363,6 +377,29 @@ return_status spdm_requester_get_measurements_test_send_message(
 		copy_mem(m_local_buffer, (uint8 *)request + header_size,
 			 message_size);
 		m_local_buffer_size += message_size;
+		return RETURN_SUCCESS;
+	case 0x22:
+		m_local_buffer_size = 0;
+		session_id = NULL;
+		app_message_size = sizeof(app_message);
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, 0xFFFFFFFF);
+		message_size = spdm_test_get_measurement_request_size(
+			spdm_context, (uint8 *)request + header_size,
+			request_size - header_size);
+		DEBUG((DEBUG_INFO, "Request (0x%x):\n",
+		       request_size));
+		internal_dump_hex(request, request_size);
+		spdm_transport_test_decode_message(
+			spdm_context, &session_id, &is_app_message,
+			FALSE, request_size, (uint8 *)request,
+			&app_message_size, app_message);
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+		copy_mem(m_local_buffer, app_message,
+			 app_message_size - 3);
+		m_local_buffer_size += app_message_size - 3;
 		return RETURN_SUCCESS;
 	default:
 		return RETURN_DEVICE_ERROR;
@@ -2395,7 +2432,101 @@ return_status spdm_requester_get_measurements_test_receive_message(
     }
   }
     return RETURN_SUCCESS;
+	case 0x22: {
+		spdm_measurements_response_t *spdm_response;
+		uint8 *ptr;
+		uint8 hash_data[MAX_HASH_SIZE];
+		uintn sig_size;
+		uintn measurment_sig_size;
+		spdm_measurement_block_dmtf_t *measurment_block;
+		uint8 temp_buf[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+		uintn temp_buf_size;
+		uint32 session_id;
+		spdm_session_info_t *session_info;
 
+		session_id = 0xFFFFFFFF;
+		((spdm_context_t *)spdm_context)
+			->connection_info.algorithm.base_asym_algo =
+			m_use_asym_algo;
+		((spdm_context_t *)spdm_context)
+			->connection_info.algorithm.base_hash_algo =
+			m_use_hash_algo;
+		((spdm_context_t *)spdm_context)
+			->connection_info.algorithm.measurement_hash_algo =
+			m_use_measurement_hash_algo;
+		measurment_sig_size =
+			SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
+			spdm_get_asym_signature_size(m_use_asym_algo);
+		temp_buf_size = sizeof(spdm_measurements_response_t) +
+				sizeof(spdm_measurement_block_dmtf_t) +
+				spdm_get_measurement_hash_size(
+					m_use_measurement_hash_algo) +
+				measurment_sig_size;
+		spdm_response = (void *)temp_buf;
+
+		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+		spdm_response->header.request_response_code = SPDM_MEASUREMENTS;
+		spdm_response->header.param1 = 0;
+		spdm_response->header.param2 = 0;
+		spdm_response->number_of_blocks = 1;
+		spdm_write_uint24(
+			spdm_response->measurement_record_length,
+			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
+				 spdm_get_measurement_hash_size(
+					 m_use_measurement_hash_algo)));
+		measurment_block = (void *)(spdm_response + 1);
+		set_mem(measurment_block,
+			sizeof(spdm_measurement_block_dmtf_t) +
+				spdm_get_measurement_hash_size(
+					m_use_measurement_hash_algo),
+			1);
+		measurment_block->Measurement_block_common_header
+			.measurement_specification =
+			SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+		measurment_block->Measurement_block_common_header
+			.measurement_size =
+			(uint16)(sizeof(spdm_measurement_block_dmtf_header_t) +
+				 spdm_get_measurement_hash_size(
+					 m_use_measurement_hash_algo));
+		ptr = (void *)((uint8 *)spdm_response + temp_buf_size -
+			       measurment_sig_size);
+		spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+		ptr += SPDM_NONCE_SIZE;
+		*(uint16 *)ptr = 0;
+		ptr += sizeof(uint16);
+		copy_mem(&m_local_buffer[m_local_buffer_size], spdm_response,
+			 (uintn)ptr - (uintn)spdm_response);
+		m_local_buffer_size += ((uintn)ptr - (uintn)spdm_response);
+		DEBUG((DEBUG_INFO, "m_local_buffer_size (0x%x):\n",
+		       m_local_buffer_size));
+		internal_dump_hex(m_local_buffer, m_local_buffer_size);
+		spdm_hash_all(m_use_hash_algo, m_local_buffer,
+			      m_local_buffer_size, hash_data);
+		DEBUG((DEBUG_INFO, "HashDataSize (0x%x):\n",
+		       spdm_get_hash_size(m_use_hash_algo)));
+		internal_dump_hex(m_local_buffer, m_local_buffer_size);
+		sig_size = spdm_get_asym_signature_size(m_use_asym_algo);
+		spdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+					 m_use_asym_algo, m_use_hash_algo,
+					 FALSE, m_local_buffer, m_local_buffer_size,
+					 ptr, &sig_size);
+		ptr += sig_size;
+
+		spdm_transport_test_encode_message(spdm_context, &session_id, FALSE,
+						   FALSE, temp_buf_size,
+						   temp_buf, response_size,
+						   response);
+		session_info = spdm_get_session_info_via_session_id(
+			spdm_context, session_id);
+		if (session_info == NULL) {
+			return RETURN_DEVICE_ERROR;
+		}
+		/* WALKAROUND: If just use single context to encode message and then decode message */
+		((spdm_secured_message_context_t
+			  *)(session_info->secured_message_context))
+			->application_secret.response_data_sequence_number--;
+	}
+		return RETURN_SUCCESS;
 	default:
 		return RETURN_DEVICE_ERROR;
 	}
@@ -4394,6 +4525,92 @@ void test_spdm_requester_get_measurements_case33(void **state) {
   free(data);
 }
 
+/**
+  Test 34: Successful response to get a session based measurement with signature
+  Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
+**/
+void test_spdm_requester_get_measurements_case34(void **state)
+{
+	return_status status;
+	spdm_test_context_t *spdm_test_context;
+	spdm_context_t *spdm_context;
+	uint32 session_id;
+	spdm_session_info_t *session_info;
+	uint8 number_of_block;
+	uint32 measurement_record_length;
+	uint8 measurement_record[MAX_SPDM_MEASUREMENT_RECORD_SIZE];
+	uint8 request_attribute;
+	void *data;
+	uintn data_size;
+	void *hash;
+	uintn hash_size;
+
+	spdm_test_context = *state;
+	spdm_context = spdm_test_context->spdm_context;
+	spdm_test_context->case_id = 0x22;
+	spdm_context->connection_info.connection_state =
+		SPDM_CONNECTION_STATE_AUTHENTICATED;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
+	read_responder_public_certificate_chain(m_use_hash_algo,
+						m_use_asym_algo, &data,
+						&data_size, &hash, &hash_size);
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+	spdm_context->connection_info.capability.flags |=
+		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+	spdm_context->local_context.capability.flags |=
+		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+	spdm_context->connection_info.algorithm.dhe_named_group =
+		m_use_dhe_algo;
+	spdm_context->connection_info.algorithm.aead_cipher_suite =
+		m_use_aead_algo;
+	zero_mem(m_local_psk_hint, 32);
+	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+		 sizeof(TEST_PSK_HINT_STRING));
+	spdm_context->local_context.psk_hint_size =
+		sizeof(TEST_PSK_HINT_STRING);
+	spdm_context->local_context.psk_hint = m_local_psk_hint;
+	session_id = 0xFFFFFFFF;
+	session_info = &spdm_context->session_info[0];
+	spdm_session_info_init(spdm_context, session_info, session_id, TRUE);
+	spdm_secured_message_set_session_state(
+		session_info->secured_message_context,
+		SPDM_SESSION_STATE_ESTABLISHED);
+
+	spdm_context->connection_info.algorithm.measurement_spec =
+		m_use_measurement_spec;
+	spdm_context->connection_info.algorithm.measurement_hash_algo =
+		m_use_measurement_hash_algo;
+	spdm_context->connection_info.algorithm.base_hash_algo =
+		m_use_hash_algo;
+	spdm_context->connection_info.algorithm.base_asym_algo =
+		m_use_asym_algo;
+	spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+		data_size;
+	copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+		 data, data_size);
+	request_attribute =
+		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
+
+	measurement_record_length = sizeof(measurement_record);
+	status = spdm_get_measurement(spdm_context, &session_id, request_attribute, 1,
+				      0, &number_of_block,
+				      &measurement_record_length,
+				      measurement_record);
+	assert_int_equal(status, RETURN_SUCCESS);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
+#endif
+	free(data);
+}
+
 spdm_test_context_t m_spdm_requester_get_measurements_test_context = {
 	SPDM_TEST_CONTEXT_SIGNATURE,
 	TRUE,
@@ -4470,6 +4687,8 @@ int spdm_requester_get_measurements_test_main(void)
 		cmocka_unit_test(test_spdm_requester_get_measurements_case32),
 		// Unexpected errors
 		cmocka_unit_test(test_spdm_requester_get_measurements_case33),
+		// Successful response to get a session based measurement with signature
+		cmocka_unit_test(test_spdm_requester_get_measurements_case34),
 	};
 
 	setup_spdm_test_context(

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -1376,8 +1376,8 @@ void test_spdm_requester_heartbeat_case11(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-		spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+		session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -1391,7 +1391,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 	status = spdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -3119,8 +3119,8 @@ void test_spdm_requester_key_update_case11(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-		spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+		session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 					spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -3146,7 +3146,7 @@ void test_spdm_requester_key_update_case11(void **state)
 		  m_rsp_secret_buffer, ((spdm_secured_message_context_t 
 		  *)(session_info->secured_message_context))->hash_size);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -1522,18 +1522,6 @@ void test_spdm_requester_psk_finish_case11(void **state)
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
 	spdm_reset_message_a(spdm_context);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-							spdm_context->transcript.message_m.max_buffer_size;
-	spdm_context->transcript.message_b.buffer_size =
-							spdm_context->transcript.message_b.max_buffer_size;
-	spdm_context->transcript.message_c.buffer_size =
-							spdm_context->transcript.message_c.max_buffer_size;
-	spdm_context->transcript.message_mut_b.buffer_size =
-							spdm_context->transcript.message_mut_b.max_buffer_size;
-	spdm_context->transcript.message_mut_c.buffer_size =
-							spdm_context->transcript.message_mut_c.max_buffer_size;
-#endif
 
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
@@ -1585,6 +1573,19 @@ void test_spdm_requester_psk_finish_case11(void **state)
 		->handshake_secret.response_handshake_sequence_number = 0;
 	spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	session_info->session_transcript.message_m.buffer_size =
+							session_info->session_transcript.message_m.max_buffer_size;
+	spdm_context->transcript.message_b.buffer_size =
+							spdm_context->transcript.message_b.max_buffer_size;
+	spdm_context->transcript.message_c.buffer_size =
+							spdm_context->transcript.message_c.max_buffer_size;
+	spdm_context->transcript.message_mut_b.buffer_size =
+							spdm_context->transcript.message_mut_b.max_buffer_size;
+	spdm_context->transcript.message_mut_c.buffer_size =
+							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
+
 	status = spdm_send_receive_psk_finish(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(
@@ -1592,7 +1593,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 			spdm_context->session_info[0].secured_message_context),
 		SPDM_SESSION_STATE_ESTABLISHED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -569,8 +569,8 @@ void test_spdm_responder_end_session_case7(void **state)
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_ESTABLISHED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-							spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+							session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -592,7 +592,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_END_SESSION_ACK);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -810,8 +810,8 @@ void test_spdm_responder_finish_case7(void **state)
 	cert_buffer = (uint8 *)data1;
 	cert_buffer_size = data_size1;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-							spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+							session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -846,7 +846,7 @@ void test_spdm_responder_finish_case7(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_FINISH_RSP);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -558,18 +558,6 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_context->local_context.psk_hint_size =
 		sizeof(TEST_PSK_HINT_STRING);
 	spdm_context->local_context.psk_hint = m_local_psk_hint;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-							spdm_context->transcript.message_m.max_buffer_size;
-	spdm_context->transcript.message_b.buffer_size =
-							spdm_context->transcript.message_b.max_buffer_size;
-	spdm_context->transcript.message_c.buffer_size =
-							spdm_context->transcript.message_c.max_buffer_size;
-	spdm_context->transcript.message_mut_b.buffer_size =
-							spdm_context->transcript.message_mut_b.max_buffer_size;
-	spdm_context->transcript.message_mut_c.buffer_size =
-							spdm_context->transcript.message_mut_c.max_buffer_size;
-#endif
 
 	session_id = 0xFFFFFFFF;
 	spdm_context->latest_session_id = session_id;
@@ -582,6 +570,18 @@ void test_spdm_responder_heartbeat_case7(void **state)
 		SPDM_SESSION_STATE_ESTABLISHED);
 
 	response_size = sizeof(response);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	session_info->session_transcript.message_m.buffer_size =
+							session_info->session_transcript.message_m.max_buffer_size;
+	spdm_context->transcript.message_b.buffer_size =
+							spdm_context->transcript.message_b.max_buffer_size;
+	spdm_context->transcript.message_c.buffer_size =
+							spdm_context->transcript.message_c.max_buffer_size;
+	spdm_context->transcript.message_mut_b.buffer_size =
+							spdm_context->transcript.message_mut_b.max_buffer_size;
+	spdm_context->transcript.message_mut_c.buffer_size =
+							spdm_context->transcript.message_mut_c.max_buffer_size;
+#endif
 	status = spdm_get_response_heartbeat(spdm_context,
 					     m_spdm_heartbeat_request1_size,
 					     &m_spdm_heartbeat_request1,
@@ -592,7 +592,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_HEARTBEAT_ACK);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -122,7 +122,7 @@ void test_spdm_responder_measurements_case1(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -177,7 +177,7 @@ void test_spdm_responder_measurements_case2(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -229,7 +229,7 @@ void test_spdm_responder_measurements_case3(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -282,7 +282,7 @@ void test_spdm_responder_measurements_case4(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -337,7 +337,7 @@ void test_spdm_responder_measurements_case5(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -397,7 +397,7 @@ void test_spdm_responder_measurements_case6(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -449,7 +449,7 @@ void test_spdm_responder_measurements_case7(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -503,7 +503,7 @@ void test_spdm_responder_measurements_case8(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -557,7 +557,7 @@ void test_spdm_responder_measurements_case9(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -608,7 +608,7 @@ void test_spdm_responder_measurements_case10(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -668,7 +668,7 @@ void test_spdm_responder_measurements_case11(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -728,7 +728,7 @@ void test_spdm_responder_measurements_case12(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -809,7 +809,7 @@ void test_spdm_responder_measurements_case13(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -879,7 +879,7 @@ void test_spdm_responder_measurements_case14(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -938,7 +938,7 @@ void test_spdm_responder_measurements_case15(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -993,7 +993,7 @@ void test_spdm_responder_measurements_case16(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1044,7 +1044,7 @@ void test_spdm_responder_measurements_case17(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	;
@@ -1103,7 +1103,7 @@ void test_spdm_responder_measurements_case18(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	read_responder_public_certificate_chain(m_use_hash_algo,
@@ -1175,7 +1175,7 @@ void test_spdm_responder_measurements_case19(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1229,7 +1229,7 @@ void test_spdm_responder_measurements_case20(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1282,7 +1282,7 @@ void test_spdm_responder_measurements_case21(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -1337,7 +1337,7 @@ void test_spdm_responder_measurements_case22(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context);
+	spdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -788,8 +788,8 @@ void test_spdm_responder_psk_finish_case7(void **state)
 			      sizeof(spdm_psk_finish_request_t));
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	spdm_context->transcript.message_m.buffer_size =
-							spdm_context->transcript.message_m.max_buffer_size;
+	session_info->session_transcript.message_m.buffer_size =
+							session_info->session_transcript.message_m.max_buffer_size;
 	spdm_context->transcript.message_b.buffer_size =
 							spdm_context->transcript.message_b.max_buffer_size;
 	spdm_context->transcript.message_c.buffer_size =
@@ -817,7 +817,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_PSK_FINISH_RSP);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-	assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
+	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_c.buffer_size, 0);
 	assert_int_equal(spdm_context->transcript.message_mut_b.buffer_size, 0);


### PR DESCRIPTION
Measurement transcript hash shall be calculated per session
    
REF: #91
    
Should not mix the measurement transcript hash across
multiple sessions. The signature should be per session.