### PR TITLE
Optimize Get Measurements code path 

### DIFF
--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -27,19 +27,22 @@
                                        It must align with measurement_specification (SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_*)
   @param  measurement_hash_algo          Indicates the measurement hash algorithm.
                                        It must align with measurement_hash_algo (SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_*)
-  @param  device_measurement_count       The count of the device measurement block.
-  @param  device_measurement            A pointer to a destination buffer to store the concatenation of all device measurement blocks.
-  @param  device_measurement_size        On input, indicates the size in bytes of the destination buffer.
+  @param  measurement_index      The index of the measurement to collect.
+  @param  measurements_count       The count of the device measurement block.
+  @param  measurements            A pointer to a destination buffer to store the concatenation of all device measurement blocks.
+  @param  measurements_size        On input, indicates the size in bytes of the destination buffer.
                                        On output, indicates the size in bytes of all device measurement blocks in the buffer.
 
-  @retval TRUE  the device measurement collection success and measurement is returned.
-  @retval FALSE the device measurement collection fail.
+  @retval RETURN_SUCCESS             Successfully returned measurement_count and optionally measurements, measurements_size.
+  @retval RETURN_BUFFER_TOO_SMALL    "measurements" buffer too small for measurements.
+  @retval RETURN_INVALID_PARAMETER   Invalid parameter passed to function.
+  @retval RETURN_***                 Any other RETURN_ error from base.h
 **/
-typedef boolean (*spdm_measurement_collection_func)(
+typedef return_status (*spdm_measurement_collection_func)(
 	IN spdm_version_number_t spdm_version,
 	IN uint8 measurement_specification, IN uint32 measurement_hash_algo,
-	OUT uint8 *device_measurement_count, OUT void *device_measurement,
-	IN OUT uintn *device_measurement_size);
+	IN uint8 measurement_index, OUT uint8 *measurement_count,
+	OUT void *measurement, IN OUT uintn *measurement_size);
 
 /**
   Sign an SPDM message data.
@@ -112,7 +115,7 @@ typedef boolean (*spdm_psk_hkdf_expand_func)(
   Collect the device measurement.
 
   libspdm will call this function to retrieve the measurements for a device.
-  The "device_measurement_index" parameter indicates the measurement requested.
+  The "measurement_index" parameter indicates the measurement requested.
 
   @param  measurement_specification     Indicates the measurement specification.
   Must be a SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_* value in spdm.h.
@@ -158,12 +161,17 @@ typedef boolean (*spdm_psk_hkdf_expand_func)(
   On input, indicates the size in bytes of the destination buffer.
   On output, indicates the total size in bytes of all device measurement
   blocks in the buffer. This field should only be modified if
-  "device_measurement_index" is non-zero.
+  "measurement_index" is non-zero.
 
-  @retval TRUE  the measurement collection succeeded and measurement is returned.
-  @retval FALSE the measurement collection failed.
+  @retval RETURN_SUCCESS             Successfully returned measurement_count,
+                                     measurements, measurements_size.
+  @retval RETURN_BUFFER_TOO_SMALL    measurements buffer too small for measurements.
+  @retval RETURN_INVALID_PARAMETER   Invalid parameter passed to function.
+  @retval RETURN_NOT_FOUND           Unsupported measurement index.
+  @retval RETURN_***                 Any other RETURN_ error from base.h
+                                     indicating the type of failure
 **/
