### PR TITLE
Fix for bug wrong measurement buffer size used for copy and hash.

### DIFF
--- a/library/spdm_common_lib/crypto_service.c
+++ b/library/spdm_common_lib/crypto_service.c
@@ -1003,11 +1003,12 @@ spdm_generate_measurement_summary_hash(IN spdm_context_t *spdm_context,
 					cached_measurment_block
 						->Measurement_block_common_header
 						.measurement_size);
+
+				measurment_data_size +=
+					cached_measurment_block
+						->Measurement_block_common_header
+						.measurement_size;
 			}
-			measurment_data_size +=
-				cached_measurment_block
-					->Measurement_block_common_header
-					.measurement_size;
 			cached_measurment_block =
 				(void *)((uintn)cached_measurment_block +
 					 measurment_block_size);


### PR DESCRIPTION
Fix #254

Bug fix for [Incorrect measurements buffer size hashed in spdm_generate_measurement_summary_hash #254](https://github.com/DMTF/libspdm/issues/254)

Signed-off-by: Kong, Richard <richard.kong@intel.com>