### PR TITLE
Fix unused code

### DIFF
--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -333,7 +333,6 @@ boolean spdm_calculate_l1l2(IN void *context, IN void *session_info,
 				IN OUT uintn *l1l2_buffer_size, OUT void *l1l2_buffer)
 {
 	spdm_context_t *spdm_context;
-	return_status status;
 	spdm_session_info_t *spdm_session_info;
 	uint32 hash_size;
 	uint8 hash_data[MAX_HASH_SIZE];

--- a/unit_test/test_crypt/sm2_verify.c
+++ b/unit_test/test_crypt/sm2_verify.c
@@ -159,7 +159,7 @@ return_status validate_crypt_sm2(void)
 	//
 	sig_size = sizeof(signature);
 	my_print("\n- SM2 Signing ... ");
-	status = sm2_dsa_sign(Sm2_1, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_sign(Sm2_1, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				sizeof(message), signature, &sig_size);
 	if (!status) {
 		my_print("[Fail]");
@@ -168,7 +168,7 @@ return_status validate_crypt_sm2(void)
 	}
 
 	my_print("SM2 Verification ... ");
-	status = sm2_dsa_verify(Sm2_1, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_verify(Sm2_1, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				  sizeof(message), signature, sig_size);
 	if (!status) {
 		my_print("[Fail]");
@@ -231,7 +231,7 @@ return_status validate_crypt_sm2(void)
 	//
 	sig_size = sizeof(signature);
 	my_print("\n- sm2 Signing in Context1 ... ");
-	status = sm2_dsa_sign(Sm2_1, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_sign(Sm2_1, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				sizeof(message), signature, &sig_size);
 	if (!status) {
 		my_print("[Fail]");
@@ -241,7 +241,7 @@ return_status validate_crypt_sm2(void)
 	}
 
 	my_print("sm2 Verification in Context2 ... ");
-	status = sm2_dsa_verify(Sm2_2, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_verify(Sm2_2, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				  sizeof(message), signature, sig_size);
 	if (!status) {
 		my_print("[Fail]");

--- a/unit_test/test_crypt/sm2_verify2.c
+++ b/unit_test/test_crypt/sm2_verify2.c
@@ -132,7 +132,7 @@ return_status validate_crypt_sm2_2(void)
 	//
 	sig_size = sizeof(signature);
 	my_print("\n- SM2 Signing ... ");
-	status = sm2_dsa_sign(sm2_priv_key, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_sign(sm2_priv_key, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				sizeof(message), signature, &sig_size);
 	if (!status) {
 		my_print("[Fail]");
@@ -144,7 +144,7 @@ return_status validate_crypt_sm2_2(void)
 	}
 
 	my_print("\n- SM2 Verification ... ");
-	status = sm2_dsa_verify(sm2_pub_key, CRYPTO_NID_SM3_256, DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
+	status = sm2_dsa_verify(sm2_pub_key, CRYPTO_NID_SM3_256, (uint8 *)DEFAULT_SM2_ID, sizeof(DEFAULT_SM2_ID) - 1, message,
 				  sizeof(message), signature, sig_size);
 	if (!status) {
 		my_print("[Fail]");

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1172,7 +1172,9 @@ void test_spdm_requester_get_certificate_case2(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1191,8 +1193,6 @@ void test_spdm_requester_get_certificate_case2(void **state)
 		internal_dump_hex(
 			root_cert,
 			root_cert_size);
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	spdm_context->local_context.peer_root_cert_provision_size =
 		root_cert_size;
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
@@ -1212,6 +1212,8 @@ void test_spdm_requester_get_certificate_case2(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1391,8 +1393,9 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
-
+#endif
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0x6;
@@ -1406,8 +1409,6 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	x509_get_cert_from_cert_chain((uint8 *)data + sizeof(spdm_cert_chain_t) + hash_size,
 						data_size - sizeof(spdm_cert_chain_t) - hash_size, 0,
 						&root_cert, &root_cert_size);
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	spdm_context->local_context.peer_root_cert_provision_size =
 		root_cert_size;
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
@@ -1423,6 +1424,8 @@ void test_spdm_requester_get_certificate_case6(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1549,7 +1552,9 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1564,8 +1569,6 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	x509_get_cert_from_cert_chain((uint8 *)data + sizeof(spdm_cert_chain_t) + hash_size,
 						data_size - sizeof(spdm_cert_chain_t) - hash_size, 0,
 						&root_cert, &root_cert_size);
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	spdm_context->local_context.peer_root_cert_provision_size =
 		root_cert_size;
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
@@ -1581,6 +1584,8 @@ void test_spdm_requester_get_certificate_case9(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1606,7 +1611,9 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1621,8 +1628,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	x509_get_cert_from_cert_chain((uint8 *)data + sizeof(spdm_cert_chain_t) + hash_size,
 						data_size - sizeof(spdm_cert_chain_t) - hash_size, 0,
 						&root_cert, &root_cert_size);
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
+
 	spdm_context->local_context.peer_root_cert_provision_size = 0;
 	spdm_context->local_context.peer_root_cert_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision = data;
@@ -1637,6 +1643,8 @@ void test_spdm_requester_get_certificate_case10(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1662,8 +1670,9 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
-
+#endif
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0xB;
@@ -1689,8 +1698,6 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	// Reseting message buffer
 	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
@@ -1698,6 +1705,8 @@ void test_spdm_requester_get_certificate_case11(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1723,7 +1732,9 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1753,8 +1764,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	// Reseting message buffer
 	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
+
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
@@ -1762,6 +1772,8 @@ void test_spdm_requester_get_certificate_case12(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1787,7 +1799,9 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1814,8 +1828,6 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	// Reseting message buffer
 	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
@@ -1823,6 +1835,8 @@ void test_spdm_requester_get_certificate_case13(void **state)
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
 			 sizeof(spdm_get_certificate_request_t) * count +
 				 sizeof(spdm_certificate_response_t) * count +
@@ -1848,9 +1862,10 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
-	uintn count;
 	uint16 get_cert_length;
-
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	uintn count;
+#endif
 	// Get certificate chain byte by byte
 	get_cert_length = 1;
 
@@ -1879,7 +1894,6 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	// Reseting message buffer
 	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
-	count = (data_size + get_cert_length - 1) / get_cert_length;
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
@@ -1889,6 +1903,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + get_cert_length - 1) / get_cert_length;
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +
@@ -1916,7 +1931,9 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	uintn hash_size;
 	uint8 *root_cert;
 	uintn root_cert_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn count;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -1943,8 +1960,6 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	// Reseting message buffer
 	spdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
-	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
-		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
@@ -1954,6 +1969,8 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	//assert_int_equal (status, RETURN_SUCCESS);
 	if (status == RETURN_SUCCESS) {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + MAX_SPDM_CERT_CHAIN_BLOCK_LEN - 1) /
+		MAX_SPDM_CERT_CHAIN_BLOCK_LEN;
 		assert_int_equal(
 			spdm_context->transcript.message_b.buffer_size,
 			sizeof(spdm_get_certificate_request_t) * count +

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1243,10 +1243,12 @@ void test_spdm_requester_get_digests_case15(void **state)
 **/
 void test_spdm_requester_get_digests_case16(void **state)
 {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	return_status status;
+	uint8 slot_mask;
+#endif
 	spdm_test_context_t *spdm_test_context;
 	spdm_context_t *spdm_context;
-	uint8 slot_mask;
 	uint8 total_digest_buffer[MAX_HASH_SIZE * MAX_SPDM_SLOT_COUNT];
 
 	spdm_test_context = *state;
@@ -1271,9 +1273,9 @@ void test_spdm_requester_get_digests_case16(void **state)
 #endif
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	status =
 		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #endif
 }

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -74,14 +74,7 @@ return_status spdm_requester_get_measurements_test_send_message(
 	boolean is_app_message;
 	uint8 app_message[MAX_SPDM_MESSAGE_BUFFER_SIZE];
 	uintn app_message_size;
-	spdm_secured_message_callbacks_t spdm_secured_message_callbacks_t;
 
-	spdm_secured_message_callbacks_t.version =
-		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
-	spdm_secured_message_callbacks_t.get_sequence_number =
-		test_get_sequence_number;
-	spdm_secured_message_callbacks_t.get_max_random_number_count =
-		test_get_max_random_number_count;
 	spdm_test_context = get_spdm_test_context();
 	header_size = sizeof(test_message_header_t);
 	switch (spdm_test_context->case_id) {
@@ -4164,8 +4157,9 @@ void test_spdm_requester_get_measurements_case28(void **state)
 	uintn data_size;
 	void *hash;
 	uintn hash_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn ExpectedBufferSize;
-
+#endif
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0x1C;
@@ -4194,7 +4188,6 @@ void test_spdm_requester_get_measurements_case28(void **state)
 		 data, data_size);
 	request_attribute =
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
-	ExpectedBufferSize = 0;
 
 	measurement_record_length = sizeof(measurement_record);
 	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
@@ -4203,6 +4196,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 				      measurement_record);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	ExpectedBufferSize = 0;
 	assert_int_equal(spdm_context->transcript.message_m.buffer_size,
 			 ExpectedBufferSize);
 #endif

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -881,10 +881,10 @@ void test_spdm_responder_certificate_case12(void **state)
 	spdm_certificate_response_t *spdm_response;
 	void *data;
 	uintn data_size;
-
-	uintn count;
 	uint16 expected_chunk_size;
-
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	uintn count;
+#endif
 	// Setting up the spdm_context and loading a sample certificate chain
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -907,8 +907,6 @@ void test_spdm_responder_certificate_case12(void **state)
 	m_spdm_get_certificate_request3.length = 1;
 	expected_chunk_size = 1;
 
-	count = (data_size + m_spdm_get_certificate_request3.length - 1) /
-		m_spdm_get_certificate_request3.length;
 
 	// reseting an internal buffer to avoid overflow and prevent tests to succeed
 	spdm_reset_message_b(spdm_context);
@@ -956,6 +954,8 @@ void test_spdm_responder_certificate_case12(void **state)
 		if (spdm_response->header.request_response_code ==
 		    SPDM_CERTIFICATE) {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	count = (data_size + m_spdm_get_certificate_request3.length - 1) /
+		m_spdm_get_certificate_request3.length;
 			assert_int_equal(
 				spdm_context->transcript.message_b.buffer_size,
 				sizeof(spdm_get_certificate_request_t) * count +

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -334,8 +334,9 @@ void test_spdm_responder_digests_case7(void **state)
 	spdm_context_t *spdm_context;
 	uintn response_size;
 	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_digest_response_t *spdm_response;
-
+#endif
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0x7;
@@ -366,8 +367,8 @@ void test_spdm_responder_digests_case7(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
 #endif
-	spdm_response = (void *)response;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,
@@ -382,12 +383,14 @@ void test_spdm_responder_digests_case7(void **state)
 **/
 void test_spdm_responder_digests_case8(void **state)
 {
-	return_status status;
 	spdm_test_context_t *spdm_test_context;
 	spdm_context_t *spdm_context;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	uintn response_size;
 	uint8 response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+	return_status status;
 	spdm_digest_response_t *spdm_response;
+#endif
 
 	spdm_test_context = *state;
 	spdm_context = spdm_test_context->spdm_context;
@@ -406,22 +409,22 @@ void test_spdm_responder_digests_case8(void **state)
 		(uint8)(0xFF));
 	spdm_context->local_context.slot_count = 1;
 
-	response_size = sizeof(response);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_b.buffer_size =
 		spdm_context->transcript.message_b.max_buffer_size -
 		sizeof(spdm_get_digest_request_t);
 #endif
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	response_size = sizeof(response);
 	status = spdm_get_response_digests(spdm_context,
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,
 					   &response_size, response);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(response_size, sizeof(spdm_error_response_t));
 #endif
-	spdm_response = (void *)response;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+	spdm_response = (void *)response;
 	assert_int_equal(spdm_response->header.request_response_code,
 			 SPDM_ERROR);
 	assert_int_equal(spdm_response->header.param1,


### PR DESCRIPTION
Fix unused variables generated by conditional compilation directives.
The Liunx and Windows unit tests passed.
Signed-off-by: Xiaohanjlll <hanx.xiao@intel.com>