-boolean spdm_measurement_collection(
+return_status spdm_measurement_collection(
 				    IN spdm_version_number_t spdm_version,
 				    IN uint8  measurement_specification,
 				    IN uint32 measurement_hash_algo,

--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -111,25 +111,66 @@ typedef boolean (*spdm_psk_hkdf_expand_func)(
 /**
   Collect the device measurement.
 
-  @param  measurement_specification     Indicates the measurement specification.
-                                       It must align with measurement_specification (SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_*)
-  @param  measurement_hash_algo          Indicates the measurement hash algorithm.
-                                       It must align with measurement_hash_algo (SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_*)
-  @param  device_measurement_count       The count of the device measurement block.
-  @param  device_measurement            A pointer to a destination buffer to store the concatenation of all device measurement blocks.
-  @param  device_measurement_size        On input, indicates the size in bytes of the destination buffer.
-                                       On output, indicates the size in bytes of all device measurement blocks in the buffer.
+  libspdm will call this function to retrieve the measurements for a device.
+  The "device_measurement_index" parameter indicates the measurement requested.
 
-  @retval TRUE  the device measurement collection success and measurement is returned.
-  @retval FALSE the device measurement collection fail.
+  @param  measurement_specification     Indicates the measurement specification.
+  Must be a SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_* value in spdm.h.
+
+  @param  measurement_hash_algo         Indicates the measurement hash algorithm.
+  Must be SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_* value in spdm.h.
+
+  @param  measurement_index      The index of the measurement to collect.
+
+  A value of [0x0] requests only the total number of measurements to be returned
+  in "measurements_count". The parameters "measurements" and
+  "measurements_size" will be left unmodified.
+
+  A value of [1-0xFE] requests a single measurement for that measurement index
+  be returned. On success, "measurements_count" will be set to 1 and the
+  "measurements" and "measurements_size" fields will be set based
+  on the single measurement. An invalid measurement index will cause
+  "measurements_count" to return 0.
+
+  A value of [0xFF] requests all measurements be returned.
+  On success, "measurements_count", "measurements", and "measurements_size"
+  fields will be set with data from all measurements.
+
+  @param  measurements_count
+
+  When "measurement_index" is zero, returns the total count of
+  measurements available for the device. None of the actual measurements are
+  returned however, and "measurements" and "measurements_size" are unmodified.
+
+  When "measurement_index" is non-zero, returns the number of measurements
+  returned in "measurements" and "measurements_size". If "measurements_index"
+  is an invalid index not supported by the device, "measurements_count" will
+  return 0.
+
+  @param  measurements
+
+  A pointer to a destination buffer to store the concatenation of all device
+  measurement blocks. This buffer will only be modified if
+  "measurement_index" is non-zero.
+
+  @param  measurements_size
+
+  On input, indicates the size in bytes of the destination buffer.
+  On output, indicates the total size in bytes of all device measurement
+  blocks in the buffer. This field should only be modified if
+  "device_measurement_index" is non-zero.
+
+  @retval TRUE  the measurement collection succeeded and measurement is returned.
+  @retval FALSE the measurement collection failed.
 **/
 boolean spdm_measurement_collection(
 				    IN spdm_version_number_t spdm_version,
-				    IN uint8 measurement_specification,
+				    IN uint8  measurement_specification,
 				    IN uint32 measurement_hash_algo,
-				    OUT uint8 *device_measurement_count,
-				    OUT void *device_measurement,
-				    IN OUT uintn *device_measurement_size);
+				    IN uint8 measurement_index,
+				    OUT uint8 *measurements_count,
+				    OUT void *measurements,
+				    IN OUT uintn *measurements_size);
 
 /**
   Sign an SPDM message data.

--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -935,9 +935,10 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 		ret = spdm_measurement_collection(
 			spdm_context->connection_info.version,
 			spdm_context->connection_info.algorithm.measurement_spec,
-			spdm_context->connection_info.algorithm
-				.measurement_hash_algo,
-			&device_measurement_count, device_measurement,
+			spdm_context->connection_info.algorithm.measurement_hash_algo,
+			0xFF, // Get all measurements
+			&device_measurement_count,
+			device_measurement,
 			&device_measurement_size);
 		if (!ret) {
 			return ret;

--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -916,7 +916,7 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 	uint8 device_measurement[MAX_SPDM_MEASUREMENT_RECORD_SIZE];
 	uint8 device_measurement_count;
 	uintn device_measurement_size;
-	boolean ret;
+	return_status status;
 
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, is_requester, 0,
@@ -932,7 +932,7 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 	case SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH:
 		// get all measurement data
 		device_measurement_size = sizeof(device_measurement);
-		ret = spdm_measurement_collection(
+		status = spdm_measurement_collection(
 			spdm_context->connection_info.version,
 			spdm_context->connection_info.algorithm.measurement_spec,
 			spdm_context->connection_info.algorithm.measurement_hash_algo,
@@ -940,8 +940,8 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 			&device_measurement_count,
 			device_measurement,
 			&device_measurement_size);
-		if (!ret) {
-			return ret;
+		if (RETURN_ERROR(status)) {
+			return FALSE;
 		}
 
 		ASSERT(device_measurement_count <=

--- a/library/spdm_responder_lib/measurements.c
+++ b/library/spdm_responder_lib/measurements.c
@@ -308,12 +308,6 @@ return_status spdm_get_response_measurements(IN void *context,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
-		else if (status == RETURN_BUFFER_TOO_SMALL) {
-			spdm_generate_error_response(
-				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
-				0, response_size, response);
-			return RETURN_BUFFER_TOO_SMALL;
-		}
 		else {
 			spdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -23,10 +23,10 @@
   @param  device_measurement_size        On input, indicates the size in bytes of the destination buffer.
                                        On output, indicates the size in bytes of all device measurement blocks in the buffer.
 
-  @retval TRUE  the device measurement collection success and measurement is returned.
-  @retval FALSE the device measurement collection fail.
+  @retval RETURN_SUCCESS             Successfully returned measurement_count and optionally measurements, measurements_size.
+  @retval RETURN_***                 Any other RETURN_error code indicating the type of measurement collection failure.
 **/
-boolean spdm_measurement_collection(
+return_status spdm_measurement_collection(
 				    IN spdm_version_number_t spdm_version,
 				    IN uint8 measurement_specification,
 				    IN uint32 measurement_hash_algo,
@@ -35,7 +35,7 @@ boolean spdm_measurement_collection(
 				    OUT void *device_measurement,
 				    IN OUT uintn *device_measurement_size)
 {
-	return FALSE;
+	return RETURN_UNSUPPORTED;
 }
 
 /**

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -30,6 +30,7 @@ boolean spdm_measurement_collection(
 				    IN spdm_version_number_t spdm_version,
 				    IN uint8 measurement_specification,
 				    IN uint32 measurement_hash_algo,
+				    IN uint8 mesurements_index,
 				    OUT uint8 *device_measurement_count,
 				    OUT void *device_measurement,
 				    IN OUT uintn *device_measurement_size)


### PR DESCRIPTION
Fix #179

This change optimizes the get measurements code path related to [https://github.com/DMTF/libspdm/issues/179](https://github.com/DMTF/libspdm/issues/179)

- 4.5K is saved off the stack by not using an extra local buffer for copying measurements when **spdm_get_response_measurements** calls **spdm_measurement_collection**. The response buffer is passed instead and **spdm_measurement_collection** will fill in the response buffer directly.
- The size of the **spdm_get_response_measurements** code is reduced from ~1.3K to ~500bytes (Release build x64). The size of **spdm_measurement_collection**, which is just an example, increases slightly by ~180 bytes.
- **spdm_measurement_collection** now receives and "**measurements_index**" so it does not need to calculate all measurements when only one is really needed.

Tested this running x64 release and x64 debug unit tests for crypt\common\requester\responder. Also tested spdm_emu x64 debug.

Please review this carefully as it is quite a change.

I believe there is also potential for optimization down the challenge_auth, key_exchange, psk_exchange code paths as they use spdm_generate_measurement_summary_hash which also uses spdm_measurement_collection.

Signed-off-by: Kong, Richard <richard.kong@intel.com>