### PR TITLE
Rename functions

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -293,7 +293,7 @@ typedef struct {
 	uint32 last_spdm_request_session_id;
 	boolean last_spdm_request_session_id_valid;
 	//
-	// Cache the error in spdm_process_request. It is handled in spdm_build_response.
+	// Cache the error in libspdm_process_request. It is handled in libspdm_build_response.
 	//
 	spdm_error_struct_t last_spdm_error;
 

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -62,7 +62,7 @@ typedef struct {
 	void *peer_cert_chain_provision;
 	uintn peer_cert_chain_provision_size;
 	// Peer Cert verify
-	spdm_verify_spdm_cert_chain_func verify_peer_spdm_cert_chain;
+	libspdm_verify_spdm_cert_chain_func verify_peer_spdm_cert_chain;
 	//
 	// PSK provision locally
 	//
@@ -269,13 +269,13 @@ typedef struct {
 	//
 	// IO information
 	//
-	spdm_device_send_message_func send_message;
-	spdm_device_receive_message_func receive_message;
+	libspdm_device_send_message_func send_message;
+	libspdm_device_receive_message_func receive_message;
 	//
 	// Transport Layer infomration
 	//
-	spdm_transport_encode_message_func transport_encode_message;
-	spdm_transport_decode_message_func transport_decode_message;
+	libspdm_transport_encode_message_func transport_encode_message;
+	libspdm_transport_decode_message_func transport_decode_message;
 
 	//
 	// command status

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -65,7 +65,7 @@ typedef struct {
 	uintn psk_hint_size;
 	void *psk_hint;
 	//
-	// Cache the error in spdm_decode_secured_message. It is handled in spdm_build_response.
+	// Cache the error in spdm_decode_secured_message. It is handled in libspdm_build_response.
 	//
 	spdm_error_struct_t last_spdm_error;
 } spdm_secured_message_context_t;

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -113,7 +113,7 @@ typedef enum {
 	SPDM_DATA_SESSION_END_SESSION_ATTRIBUTES,
 	//
 	// Opaque data that can be used by the application
-	// during callback functions such spdm_device_send_message_func.
+	// during callback functions such libspdm_device_send_message_func.
 	//
 	SPDM_DATA_OPAQUE_CONTEXT_DATA,
 	//
@@ -215,7 +215,7 @@ typedef enum {
   @retval RETURN_ACCESS_DENIED         The data_type cannot be set.
   @retval RETURN_NOT_READY             data is not ready to set.
 **/
-return_status spdm_set_data(IN void *spdm_context,
+return_status libspdm_set_data(IN void *spdm_context,
 			    IN spdm_data_type_t data_type,
 			    IN spdm_data_parameter_t *parameter, IN void *data,
 			    IN uintn data_size);
@@ -239,7 +239,7 @@ return_status spdm_set_data(IN void *spdm_context,
   @retval RETURN_NOT_READY             The data is not ready to return.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_get_data(IN void *spdm_context,
+return_status libspdm_get_data(IN void *spdm_context,
 			    IN spdm_data_type_t data_type,
 			    IN spdm_data_parameter_t *parameter,
 			    IN OUT void *data, IN OUT uintn *data_size);
@@ -251,7 +251,7 @@ return_status spdm_get_data(IN void *spdm_context,
 
   @return Last error of an SPDM context.
 */
-uint32 spdm_get_last_error(IN void *spdm_context);
+uint32 libspdm_get_last_error(IN void *spdm_context);
 
 /**
   Get the last SPDM error struct of an SPDM context.
@@ -259,7 +259,7 @@ uint32 spdm_get_last_error(IN void *spdm_context);
   @param  spdm_context                  A pointer to the SPDM context.
   @param  last_spdm_error                Last SPDM error struct of an SPDM context.
 */
-void spdm_get_last_spdm_error_struct(IN void *spdm_context,
+void libspdm_get_last_spdm_error_struct(IN void *spdm_context,
 				     OUT spdm_error_struct_t *last_spdm_error);
 
 /**
@@ -268,33 +268,33 @@ void spdm_get_last_spdm_error_struct(IN void *spdm_context,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  last_spdm_error                Last SPDM error struct of an SPDM context.
 */
-void spdm_set_last_spdm_error_struct(IN void *spdm_context,
+void libspdm_set_last_spdm_error_struct(IN void *spdm_context,
 				     IN spdm_error_struct_t *last_spdm_error);
 
 /**
   Initialize an SPDM context.
 
-  The size in bytes of the spdm_context can be returned by spdm_get_context_size.
+  The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
 */
-void spdm_init_context(IN void *spdm_context);
+void libspdm_init_context(IN void *spdm_context);
 
 /**
   Reset an SPDM context.
 
-  The size in bytes of the spdm_context can be returned by spdm_get_context_size.
+  The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
 */
-void spdm_reset_context(IN void *context);
+void libspdm_reset_context(IN void *context);
 
 /**
   Return the size in bytes of the SPDM context.
 
   @return the size in bytes of the SPDM context.
 **/
-uintn spdm_get_context_size(void);
+uintn libspdm_get_context_size(void);
 
 /**
   Send an SPDM transport layer message to a device.
@@ -324,7 +324,7 @@ uintn spdm_get_context_size(void);
   @retval RETURN_TIMEOUT               A timeout occurred while waiting for the SPDM message
                                        to execute.
 **/
-typedef return_status (*spdm_device_send_message_func)(IN void *spdm_context,
+typedef return_status (*libspdm_device_send_message_func)(IN void *spdm_context,
 						       IN uintn message_size,
 						       IN void *message,
 						       IN uint64 timeout);
@@ -358,22 +358,22 @@ typedef return_status (*spdm_device_send_message_func)(IN void *spdm_context,
   @retval RETURN_TIMEOUT               A timeout occurred while waiting for the SPDM message
                                        to execute.
 **/
-typedef return_status (*spdm_device_receive_message_func)(
+typedef return_status (*libspdm_device_receive_message_func)(
 	IN void *spdm_context, IN OUT uintn *message_size, IN OUT void *message,
 	IN uint64 timeout);
 
 /**
   Register SPDM device input/output functions.
 
-  This function must be called after spdm_init_context, and before any SPDM communication.
+  This function must be called after libspdm_init_context, and before any SPDM communication.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  send_message                  The fuction to send an SPDM transport layer message.
   @param  receive_message               The fuction to receive an SPDM transport layer message.
 **/
-void spdm_register_device_io_func(
-	IN void *spdm_context, IN spdm_device_send_message_func send_message,
-	IN spdm_device_receive_message_func receive_message);
+void libspdm_register_device_io_func(
+	IN void *spdm_context, IN libspdm_device_send_message_func send_message,
+	IN libspdm_device_receive_message_func receive_message);
 
 /**
   Encode an SPDM or APP message to a transport layer message.
@@ -400,7 +400,7 @@ void spdm_register_device_io_func(
   @retval RETURN_SUCCESS               The message is encoded successfully.
   @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
 **/
-typedef return_status (*spdm_transport_encode_message_func)(
+typedef return_status (*libspdm_transport_encode_message_func)(
 	IN void *spdm_context, IN uint32 *session_id, IN boolean is_app_message,
 	IN boolean is_requester, IN uintn spdm_message_size,
 	IN void *spdm_message, IN OUT uintn *transport_message_size,
@@ -432,7 +432,7 @@ typedef return_status (*spdm_transport_encode_message_func)(
   @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
   @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
 **/
-typedef return_status (*spdm_transport_decode_message_func)(
+typedef return_status (*libspdm_transport_decode_message_func)(
 	IN void *spdm_context, OUT uint32 **session_id,
 	OUT boolean *is_app_message, IN boolean is_requester,
 	IN uintn transport_message_size, IN void *transport_message,
@@ -441,16 +441,16 @@ typedef return_status (*spdm_transport_decode_message_func)(
 /**
   Register SPDM transport layer encode/decode functions for SPDM or APP messages.
 
-  This function must be called after spdm_init_context, and before any SPDM communication.
+  This function must be called after libspdm_init_context, and before any SPDM communication.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  transport_encode_message       The fuction to encode an SPDM or APP message to a transport layer message.
   @param  transport_decode_message       The fuction to decode an SPDM or APP message from a transport layer message.
 **/
-void spdm_register_transport_layer_func(
+void libspdm_register_transport_layer_func(
 	IN void *spdm_context,
-	IN spdm_transport_encode_message_func transport_encode_message,
-	IN spdm_transport_decode_message_func transport_decode_message);
+	IN libspdm_transport_encode_message_func transport_encode_message,
+	IN libspdm_transport_decode_message_func transport_decode_message);
 
 /**
   Verify a SPDM cert chain in a slot.
@@ -475,7 +475,7 @@ void spdm_register_transport_layer_func(
   @retval RETURN_SUCCESS                The cert chain verification pass.
   @retval RETURN_SECURIY_VIOLATION      The cert chain verification fail.
 **/
-typedef return_status (*spdm_verify_spdm_cert_chain_func)(
+typedef return_status (*libspdm_verify_spdm_cert_chain_func)(
 	IN void *spdm_context, IN uint8 slot_id,
 	IN uintn cert_chain_size, IN void *cert_chain,
 	OUT void **trust_anchor OPTIONAL,
@@ -490,49 +490,49 @@ typedef return_status (*spdm_verify_spdm_cert_chain_func)(
     2) The trust anchor, according SPDM_DATA_PEER_PUBLIC_ROOT_CERT or SPDM_DATA_PEER_PUBLIC_CERT_CHAIN.
   If it is registered, SPDM lib will use this function to verify the certificate.
 
-  This function must be called after spdm_init_context, and before any SPDM communication.
+  This function must be called after libspdm_init_context, and before any SPDM communication.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  verify_certificate            The fuction to verify an SPDM certificate after GET_CERTIFICATE.
 **/
-void spdm_register_verify_spdm_cert_chain_func(
+void libspdm_register_verify_spdm_cert_chain_func(
 	IN void *spdm_context,
-	IN spdm_verify_spdm_cert_chain_func verify_spdm_cert_chain);
+	IN libspdm_verify_spdm_cert_chain_func verify_spdm_cert_chain);
 
 /**
   Reset message A cache in SPDM context.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_a(IN void *spdm_context);
+void libspdm_reset_message_a(IN void *spdm_context);
 
 /**
   Reset message B cache in SPDM context.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_b(IN void *spdm_context);
+void libspdm_reset_message_b(IN void *spdm_context);
 
 /**
   Reset message C cache in SPDM context.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_c(IN void *spdm_context);
+void libspdm_reset_message_c(IN void *spdm_context);
 
 /**
   Reset message MutB cache in SPDM context.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_mut_b(IN void *spdm_context);
+void libspdm_reset_message_mut_b(IN void *spdm_context);
 
 /**
   Reset message MutC cache in SPDM context.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_mut_c(IN void *spdm_context);
+void libspdm_reset_message_mut_c(IN void *spdm_context);
 
 /**
   Reset message M cache in SPDM context.
@@ -542,7 +542,7 @@ void spdm_reset_message_mut_c(IN void *spdm_context);
   @param  spdm_context                  A pointer to the SPDM context.
   @param  session_info                  A pointer to the SPDM session context.
 **/
-void spdm_reset_message_m(IN void *context, IN void *session_info);
+void libspdm_reset_message_m(IN void *context, IN void *session_info);
 
 /**
   Reset message K cache in SPDM context.
@@ -550,7 +550,7 @@ void spdm_reset_message_m(IN void *context, IN void *session_info);
   @param  spdm_context                  A pointer to the SPDM context.
   @param  spdm_session_info              A pointer to the SPDM session context.
 **/
-void spdm_reset_message_k(IN void *context, IN void *spdm_session_info);
+void libspdm_reset_message_k(IN void *context, IN void *spdm_session_info);
 
 /**
   Reset message F cache in SPDM context.
@@ -558,7 +558,7 @@ void spdm_reset_message_k(IN void *context, IN void *spdm_session_info);
   @param  spdm_context                  A pointer to the SPDM context.
   @param  spdm_session_info              A pointer to the SPDM session context.
 **/
-void spdm_reset_message_f(IN void *context, IN void *spdm_session_info);
+void libspdm_reset_message_f(IN void *context, IN void *spdm_session_info);
 
 /**
   Append message A cache in SPDM context.
@@ -570,7 +570,7 @@ void spdm_reset_message_f(IN void *context, IN void *spdm_session_info);
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_a(IN void *spdm_context, IN void *message,
+return_status libspdm_append_message_a(IN void *spdm_context, IN void *message,
 				    IN uintn message_size);
 
 /**
@@ -583,7 +583,7 @@ return_status spdm_append_message_a(IN void *spdm_context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_b(IN void *spdm_context, IN void *message,
+return_status libspdm_append_message_b(IN void *spdm_context, IN void *message,
 				    IN uintn message_size);
 
 /**
@@ -596,7 +596,7 @@ return_status spdm_append_message_b(IN void *spdm_context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_c(IN void *spdm_context, IN void *message,
+return_status libspdm_append_message_c(IN void *spdm_context, IN void *message,
 				    IN uintn message_size);
 
 /**
@@ -609,7 +609,7 @@ return_status spdm_append_message_c(IN void *spdm_context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_mut_b(IN void *spdm_context, IN void *message,
+return_status libspdm_append_message_mut_b(IN void *spdm_context, IN void *message,
 					IN uintn message_size);
 
 /**
@@ -622,7 +622,7 @@ return_status spdm_append_message_mut_b(IN void *spdm_context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_mut_c(IN void *spdm_context, IN void *message,
+return_status libspdm_append_message_mut_c(IN void *spdm_context, IN void *message,
 					IN uintn message_size);
 
 /**
@@ -638,7 +638,7 @@ return_status spdm_append_message_mut_c(IN void *spdm_context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_m(IN void *context, IN void *session_info,
+return_status libspdm_append_message_m(IN void *context, IN void *session_info,
 					IN void *message, IN uintn message_size);
 
 /**
@@ -653,7 +653,7 @@ return_status spdm_append_message_m(IN void *context, IN void *session_info,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_k(IN void *context, IN void *spdm_session_info,
+return_status libspdm_append_message_k(IN void *context, IN void *spdm_session_info,
             IN boolean is_requester, IN void *message, IN uintn message_size);
 
 /**
@@ -668,7 +668,7 @@ return_status spdm_append_message_k(IN void *context, IN void *spdm_session_info
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_f(IN void *context, IN void *spdm_session_info,
+return_status libspdm_append_message_f(IN void *context, IN void *spdm_session_info,
             IN boolean is_requester, IN void *message, IN uintn message_size);
 
 /**
@@ -679,7 +679,7 @@ return_status spdm_append_message_f(IN void *context, IN void *spdm_session_info
 
   @return session info.
 **/
-void *spdm_get_session_info_via_session_id(IN void *spdm_context,
+void *libspdm_get_session_info_via_session_id(IN void *spdm_context,
 					   IN uint32 session_id);
 
 /**
@@ -690,7 +690,7 @@ void *spdm_get_session_info_via_session_id(IN void *spdm_context,
 
   @return secured message context.
 **/
-void *spdm_get_secured_message_context_via_session_id(IN void *spdm_context,
+void *libspdm_get_secured_message_context_via_session_id(IN void *spdm_context,
 						      IN uint32 session_id);
 
 /**
@@ -701,7 +701,7 @@ void *spdm_get_secured_message_context_via_session_id(IN void *spdm_context,
   @return secured message context.
 **/
 void *
-spdm_get_secured_message_context_via_session_info(IN void *spdm_session_info);
+libspdm_get_secured_message_context_via_session_info(IN void *spdm_session_info);
 
 /**
   This function assigns a new session ID.
@@ -711,7 +711,7 @@ spdm_get_secured_message_context_via_session_info(IN void *spdm_session_info);
 
   @return session info associated with this new session ID.
 **/
-void *spdm_assign_session_id(IN void *spdm_context, IN uint32 session_id,
+void *libspdm_assign_session_id(IN void *spdm_context, IN uint32 session_id,
 			     IN boolean use_psk);
 
 /**
@@ -722,7 +722,7 @@ void *spdm_assign_session_id(IN void *spdm_context, IN uint32 session_id,
 
   @return freed session info assicated with this session ID.
 **/
-void *spdm_free_session_id(IN void *spdm_context, IN uint32 session_id);
+void *libspdm_free_session_id(IN void *spdm_context, IN uint32 session_id);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
@@ -737,7 +737,7 @@ void *spdm_free_session_id(IN void *spdm_context, IN uint32 session_id);
 
   @retval RETURN_SUCCESS  current TH data is calculated.
 */
-boolean spdm_calculate_th_for_exchange(
+boolean libspdm_calculate_th_for_exchange(
 	IN void *spdm_context, IN void *spdm_session_info,
 	IN uint8 *cert_chain_buffer, OPTIONAL IN uintn cert_chain_buffer_size,
 	OPTIONAL IN OUT uintn *th_data_buffer_size, OUT void *th_data_buffer);
@@ -752,7 +752,7 @@ boolean spdm_calculate_th_for_exchange(
 
   @retval RETURN_SUCCESS  current TH hash is calculated.
 */
-boolean spdm_calculate_th_hash_for_exchange(
+boolean libspdm_calculate_th_hash_for_exchange(
 	IN void *context, IN void *spdm_session_info,
 	OPTIONAL IN OUT uintn *th_hash_buffer_size, OUT void *th_hash_buffer);
 
@@ -766,7 +766,7 @@ boolean spdm_calculate_th_hash_for_exchange(
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_exchange_rsp(
+boolean libspdm_calculate_th_hmac_for_exchange_rsp(
 	IN void *context, IN void *spdm_session_info, IN boolean is_requester,
 	OPTIONAL IN OUT uintn *th_hmac_buffer_size, OUT void *th_hmac_buffer);
 #endif
@@ -786,7 +786,7 @@ boolean spdm_calculate_th_hmac_for_exchange_rsp(
 
   @retval RETURN_SUCCESS  current TH data is calculated.
 */
-boolean spdm_calculate_th_for_finish(IN void *spdm_context,
+boolean libspdm_calculate_th_for_finish(IN void *spdm_context,
 				     IN void *spdm_session_info,
 				     IN uint8 *cert_chain_buffer,
 				     OPTIONAL IN uintn cert_chain_buffer_size,
@@ -805,7 +805,7 @@ boolean spdm_calculate_th_for_finish(IN void *spdm_context,
 
   @retval RETURN_SUCCESS  current TH hash is calculated.
 */
-boolean spdm_calculate_th_hash_for_finish(IN void *spdm_context,
+boolean libspdm_calculate_th_hash_for_finish(IN void *spdm_context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hash_buffer_size,
 				     OUT void *th_hash_buffer);
@@ -820,7 +820,7 @@ boolean spdm_calculate_th_hash_for_finish(IN void *spdm_context,
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_finish_rsp(IN void *spdm_context,
+boolean libspdm_calculate_th_hmac_for_finish_rsp(IN void *spdm_context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hmac_buffer_size,
 				     OUT void *th_hmac_buffer);
@@ -835,7 +835,7 @@ boolean spdm_calculate_th_hmac_for_finish_rsp(IN void *spdm_context,
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_finish_req(IN void *spdm_context,
+boolean libspdm_calculate_th_hmac_for_finish_req(IN void *spdm_context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hmac_buffer_size,
 				     OUT void *th_hmac_buffer);
@@ -851,7 +851,7 @@ boolean spdm_calculate_th_hmac_for_finish_req(IN void *spdm_context,
 
   @retval RETURN_SUCCESS  th1 hash is calculated.
 */
-return_status spdm_calculate_th1_hash(IN void *spdm_context,
+return_status libspdm_calculate_th1_hash(IN void *spdm_context,
 				      IN void *spdm_session_info,
 				      IN boolean is_requester,
 				      OUT uint8 *th1_hash_data);
@@ -866,7 +866,7 @@ return_status spdm_calculate_th1_hash(IN void *spdm_context,
 
   @retval RETURN_SUCCESS  th2 hash is calculated.
 */
-return_status spdm_calculate_th2_hash(IN void *spdm_context,
+return_status libspdm_calculate_th2_hash(IN void *spdm_context,
 				      IN void *spdm_session_info,
 				      IN boolean is_requester,
 				      OUT uint8 *th2_hash_data);
@@ -881,7 +881,7 @@ return_status spdm_calculate_th2_hash(IN void *spdm_context,
   @retval TRUE  Peer certificate chain buffer including spdm_cert_chain_t header is returned.
   @retval FALSE Peer certificate chain buffer including spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_peer_cert_chain_buffer(IN void *spdm_context,
+boolean libspdm_get_peer_cert_chain_buffer(IN void *spdm_context,
 					OUT void **cert_chain_buffer,
 					OUT uintn *cert_chain_buffer_size);
 
@@ -895,7 +895,7 @@ boolean spdm_get_peer_cert_chain_buffer(IN void *spdm_context,
   @retval TRUE  Peer certificate chain data without spdm_cert_chain_t header is returned.
   @retval FALSE Peer certificate chain data without spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_peer_cert_chain_data(IN void *spdm_context,
+boolean libspdm_get_peer_cert_chain_data(IN void *spdm_context,
 				      OUT void **cert_chain_data,
 				      OUT uintn *cert_chain_data_size);
 
@@ -909,7 +909,7 @@ boolean spdm_get_peer_cert_chain_data(IN void *spdm_context,
   @retval TRUE  Local used certificate chain buffer including spdm_cert_chain_t header is returned.
   @retval FALSE Local used certificate chain buffer including spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_local_cert_chain_buffer(IN void *spdm_context,
+boolean libspdm_get_local_cert_chain_buffer(IN void *spdm_context,
 					 OUT void **cert_chain_buffer,
 					 OUT uintn *cert_chain_buffer_size);
 
@@ -923,7 +923,7 @@ boolean spdm_get_local_cert_chain_buffer(IN void *spdm_context,
   @retval TRUE  Local used certificate chain data without spdm_cert_chain_t header is returned.
   @retval FALSE Local used certificate chain data without spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_local_cert_chain_data(IN void *spdm_context,
+boolean libspdm_get_local_cert_chain_data(IN void *spdm_context,
 				       OUT void **cert_chain_data,
 				       OUT uintn *cert_chain_data_size);
 
@@ -934,7 +934,7 @@ boolean spdm_get_local_cert_chain_data(IN void *spdm_context,
 
   @return The 24-bit value read from buffer.
 **/
-uint32 spdm_read_uint24(IN uint8 *buffer);
+uint32 libspdm_read_uint24(IN uint8 *buffer);
 
 /**
   Writes a 24-bit value to memory that may be unaligned.
@@ -944,6 +944,6 @@ uint32 spdm_read_uint24(IN uint8 *buffer);
 
   @return The 24-bit value to write to buffer.
 **/
-uint32 spdm_write_uint24(IN uint8 *buffer, IN uint32 value);
+uint32 libspdm_write_uint24(IN uint8 *buffer, IN uint32 value);
 
 #endif

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -25,7 +25,7 @@
   @retval RETURN_SUCCESS               The SPDM request is sent successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM request is sent to the device.
 **/
-return_status spdm_send_request(IN void *spdm_context, IN uint32 *session_id,
+return_status libspdm_send_request(IN void *spdm_context, IN uint32 *session_id,
 				IN boolean is_app_message,
 				IN uintn request_size, IN void *request);
 
@@ -45,7 +45,7 @@ return_status spdm_send_request(IN void *spdm_context, IN uint32 *session_id,
   @retval RETURN_SUCCESS               The SPDM response is received successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is received from the device.
 **/
-return_status spdm_receive_response(IN void *spdm_context,
+return_status libspdm_receive_response(IN void *spdm_context,
 				    IN uint32 *session_id,
 				    IN boolean is_app_message,
 				    IN OUT uintn *response_size,
@@ -64,7 +64,7 @@ return_status spdm_receive_response(IN void *spdm_context,
   @retval RETURN_SUCCESS               The connection is initialized successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
 **/
-return_status spdm_init_connection(IN void *spdm_context,
+return_status libspdm_init_connection(IN void *spdm_context,
 				   IN boolean get_version_only);
 
 /**
@@ -84,7 +84,7 @@ return_status spdm_init_connection(IN void *spdm_context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_digest(IN void *spdm_context, OUT uint8 *slot_mask,
+return_status libspdm_get_digest(IN void *spdm_context, OUT uint8 *slot_mask,
 			      OUT void *total_digest_buffer);
 
 /**
@@ -107,7 +107,7 @@ return_status spdm_get_digest(IN void *spdm_context, OUT uint8 *slot_mask,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate(IN void *spdm_context, IN uint8 slot_id,
+return_status libspdm_get_certificate(IN void *spdm_context, IN uint8 slot_id,
 				   IN OUT uintn *cert_chain_size,
 				   OUT void *cert_chain);
 
@@ -133,7 +133,7 @@ return_status spdm_get_certificate(IN void *spdm_context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
+return_status libspdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
 				   IN OUT uintn *cert_chain_size,
 				   OUT void *cert_chain,
 				   OUT void **trust_anchor OPTIONAL,
@@ -160,7 +160,7 @@ return_status spdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_choose_length(IN void *spdm_context,
+return_status libspdm_get_certificate_choose_length(IN void *spdm_context,
 						 IN uint8 slot_id,
 						 IN uint16 length,
 						 IN OUT uintn *cert_chain_size,
@@ -189,7 +189,7 @@ return_status spdm_get_certificate_choose_length(IN void *spdm_context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_choose_length_ex(IN void *context,
+return_status libspdm_get_certificate_choose_length_ex(IN void *context,
 						 IN uint8 slot_id,
 						 IN uint16 length,
 						 IN OUT uintn *cert_chain_size,
@@ -215,7 +215,7 @@ return_status spdm_get_certificate_choose_length_ex(IN void *context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_challenge(IN void *spdm_context, IN uint8 slot_id,
+return_status libspdm_challenge(IN void *spdm_context, IN uint8 slot_id,
 			     IN uint8 measurement_hash_type,
 			     OUT void *measurement_hash);
 
@@ -240,7 +240,7 @@ return_status spdm_challenge(IN void *spdm_context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_challenge_ex(IN void *context, IN uint8 slot_id,
+return_status libspdm_challenge_ex(IN void *context, IN uint8 slot_id,
 			     IN uint8 measurement_hash_type,
 			     OUT void *measurement_hash,
 			     IN void *requester_nonce_in OPTIONAL,
@@ -269,7 +269,7 @@ return_status spdm_challenge_ex(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_measurement(IN void *spdm_context, IN uint32 *session_id,
+return_status libspdm_get_measurement(IN void *spdm_context, IN uint32 *session_id,
 				   IN uint8 request_attribute,
 				   IN uint8 measurement_operation,
 				   IN uint8 slot_id,
@@ -302,7 +302,7 @@ return_status spdm_get_measurement(IN void *spdm_context, IN uint32 *session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_measurement_ex(IN void *context, IN uint32 *session_id,
+return_status libspdm_get_measurement_ex(IN void *context, IN uint32 *session_id,
 				   IN uint8 request_attribute,
 				   IN uint8 measurement_operation,
 				   IN uint8 slot_id_param,
@@ -333,7 +333,7 @@ return_status spdm_get_measurement_ex(IN void *context, IN uint32 *session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_start_session(IN void *spdm_context, IN boolean use_psk,
+return_status libspdm_start_session(IN void *spdm_context, IN boolean use_psk,
 				 IN uint8 measurement_hash_type,
 				 IN uint8 slot_id, OUT uint32 *session_id,
 				 OUT uint8 *heartbeat_period,
@@ -374,7 +374,7 @@ return_status spdm_start_session(IN void *spdm_context, IN boolean use_psk,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_start_session_ex(IN void *spdm_context, IN boolean use_psk,
+return_status libspdm_start_session_ex(IN void *spdm_context, IN boolean use_psk,
 				 IN uint8 measurement_hash_type,
 				 IN uint8 slot_id, OUT uint32 *session_id,
 				 OUT uint8 *heartbeat_period,
@@ -398,7 +398,7 @@ return_status spdm_start_session_ex(IN void *spdm_context, IN boolean use_psk,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_stop_session(IN void *spdm_context, IN uint32 session_id,
+return_status libspdm_stop_session(IN void *spdm_context, IN uint32 session_id,
 				IN uint8 end_session_attributes);
 
 /**
@@ -428,7 +428,7 @@ return_status spdm_stop_session(IN void *spdm_context, IN uint32 session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_send_receive_data(IN void *spdm_context,
+return_status libspdm_send_receive_data(IN void *spdm_context,
 				     IN uint32 *session_id,
 				     IN boolean is_app_message,
 				     IN void *request, IN uintn request_size,
@@ -446,7 +446,7 @@ return_status spdm_send_receive_data(IN void *spdm_context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_heartbeat(IN void *spdm_context, IN uint32 session_id);
+return_status libspdm_heartbeat(IN void *spdm_context, IN uint32 session_id);
 
 /**
   This function sends KEY_UPDATE
@@ -463,7 +463,7 @@ return_status spdm_heartbeat(IN void *spdm_context, IN uint32 session_id);
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_key_update(IN void *spdm_context, IN uint32 session_id,
+return_status libspdm_key_update(IN void *spdm_context, IN uint32 session_id,
 			      IN boolean single_direction);
 
 /**
@@ -480,7 +480,7 @@ return_status spdm_key_update(IN void *spdm_context, IN uint32 session_id,
   @retval RETURN_SUCCESS               The SPDM Encapsulated requests are sent and the responses are received.
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
 **/
-return_status spdm_send_receive_encap_request(IN void *spdm_context,
+return_status libspdm_send_receive_encap_request(IN void *spdm_context,
 					      IN uint32 *session_id);
 
 /**
@@ -500,7 +500,7 @@ return_status spdm_send_receive_encap_request(IN void *spdm_context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-typedef return_status (*spdm_get_encap_response_func)(
+typedef return_status (*libspdm_get_encap_response_func)(
 	IN void *spdm_context, IN uintn spdm_request_size,
 	IN void *spdm_request, IN OUT uintn *spdm_response_size,
 	OUT void *spdm_response);
@@ -514,14 +514,14 @@ typedef return_status (*spdm_get_encap_response_func)(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  get_encap_response_func         The function to process the encapsuled message.
 **/
-void spdm_register_get_encap_response_func(IN void *spdm_context,
-					   IN spdm_get_encap_response_func
+void libspdm_register_get_encap_response_func(IN void *spdm_context,
+					   IN libspdm_get_encap_response_func
 						   get_encap_response_func);
 
 /**
   Generate encapsulated ERROR message.
 
-  This function can be called in spdm_get_encap_response_func.
+  This function can be called in libspdm_get_encap_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -535,14 +535,14 @@ void spdm_register_get_encap_response_func(IN void *spdm_context,
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_encap_error_response(
+return_status libspdm_generate_encap_error_response(
 	IN void *spdm_context, IN uint8 error_code, IN uint8 error_data,
 	IN OUT uintn *spdm_response_size, OUT void *spdm_response);
 
 /**
   Generate encapsulated ERROR message with extended error data.
 
-  This function can be called in spdm_get_encap_response_func.
+  This function can be called in libspdm_get_encap_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -558,7 +558,7 @@ return_status spdm_generate_encap_error_response(
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_encap_extended_error_response(
+return_status libspdm_generate_encap_extended_error_response(
 	IN void *spdm_context, IN uint8 error_code, IN uint8 error_data,
 	IN uintn extended_error_data_size, IN uint8 *extended_error_data,
 	IN OUT uintn *spdm_response_size, OUT void *spdm_response);

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -55,8 +55,8 @@ return_status libspdm_receive_response(IN void *spdm_context,
   This function sends GET_VERSION, GET_CAPABILITIES, NEGOTIATE_ALGORITHMS
   to initialize the connection with SPDM responder.
 
-  Before this function, the requester configuration data can be set via spdm_set_data.
-  After this function, the negotiated configuration data can be got via spdm_get_data.
+  Before this function, the requester configuration data can be set via libspdm_set_data.
+  After this function, the negotiated configuration data can be got via libspdm_get_data.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  get_version_only               If the requester sends GET_VERSION only or not.

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -34,7 +34,7 @@
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-typedef return_status (*spdm_get_response_func)(
+typedef return_status (*libspdm_get_response_func)(
 	IN void *spdm_context, IN uint32 *session_id, IN boolean is_app_message,
 	IN uintn request_size, IN void *request, IN OUT uintn *response_size,
 	OUT void *response);
@@ -48,8 +48,8 @@ typedef return_status (*spdm_get_response_func)(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  get_response_func              The function to process the encapsuled message.
 **/
-void spdm_register_get_response_func(
-	IN void *spdm_context, IN spdm_get_response_func get_response_func);
+void libspdm_register_get_response_func(
+	IN void *spdm_context, IN libspdm_get_response_func get_response_func);
 
 /**
   Process a SPDM request from a device.
@@ -67,7 +67,7 @@ void spdm_register_get_response_func(
   @retval RETURN_SUCCESS               The SPDM request is received successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM request is received from the device.
 **/
-return_status spdm_process_request(IN void *spdm_context,
+return_status libspdm_process_request(IN void *spdm_context,
 				   OUT uint32 **session_id,
 				   OUT boolean *is_app_message,
 				   IN uintn request_size, IN void *request);
@@ -88,7 +88,7 @@ return_status spdm_process_request(IN void *spdm_context,
   @retval RETURN_SUCCESS               The SPDM response is sent successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is sent to the device.
 **/
-return_status spdm_build_response(IN void *spdm_context, IN uint32 *session_id,
+return_status libspdm_build_response(IN void *spdm_context, IN uint32 *session_id,
 				  IN boolean is_app_message,
 				  IN OUT uintn *response_size,
 				  OUT void *response);
@@ -99,7 +99,7 @@ return_status spdm_build_response(IN void *spdm_context, IN uint32 *session_id,
   The message can be a normal message or a secured message in SPDM session.
   The message can be an SPDM message or an APP message.
 
-  This function is called in spdm_responder_dispatch_message to process the message.
+  This function is called in libspdm_responder_dispatch_message to process the message.
   The alternative is: an SPDM responder may receive the request message directly
   and call this function to process it, then send the response message.
 
@@ -120,7 +120,7 @@ return_status spdm_build_response(IN void *spdm_context, IN uint32 *session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_process_message(IN void *context, IN OUT uint32 **session_id,
+return_status libspdm_process_message(IN void *context, IN OUT uint32 **session_id,
 				   IN void *request, IN uintn request_size,
 				   OUT void *response,
 				   IN OUT uintn *response_size);
@@ -138,12 +138,12 @@ return_status spdm_process_message(IN void *context, IN OUT uint32 **session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_UNSUPPORTED           One request message is not supported.
 **/
-return_status spdm_responder_dispatch_message(IN void *spdm_context);
+return_status libspdm_responder_dispatch_message(IN void *spdm_context);
 
 /**
   Generate ERROR message.
 
-  This function can be called in spdm_get_response_func.
+  This function can be called in libspdm_get_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -157,7 +157,7 @@ return_status spdm_responder_dispatch_message(IN void *spdm_context);
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_error_response(IN void *spdm_context,
+return_status libspdm_generate_error_response(IN void *spdm_context,
 					   IN uint8 error_code,
 					   IN uint8 error_data,
 					   IN OUT uintn *spdm_response_size,
@@ -166,7 +166,7 @@ return_status spdm_generate_error_response(IN void *spdm_context,
 /**
   Generate ERROR message with extended error data.
 
-  This function can be called in spdm_get_response_func.
+  This function can be called in libspdm_get_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -182,7 +182,7 @@ return_status spdm_generate_error_response(IN void *spdm_context,
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_extended_error_response(
+return_status libspdm_generate_extended_error_response(
 	IN void *context, IN uint8 error_code, IN uint8 error_data,
 	IN uintn extended_error_data_size, IN uint8 *extended_error_data,
 	IN OUT uintn *spdm_response_size, OUT void *spdm_response);
@@ -194,7 +194,7 @@ return_status spdm_generate_extended_error_response(
   @param  session_id                    The session_id of a session.
   @param  session_state                 The state of a session.
 **/
-typedef void (*spdm_session_state_callback_func)(
+typedef void (*libspdm_session_state_callback_func)(
 	IN void *spdm_context, IN uint32 session_id,
 	IN spdm_session_state_t session_state);
 
@@ -209,9 +209,9 @@ typedef void (*spdm_session_state_callback_func)(
   @retval RETURN_SUCCESS          The callback is registered.
   @retval RETURN_ALREADY_STARTED  No enough memory to register the callback.
 **/
-return_status spdm_register_session_state_callback_func(
+return_status libspdm_register_session_state_callback_func(
 	IN void *spdm_context,
-	IN spdm_session_state_callback_func spdm_session_state_callback);
+	IN libspdm_session_state_callback_func spdm_session_state_callback);
 
 /**
   Notify the connection state to an SPDM context register.
@@ -219,7 +219,7 @@ return_status spdm_register_session_state_callback_func(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  connection_state              Indicate the SPDM connection state.
 **/
-typedef void (*spdm_connection_state_callback_func)(
+typedef void (*libspdm_connection_state_callback_func)(
 	IN void *spdm_context, IN spdm_connection_state_t connection_state);
 
 /**
@@ -233,15 +233,15 @@ typedef void (*spdm_connection_state_callback_func)(
   @retval RETURN_SUCCESS          The callback is registered.
   @retval RETURN_ALREADY_STARTED  No enough memory to register the callback.
 **/
-return_status spdm_register_connection_state_callback_func(
+return_status libspdm_register_connection_state_callback_func(
 	IN void *spdm_context,
-	IN spdm_connection_state_callback_func spdm_connection_state_callback);
+	IN libspdm_connection_state_callback_func spdm_connection_state_callback);
 
 /**
   This function initializes the key_update encapsulated state.
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_init_key_update_encap_state(IN void *spdm_context);
+void libspdm_init_key_update_encap_state(IN void *spdm_context);
 
 #endif

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -41,7 +41,7 @@ boolean need_session_info_for_data(IN spdm_data_type_t data_type)
   @retval RETURN_ACCESS_DENIED         The data_type cannot be set.
   @retval RETURN_NOT_READY             data is not ready to set.
 **/
-return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
+return_status libspdm_set_data(IN void *context, IN spdm_data_type_t data_type,
 			    IN spdm_data_parameter_t *parameter, IN void *data,
 			    IN uintn data_size)
 {
@@ -62,7 +62,7 @@ return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
 			return RETURN_INVALID_PARAMETER;
 		}
 		session_id = *(uint32 *)parameter->additional_data;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_INVALID_PARAMETER;
@@ -403,7 +403,7 @@ return_status spdm_set_data(IN void *context, IN spdm_data_type_t data_type,
   @retval RETURN_NOT_READY             The data is not ready to return.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
+return_status libspdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 			    IN spdm_data_parameter_t *parameter,
 			    IN OUT void *data, IN OUT uintn *data_size)
 {
@@ -424,7 +424,7 @@ return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 			return RETURN_INVALID_PARAMETER;
 		}
 		session_id = *(uint32 *)parameter->additional_data;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_INVALID_PARAMETER;
@@ -581,7 +581,7 @@ return_status spdm_get_data(IN void *context, IN spdm_data_type_t data_type,
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_a(IN void *context)
+void libspdm_reset_message_a(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -594,7 +594,7 @@ void spdm_reset_message_a(IN void *context)
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_b(IN void *context)
+void libspdm_reset_message_b(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -615,7 +615,7 @@ void spdm_reset_message_b(IN void *context)
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_c(IN void *context)
+void libspdm_reset_message_c(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -636,7 +636,7 @@ void spdm_reset_message_c(IN void *context)
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_mut_b(IN void *context)
+void libspdm_reset_message_mut_b(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -657,7 +657,7 @@ void spdm_reset_message_mut_b(IN void *context)
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_reset_message_mut_c(IN void *context)
+void libspdm_reset_message_mut_c(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -681,7 +681,7 @@ void spdm_reset_message_mut_c(IN void *context)
   @param  spdm_context                  A pointer to the SPDM context.
   @param  session_info                  A pointer to the SPDM session context.
 **/
-void spdm_reset_message_m(IN void *context, IN void *session_info)
+void libspdm_reset_message_m(IN void *context, IN void *session_info)
 {
 	spdm_context_t *spdm_context;
 	spdm_session_info_t *spdm_session_info;
@@ -717,7 +717,7 @@ void spdm_reset_message_m(IN void *context, IN void *session_info)
   @param  spdm_context                  A pointer to the SPDM context.
   @param  spdm_session_info              A pointer to the SPDM session context.
 **/
-void spdm_reset_message_k(IN void *context, IN void *session_info)
+void libspdm_reset_message_k(IN void *context, IN void *session_info)
 {
 	spdm_session_info_t *spdm_session_info;
 
@@ -775,7 +775,7 @@ void spdm_reset_message_k(IN void *context, IN void *session_info)
   @param  spdm_context                  A pointer to the SPDM context.
   @param  spdm_session_info              A pointer to the SPDM session context.
 **/
-void spdm_reset_message_f(IN void *context, IN void *session_info)
+void libspdm_reset_message_f(IN void *context, IN void *session_info)
 {
 	spdm_session_info_t *spdm_session_info;
 
@@ -830,7 +830,7 @@ void spdm_reset_message_buffer_via_request_code(IN void *context, IN void *sessi
 	  Any request other than SPDM_GET_MEASUREMENTS resets L1/L2
 	*/
 	if (request_code != SPDM_GET_MEASUREMENTS) {
-		spdm_reset_message_m(spdm_context, session_info);
+		libspdm_reset_message_m(spdm_context, session_info);
 	}
 	/**
 	  If the Requester issued GET_MEASUREMENTS or KEY_EXCHANGE or FINISH or PSK_EXCHANGE 
@@ -850,17 +850,17 @@ void spdm_reset_message_buffer_via_request_code(IN void *context, IN void *sessi
 	case SPDM_END_SESSION:
 		if (spdm_context->connection_info.connection_state <
 			SPDM_CONNECTION_STATE_AUTHENTICATED) {
-			spdm_reset_message_b(spdm_context);
-			spdm_reset_message_c(spdm_context);
-			spdm_reset_message_mut_b(spdm_context);
-			spdm_reset_message_mut_c(spdm_context);
+			libspdm_reset_message_b(spdm_context);
+			libspdm_reset_message_c(spdm_context);
+			libspdm_reset_message_mut_b(spdm_context);
+			libspdm_reset_message_mut_c(spdm_context);
 		}
 		break;
 	case SPDM_DELIVER_ENCAPSULATED_RESPONSE:
 		if (spdm_context->connection_info.connection_state <
 			SPDM_CONNECTION_STATE_AUTHENTICATED) {
-			spdm_reset_message_b(spdm_context);
-			spdm_reset_message_c(spdm_context);
+			libspdm_reset_message_b(spdm_context);
+			libspdm_reset_message_c(spdm_context);
 		}
 		break;
 	default:
@@ -877,7 +877,7 @@ void spdm_reset_message_buffer_via_request_code(IN void *context, IN void *sessi
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_a(IN void *context, IN void *message,
+return_status libspdm_append_message_a(IN void *context, IN void *message,
 				    IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -897,7 +897,7 @@ return_status spdm_append_message_a(IN void *context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_b(IN void *context, IN void *message,
+return_status libspdm_append_message_b(IN void *context, IN void *message,
 				    IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -933,7 +933,7 @@ return_status spdm_append_message_b(IN void *context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_c(IN void *context, IN void *message,
+return_status libspdm_append_message_c(IN void *context, IN void *message,
 				    IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -969,7 +969,7 @@ return_status spdm_append_message_c(IN void *context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_mut_b(IN void *context, IN void *message,
+return_status libspdm_append_message_mut_b(IN void *context, IN void *message,
 					IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -1001,7 +1001,7 @@ return_status spdm_append_message_mut_b(IN void *context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_mut_c(IN void *context, IN void *message,
+return_status libspdm_append_message_mut_c(IN void *context, IN void *message,
 					IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -1036,7 +1036,7 @@ return_status spdm_append_message_mut_c(IN void *context, IN void *message,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_m(IN void *context, IN void *session_info,
+return_status libspdm_append_message_m(IN void *context, IN void *session_info,
 					IN void *message, IN uintn message_size)
 {
 	spdm_context_t *spdm_context;
@@ -1089,7 +1089,7 @@ return_status spdm_append_message_m(IN void *context, IN void *session_info,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_k(IN void *context, IN void *session_info,
+return_status libspdm_append_message_k(IN void *context, IN void *session_info,
             IN boolean is_requester, IN void *message, IN uintn message_size)
 {
 	spdm_session_info_t *spdm_session_info;
@@ -1117,10 +1117,10 @@ return_status spdm_append_message_k(IN void *context, IN void *session_info,
 		if (spdm_session_info->session_transcript.digest_context_th == NULL) {
 			if (!spdm_session_info->use_psk) {
 				if (is_requester) {
-					result = spdm_get_peer_cert_chain_buffer(
+					result = libspdm_get_peer_cert_chain_buffer(
 						spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 				} else {
-					result = spdm_get_local_cert_chain_buffer(
+					result = libspdm_get_local_cert_chain_buffer(
 						spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 				}
 				if (!result) {
@@ -1229,7 +1229,7 @@ return_status spdm_append_message_k(IN void *context, IN void *session_info,
   @return RETURN_SUCCESS          message is appended.
   @return RETURN_OUT_OF_RESOURCES message is not appended because the internal cache is full.
 **/
-return_status spdm_append_message_f(IN void *context, IN void *session_info, 
+return_status libspdm_append_message_f(IN void *context, IN void *session_info, 
             IN boolean is_requester, IN void *message, IN uintn message_size)
 {
 	spdm_session_info_t *spdm_session_info;
@@ -1259,24 +1259,24 @@ return_status spdm_append_message_f(IN void *context, IN void *session_info,
 			//
 			// digest_context_th might be NULL in unit test, where message_k is hardcoded.
 			// hmac_{rsp,req}_context_th might be NULL in real case, because
-			//   after finished_key_ready is generated, no one trigger spdm_append_message_k.
+			//   after finished_key_ready is generated, no one trigger libspdm_append_message_k.
 			// trigger message_k to initialize by using zero length message_k, no impact to hash or HMAC.
 			//   only temp_message_k is appended.
 			//
 			if (spdm_session_info->session_transcript.digest_context_th == NULL ||
 				spdm_session_info->session_transcript.hmac_rsp_context_th == NULL ||
 				spdm_session_info->session_transcript.hmac_req_context_th == NULL) {
-				spdm_append_message_k (context, session_info, is_requester, NULL, 0);
+				libspdm_append_message_k (context, session_info, is_requester, NULL, 0);
 			}
 
 			if (!spdm_session_info->use_psk && spdm_session_info->mut_auth_requested) {
 				if (is_requester) {
-					result = spdm_get_local_cert_chain_buffer(
+					result = libspdm_get_local_cert_chain_buffer(
 						spdm_context,
 						(void **)&mut_cert_chain_buffer,
 						&mut_cert_chain_buffer_size);
 				} else {
-					result = spdm_get_peer_cert_chain_buffer(
+					result = libspdm_get_peer_cert_chain_buffer(
 						spdm_context,
 						(void **)&mut_cert_chain_buffer,
 						&mut_cert_chain_buffer_size);
@@ -1439,15 +1439,15 @@ spdm_is_capabilities_flag_supported(IN spdm_context_t *spdm_context,
 /**
   Register SPDM device input/output functions.
 
-  This function must be called after spdm_init_context, and before any SPDM communication.
+  This function must be called after libspdm_init_context, and before any SPDM communication.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  send_message                  The fuction to send an SPDM transport layer message.
   @param  receive_message               The fuction to receive an SPDM transport layer message.
 **/
-void spdm_register_device_io_func(
-	IN void *context, IN spdm_device_send_message_func send_message,
-	IN spdm_device_receive_message_func receive_message)
+void libspdm_register_device_io_func(
+	IN void *context, IN libspdm_device_send_message_func send_message,
+	IN libspdm_device_receive_message_func receive_message)
 {
 	spdm_context_t *spdm_context;
 
@@ -1460,16 +1460,16 @@ void spdm_register_device_io_func(
 /**
   Register SPDM transport layer encode/decode functions for SPDM or APP messages.
 
-  This function must be called after spdm_init_context, and before any SPDM communication.
+  This function must be called after libspdm_init_context, and before any SPDM communication.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  transport_encode_message       The fuction to encode an SPDM or APP message to a transport layer message.
   @param  transport_decode_message       The fuction to decode an SPDM or APP message from a transport layer message.
 **/
-void spdm_register_transport_layer_func(
+void libspdm_register_transport_layer_func(
 	IN void *context,
-	IN spdm_transport_encode_message_func transport_encode_message,
-	IN spdm_transport_decode_message_func transport_decode_message)
+	IN libspdm_transport_encode_message_func transport_encode_message,
+	IN libspdm_transport_decode_message_func transport_decode_message)
 {
 	spdm_context_t *spdm_context;
 
@@ -1486,7 +1486,7 @@ void spdm_register_transport_layer_func(
 
   @return Last error of an SPDM context.
 */
-uint32 spdm_get_last_error(IN void *context)
+uint32 libspdm_get_last_error(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -1500,7 +1500,7 @@ uint32 spdm_get_last_error(IN void *context)
   @param  spdm_context                  A pointer to the SPDM context.
   @param  last_spdm_error                Last SPDM error struct of an SPDM context.
 */
-void spdm_get_last_spdm_error_struct(IN void *context,
+void libspdm_get_last_spdm_error_struct(IN void *context,
 				     OUT spdm_error_struct_t *last_spdm_error)
 {
 	spdm_context_t *spdm_context;
@@ -1516,7 +1516,7 @@ void spdm_get_last_spdm_error_struct(IN void *context,
   @param  spdm_context                  A pointer to the SPDM context.
   @param  last_spdm_error                Last SPDM error struct of an SPDM context.
 */
-void spdm_set_last_spdm_error_struct(IN void *context,
+void libspdm_set_last_spdm_error_struct(IN void *context,
 				     IN spdm_error_struct_t *last_spdm_error)
 {
 	spdm_context_t *spdm_context;
@@ -1529,11 +1529,11 @@ void spdm_set_last_spdm_error_struct(IN void *context,
 /**
   Initialize an SPDM context.
 
-  The size in bytes of the spdm_context can be returned by spdm_get_context_size.
+  The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
 */
-void spdm_init_context(IN void *context)
+void libspdm_init_context(IN void *context)
 {
 	spdm_context_t *spdm_context;
 	void *secured_message_context;
@@ -1602,11 +1602,11 @@ void spdm_init_context(IN void *context)
 /**
   Reset an SPDM context.
 
-  The size in bytes of the spdm_context can be returned by spdm_get_context_size.
+  The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
 */
-void spdm_reset_context(IN void *context)
+void libspdm_reset_context(IN void *context)
 {
 	spdm_context_t *spdm_context;
 	uintn index;
@@ -1641,7 +1641,7 @@ void spdm_reset_context(IN void *context)
 
   @return the size in bytes of the SPDM context.
 **/
-uintn spdm_get_context_size(void)
+uintn libspdm_get_context_size(void)
 {
 	return sizeof(spdm_context_t) +
 	       spdm_secured_message_get_context_size() * MAX_SPDM_SESSION_COUNT;

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -83,7 +83,7 @@ void spdm_session_info_init(IN spdm_context_t *spdm_context,
 
   @return session info.
 **/
-void *spdm_get_session_info_via_session_id(IN void *context,
+void *libspdm_get_session_info_via_session_id(IN void *context,
 					   IN uint32 session_id)
 {
 	spdm_context_t *spdm_context;
@@ -92,7 +92,7 @@ void *spdm_get_session_info_via_session_id(IN void *context,
 
 	if (session_id == INVALID_SESSION_ID) {
 		DEBUG((DEBUG_ERROR,
-		       "spdm_get_session_info_via_session_id - Invalid session_id\n"));
+		       "libspdm_get_session_info_via_session_id - Invalid session_id\n"));
 		ASSERT(FALSE);
 		return NULL;
 	}
@@ -107,7 +107,7 @@ void *spdm_get_session_info_via_session_id(IN void *context,
 	}
 
 	DEBUG((DEBUG_ERROR,
-	       "spdm_get_session_info_via_session_id - not found session_id\n"));
+	       "libspdm_get_session_info_via_session_id - not found session_id\n"));
 	return NULL;
 }
 
@@ -119,13 +119,13 @@ void *spdm_get_session_info_via_session_id(IN void *context,
 
   @return secured message context.
 **/
-void *spdm_get_secured_message_context_via_session_id(IN void *spdm_context,
+void *libspdm_get_secured_message_context_via_session_id(IN void *spdm_context,
 						      IN uint32 session_id)
 {
 	spdm_session_info_t *session_info;
 
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		return NULL;
 	} else {
@@ -141,7 +141,7 @@ void *spdm_get_secured_message_context_via_session_id(IN void *spdm_context,
   @return secured message context.
 **/
 void *
-spdm_get_secured_message_context_via_session_info(IN void *spdm_session_info)
+libspdm_get_secured_message_context_via_session_info(IN void *spdm_session_info)
 {
 	spdm_session_info_t *session_info;
 
@@ -161,7 +161,7 @@ spdm_get_secured_message_context_via_session_info(IN void *spdm_session_info)
 
   @return session info associated with this new session ID.
 **/
-void *spdm_assign_session_id(IN void *context, IN uint32 session_id,
+void *libspdm_assign_session_id(IN void *context, IN uint32 session_id,
 			     IN boolean use_psk)
 {
 	spdm_context_t *spdm_context;
@@ -172,7 +172,7 @@ void *spdm_assign_session_id(IN void *context, IN uint32 session_id,
 
 	if (session_id == INVALID_SESSION_ID) {
 		DEBUG((DEBUG_ERROR,
-		       "spdm_assign_session_id - Invalid session_id\n"));
+		       "libspdm_assign_session_id - Invalid session_id\n"));
 		ASSERT(FALSE);
 		return NULL;
 	}
@@ -182,7 +182,7 @@ void *spdm_assign_session_id(IN void *context, IN uint32 session_id,
 	for (index = 0; index < MAX_SPDM_SESSION_COUNT; index++) {
 		if (session_info[index].session_id == session_id) {
 			DEBUG((DEBUG_ERROR,
-			       "spdm_assign_session_id - Duplicated session_id\n"));
+			       "libspdm_assign_session_id - Duplicated session_id\n"));
 			ASSERT(FALSE);
 			return NULL;
 		}
@@ -198,7 +198,7 @@ void *spdm_assign_session_id(IN void *context, IN uint32 session_id,
 		}
 	}
 
-	DEBUG((DEBUG_ERROR, "spdm_assign_session_id - MAX session_id\n"));
+	DEBUG((DEBUG_ERROR, "libspdm_assign_session_id - MAX session_id\n"));
 	return NULL;
 }
 
@@ -262,7 +262,7 @@ uint16 spdm_allocate_rsp_session_id(IN spdm_context_t *spdm_context)
 
   @return freed session info assicated with this session ID.
 **/
-void *spdm_free_session_id(IN void *context, IN uint32 session_id)
+void *libspdm_free_session_id(IN void *context, IN uint32 session_id)
 {
 	spdm_context_t *spdm_context;
 	spdm_session_info_t *session_info;
@@ -272,7 +272,7 @@ void *spdm_free_session_id(IN void *context, IN uint32 session_id)
 
 	if (session_id == INVALID_SESSION_ID) {
 		DEBUG((DEBUG_ERROR,
-		       "spdm_free_session_id - Invalid session_id\n"));
+		       "libspdm_free_session_id - Invalid session_id\n"));
 		ASSERT(FALSE);
 		return NULL;
 	}
@@ -287,7 +287,7 @@ void *spdm_free_session_id(IN void *context, IN uint32 session_id)
 		}
 	}
 
-	DEBUG((DEBUG_ERROR, "spdm_free_session_id - MAX session_id\n"));
+	DEBUG((DEBUG_ERROR, "libspdm_free_session_id - MAX session_id\n"));
 	ASSERT(FALSE);
 	return NULL;
 }

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -16,7 +16,7 @@
   @retval TRUE  Peer certificate chain buffer including spdm_cert_chain_t header is returned.
   @retval FALSE Peer certificate chain buffer including spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_peer_cert_chain_buffer(IN void *context,
+boolean libspdm_get_peer_cert_chain_buffer(IN void *context,
 					OUT void **cert_chain_buffer,
 					OUT uintn *cert_chain_buffer_size)
 {
@@ -53,7 +53,7 @@ boolean spdm_get_peer_cert_chain_buffer(IN void *context,
   @retval TRUE  Peer certificate chain data without spdm_cert_chain_t header is returned.
   @retval FALSE Peer certificate chain data without spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_peer_cert_chain_data(IN void *context,
+boolean libspdm_get_peer_cert_chain_data(IN void *context,
 				      OUT void **cert_chain_data,
 				      OUT uintn *cert_chain_data_size)
 {
@@ -63,7 +63,7 @@ boolean spdm_get_peer_cert_chain_data(IN void *context,
 
 	spdm_context = context;
 
-	result = spdm_get_peer_cert_chain_buffer(spdm_context, cert_chain_data,
+	result = libspdm_get_peer_cert_chain_buffer(spdm_context, cert_chain_data,
 						 cert_chain_data_size);
 	if (!result) {
 		return FALSE;
@@ -89,7 +89,7 @@ boolean spdm_get_peer_cert_chain_data(IN void *context,
   @retval TRUE  Local used certificate chain buffer including spdm_cert_chain_t header is returned.
   @retval FALSE Local used certificate chain buffer including spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_local_cert_chain_buffer(IN void *context,
+boolean libspdm_get_local_cert_chain_buffer(IN void *context,
 					 OUT void **cert_chain_buffer,
 					 OUT uintn *cert_chain_buffer_size)
 {
@@ -118,7 +118,7 @@ boolean spdm_get_local_cert_chain_buffer(IN void *context,
   @retval TRUE  Local used certificate chain data without spdm_cert_chain_t header is returned.
   @retval FALSE Local used certificate chain data without spdm_cert_chain_t header is not found.
 **/
-boolean spdm_get_local_cert_chain_data(IN void *context,
+boolean libspdm_get_local_cert_chain_data(IN void *context,
 				       OUT void **cert_chain_data,
 				       OUT uintn *cert_chain_data_size)
 {
@@ -128,7 +128,7 @@ boolean spdm_get_local_cert_chain_data(IN void *context,
 
 	spdm_context = context;
 
-	result = spdm_get_local_cert_chain_buffer(spdm_context, cert_chain_data,
+	result = libspdm_get_local_cert_chain_buffer(spdm_context, cert_chain_data,
 						  cert_chain_data_size);
 	if (!result) {
 		return FALSE;
@@ -700,7 +700,7 @@ boolean spdm_verify_certificate_chain_hash(IN spdm_context_t *spdm_context,
 	uintn cert_chain_buffer_size;
 	boolean result;
 
-	result = spdm_get_peer_cert_chain_buffer(spdm_context,
+	result = libspdm_get_peer_cert_chain_buffer(spdm_context,
 						 (void **)&cert_chain_buffer,
 						 &cert_chain_buffer_size);
 	if (!result) {
@@ -772,7 +772,7 @@ boolean spdm_verify_challenge_auth_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-	result = spdm_get_peer_cert_chain_data(
+	result = libspdm_get_peer_cert_chain_data(
 		spdm_context, (void **)&cert_chain_data, &cert_chain_data_size);
 	if (!result) {
 		return FALSE;
@@ -1128,7 +1128,7 @@ boolean spdm_verify_measurement_signature(IN spdm_context_t *spdm_context,
 		return FALSE;
 	}
 
-	result = spdm_get_peer_cert_chain_data(
+	result = libspdm_get_peer_cert_chain_data(
 		spdm_context, (void **)&cert_chain_data, &cert_chain_data_size);
 	if (!result) {
 		return FALSE;

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -19,7 +19,7 @@
 
   @retval RETURN_SUCCESS  current TH data is calculated.
 */
-boolean spdm_calculate_th_for_exchange(
+boolean libspdm_calculate_th_for_exchange(
 	IN void *context, IN void *spdm_session_info, IN uint8 *cert_chain_buffer,
 	OPTIONAL IN uintn cert_chain_buffer_size,
 	OPTIONAL IN OUT uintn *th_data_buffer_size, OUT void *th_data_buffer)
@@ -97,7 +97,7 @@ boolean spdm_calculate_th_for_exchange(
 
   @retval RETURN_SUCCESS  current TH hash is calculated.
 */
-boolean spdm_calculate_th_hash_for_exchange(
+boolean libspdm_calculate_th_hash_for_exchange(
 	IN void *context, IN void *spdm_session_info,
 	OPTIONAL IN OUT uintn *th_hash_buffer_size, OUT void *th_hash_buffer)
 {
@@ -138,7 +138,7 @@ boolean spdm_calculate_th_hash_for_exchange(
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_exchange_rsp(
+boolean libspdm_calculate_th_hmac_for_exchange_rsp(
 	IN void *context, IN void *spdm_session_info, IN boolean is_requester,
 	OPTIONAL IN OUT uintn *th_hmac_buffer_size, OUT void *th_hmac_buffer)
 {
@@ -159,7 +159,7 @@ boolean spdm_calculate_th_hmac_for_exchange_rsp(
 
 	if (session_info->session_transcript.hmac_rsp_context_th == NULL) {
 		// trigger message_k to initialize hmac context after finished_key is ready.
-		spdm_append_message_k (context, spdm_session_info, is_requester, NULL, 0);
+		libspdm_append_message_k (context, spdm_session_info, is_requester, NULL, 0);
 		ASSERT(session_info->session_transcript.hmac_rsp_context_th != NULL);
 	}
 
@@ -192,7 +192,7 @@ boolean spdm_calculate_th_hmac_for_exchange_rsp(
 
   @retval RETURN_SUCCESS  current TH data is calculated.
 */
-boolean spdm_calculate_th_for_finish(IN void *context,
+boolean libspdm_calculate_th_for_finish(IN void *context,
 				     IN void *spdm_session_info,
 				     IN uint8 *cert_chain_buffer,
 				     OPTIONAL IN uintn cert_chain_buffer_size,
@@ -304,7 +304,7 @@ boolean spdm_calculate_th_for_finish(IN void *context,
 
   @retval RETURN_SUCCESS  current TH hash is calculated.
 */
-boolean spdm_calculate_th_hash_for_finish(IN void *context,
+boolean libspdm_calculate_th_hash_for_finish(IN void *context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hash_buffer_size,
 				     OUT void *th_hash_buffer)
@@ -346,7 +346,7 @@ boolean spdm_calculate_th_hash_for_finish(IN void *context,
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_finish_rsp(IN void *context,
+boolean libspdm_calculate_th_hmac_for_finish_rsp(IN void *context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hmac_buffer_size,
 				     OUT void *th_hmac_buffer)
@@ -391,7 +391,7 @@ boolean spdm_calculate_th_hmac_for_finish_rsp(IN void *context,
 
   @retval RETURN_SUCCESS  current TH hmac is calculated.
 */
-boolean spdm_calculate_th_hmac_for_finish_req(IN void *context,
+boolean libspdm_calculate_th_hmac_for_finish_req(IN void *context,
 				     IN void *spdm_session_info,
 				     OPTIONAL IN OUT uintn *th_hmac_buffer_size,
 				     OUT void *th_hmac_buffer)
@@ -458,7 +458,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_local_cert_chain_buffer(
+	result = libspdm_get_local_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
@@ -466,7 +466,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(
+	result = libspdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
 	if (!result) {
@@ -477,7 +477,7 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
 #else
-	result = spdm_calculate_th_hash_for_exchange(
+	result = libspdm_calculate_th_hash_for_exchange(
 		spdm_context, session_info, &hash_size, hash_data);
 	if (!result) {
 		return FALSE;
@@ -536,7 +536,7 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_local_cert_chain_buffer(
+	result = libspdm_get_local_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
@@ -544,7 +544,7 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(
+	result = libspdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
 	if (!result) {
@@ -555,7 +555,7 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_exchange_rsp(
+	result = libspdm_calculate_th_hmac_for_exchange_rsp(
 		spdm_context, session_info, FALSE, &hash_size, hmac_data);
 	if (!result) {
 		return FALSE;
@@ -602,7 +602,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_peer_cert_chain_buffer(
+	result = libspdm_get_peer_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
@@ -610,7 +610,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(
+	result = libspdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
 	if (!result) {
@@ -621,7 +621,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
 #else
-	result = spdm_calculate_th_hash_for_exchange(
+	result = libspdm_calculate_th_hash_for_exchange(
 		spdm_context, session_info, &hash_size, hash_data);
 	if (!result) {
 		return FALSE;
@@ -638,7 +638,7 @@ boolean spdm_verify_key_exchange_rsp_signature(
 	//
 	// Get leaf cert from cert chain
 	//
-	result = spdm_get_peer_cert_chain_data(
+	result = libspdm_get_peer_cert_chain_data(
 		spdm_context, (void **)&cert_chain_data, &cert_chain_data_size);
 	if (!result) {
 		return FALSE;
@@ -712,7 +712,7 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	ASSERT(hash_size == hmac_data_size);
 
-	result = spdm_get_peer_cert_chain_buffer(
+	result = libspdm_get_peer_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
@@ -720,7 +720,7 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(
+	result = libspdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
 	if (!result) {
@@ -731,7 +731,7 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, calc_hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_exchange_rsp(
+	result = libspdm_calculate_th_hmac_for_exchange_rsp(
 		spdm_context, session_info, TRUE, &hash_size, calc_hmac_data);
 	if (!result) {
 		return FALSE;
@@ -783,13 +783,13 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_peer_cert_chain_buffer(
+	result = libspdm_get_peer_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
-	result = spdm_get_local_cert_chain_buffer(spdm_context,
+	result = libspdm_get_local_cert_chain_buffer(spdm_context,
 						(void **)&mut_cert_chain_buffer,
 						&mut_cert_chain_buffer_size);
 	if (!result) {
@@ -798,7 +798,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -810,7 +810,7 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
 #else
-	result = spdm_calculate_th_hash_for_finish(
+	result = libspdm_calculate_th_hash_for_finish(
 		spdm_context, session_info, &hash_size, hash_data);
 	if (!result) {
 		return FALSE;
@@ -871,14 +871,14 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_peer_cert_chain_buffer(
+	result = libspdm_get_peer_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
 	if (session_info->mut_auth_requested) {
-		result = spdm_get_local_cert_chain_buffer(
+		result = libspdm_get_local_cert_chain_buffer(
 			spdm_context, (void **)&mut_cert_chain_buffer,
 			&mut_cert_chain_buffer_size);
 		if (!result) {
@@ -891,7 +891,7 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -903,7 +903,7 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, calc_hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_req(
+	result = libspdm_calculate_th_hmac_for_finish_req(
 		spdm_context, session_info, &hash_size, calc_hmac_data);
 	if (!result) {
 		return FALSE;
@@ -954,13 +954,13 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_local_cert_chain_buffer(
+	result = libspdm_get_local_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
-	result = spdm_get_peer_cert_chain_buffer(spdm_context,
+	result = libspdm_get_peer_cert_chain_buffer(spdm_context,
 					       (void **)&mut_cert_chain_buffer,
 					       &mut_cert_chain_buffer_size);
 	if (!result) {
@@ -969,7 +969,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -981,7 +981,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, hash_data);
 #else
-	result = spdm_calculate_th_hash_for_finish(
+	result = libspdm_calculate_th_hash_for_finish(
 		spdm_context, session_info, &hash_size, hash_data);
 	if (!result) {
 		return FALSE;
@@ -998,7 +998,7 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
 	//
 	// Get leaf cert from cert chain
 	//
-	result = spdm_get_peer_cert_chain_data(spdm_context,
+	result = libspdm_get_peer_cert_chain_data(spdm_context,
 					       (void **)&mut_cert_chain_data,
 					       &mut_cert_chain_data_size);
 	if (!result) {
@@ -1075,14 +1075,14 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	ASSERT(hmac_size == hash_size);
 
-	result = spdm_get_local_cert_chain_buffer(
+	result = libspdm_get_local_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
 	if (session_info->mut_auth_requested) {
-		result = spdm_get_peer_cert_chain_buffer(
+		result = libspdm_get_peer_cert_chain_buffer(
 			spdm_context, (void **)&mut_cert_chain_buffer,
 			&mut_cert_chain_buffer_size);
 		if (!result) {
@@ -1095,7 +1095,7 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -1107,7 +1107,7 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_req(
+	result = libspdm_calculate_th_hmac_for_finish_req(
 		spdm_context, session_info, &hash_size, hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1154,14 +1154,14 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 	hash_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
-	result = spdm_get_local_cert_chain_buffer(
+	result = libspdm_get_local_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
 	if (session_info->mut_auth_requested) {
-		result = spdm_get_peer_cert_chain_buffer(
+		result = libspdm_get_peer_cert_chain_buffer(
 			spdm_context, (void **)&mut_cert_chain_buffer,
 			&mut_cert_chain_buffer_size);
 		if (!result) {
@@ -1174,7 +1174,7 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -1186,7 +1186,7 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_rsp(
+	result = libspdm_calculate_th_hmac_for_finish_rsp(
 		spdm_context, session_info, &hash_size, hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1232,14 +1232,14 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	ASSERT(hash_size == hmac_data_size);
 
-	result = spdm_get_peer_cert_chain_buffer(
+	result = libspdm_get_peer_cert_chain_buffer(
 		spdm_context, (void **)&cert_chain_buffer, &cert_chain_buffer_size);
 	if (!result) {
 		return FALSE;
 	}
 
 	if (session_info->mut_auth_requested) {
-		result = spdm_get_local_cert_chain_buffer(
+		result = libspdm_get_local_cert_chain_buffer(
 			spdm_context, (void **)&mut_cert_chain_buffer,
 			&mut_cert_chain_buffer_size);
 		if (!result) {
@@ -1252,7 +1252,7 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -1264,7 +1264,7 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, calc_hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_rsp(
+	result = libspdm_calculate_th_hmac_for_finish_rsp(
 		spdm_context, session_info, &hash_size, calc_hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1311,7 +1311,7 @@ spdm_generate_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(spdm_context, session_info,
+	result = libspdm_calculate_th_for_exchange(spdm_context, session_info,
 						NULL, 0, &th_curr_data_size,
 						th_curr_data);
 	if (!result) {
@@ -1322,7 +1322,7 @@ spdm_generate_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_exchange_rsp(
+	result = libspdm_calculate_th_hmac_for_exchange_rsp(
 		spdm_context, session_info, FALSE, &hash_size, hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1367,7 +1367,7 @@ boolean spdm_verify_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(spdm_context, session_info,
+	result = libspdm_calculate_th_for_exchange(spdm_context, session_info,
 						NULL, 0, &th_curr_data_size,
 						th_curr_data);
 	if (!result) {
@@ -1378,7 +1378,7 @@ boolean spdm_verify_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, calc_hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_exchange_rsp(
+	result = libspdm_calculate_th_hmac_for_exchange_rsp(
 		spdm_context, session_info, TRUE, &hash_size, calc_hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1426,7 +1426,7 @@ spdm_generate_psk_exchange_req_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(spdm_context, session_info, NULL,
+	result = libspdm_calculate_th_for_finish(spdm_context, session_info, NULL,
 					      0, NULL, 0, &th_curr_data_size,
 					      th_curr_data);
 	if (!result) {
@@ -1437,7 +1437,7 @@ spdm_generate_psk_exchange_req_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, calc_hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_req(
+	result = libspdm_calculate_th_hmac_for_finish_req(
 		spdm_context, session_info, &hash_size, calc_hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1481,7 +1481,7 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(spdm_context, session_info, NULL,
+	result = libspdm_calculate_th_for_finish(spdm_context, session_info, NULL,
 					      0, NULL, 0, &th_curr_data_size,
 					      th_curr_data);
 	if (!result) {
@@ -1492,7 +1492,7 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
 		session_info->secured_message_context, th_curr_data,
 		th_curr_data_size, hmac_data);
 #else
-	result = spdm_calculate_th_hmac_for_finish_req(
+	result = libspdm_calculate_th_hmac_for_finish_req(
 		spdm_context, session_info, &hash_size, hmac_data);
 	if (!result) {
 		return FALSE;
@@ -1521,7 +1521,7 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
 
   @retval RETURN_SUCCESS  th1 hash is calculated.
 */
-return_status spdm_calculate_th1_hash(IN void *context,
+return_status libspdm_calculate_th1_hash(IN void *context,
 				      IN void *spdm_session_info,
 				      IN boolean is_requester,
 				      OUT uint8 *th1_hash_data)
@@ -1548,11 +1548,11 @@ return_status spdm_calculate_th1_hash(IN void *context,
 
 	if (!session_info->use_psk) {
 		if (is_requester) {
-			result = spdm_get_peer_cert_chain_buffer(
+			result = libspdm_get_peer_cert_chain_buffer(
 				spdm_context, (void **)&cert_chain_buffer,
 				&cert_chain_buffer_size);
 		} else {
-			result = spdm_get_local_cert_chain_buffer(
+			result = libspdm_get_local_cert_chain_buffer(
 				spdm_context, (void **)&cert_chain_buffer,
 				&cert_chain_buffer_size);
 		}
@@ -1566,7 +1566,7 @@ return_status spdm_calculate_th1_hash(IN void *context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_exchange(
+	result = libspdm_calculate_th_for_exchange(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
 	if (!result) {
@@ -1576,7 +1576,7 @@ return_status spdm_calculate_th1_hash(IN void *context,
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, th1_hash_data);
 #else
-	result = spdm_calculate_th_hash_for_exchange(
+	result = libspdm_calculate_th_hash_for_exchange(
 		spdm_context, session_info, &hash_size, th1_hash_data);
 	if (!result) {
 		return FALSE;
@@ -1599,7 +1599,7 @@ return_status spdm_calculate_th1_hash(IN void *context,
 
   @retval RETURN_SUCCESS  th2 hash is calculated.
 */
-return_status spdm_calculate_th2_hash(IN void *context,
+return_status libspdm_calculate_th2_hash(IN void *context,
 				      IN void *spdm_session_info,
 				      IN boolean is_requester,
 				      OUT uint8 *th2_hash_data)
@@ -1628,11 +1628,11 @@ return_status spdm_calculate_th2_hash(IN void *context,
 
 	if (!session_info->use_psk) {
 		if (is_requester) {
-			result = spdm_get_peer_cert_chain_buffer(
+			result = libspdm_get_peer_cert_chain_buffer(
 				spdm_context, (void **)&cert_chain_buffer,
 				&cert_chain_buffer_size);
 		} else {
-			result = spdm_get_local_cert_chain_buffer(
+			result = libspdm_get_local_cert_chain_buffer(
 				spdm_context, (void **)&cert_chain_buffer,
 				&cert_chain_buffer_size);
 		}
@@ -1641,12 +1641,12 @@ return_status spdm_calculate_th2_hash(IN void *context,
 		}
 		if (session_info->mut_auth_requested) {
 			if (is_requester) {
-				result = spdm_get_local_cert_chain_buffer(
+				result = libspdm_get_local_cert_chain_buffer(
 					spdm_context,
 					(void **)&mut_cert_chain_buffer,
 					&mut_cert_chain_buffer_size);
 			} else {
-				result = spdm_get_peer_cert_chain_buffer(
+				result = libspdm_get_peer_cert_chain_buffer(
 					spdm_context,
 					(void **)&mut_cert_chain_buffer,
 					&mut_cert_chain_buffer_size);
@@ -1667,7 +1667,7 @@ return_status spdm_calculate_th2_hash(IN void *context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	th_curr_data_size = sizeof(th_curr_data);
-	result = spdm_calculate_th_for_finish(
+	result = libspdm_calculate_th_for_finish(
 		spdm_context, session_info, cert_chain_buffer,
 		cert_chain_buffer_size, mut_cert_chain_buffer,
 		mut_cert_chain_buffer_size, &th_curr_data_size, th_curr_data);
@@ -1678,7 +1678,7 @@ return_status spdm_calculate_th2_hash(IN void *context,
 	spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
 		      th_curr_data, th_curr_data_size, th2_hash_data);
 #else
-	result = spdm_calculate_th_hash_for_finish(
+	result = libspdm_calculate_th_hash_for_finish(
 		spdm_context, session_info, &hash_size, th2_hash_data);
 	if (!result) {
 		return FALSE;

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -70,7 +70,7 @@ void internal_dump_hex(IN uint8 *data, IN uintn size)
 
   @return The 24-bit value read from buffer.
 **/
-uint32 spdm_read_uint24(IN uint8 *buffer)
+uint32 libspdm_read_uint24(IN uint8 *buffer)
 {
 	return (uint32)(buffer[0] | buffer[1] << 8 | buffer[2] << 16);
 }
@@ -83,7 +83,7 @@ uint32 spdm_read_uint24(IN uint8 *buffer)
 
   @return The 24-bit value to write to buffer.
 **/
-uint32 spdm_write_uint24(IN uint8 *buffer, IN uint32 value)
+uint32 libspdm_write_uint24(IN uint8 *buffer, IN uint32 value)
 {
 	buffer[0] = (uint8)(value & 0xFF);
 	buffer[1] = (uint8)((value >> 8) & 0xFF);

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -278,7 +278,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 		DEBUG((DEBUG_INFO, "BasicMutAuth :\n"));
 		status = spdm_encapsulated_request(spdm_context, NULL, 0, NULL);
 		DEBUG((DEBUG_INFO,
-		       "spdm_challenge - spdm_encapsulated_request - %p\n",
+		       "libspdm_challenge - spdm_encapsulated_request - %p\n",
 		       status));
 		if (RETURN_ERROR(status)) {
 			spdm_reset_message_c(spdm_context);
@@ -312,7 +312,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_challenge(IN void *context, IN uint8 slot_id,
+return_status libspdm_challenge(IN void *context, IN uint8 slot_id,
 			     IN uint8 measurement_hash_type,
 			     OUT void *measurement_hash)
 {
@@ -355,7 +355,7 @@ return_status spdm_challenge(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_challenge_ex(IN void *context, IN uint8 slot_id,
+return_status libspdm_challenge_ex(IN void *context, IN uint8 slot_id,
 			     IN uint8 measurement_hash_type,
 			     OUT void *measurement_hash,
 			     IN void *requester_nonce_in OPTIONAL,

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -228,7 +228,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	//
 	// Cache data
 	//
-	status = spdm_append_message_c(spdm_context, &spdm_request,
+	status = libspdm_append_message_c(spdm_context, &spdm_request,
 				       sizeof(spdm_request));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -243,10 +243,10 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 			     hash_size + SPDM_NONCE_SIZE +
 			     measurement_summary_hash_size + sizeof(uint16) +
 			     opaque_length + signature_size;
-	status = spdm_append_message_c(spdm_context, &spdm_response,
+	status = libspdm_append_message_c(spdm_context, &spdm_response,
 				       spdm_response_size - signature_size);
 	if (RETURN_ERROR(status)) {
-		spdm_reset_message_c(spdm_context);
+		libspdm_reset_message_c(spdm_context);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -261,7 +261,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 	result = spdm_verify_challenge_auth_signature(
 		spdm_context, TRUE, signature, signature_size);
 	if (!result) {
-		spdm_reset_message_c(spdm_context);
+		libspdm_reset_message_c(spdm_context);
 		spdm_context->error_state =
 			SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;
 		return RETURN_SECURITY_VIOLATION;
@@ -281,7 +281,7 @@ return_status try_spdm_challenge(IN void *context, IN uint8 slot_id,
 		       "libspdm_challenge - spdm_encapsulated_request - %p\n",
 		       status));
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_c(spdm_context);
+			libspdm_reset_message_c(spdm_context);
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_CERTIFICATE_FAILURE;
 			return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -18,7 +18,7 @@
   @retval RETURN_SUCCESS               The connection is initialized successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
 **/
-return_status spdm_init_connection(IN void *context,
+return_status libspdm_init_connection(IN void *context,
 				   IN boolean get_version_only)
 {
 	return_status status;
@@ -64,7 +64,7 @@ return_status spdm_init_connection(IN void *context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_start_session(IN void *context, IN boolean use_psk,
+return_status libspdm_start_session(IN void *context, IN boolean use_psk,
 				 IN uint8 measurement_hash_type,
 				 IN uint8 slot_id, OUT uint32 *session_id,
 				 OUT uint8 *heartbeat_period,
@@ -89,7 +89,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 			measurement_hash);
 		if (RETURN_ERROR(status)) {
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_key_exchange - %p\n",
+			       "libspdm_start_session - spdm_send_receive_key_exchange - %p\n",
 			       status));
 			return status;
 		}
@@ -113,7 +113,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 				session_info->mut_auth_requested,
 				&req_slot_id_param);
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_encapsulated_request - %p\n",
+			       "libspdm_start_session - spdm_encapsulated_request - %p\n",
 			       status));
 			if (RETURN_ERROR(status)) {
 				return status;
@@ -121,7 +121,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 			break;
 		default:
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - unknown mut_auth_requested - 0x%x\n",
+			       "libspdm_start_session - unknown mut_auth_requested - 0x%x\n",
 			       session_info->mut_auth_requested));
 			return RETURN_UNSUPPORTED;
 		}
@@ -132,7 +132,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 		status = spdm_send_receive_finish(spdm_context, *session_id,
 						  req_slot_id_param);
 		DEBUG((DEBUG_INFO,
-		       "spdm_start_session - spdm_send_receive_finish - %p\n",
+		       "libspdm_start_session - spdm_send_receive_finish - %p\n",
 		       status));
 		#else // SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 		ASSERT(FALSE);
@@ -145,7 +145,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 			heartbeat_period, measurement_hash);
 		if (RETURN_ERROR(status)) {
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_psk_exchange - %p\n",
+			       "libspdm_start_session - spdm_send_receive_psk_exchange - %p\n",
 			       status));
 			return status;
 		}
@@ -157,7 +157,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
 			status = spdm_send_receive_psk_finish(spdm_context,
 							      *session_id);
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_psk_finish - %p\n",
+			       "libspdm_start_session - spdm_send_receive_psk_finish - %p\n",
 			       status));
 		}
 		#endif // SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
@@ -200,7 +200,7 @@ return_status spdm_start_session(IN void *context, IN boolean use_psk,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
+return_status libspdm_start_session_ex(IN void *context, IN boolean use_psk,
 				 IN uint8 measurement_hash_type,
 				 IN uint8 slot_id, OUT uint32 *session_id,
 				 OUT uint8 *heartbeat_period,
@@ -235,7 +235,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 			requester_random, responder_random);
 		if (RETURN_ERROR(status)) {
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_key_exchange - %p\n",
+			       "libspdm_start_session - spdm_send_receive_key_exchange - %p\n",
 			       status));
 			return status;
 		}
@@ -259,7 +259,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 				session_info->mut_auth_requested,
 				&req_slot_id_param);
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_encapsulated_request - %p\n",
+			       "libspdm_start_session - spdm_encapsulated_request - %p\n",
 			       status));
 			if (RETURN_ERROR(status)) {
 				return status;
@@ -267,7 +267,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 			break;
 		default:
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - unknown mut_auth_requested - 0x%x\n",
+			       "libspdm_start_session - unknown mut_auth_requested - 0x%x\n",
 			       session_info->mut_auth_requested));
 			return RETURN_UNSUPPORTED;
 		}
@@ -278,7 +278,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 		status = spdm_send_receive_finish(spdm_context, *session_id,
 						  req_slot_id_param);
 		DEBUG((DEBUG_INFO,
-		       "spdm_start_session - spdm_send_receive_finish - %p\n",
+		       "libspdm_start_session - spdm_send_receive_finish - %p\n",
 		       status));
 		#else // SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 		ASSERT(FALSE);
@@ -294,7 +294,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 			responder_random, responder_random_size);
 		if (RETURN_ERROR(status)) {
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_psk_exchange - %p\n",
+			       "libspdm_start_session - spdm_send_receive_psk_exchange - %p\n",
 			       status));
 			return status;
 		}
@@ -306,7 +306,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
 			status = spdm_send_receive_psk_finish(spdm_context,
 							      *session_id);
 			DEBUG((DEBUG_INFO,
-			       "spdm_start_session - spdm_send_receive_psk_finish - %p\n",
+			       "libspdm_start_session - spdm_send_receive_psk_finish - %p\n",
 			       status));
 		}
 		#else // SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
@@ -331,7 +331,7 @@ return_status spdm_start_session_ex(IN void *context, IN boolean use_psk,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_stop_session(IN void *context, IN uint32 session_id,
+return_status libspdm_stop_session(IN void *context, IN uint32 session_id,
 				IN uint8 end_session_attributes)
 {
 	return_status status;
@@ -341,7 +341,7 @@ return_status spdm_stop_session(IN void *context, IN uint32 session_id,
 
 	status = spdm_send_receive_end_session(spdm_context, session_id,
 					       end_session_attributes);
-	DEBUG((DEBUG_INFO, "spdm_stop_session - %p\n", status));
+	DEBUG((DEBUG_INFO, "libspdm_stop_session - %p\n", status));
 
 	return status;
 }
@@ -373,7 +373,7 @@ return_status spdm_stop_session(IN void *context, IN uint32 session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_send_receive_data(IN void *context, IN uint32 *session_id,
+return_status libspdm_send_receive_data(IN void *context, IN uint32 *session_id,
 				     IN boolean is_app_message,
 				     IN void *request, IN uintn request_size,
 				     IN OUT void *response,
@@ -384,13 +384,13 @@ return_status spdm_send_receive_data(IN void *context, IN uint32 *session_id,
 
 	spdm_context = context;
 
-	status = spdm_send_request(spdm_context, session_id, is_app_message,
+	status = libspdm_send_request(spdm_context, session_id, is_app_message,
 				   request_size, request);
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;
 	}
 
-	status = spdm_receive_response(spdm_context, session_id, is_app_message,
+	status = libspdm_receive_response(spdm_context, session_id, is_app_message,
 				       response_size, response);
 	if (RETURN_ERROR(status)) {
 		return RETURN_DEVICE_ERROR;

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -10,8 +10,8 @@
   This function sends GET_VERSION, GET_CAPABILITIES, NEGOTIATE_ALGORITHM
   to initialize the connection with SPDM responder.
 
-  Before this function, the requester configuration data can be set via spdm_set_data.
-  After this function, the negotiated configuration data can be got via spdm_get_data.
+  Before this function, the requester configuration data can be set via libspdm_set_data.
+  After this function, the negotiated configuration data can be got via libspdm_get_data.
 
   @param  spdm_context                  A pointer to the SPDM context.
 
@@ -94,7 +94,7 @@ return_status libspdm_start_session(IN void *context, IN boolean use_psk,
 			return status;
 		}
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		if (session_info == NULL) {
 			ASSERT(FALSE);
@@ -240,7 +240,7 @@ return_status libspdm_start_session_ex(IN void *context, IN boolean use_psk,
 			return status;
 		}
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		if (session_info == NULL) {
 			ASSERT(FALSE);

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -128,7 +128,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	//
 	// Cache
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_encap_error_response(
@@ -137,7 +137,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_mut_b(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_encap_error_response(

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -46,14 +46,14 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP, 0)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_CERTIFICATE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_get_certificate_request_t)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -62,7 +62,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	slot_id = spdm_request->header.param1;
 
 	if (slot_id >= spdm_context->local_context.slot_count) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -70,7 +70,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 
 	if (spdm_context->local_context
 					  .local_cert_chain_provision[slot_id] == NULL) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 		return RETURN_SUCCESS;
@@ -84,7 +84,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 
 	if (offset >= spdm_context->local_context
 			      .local_cert_chain_provision_size[slot_id]) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -131,7 +131,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	status = spdm_append_message_mut_b(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -140,7 +140,7 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 	status = spdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -128,7 +128,7 @@ return_status spdm_get_encap_response_challenge_auth(
 	//
 	// Calc Sign
 	//
-	status = spdm_append_message_mut_c(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_c(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_encap_error_response(
@@ -137,10 +137,10 @@ return_status spdm_get_encap_response_challenge_auth(
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_mut_c(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_c(spdm_context, spdm_response,
 					   (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		spdm_reset_message_mut_c(spdm_context);
+		libspdm_reset_message_mut_c(spdm_context);
 		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -48,14 +48,14 @@ return_status spdm_get_encap_response_challenge_auth(
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP, 0)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_CHALLENGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_challenge_request_t)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -65,7 +65,7 @@ return_status spdm_get_encap_response_challenge_auth(
 
 	if ((slot_id != 0xFF) &&
 	    (slot_id >= spdm_context->local_context.slot_count)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -131,7 +131,7 @@ return_status spdm_get_encap_response_challenge_auth(
 	status = spdm_append_message_mut_c(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -141,7 +141,7 @@ return_status spdm_get_encap_response_challenge_auth(
 					   (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_reset_message_mut_c(spdm_context);
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -149,7 +149,7 @@ return_status spdm_get_encap_response_challenge_auth(
 	result =
 		spdm_generate_challenge_auth_signature(spdm_context, TRUE, ptr);
 	if (!result) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -45,14 +45,14 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP, 0)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_DIGESTS, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_get_digest_request_t)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -86,7 +86,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	     index++) {
 		if (spdm_context->local_context
 						  .local_cert_chain_provision[index] == NULL) {
-			spdm_generate_encap_error_response(
+			libspdm_generate_encap_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -101,7 +101,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	status = spdm_append_message_mut_b(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -110,7 +110,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	status = spdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -98,7 +98,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 	//
 	// Cache
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_request,
 					   request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_encap_error_response(
@@ -107,7 +107,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_mut_b(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_response,
 					   *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_encap_error_response(

--- a/library/spdm_requester_lib/libspdm_req_encap_error.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_error.c
@@ -9,7 +9,7 @@
 /**
   Generate encapsulated ERROR message.
 
-  This function can be called in spdm_get_encap_response_func.
+  This function can be called in libspdm_get_encap_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -23,7 +23,7 @@
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_encap_error_response(IN void *context,
+return_status libspdm_generate_encap_error_response(IN void *context,
 						 IN uint8 error_code,
 						 IN uint8 error_data,
 						 IN OUT uintn *response_size,
@@ -46,7 +46,7 @@ return_status spdm_generate_encap_error_response(IN void *context,
 /**
   Generate encapsulated ERROR message with extended error data.
 
-  This function can be called in spdm_get_encap_response_func.
+  This function can be called in libspdm_get_encap_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -62,7 +62,7 @@ return_status spdm_generate_encap_error_response(IN void *context,
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_encap_extended_error_response(
+return_status libspdm_generate_encap_extended_error_response(
 	IN void *context, IN uint8 error_code, IN uint8 error_data,
 	IN uintn extended_error_data_size, IN uint8 *extended_error_data,
 	IN OUT uintn *response_size, OUT void *response)

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -43,14 +43,14 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_KEY_UPDATE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (!spdm_context->last_spdm_request_session_id_valid) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -59,7 +59,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 	session_info =
 		spdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -67,14 +67,14 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_key_update_request_t)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -90,7 +90,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 			SPDM_KEY_UPDATE_ACTION_RESPONDER);
 		break;
 	case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS:
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		break;
@@ -103,7 +103,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 			SPDM_KEY_UPDATE_ACTION_RESPONDER, TRUE);
 		break;
 	default:
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 			response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -57,7 +57,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
 	}
 	session_id = spdm_context->last_spdm_request_session_id;
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		libspdm_generate_encap_error_response(
 			context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -8,7 +8,7 @@
 
 typedef struct {
 	uint8 request_response_code;
-	spdm_get_encap_response_func get_encap_response_func;
+	libspdm_get_encap_response_func get_encap_response_func;
 } spdm_get_encap_response_struct_t;
 
 spdm_get_encap_response_struct_t m_spdm_get_encap_response_struct[] = {
@@ -34,8 +34,8 @@ spdm_get_encap_response_struct_t m_spdm_get_encap_response_struct[] = {
   @param  spdm_context                  A pointer to the SPDM context.
   @param  get_encap_response_func         The function to process the encapsuled message.
 **/
-void spdm_register_get_encap_response_func(IN void *context,
-					   IN spdm_get_encap_response_func
+void libspdm_register_get_encap_response_func(IN void *context,
+					   IN libspdm_get_encap_response_func
 						   get_encap_response_func)
 {
 	spdm_context_t *spdm_context;
@@ -53,7 +53,7 @@ void spdm_register_get_encap_response_func(IN void *context,
 
   @return GET_ENCAP_RESPONSE function according to the request code.
 **/
-spdm_get_encap_response_func
+libspdm_get_encap_response_func
 SpdmGetEncapResponseFuncViaRequestCode(IN uint8 request_response_code)
 {
 	uintn index;
@@ -90,13 +90,13 @@ return_status SpdmProcessEncapsulatedRequest(IN spdm_context_t *spdm_context,
 					     IN OUT uintn *encap_response_size,
 					     OUT void *encap_response)
 {
-	spdm_get_encap_response_func get_encap_response_func;
+	libspdm_get_encap_response_func get_encap_response_func;
 	return_status status;
 	spdm_message_header_t *spdm_requester;
 
 	spdm_requester = encap_request;
 	if (encap_request_size < sizeof(spdm_message_header_t)) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			spdm_requester->request_response_code,
 			encap_response_size, encap_response);
@@ -106,7 +106,7 @@ return_status SpdmProcessEncapsulatedRequest(IN spdm_context_t *spdm_context,
 		spdm_requester->request_response_code);
 	if (get_encap_response_func == NULL) {
 		get_encap_response_func =
-			(spdm_get_encap_response_func)
+			(libspdm_get_encap_response_func)
 				spdm_context->get_encap_response_func;
 	}
 	if (get_encap_response_func != NULL) {
@@ -117,7 +117,7 @@ return_status SpdmProcessEncapsulatedRequest(IN spdm_context_t *spdm_context,
 		status = RETURN_NOT_FOUND;
 	}
 	if (status != RETURN_SUCCESS) {
-		spdm_generate_encap_error_response(
+		libspdm_generate_encap_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			spdm_requester->request_response_code,
 			encap_response_size, encap_response);
@@ -394,7 +394,7 @@ return_status spdm_encapsulated_request(IN spdm_context_t *spdm_context,
   @retval RETURN_SUCCESS               The SPDM Encapsulated requests are sent and the responses are received.
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
 **/
-return_status spdm_send_receive_encap_request(IN void *spdm_context,
+return_status libspdm_send_receive_encap_request(IN void *spdm_context,
 					      IN uint32 *session_id)
 {
 	return spdm_encapsulated_request(spdm_context, session_id, 0, NULL);

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -178,7 +178,7 @@ return_status spdm_encapsulated_request(IN spdm_context_t *spdm_context,
 	}
 
 	if (session_id != NULL) {
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		if (session_info == NULL) {
 			ASSERT(FALSE);
@@ -196,8 +196,8 @@ return_status spdm_encapsulated_request(IN spdm_context_t *spdm_context,
 	//
 	// Cache
 	//
-	spdm_reset_message_mut_b(spdm_context);
-	spdm_reset_message_mut_c(spdm_context);
+	libspdm_reset_message_mut_b(spdm_context);
+	libspdm_reset_message_mut_c(spdm_context);
 
 	if (session_id == NULL) {
 		spdm_context->last_spdm_request_session_id_valid = FALSE;

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -42,7 +42,7 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
 		return RETURN_UNSUPPORTED;
 	}
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return RETURN_UNSUPPORTED;
@@ -107,7 +107,7 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
 	spdm_secured_message_set_session_state(
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_NOT_STARTED);
-	spdm_free_session_id(spdm_context, session_id);
+	libspdm_free_session_id(spdm_context, session_id);
 
 	spdm_context->error_state = SPDM_STATUS_SUCCESS;
 

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -63,7 +63,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 	}
 
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return RETURN_UNSUPPORTED;
@@ -124,7 +124,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		sizeof(spdm_finish_request_t) + signature_size + hmac_size;
 	ptr = spdm_request.signature;
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -135,7 +135,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		if (!result) {
 			return RETURN_SECURITY_VIOLATION;
 		}
-		status = spdm_append_message_f(spdm_context, session_info, TRUE, ptr,
+		status = libspdm_append_message_f(spdm_context, session_info, TRUE, ptr,
 					       signature_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
@@ -148,7 +148,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE, ptr, hmac_size);
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
@@ -174,7 +174,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 	}
 	if (spdm_response.header.request_response_code == SPDM_ERROR) {
 		if (spdm_response.header.param1 != SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
-			spdm_reset_message_f (spdm_context, session_info);
+			libspdm_reset_message_f (spdm_context, session_info);
 		}
 		status = spdm_handle_error_response_main(
 			spdm_context, &session_id,
@@ -200,7 +200,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -219,7 +219,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_f(
+		status = libspdm_append_message_f(
 			spdm_context, session_info, TRUE,
 			(uint8 *)&spdm_response +
 				sizeof(spdm_finish_response_t),
@@ -230,7 +230,7 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n", session_id));
-	status = spdm_calculate_th2_hash(spdm_context, session_info, TRUE,
+	status = libspdm_calculate_th2_hash(spdm_context, session_info, TRUE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -172,13 +172,13 @@ return_status try_spdm_get_capabilities(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
-	status = spdm_append_message_a(spdm_context, &spdm_request,
+	status = libspdm_append_message_a(spdm_context, &spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_a(spdm_context, &spdm_response,
+	status = libspdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -166,13 +166,13 @@ return_status try_spdm_get_certificate(IN void *context, IN uint8 slot_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_b(spdm_context, &spdm_request,
+		status = libspdm_append_message_b(spdm_context, &spdm_request,
 					       sizeof(spdm_request));
 		if (RETURN_ERROR(status)) {
 			status = RETURN_SECURITY_VIOLATION;
 			goto done;
 		}
-		status = spdm_append_message_b(spdm_context, &spdm_response,
+		status = libspdm_append_message_b(spdm_context, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {
 			status = RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -270,11 +270,11 @@ done:
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate(IN void *context, IN uint8 slot_id,
+return_status libspdm_get_certificate(IN void *context, IN uint8 slot_id,
 				   IN OUT uintn *cert_chain_size,
 				   OUT void *cert_chain)
 {
-	return spdm_get_certificate_choose_length(context, slot_id,
+	return libspdm_get_certificate_choose_length(context, slot_id,
 						  MAX_SPDM_CERT_CHAIN_BLOCK_LEN,
 						  cert_chain_size, cert_chain);
 }
@@ -301,13 +301,13 @@ return_status spdm_get_certificate(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
+return_status libspdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
 				   IN OUT uintn *cert_chain_size,
 				   OUT void *cert_chain,
 				   OUT void **trust_anchor,
 				   OUT uintn *trust_anchor_size)
 {
-	return spdm_get_certificate_choose_length_ex(context, slot_id,
+	return libspdm_get_certificate_choose_length_ex(context, slot_id,
 						  MAX_SPDM_CERT_CHAIN_BLOCK_LEN,
 						  cert_chain_size, cert_chain,
 						  trust_anchor, trust_anchor_size);
@@ -334,7 +334,7 @@ return_status spdm_get_certificate_ex(IN void *context, IN uint8 slot_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_choose_length(IN void *context,
+return_status libspdm_get_certificate_choose_length(IN void *context,
 						 IN uint8 slot_id,
 						 IN uint16 length,
 						 IN OUT uintn *cert_chain_size,
@@ -380,7 +380,7 @@ return_status spdm_get_certificate_choose_length(IN void *context,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_certificate_choose_length_ex(IN void *context,
+return_status libspdm_get_certificate_choose_length_ex(IN void *context,
 						 IN uint8 slot_id,
 						 IN uint16 length,
 						 IN OUT uintn *cert_chain_size,

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -183,7 +183,7 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
+return_status libspdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 			      OUT void *total_digest_buffer)
 {
 	spdm_context_t *spdm_context;

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -127,13 +127,13 @@ return_status try_spdm_get_digest(IN void *context, OUT uint8 *slot_mask,
 	//
 	// Cache data
 	//
-	status = spdm_append_message_b(spdm_context, &spdm_request,
+	status = libspdm_append_message_b(spdm_context, &spdm_request,
 				       sizeof(spdm_request));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_b(spdm_context, &spdm_response,
+	status = libspdm_append_message_b(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -481,7 +481,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_measurement(IN void *context, IN uint32 *session_id,
+return_status libspdm_get_measurement(IN void *context, IN uint32 *session_id,
 				   IN uint8 request_attribute,
 				   IN uint8 measurement_operation,
 				   IN uint8 slot_id_param,
@@ -533,7 +533,7 @@ return_status spdm_get_measurement(IN void *context, IN uint32 *session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_get_measurement_ex(IN void *context, IN uint32 *session_id,
+return_status libspdm_get_measurement_ex(IN void *context, IN uint32 *session_id,
 				   IN uint8 request_attribute,
 				   IN uint8 measurement_operation,
 				   IN uint8 slot_id_param,

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -99,7 +99,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    SPDM_CONNECTION_STATE_NEGOTIATED) {
 			return RETURN_UNSUPPORTED;
 		}
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		if (session_info == NULL) {
 			ASSERT(FALSE);
@@ -202,7 +202,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		}
 	} else if (spdm_response.header.request_response_code !=
 		   SPDM_MEASUREMENTS) {
-		spdm_reset_message_m(spdm_context, session_info);
+		libspdm_reset_message_m(spdm_context, session_info);
 		return RETURN_DEVICE_ERROR;
 	}
 	if (spdm_response_size < sizeof(spdm_measurements_response_t)) {
@@ -215,7 +215,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (spdm_response.number_of_blocks != 0) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else if (measurement_operation ==
@@ -230,11 +230,11 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 	}
 
 	measurement_record_data_length =
-		spdm_read_uint24(spdm_response.measurement_record_length);
+		libspdm_read_uint24(spdm_response.measurement_record_length);
 	if (measurement_operation ==
 	    SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
 		if (measurement_record_data_length != 0) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 	} else {
@@ -259,13 +259,13 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		    sizeof(spdm_measurements_response_t) +
 			    measurement_record_data_length + SPDM_NONCE_SIZE +
 			    sizeof(uint16)) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_DEVICE_ERROR;
 		}
 		if (spdm_is_version_supported(spdm_context,
 					      SPDM_MESSAGE_VERSION_11) &&
 		    spdm_response.header.param2 != slot_id_param) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 		ptr = measurement_record_data + measurement_record_data_length;
@@ -297,17 +297,17 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, session_info, &spdm_request,
+		status = libspdm_append_message_m(spdm_context, session_info, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, session_info, &spdm_response,
+		status = libspdm_append_message_m(spdm_context, session_info, &spdm_response,
 					       spdm_response_size -
 						       signature_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
@@ -325,11 +325,11 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		if (!result) {
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_MEASUREMENT_AUTH_FAILURE;
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		spdm_reset_message_m(spdm_context, session_info);
+		libspdm_reset_message_m(spdm_context, session_info);
 	} else {
 		if (spdm_response_size <
 		    sizeof(spdm_measurements_response_t) +
@@ -366,16 +366,16 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32 *session_id,
 		//
 		// Cache data
 		//
-		status = spdm_append_message_m(spdm_context, session_info, &spdm_request,
+		status = libspdm_append_message_m(spdm_context, session_info, &spdm_request,
 						spdm_request_size);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;
 		}
 
-		status = spdm_append_message_m(spdm_context, session_info, &spdm_response,
+		status = libspdm_append_message_m(spdm_context, session_info, &spdm_response,
 					       spdm_response_size);
 		if (RETURN_ERROR(status)) {
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SECURITY_VIOLATION;
 		}
 	}

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -155,7 +155,7 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 	spdm_request.header.param1 = 0;
 	spdm_request.header.param2 = 0;
 
-	spdm_reset_context(spdm_context);
+	libspdm_reset_context(spdm_context);
 
 	spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
 						spdm_request.header.request_response_code);
@@ -166,9 +166,9 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 		return RETURN_DEVICE_ERROR;
 	}
 
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	spdm_response_size = sizeof(spdm_response);
 	zero_mem(&spdm_response, sizeof(spdm_response));
@@ -217,15 +217,15 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
-	status = spdm_append_message_a(spdm_context, &spdm_request,
+	status = libspdm_append_message_a(spdm_context, &spdm_request,
 				       sizeof(spdm_request));
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
-	status = spdm_append_message_a(spdm_context, &spdm_response,
+	status = libspdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_reset_message_a(spdm_context);
+		libspdm_reset_message_a(spdm_context);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -238,7 +238,7 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
 									spdm_response.version_number_entry,
 									spdm_response.version_number_entry_count);
 	if (result != TRUE) {
-		spdm_reset_message_a(spdm_context);
+		libspdm_reset_message_a(spdm_context);
 		return RETURN_DEVICE_ERROR;
 	}
 

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -102,7 +102,7 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32 session_id)
 	return RETURN_SUCCESS;
 }
 
-return_status spdm_heartbeat(IN void *context, IN uint32 session_id)
+return_status libspdm_heartbeat(IN void *context, IN uint32 session_id)
 {
 	uintn retry;
 	return_status status;

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -49,7 +49,7 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32 session_id)
 		return RETURN_UNSUPPORTED;
 	}
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return RETURN_UNSUPPORTED;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -253,7 +253,7 @@ return_status try_spdm_send_receive_key_exchange(
 	}
 	rsp_session_id = spdm_response.rsp_session_id;
 	*session_id = (req_session_id << 16) | rsp_session_id;
-	session_info = spdm_assign_session_id(spdm_context, *session_id, FALSE);
+	session_info = libspdm_assign_session_id(spdm_context, *session_id, FALSE);
 	if (session_info == NULL) {
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
@@ -279,7 +279,7 @@ return_status try_spdm_send_receive_key_exchange(
 	    sizeof(spdm_key_exchange_response_t) + dhe_key_size +
 		    measurement_summary_hash_size + sizeof(uint16) +
 		    signature_size + hmac_size) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -318,7 +318,7 @@ return_status try_spdm_send_receive_key_exchange(
 	    sizeof(spdm_key_exchange_response_t) + dhe_key_size +
 		    measurement_summary_hash_size + sizeof(uint16) +
 		    opaque_length + signature_size + hmac_size) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -327,7 +327,7 @@ return_status try_spdm_send_receive_key_exchange(
 	status = spdm_process_opaque_data_version_selection_data(
 		spdm_context, opaque_length, ptr);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -344,21 +344,21 @@ return_status try_spdm_send_receive_key_exchange(
 	//
 	// Cache session data
 	//
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size - signature_size -
 					       hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -372,7 +372,7 @@ return_status try_spdm_send_receive_key_exchange(
 	result = spdm_verify_key_exchange_rsp_signature(
 		spdm_context, session_info, signature, signature_size);
 	if (!result) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -381,9 +381,9 @@ return_status try_spdm_send_receive_key_exchange(
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, signature, signature_size);
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, signature, signature_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_secured_message_dhe_free(
 			spdm_context->connection_info.algorithm.dhe_named_group,
 			dhe_context);
@@ -401,22 +401,22 @@ return_status try_spdm_send_receive_key_exchange(
 		spdm_context->connection_info.algorithm.dhe_named_group,
 		dhe_context);
 	if (!result) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_handshake_key[%x]\n",
 	       *session_id));
-	status = spdm_calculate_th1_hash(spdm_context, session_info, TRUE,
+	status = libspdm_calculate_th1_hash(spdm_context, session_info, TRUE,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 	status = spdm_generate_session_handshake_key(
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -430,17 +430,17 @@ return_status try_spdm_send_receive_key_exchange(
 		result = spdm_verify_key_exchange_rsp_hmac(
 			spdm_context, session_info, verify_data, hmac_size);
 		if (!result) {
-			spdm_free_session_id(spdm_context, *session_id);
+			libspdm_free_session_id(spdm_context, *session_id);
 			spdm_context->error_state =
 				SPDM_STATUS_ERROR_KEY_EXCHANGE_FAILURE;
 			return RETURN_SECURITY_VIOLATION;
 		}
 		ptr += hmac_size;
 
-		status = spdm_append_message_k(spdm_context, session_info, TRUE, verify_data,
+		status = libspdm_append_message_k(spdm_context, session_info, TRUE, verify_data,
 					       hmac_size);
 		if (RETURN_ERROR(status)) {
-			spdm_free_session_id(spdm_context, *session_id);
+			libspdm_free_session_id(spdm_context, *session_id);
 			return RETURN_SECURITY_VIOLATION;
 		}
 	}

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -57,7 +57,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32 session_id,
 		return RETURN_UNSUPPORTED;
 	}
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return RETURN_UNSUPPORTED;

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -239,7 +239,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32 session_id,
 	return RETURN_SUCCESS;
 }
 
-return_status spdm_key_update(IN void *context, IN uint32 session_id,
+return_status libspdm_key_update(IN void *context, IN uint32 session_id,
 			      IN boolean single_direction)
 {
 	spdm_context_t *spdm_context;

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -209,13 +209,13 @@ return_status try_spdm_negotiate_algorithms(IN spdm_context_t *spdm_context)
 	//
 	// Cache data
 	//
-	status = spdm_append_message_a(spdm_context, &spdm_request,
+	status = libspdm_append_message_a(spdm_context, &spdm_request,
 				       spdm_request.length);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_a(spdm_context, &spdm_response,
+	status = libspdm_append_message_a(spdm_context, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -232,7 +232,7 @@ return_status try_spdm_send_receive_psk_exchange(
 	}
 	rsp_session_id = spdm_response.rsp_session_id;
 	*session_id = (req_session_id << 16) | rsp_session_id;
-	session_info = spdm_assign_session_id(spdm_context, *session_id, TRUE);
+	session_info = libspdm_assign_session_id(spdm_context, *session_id, TRUE);
 	if (session_info == NULL) {
 		return RETURN_DEVICE_ERROR;
 	}
@@ -246,7 +246,7 @@ return_status try_spdm_send_receive_psk_exchange(
 	    sizeof(spdm_psk_exchange_response_t) +
 		    spdm_response.context_length + spdm_response.opaque_length +
 		    measurement_summary_hash_size + hmac_size) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_DEVICE_ERROR;
 	}
 
@@ -255,7 +255,7 @@ return_status try_spdm_send_receive_psk_exchange(
 	status = spdm_process_opaque_data_version_selection_data(
 		spdm_context, spdm_response.opaque_length, ptr);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_UNSUPPORTED;
 	}
 
@@ -292,31 +292,31 @@ return_status try_spdm_send_receive_psk_exchange(
 	//
 	// Cache session data
 	//
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, &spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size - hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_handshake_key[%x]\n",
 	       *session_id));
-	status = spdm_calculate_th1_hash(spdm_context, session_info, TRUE,
+	status = libspdm_calculate_th1_hash(spdm_context, session_info, TRUE,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 	status = spdm_generate_session_handshake_key(
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -326,15 +326,15 @@ return_status try_spdm_send_receive_psk_exchange(
 	result = spdm_verify_psk_exchange_rsp_hmac(spdm_context, session_info,
 						   verify_data, hmac_size);
 	if (!result) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		spdm_context->error_state =
 			SPDM_STATUS_ERROR_KEY_EXCHANGE_FAILURE;
 		return RETURN_SECURITY_VIOLATION;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, TRUE, verify_data, hmac_size);
+	status = libspdm_append_message_k(spdm_context, session_info, TRUE, verify_data, hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, *session_id);
+		libspdm_free_session_id(spdm_context, *session_id);
 		return RETURN_SECURITY_VIOLATION;
 	}
 
@@ -355,7 +355,7 @@ return_status try_spdm_send_receive_psk_exchange(
 
 		DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n",
 		       session_id));
-		status = spdm_calculate_th2_hash(spdm_context, session_info,
+		status = libspdm_calculate_th2_hash(spdm_context, session_info,
 						 TRUE, th2_hash_data);
 		if (RETURN_ERROR(status)) {
 			return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -57,7 +57,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	}
 
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return RETURN_UNSUPPORTED;
@@ -79,7 +79,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	spdm_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE, (uint8 *)&spdm_request,
 				       spdm_request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -88,7 +88,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 	spdm_generate_psk_exchange_req_hmac(spdm_context, session_info,
 					    spdm_request.verify_data);
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE,
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE,
 				       (uint8 *)&spdm_request +
 					       spdm_request_size - hmac_size,
 				       hmac_size);
@@ -132,14 +132,14 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 		return RETURN_DEVICE_ERROR;
 	}
 
-	status = spdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
+	status = libspdm_append_message_f(spdm_context, session_info, TRUE, &spdm_response,
 				       spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n", session_id));
-	status = spdm_calculate_th2_hash(spdm_context, session_info, TRUE,
+	status = libspdm_calculate_th2_hash(spdm_context, session_info, TRUE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -176,7 +176,7 @@ return_status spdm_send_spdm_request(IN spdm_context_t *spdm_context,
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)) {
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		ASSERT(session_info != NULL);
 		if (session_info == NULL) {
@@ -222,7 +222,7 @@ return_status spdm_receive_spdm_response(IN spdm_context_t *spdm_context,
 		    spdm_context, TRUE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)) {
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		ASSERT(session_info != NULL);
 		if (session_info == NULL) {

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -22,7 +22,7 @@
   @retval RETURN_SUCCESS               The SPDM request is sent successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM request is sent to the device.
 **/
-return_status spdm_send_request(IN void *context, IN uint32 *session_id,
+return_status libspdm_send_request(IN void *context, IN uint32 *session_id,
 				IN boolean is_app_message,
 				IN uintn request_size, IN void *request)
 {
@@ -73,7 +73,7 @@ return_status spdm_send_request(IN void *context, IN uint32 *session_id,
   @retval RETURN_SUCCESS               The SPDM response is received successfully.
   @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is received from the device.
 **/
-return_status spdm_receive_response(IN void *context, IN uint32 *session_id,
+return_status libspdm_receive_response(IN void *context, IN uint32 *session_id,
 				    IN boolean is_app_message,
 				    IN OUT uintn *response_size,
 				    OUT void *response)
@@ -190,7 +190,7 @@ return_status spdm_send_spdm_request(IN spdm_context_t *spdm_context,
 		}
 	}
 
-	return spdm_send_request(spdm_context, session_id, FALSE, request_size,
+	return libspdm_send_request(spdm_context, session_id, FALSE, request_size,
 				 request);
 }
 
@@ -236,6 +236,6 @@ return_status spdm_receive_spdm_response(IN spdm_context_t *spdm_context,
 		}
 	}
 
-	return spdm_receive_response(spdm_context, session_id, FALSE,
+	return libspdm_receive_response(spdm_context, session_id, FALSE,
 				     response_size, response);
 }

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -544,7 +544,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		spdm_context->connection_info.algorithm.req_base_asym_alg = 0;
 		spdm_context->connection_info.algorithm.key_schedule = 0;
 	}
-	status = spdm_append_message_a(spdm_context, spdm_request,
+	status = libspdm_append_message_a(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -553,7 +553,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_a(spdm_context, spdm_response,
+	status = libspdm_append_message_a(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -196,14 +196,14 @@ return_status spdm_get_response_algorithms(IN void *context,
 	}
 	if (spdm_context->connection_info.connection_state !=
 	    SPDM_CONNECTION_STATE_AFTER_CAPABILITIES) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size < sizeof(spdm_negotiate_algorithms_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -214,7 +214,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		    sizeof(uint32) * spdm_request->ext_hash_count +
 		    sizeof(spdm_negotiate_algorithms_common_struct_table_t) *
 			    spdm_request->header.param1) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -227,7 +227,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		for (index = 0; index < spdm_request->header.param1; index++) {
 			if ((uintn)spdm_request + request_size <
 			    (uintn)struct_table) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -236,7 +236,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 			if ((uintn)spdm_request + request_size -
 				    (uintn)struct_table <
 			    sizeof(spdm_negotiate_algorithms_common_struct_table_t)) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -246,7 +246,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 			ext_alg_count = struct_table->alg_count & 0xF;
 			ext_alg_total_count += ext_alg_count;
 			if (fixed_alg_size != 2) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -256,7 +256,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				    (uintn)struct_table -
 				    sizeof(spdm_negotiate_algorithms_common_struct_table_t) <
 			    sizeof(uint32) * ext_alg_count) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -429,7 +429,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP)) {
 		if (spdm_context->connection_info.algorithm.measurement_spec !=
 		    SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -438,7 +438,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 			spdm_context->connection_info.algorithm
 				.measurement_hash_algo);
 		if (algo_size == 0) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -447,7 +447,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 	algo_size = spdm_get_hash_size(
 		spdm_context->connection_info.algorithm.base_hash_algo);
 	if (algo_size == 0) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -458,7 +458,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 		algo_size = spdm_get_asym_signature_size(
 			spdm_context->connection_info.algorithm.base_asym_algo);
 		if (algo_size == 0) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -483,7 +483,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				spdm_context->connection_info.algorithm
 					.dhe_named_group);
 			if (algo_size == 0) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -502,7 +502,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				spdm_context->connection_info.algorithm
 					.aead_cipher_suite);
 			if (algo_size == 0) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -517,7 +517,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 				spdm_context->connection_info.algorithm
 					.req_base_asym_alg);
 			if (algo_size == 0) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -547,7 +547,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 	status = spdm_append_message_a(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -556,7 +556,7 @@ return_status spdm_get_response_algorithms(IN void *context,
 	status = spdm_append_message_a(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -164,7 +164,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	}
 	if (spdm_context->connection_info.connection_state !=
 	    SPDM_CONNECTION_STATE_AFTER_VERSION) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
@@ -172,7 +172,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 
 	if (!spdm_check_request_version_compability(
 			spdm_context, spdm_request->header.spdm_version)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -180,14 +180,14 @@ return_status spdm_get_response_capabilities(IN void *context,
 
 	if (spdm_is_version_supported(spdm_context, SPDM_MESSAGE_VERSION_11)) {
 		if (request_size != sizeof(spdm_get_capabilities_request)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
 	} else {
 		if (request_size != sizeof(spdm_message_header_t)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -196,7 +196,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 
 	if (!spdm_check_request_flag_compability(
 		    spdm_request->flags, spdm_request->header.spdm_version)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -228,7 +228,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	status = spdm_append_message_a(spdm_context, spdm_request,
 			      spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_UNSPECIFIED, 0,
 						response_size, response);
 		return RETURN_SUCCESS;
@@ -237,7 +237,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 			      spdm_response, *response_size);
 
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_UNSPECIFIED, 0,
 						response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -225,7 +225,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 	//
 	// Cache
 	//
-	status = spdm_append_message_a(spdm_context, spdm_request,
+	status = libspdm_append_message_a(spdm_context, spdm_request,
 			      spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -233,7 +233,7 @@ return_status spdm_get_response_capabilities(IN void *context,
 						response_size, response);
 		return RETURN_SUCCESS;
 	}
-	status = spdm_append_message_a(spdm_context,
+	status = libspdm_append_message_a(spdm_context,
 			      spdm_response, *response_size);
 
 	if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -146,7 +146,7 @@ return_status spdm_get_response_certificate(IN void *context,
 	//
 	// Cache
 	//
-	status = spdm_append_message_b(spdm_context, spdm_request,
+	status = libspdm_append_message_b(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -155,7 +155,7 @@ return_status spdm_get_response_certificate(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_b(spdm_context, spdm_response,
+	status = libspdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -55,7 +55,7 @@ return_status spdm_get_response_certificate(IN void *context,
 	     SPDM_CONNECTION_STATE_AFTER_DIGESTS) &&
 	    (spdm_context->connection_info.connection_state !=
 	     SPDM_CONNECTION_STATE_AFTER_CERTIFICATE)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
@@ -63,14 +63,14 @@ return_status spdm_get_response_certificate(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, FALSE, 0,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_CERTIFICATE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_get_certificate_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -80,7 +80,7 @@ return_status spdm_get_response_certificate(IN void *context,
 	slot_id = spdm_request->header.param1;
 
 	if (slot_id >= spdm_context->local_context.slot_count) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -88,7 +88,7 @@ return_status spdm_get_response_certificate(IN void *context,
 
 	if (spdm_context->local_context
 					  .local_cert_chain_provision[slot_id] == NULL) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 		return RETURN_SUCCESS;
@@ -102,7 +102,7 @@ return_status spdm_get_response_certificate(IN void *context,
 
 	if (offset >= spdm_context->local_context
 			      .local_cert_chain_provision_size[slot_id]) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -149,7 +149,7 @@ return_status spdm_get_response_certificate(IN void *context,
 	status = spdm_append_message_b(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -158,7 +158,7 @@ return_status spdm_get_response_certificate(IN void *context,
 	status = spdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -58,25 +58,25 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, FALSE, 0,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP)) {
-		return spdm_generate_error_response(
+		return libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_CHALLENGE, response_size, response);
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 	}
 
 	if (request_size != sizeof(spdm_challenge_request_t)) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 	}
 	if (!spdm_is_capabilities_flag_supported(spdm_context, FALSE, 0, SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) &&
 		spdm_request->header.param2 > 0) {
-		return spdm_generate_error_response (spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST, SPDM_CHALLENGE, response_size, response);
+		return libspdm_generate_error_response (spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST, SPDM_CHALLENGE, response_size, response);
 	}
 
 	spdm_request_size = request_size;
@@ -85,7 +85,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 
 	if ((slot_id != 0xFF) &&
 	    (slot_id >= spdm_context->local_context.slot_count)) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 	}
@@ -98,7 +98,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 		spdm_context, FALSE, spdm_request->header.param2);
 	if ((measurement_summary_hash_size == 0) &&
 		(spdm_request->header.param2 != SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH)) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_INVALID_REQUEST,
 						0, response_size, response);
 	}
@@ -121,7 +121,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 		spdm_is_version_supported(spdm_context, SPDM_MESSAGE_VERSION_10)) {
 		spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
 	} else {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 	}
@@ -174,7 +174,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	result = spdm_generate_measurement_summary_hash(
 		spdm_context, FALSE, spdm_request->header.param2, ptr);
 	if (!result) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 	}
@@ -193,7 +193,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	status = spdm_append_message_c(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -203,7 +203,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_reset_message_c(spdm_context);
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 	}
@@ -211,7 +211,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 							ptr);
 	if (!result) {
 		spdm_reset_message_c(spdm_context);
-		return spdm_generate_error_response(
+		return libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 	}

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -190,7 +190,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	//
 	// Calc Sign
 	//
-	status = spdm_append_message_c(spdm_context, spdm_request,
+	status = libspdm_append_message_c(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -199,10 +199,10 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_c(spdm_context, spdm_response,
+	status = libspdm_append_message_c(spdm_context, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		spdm_reset_message_c(spdm_context);
+		libspdm_reset_message_c(spdm_context);
 		return libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -210,7 +210,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 	result = spdm_generate_challenge_auth_signature(spdm_context, FALSE,
 							ptr);
 	if (!result) {
-		spdm_reset_message_c(spdm_context);
+		libspdm_reset_message_c(spdm_context);
 		return libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_communication.c
+++ b/library/spdm_responder_lib/libspdm_rsp_communication.c
@@ -12,7 +12,7 @@
   The message can be a normal message or a secured message in SPDM session.
   The message can be an SPDM message or an APP message.
 
-  This function is called in spdm_responder_dispatch_message to process the message.
+  This function is called in libspdm_responder_dispatch_message to process the message.
   The alternative is: an SPDM responder may receive the request message directly
   and call this function to process it, then send the response message.
 
@@ -33,7 +33,7 @@
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_SECURITY_VIOLATION    Any verification fails.
 **/
-return_status spdm_process_message(IN void *context, IN OUT uint32 **session_id,
+return_status libspdm_process_message(IN void *context, IN OUT uint32 **session_id,
 				   IN void *request, IN uintn request_size,
 				   OUT void *response,
 				   IN OUT uintn *response_size)
@@ -44,13 +44,13 @@ return_status spdm_process_message(IN void *context, IN OUT uint32 **session_id,
 
 	spdm_context = context;
 
-	status = spdm_process_request(spdm_context, session_id, &is_app_message,
+	status = libspdm_process_request(spdm_context, session_id, &is_app_message,
 				      request_size, request);
 	if (RETURN_ERROR(status)) {
 		return status;
 	}
 
-	status = spdm_build_response(spdm_context, *session_id, is_app_message,
+	status = libspdm_build_response(spdm_context, *session_id, is_app_message,
 				     response_size, response);
 	if (RETURN_ERROR(status)) {
 		return status;
@@ -71,7 +71,7 @@ return_status spdm_process_message(IN void *context, IN OUT uint32 **session_id,
   @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
   @retval RETURN_UNSUPPORTED           One request message is not supported.
 **/
-return_status spdm_responder_dispatch_message(IN void *context)
+return_status libspdm_responder_dispatch_message(IN void *context)
 {
 	return_status status;
 	spdm_context_t *spdm_context;
@@ -91,7 +91,7 @@ return_status spdm_responder_dispatch_message(IN void *context)
 	}
 
 	response_size = sizeof(response);
-	status = spdm_process_message(spdm_context, &session_id, request,
+	status = libspdm_process_message(spdm_context, &session_id, request,
 				      request_size, response, &response_size);
 	if (RETURN_ERROR(status)) {
 		return status;

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -52,21 +52,21 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, FALSE, 0,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_DIGESTS, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state !=
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_get_digest_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -85,7 +85,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 		}
 	}
 	if (no_local_cert_chain) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_DIGESTS, response_size, response);
 		return RETURN_SUCCESS;
@@ -116,7 +116,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	     index++) {
 		if (spdm_context->local_context
 						  .local_cert_chain_provision[index] == NULL) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -131,7 +131,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	status = spdm_append_message_b(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -140,7 +140,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	status = spdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -128,7 +128,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 	//
 	// Cache
 	//
-	status = spdm_append_message_b(spdm_context, spdm_request,
+	status = libspdm_append_message_b(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -137,7 +137,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_b(spdm_context, spdm_response,
+	status = libspdm_append_message_b(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -61,7 +61,7 @@ return_status spdm_get_encap_request_challenge(IN spdm_context_t *spdm_context,
 	//
 	// Cache data
 	//
-	status = spdm_append_message_mut_c(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_c(spdm_context, spdm_request,
 					   *encap_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -207,7 +207,7 @@ return_status spdm_process_encap_response_challenge_auth(
 			     hash_size + SPDM_NONCE_SIZE +
 			     measurement_summary_hash_size + sizeof(uint16) +
 			     opaque_length + signature_size;
-	status = spdm_append_message_mut_c(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_c(spdm_context, spdm_response,
 					   spdm_response_size - signature_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -62,7 +62,7 @@ spdm_get_encap_request_get_certificate(IN spdm_context_t *spdm_context,
 	//
 	// Cache data
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_request,
 					   *encap_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -136,7 +136,7 @@ return_status spdm_process_encap_response_certificate(
 	//
 	// Cache data
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_response,
 					   spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
@@ -57,7 +57,7 @@ spdm_get_encap_request_get_digest(IN spdm_context_t *spdm_context,
 	//
 	// Cache data
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_request,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_request,
 					   *encap_request_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;
@@ -137,7 +137,7 @@ return_status spdm_process_encap_response_digest(
 	//
 	// Cache data
 	//
-	status = spdm_append_message_mut_b(spdm_context, spdm_response,
+	status = libspdm_append_message_mut_b(spdm_context, spdm_response,
 					   spdm_response_size);
 	if (RETURN_ERROR(status)) {
 		return RETURN_SECURITY_VIOLATION;

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -43,7 +43,7 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
 	}
 	session_id = spdm_context->last_spdm_request_session_id;
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		return RETURN_UNSUPPORTED;
 	}
@@ -129,7 +129,7 @@ return_status spdm_process_encap_response_key_update(
 	}
 	session_id = spdm_context->last_spdm_request_session_id;
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		return RETURN_UNSUPPORTED;
 	}

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -152,7 +152,7 @@ return_status spdm_process_encap_response_key_update(
 	    (spdm_response->header.param2 != spdm_request->header.param2)) {
 		if (spdm_request->header.param1 !=
 		    SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY) {
-			DEBUG((DEBUG_INFO, "spdm_key_update[%x] failed\n",
+			DEBUG((DEBUG_INFO, "libspdm_key_update[%x] failed\n",
 			       session_id));
 		} else {
 			DEBUG((DEBUG_INFO, "SpdmVerifyKey[%x] failed\n",
@@ -163,7 +163,7 @@ return_status spdm_process_encap_response_key_update(
 
 	if (spdm_request->header.param1 !=
 	    SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY) {
-		DEBUG((DEBUG_INFO, "spdm_key_update[%x] success\n",
+		DEBUG((DEBUG_INFO, "libspdm_key_update[%x] success\n",
 		       session_id));
 		*need_continue = TRUE;
 	} else {

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -205,8 +205,8 @@ void spdm_init_mut_auth_encap_state(IN spdm_context_t *spdm_context,
 	//
 	// Clear Cache
 	//
-	spdm_reset_message_mut_b(spdm_context);
-	spdm_reset_message_mut_c(spdm_context);
+	libspdm_reset_message_mut_b(spdm_context);
+	libspdm_reset_message_mut_c(spdm_context);
 
 	//
 	// Possible Sequence:
@@ -259,8 +259,8 @@ void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
 	//
 	// Clear Cache
 	//
-	spdm_reset_message_mut_b(spdm_context);
-	spdm_reset_message_mut_c(spdm_context);
+	libspdm_reset_message_mut_b(spdm_context);
+	libspdm_reset_message_mut_c(spdm_context);
 
 	//
 	// Possible Sequence:
@@ -315,8 +315,8 @@ void libspdm_init_key_update_encap_state(IN void *context)
 	spdm_context->encap_context.certificate_chain_buffer.buffer_size = 0;
 	spdm_context->response_state = SPDM_RESPONSE_STATE_PROCESSING_ENCAP;
 
-	spdm_reset_message_mut_b(spdm_context);
-	spdm_reset_message_mut_c(spdm_context);
+	libspdm_reset_message_mut_b(spdm_context);
+	libspdm_reset_message_mut_c(spdm_context);
 
 	zero_mem(spdm_context->encap_context.request_op_code_sequence,
 		 sizeof(spdm_context->encap_context.request_op_code_sequence));

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -300,7 +300,7 @@ void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
 
   @param  spdm_context                  A pointer to the SPDM context.
 **/
-void spdm_init_key_update_encap_state(IN void *context)
+void libspdm_init_key_update_encap_state(IN void *context)
 {
 	spdm_context_t *spdm_context;
 
@@ -360,7 +360,7 @@ return_status spdm_get_response_encapsulated_request(
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_ENCAPSULATED_REQUEST, response_size, response);
 		return RETURN_SUCCESS;
@@ -369,7 +369,7 @@ return_status spdm_get_response_encapsulated_request(
 	    SPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
 		if (spdm_context->response_state ==
 		    SPDM_RESPONSE_STATE_NORMAL) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -382,7 +382,7 @@ return_status spdm_get_response_encapsulated_request(
 	}
 
 	if (request_size != sizeof(spdm_get_encapsulated_request_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -407,7 +407,7 @@ return_status spdm_get_response_encapsulated_request(
 	status = spdm_process_encapsulated_response(
 		context, 0, NULL, &encap_request_size, encap_request);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
 			response_size, response);
 		spdm_context->response_state = SPDM_RESPONSE_STATE_NORMAL;
@@ -462,7 +462,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_DELIVER_ENCAPSULATED_RESPONSE, response_size,
 			response);
@@ -472,7 +472,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 	    SPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
 		if (spdm_context->response_state ==
 		    SPDM_RESPONSE_STATE_NORMAL) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -486,7 +486,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 
 	if (request_size <=
 	    sizeof(spdm_deliver_encapsulated_response_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -496,7 +496,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 
 	if (spdm_request->header.param1 !=
 	    spdm_context->encap_context.request_id) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -523,7 +523,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 			     sizeof(spdm_encapsulated_response_ack_response_t);
 	encap_request = spdm_response + 1;
 	if (encap_response_size < sizeof(spdm_message_header_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -536,7 +536,7 @@ return_status spdm_get_response_encapsulated_response_ack(
 		context, encap_response_size, encap_response,
 		&encap_request_size, encap_request);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
 			response_size, response);
 		spdm_context->response_state = SPDM_RESPONSE_STATE_NORMAL;

--- a/library/spdm_responder_lib/libspdm_rsp_end_session.c
+++ b/library/spdm_responder_lib/libspdm_rsp_end_session.c
@@ -58,7 +58,7 @@ return_status spdm_get_response_end_session(IN void *context,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
-	session_info = spdm_get_session_info_via_session_id(
+	session_info = libspdm_get_session_info_via_session_id(
 		spdm_context, spdm_context->last_spdm_request_session_id);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_end_session.c
+++ b/library/spdm_responder_lib/libspdm_rsp_end_session.c
@@ -46,14 +46,14 @@ return_status spdm_get_response_end_session(IN void *context,
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (!spdm_context->last_spdm_request_session_id_valid) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -61,7 +61,7 @@ return_status spdm_get_response_end_session(IN void *context,
 	session_info = spdm_get_session_info_via_session_id(
 		spdm_context, spdm_context->last_spdm_request_session_id);
 	if (session_info == NULL) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -69,14 +69,14 @@ return_status spdm_get_response_end_session(IN void *context,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_end_session_request_t)) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_error.c
+++ b/library/spdm_responder_lib/libspdm_rsp_error.c
@@ -9,7 +9,7 @@
 /**
   Generate ERROR message.
 
-  This function can be called in spdm_get_response_func.
+  This function can be called in libspdm_get_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -23,7 +23,7 @@
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_error_response(IN void *context,
+return_status libspdm_generate_error_response(IN void *context,
 					   IN uint8 error_code,
 					   IN uint8 error_data,
 					   IN OUT uintn *response_size,
@@ -50,7 +50,7 @@ return_status spdm_generate_error_response(IN void *context,
 /**
   Generate ERROR message with extended error data.
 
-  This function can be called in spdm_get_response_func.
+  This function can be called in libspdm_get_response_func.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  error_code                    The error code of the message.
@@ -66,7 +66,7 @@ return_status spdm_generate_error_response(IN void *context,
   @retval RETURN_SUCCESS               The error message is generated.
   @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
 **/
-return_status spdm_generate_extended_error_response(
+return_status libspdm_generate_extended_error_response(
 	IN void *context, IN uint8 error_code, IN uint8 error_data,
 	IN uintn extended_error_data_size, IN uint8 *extended_error_data,
 	IN OUT uintn *response_size, OUT void *response)

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -94,7 +94,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		session_id = spdm_context->latest_session_id;
 	}
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
@@ -159,7 +159,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
-	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
+	status = libspdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -178,7 +178,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 				response_size, response);
 			return RETURN_SUCCESS;
 		}
-		status = spdm_append_message_f(
+		status = libspdm_append_message_f(
 			spdm_context, session_info, FALSE,
 			(uint8 *)request + sizeof(spdm_finish_request_t),
 			signature_size);
@@ -202,7 +202,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_f(spdm_context, session_info, FALSE,
+	status = libspdm_append_message_f(spdm_context, session_info, FALSE,
 				       (uint8 *)request + signature_size +
 					       sizeof(spdm_finish_request_t),
 				       hmac_size);
@@ -230,7 +230,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	spdm_response->header.param1 = 0;
 	spdm_response->header.param2 = 0;
 
-	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
+	status = libspdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -254,7 +254,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			return RETURN_SUCCESS;
 		}
 
-		status = spdm_append_message_f(
+		status = libspdm_append_message_f(
 			spdm_context, session_info, FALSE,
 			(uint8 *)spdm_response + sizeof(spdm_finish_request_t),
 			hmac_size);
@@ -267,7 +267,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n", session_id));
-	status = spdm_calculate_th2_hash(spdm_context, session_info, FALSE,
+	status = libspdm_calculate_th2_hash(spdm_context, session_info, FALSE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -56,14 +56,14 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_KEY_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
@@ -74,7 +74,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)) {
 		// No handshake in clear, then it must be in a session.
 		if (!spdm_context->last_spdm_request_session_id_valid) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 				response_size, response);
 			return RETURN_SUCCESS;
@@ -82,7 +82,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	} else {
 		// handshake in clear, then it must not be in a session.
 		if (spdm_context->last_spdm_request_session_id_valid) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 				response_size, response);
 			return RETURN_SUCCESS;
@@ -96,7 +96,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	session_info =
 		spdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -104,7 +104,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_HANDSHAKING) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -114,7 +114,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	     (spdm_request->header.param1 != 0)) ||
 	    ((session_info->mut_auth_requested != 0) &&
 	     (spdm_request->header.param1 == 0))) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -132,7 +132,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 
 	if (request_size !=
 	    sizeof(spdm_finish_request_t) + signature_size + hmac_size) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -141,7 +141,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	req_slot_id = spdm_request->header.param2;
 	if ((req_slot_id != 0xFF) &&
 	    (req_slot_id >= spdm_context->local_context.slot_count)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -150,7 +150,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 		req_slot_id = spdm_context->encap_context.req_slot_id;
 	}
 	if (req_slot_id != spdm_context->encap_context.req_slot_id) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -162,7 +162,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       sizeof(spdm_finish_request_t));
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -173,7 +173,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			(uint8 *)request + sizeof(spdm_finish_request_t),
 			signature_size);
 		if (!result) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
 				response_size, response);
 			return RETURN_SUCCESS;
@@ -183,7 +183,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			(uint8 *)request + sizeof(spdm_finish_request_t),
 			signature_size);
 		if (RETURN_ERROR(status)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -196,7 +196,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			sizeof(spdm_finish_request_t),
 		hmac_size);
 	if (!result) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -207,7 +207,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 					       sizeof(spdm_finish_request_t),
 				       hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -233,7 +233,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       sizeof(spdm_finish_response_t));
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -247,7 +247,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			spdm_context, session_info,
 			(uint8 *)spdm_response + sizeof(spdm_finish_request_t));
 		if (!result) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
@@ -259,7 +259,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 			(uint8 *)spdm_response + sizeof(spdm_finish_request_t),
 			hmac_size);
 		if (RETURN_ERROR(status)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -270,7 +270,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	status = spdm_calculate_th2_hash(spdm_context, session_info, FALSE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -278,7 +278,7 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
 	status = spdm_generate_session_data_key(
 		session_info->secured_message_context, th2_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -32,12 +32,12 @@ return_status spdm_responder_handle_response_state(IN void *context,
 	spdm_context = context;
 	switch (spdm_context->response_state) {
 	case SPDM_RESPONSE_STATE_BUSY:
-		spdm_generate_error_response(spdm_context, SPDM_ERROR_CODE_BUSY,
+		libspdm_generate_error_response(spdm_context, SPDM_ERROR_CODE_BUSY,
 					     0, response_size, response);
 		// NOTE: Need to reset status to Normal in up level
 		return RETURN_SUCCESS;
 	case SPDM_RESPONSE_STATE_NEED_RESYNC:
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_REQUEST_RESYNCH, 0,
 					     response_size, response);
 		// NOTE: Need to let SPDM_VERSION reset the State
@@ -57,7 +57,7 @@ return_status spdm_responder_handle_response_state(IN void *context,
 			spdm_context->error_data.request_code = request_code;
 			spdm_context->error_data.token = spdm_context->current_token++;
 		}
-		spdm_generate_extended_error_response(
+		libspdm_generate_extended_error_response(
 			spdm_context, SPDM_ERROR_CODE_RESPONSE_NOT_READY, 0,
 			sizeof(spdm_error_data_response_not_ready_t),
 			(uint8 *)(void *)&spdm_context->error_data,
@@ -65,7 +65,7 @@ return_status spdm_responder_handle_response_state(IN void *context,
 		// NOTE: Need to reset status to Normal in up level
 		return RETURN_SUCCESS;
 	case SPDM_RESPONSE_STATE_PROCESSING_ENCAP:
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_REQUEST_IN_FLIGHT,
 					     0, response_size, response);
 		// NOTE: Need let SPDM_ENCAPSULATED_RESPONSE_ACK reset the State

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -67,7 +67,7 @@ return_status spdm_get_response_heartbeat(IN void *context,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
-	session_info = spdm_get_session_info_via_session_id(
+	session_info = libspdm_get_session_info_via_session_id(
 		spdm_context, spdm_context->last_spdm_request_session_id);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -48,21 +48,21 @@ return_status spdm_get_response_heartbeat(IN void *context,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (!spdm_context->last_spdm_request_session_id_valid) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -70,7 +70,7 @@ return_status spdm_get_response_heartbeat(IN void *context,
 	session_info = spdm_get_session_info_via_session_id(
 		spdm_context, spdm_context->last_spdm_request_session_id);
 	if (session_info == NULL) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -78,14 +78,14 @@ return_status spdm_get_response_heartbeat(IN void *context,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_heartbeat_request_t)) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -196,7 +196,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	session_id = (req_session_id << 16) | rsp_session_id;
-	session_info = spdm_assign_session_id(spdm_context, session_id, FALSE);
+	session_info = libspdm_assign_session_id(spdm_context, session_id, FALSE);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
@@ -255,7 +255,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		spdm_context->connection_info.algorithm.dhe_named_group,
 		dhe_context);
 	if (!result) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -267,7 +267,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	result = spdm_generate_measurement_summary_hash(
 		spdm_context, FALSE, spdm_request->header.param1, ptr);
 	if (!result) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -288,19 +288,19 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		spdm_context->local_context
 			.local_cert_chain_provision_size[slot_id];
 
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -309,16 +309,16 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	result = spdm_generate_key_exchange_rsp_signature(spdm_context,
 							  session_info, ptr);
 	if (!result) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			SPDM_KEY_EXCHANGE_RSP, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, signature_size);
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, ptr, signature_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -327,10 +327,10 @@ return_status spdm_get_response_key_exchange(IN void *context,
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_handshake_key[%x]\n",
 	       session_id));
-	status = spdm_calculate_th1_hash(spdm_context, session_info, FALSE,
+	status = libspdm_calculate_th1_hash(spdm_context, session_info, FALSE,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -339,7 +339,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	status = spdm_generate_session_handshake_key(
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -355,16 +355,16 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		result = spdm_generate_key_exchange_rsp_hmac(spdm_context,
 							     session_info, ptr);
 		if (!result) {
-			spdm_free_session_id(spdm_context, session_id);
+			libspdm_free_session_id(spdm_context, session_id);
 			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
-		status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
+		status = libspdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 		if (RETURN_ERROR(status)) {
-			spdm_free_session_id(spdm_context, session_id);
+			libspdm_free_session_id(spdm_context, session_id);
 			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -65,14 +65,14 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_KEY_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
@@ -86,7 +86,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		    SPDM_STATUS_SUCCESS) {
 			DEBUG((DEBUG_INFO,
 			       "spdm_get_response_key_exchange fail due to Mutual Auth fail\n"));
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -96,7 +96,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 			spdm_context, FALSE,
 			0, SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) &&
 			spdm_request->header.param1 > 0) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_KEY_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
@@ -105,7 +105,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	slot_id = spdm_request->header.param2;
 	if ((slot_id != 0xFF) &&
 	    (slot_id >= spdm_context->local_context.slot_count)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -126,13 +126,13 @@ return_status spdm_get_response_key_exchange(IN void *context,
 
 	if ((measurement_summary_hash_size == 0) &&
 		(spdm_request->header.param2 != SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH)) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_INVALID_REQUEST,
 						0, response_size, response);
 	}
 	if (request_size < sizeof(spdm_key_exchange_request_t) + dhe_key_size +
 				   sizeof(uint16)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -142,7 +142,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 			    sizeof(spdm_key_exchange_request_t) + dhe_key_size);
 	if (request_size < sizeof(spdm_key_exchange_request_t) + dhe_key_size +
 				   sizeof(uint16) + opaque_data_length) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -155,7 +155,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	status = spdm_process_opaque_data_supported_version_data(
 		spdm_context, opaque_data_length, ptr);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -190,7 +190,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	req_session_id = spdm_request->req_session_id;
 	rsp_session_id = spdm_allocate_rsp_session_id(spdm_context);
 	if (rsp_session_id == (INVALID_SESSION_ID & 0xFFFF)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -198,7 +198,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	session_id = (req_session_id << 16) | rsp_session_id;
 	session_info = spdm_assign_session_id(spdm_context, session_id, FALSE);
 	if (session_info == NULL) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -256,7 +256,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		dhe_context);
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -268,7 +268,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		spdm_context, FALSE, spdm_request->header.param1, ptr);
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -291,7 +291,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -301,7 +301,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -310,7 +310,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 							  session_info, ptr);
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			SPDM_KEY_EXCHANGE_RSP, response_size, response);
 		return RETURN_SUCCESS;
@@ -319,7 +319,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, signature_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -331,7 +331,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -340,7 +340,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -356,7 +356,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 							     session_info, ptr);
 		if (!result) {
 			spdm_free_session_id(spdm_context, session_id);
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
@@ -365,7 +365,7 @@ return_status spdm_get_response_key_exchange(IN void *context,
 		status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 		if (RETURN_ERROR(status)) {
 			spdm_free_session_id(spdm_context, session_id);
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -71,7 +71,7 @@ return_status spdm_get_response_key_update(IN void *context,
 	}
 	session_id = spdm_context->last_spdm_request_session_id;
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -50,21 +50,21 @@ return_status spdm_get_response_key_update(IN void *context,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_KEY_UPDATE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (!spdm_context->last_spdm_request_session_id_valid) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -73,7 +73,7 @@ return_status spdm_get_response_key_update(IN void *context,
 	session_info =
 		spdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -81,14 +81,14 @@ return_status spdm_get_response_key_update(IN void *context,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (request_size != sizeof(spdm_key_update_request_t)) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -105,7 +105,7 @@ return_status spdm_get_response_key_update(IN void *context,
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY ||
 				 prev_spdm_request->header.param1 ==
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-				spdm_generate_error_response(context,
+				libspdm_generate_error_response(context,
 							     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 							     response_size, response);
 				return RETURN_SUCCESS;
@@ -123,7 +123,7 @@ return_status spdm_get_response_key_update(IN void *context,
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY ||
 				 prev_spdm_request->header.param1 ==
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-				spdm_generate_error_response(context,
+				libspdm_generate_error_response(context,
 							     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 							     response_size, response);
 				return RETURN_SUCCESS;
@@ -154,7 +154,7 @@ return_status spdm_get_response_key_update(IN void *context,
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY &&
 				prev_spdm_request->header.param1 !=
 				      SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-				spdm_generate_error_response(context,
+				libspdm_generate_error_response(context,
 							     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 							     response_size, response);
 				return RETURN_SUCCESS;
@@ -168,7 +168,7 @@ return_status spdm_get_response_key_update(IN void *context,
 			break;
 		default:
 			DEBUG((DEBUG_INFO, "espurious case\n"));
-			spdm_generate_error_response(context,
+			libspdm_generate_error_response(context,
 						     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 						     response_size, response);
 			return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -52,7 +52,7 @@ boolean spdm_create_measurement_signature(IN spdm_context_t *spdm_context,
 		 spdm_context->local_context.opaque_measurement_rsp_size);
 	ptr += spdm_context->local_context.opaque_measurement_rsp_size;
 
-	status = spdm_append_message_m(spdm_context, session_info, response_message,
+	status = libspdm_append_message_m(spdm_context, session_info, response_message,
 				       response_message_size - signature_size);
 	if (RETURN_ERROR(status)) {
 		return FALSE;
@@ -176,7 +176,7 @@ return_status spdm_get_response_measurements(IN void *context,
 				response_size, response);
 			return RETURN_SUCCESS;
 		}
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context,
 			spdm_context->last_spdm_request_session_id);
 		if (session_info == NULL) {
@@ -335,7 +335,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		spdm_response->header.param1 = measurements_count;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 0;
-		spdm_write_uint24(spdm_response->measurement_record_length, 0);
+		libspdm_write_uint24(spdm_response->measurement_record_length, 0);
 
 		break;
 
@@ -375,7 +375,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = measurements_count;
-		spdm_write_uint24(spdm_response->measurement_record_length,
+		libspdm_write_uint24(spdm_response->measurement_record_length,
 				  (uint32)measurements_size);
 
 		break;
@@ -398,7 +398,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(spdm_response->measurement_record_length,
+		libspdm_write_uint24(spdm_response->measurement_record_length,
 			(uint32)measurements_size);
 
 		break;
@@ -429,7 +429,7 @@ return_status spdm_get_response_measurements(IN void *context,
 	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
-	status = spdm_append_message_m(
+	status = libspdm_append_message_m(
 			spdm_context, session_info, spdm_request,
 			request_size);
 	if (RETURN_ERROR(status)) {
@@ -452,19 +452,19 @@ return_status spdm_get_response_measurements(IN void *context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				SPDM_GET_MEASUREMENTS,
 				response_size, response);
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SUCCESS;
 		}
 		//reset
-		spdm_reset_message_m(spdm_context, session_info);
+		libspdm_reset_message_m(spdm_context, session_info);
 	} else {
-		status = spdm_append_message_m(spdm_context, session_info, spdm_response,
+		status = libspdm_append_message_m(spdm_context, session_info, spdm_response,
 					       *response_size);
 		if (RETURN_ERROR(status)) {
 			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
-			spdm_reset_message_m(spdm_context, session_info);
+			libspdm_reset_message_m(spdm_context, session_info);
 			return RETURN_SUCCESS;
 		}
 	}

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -152,7 +152,7 @@ return_status spdm_get_response_measurements(IN void *context,
 	if (!spdm_is_capabilities_flag_supported(
 		    spdm_context, FALSE, 0,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_GET_MEASUREMENTS, response_size, response);
 		return RETURN_SUCCESS;
@@ -160,7 +160,7 @@ return_status spdm_get_response_measurements(IN void *context,
 	if (!spdm_context->last_spdm_request_session_id_valid) {
 		if (spdm_context->connection_info.connection_state <
 		    SPDM_CONNECTION_STATE_AUTHENTICATED) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -170,7 +170,7 @@ return_status spdm_get_response_measurements(IN void *context,
 	} else {
 		if (spdm_context->connection_info.connection_state <
 		    SPDM_CONNECTION_STATE_NEGOTIATED) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -180,7 +180,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			spdm_context,
 			spdm_context->last_spdm_request_session_id);
 		if (session_info == NULL) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -189,7 +189,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		session_state = spdm_secured_message_get_session_state(
 			session_info->secured_message_context);
 		if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
 				response_size, response);
@@ -203,7 +203,7 @@ return_status spdm_get_response_measurements(IN void *context,
 					      SPDM_MESSAGE_VERSION_11)) {
 			if (request_size <
 			    sizeof(spdm_get_measurements_request_t)) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -214,7 +214,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			if (request_size <
 			    sizeof(spdm_get_measurements_request_t) -
 				    sizeof(spdm_request->SlotIDParam)) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -225,7 +225,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		}
 	} else {
 		if (request_size != sizeof(spdm_message_header_t)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -238,7 +238,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		if (!spdm_is_capabilities_flag_supported(
 			    spdm_context, FALSE, 0,
 			    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -282,7 +282,7 @@ return_status spdm_get_response_measurements(IN void *context,
 	if (measurements_size > spdm_response_size) {
 		measurements_size -= spdm_response_size;
 	} else {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED,
 					     0, response_size, response);
 		return RETURN_BUFFER_TOO_SMALL;
@@ -303,13 +303,13 @@ return_status spdm_get_response_measurements(IN void *context,
 	if (RETURN_ERROR(status)) {
 
 		if (status == RETURN_NOT_FOUND) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
 		}
 		else {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -413,7 +413,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			if ((slot_id_param != 0xF) &&
 			    (slot_id_param >=
 			     spdm_context->local_context.slot_count)) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					response_size, response);
@@ -433,7 +433,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			spdm_context, session_info, spdm_request,
 			request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_UNSPECIFIED, 0,
 						response_size, response);
 		return RETURN_SUCCESS;
@@ -447,7 +447,7 @@ return_status spdm_get_response_measurements(IN void *context,
 			spdm_context, session_info, spdm_response,
 			spdm_response_size);
 		if (!ret) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSPECIFIED,
 				SPDM_GET_MEASUREMENTS,
@@ -461,7 +461,7 @@ return_status spdm_get_response_measurements(IN void *context,
 		status = spdm_append_message_m(spdm_context, session_info, spdm_response,
 					       *response_size);
 		if (RETURN_ERROR(status)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			spdm_reset_message_m(spdm_context, session_info);

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -223,7 +223,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		return RETURN_SUCCESS;
 	}
 	session_id = (req_session_id << 16) | rsp_session_id;
-	session_info = spdm_assign_session_id(spdm_context, session_id, TRUE);
+	session_info = libspdm_assign_session_id(spdm_context, session_id, TRUE);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
@@ -251,7 +251,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 						0, response_size, response);
 	}
 	if (!result) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -270,19 +270,19 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	ptr += opaque_psk_exchange_rsp_size;
 
 
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 	
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -291,10 +291,10 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_handshake_key[%x]\n",
 	       session_id));
-	status = spdm_calculate_th1_hash(spdm_context, session_info, FALSE,
+	status = libspdm_calculate_th1_hash(spdm_context, session_info, FALSE,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -303,7 +303,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	status = spdm_generate_session_handshake_key(
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -313,15 +313,15 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	result = spdm_generate_psk_exchange_rsp_hmac(spdm_context, session_info,
 						     ptr);
 	if (!result) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 		return RETURN_SUCCESS;
 	}
-	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
+	status = libspdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_free_session_id(spdm_context, session_id);
+		libspdm_free_session_id(spdm_context, session_id);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
@@ -339,7 +339,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 
 		DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n",
 		       session_id));
-		status = spdm_calculate_th2_hash(spdm_context, session_info,
+		status = libspdm_calculate_th2_hash(spdm_context, session_info,
 						 FALSE, th2_hash_data);
 		if (RETURN_ERROR(status)) {
 			libspdm_generate_error_response(

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -66,14 +66,14 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_PSK_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
@@ -87,7 +87,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 			if (spdm_context->connection_info.algorithm
 				    .measurement_spec !=
 			    SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 					SPDM_PSK_EXCHANGE, response_size,
@@ -98,7 +98,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 				spdm_context->connection_info.algorithm
 					.measurement_hash_algo);
 			if (algo_size == 0) {
-				spdm_generate_error_response(
+				libspdm_generate_error_response(
 					spdm_context,
 					SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 					SPDM_PSK_EXCHANGE, response_size,
@@ -109,7 +109,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		algo_size = spdm_get_hash_size(
 			spdm_context->connection_info.algorithm.base_hash_algo);
 		if (algo_size == 0) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 				SPDM_PSK_EXCHANGE, response_size, response);
@@ -117,7 +117,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		}
 		if (spdm_context->connection_info.algorithm.key_schedule !=
 		    SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context,
 				SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 				SPDM_PSK_EXCHANGE, response_size, response);
@@ -133,7 +133,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		    SPDM_STATUS_SUCCESS) {
 			DEBUG((DEBUG_INFO,
 			       "spdm_get_response_psk_exchange fail due to Mutual Auth fail\n"));
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -143,14 +143,14 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 			spdm_context, FALSE,
 			0, SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) &&
 			spdm_request->header.param1 > 0) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_PSK_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	slot_id = spdm_request->header.param2;
 	if (slot_id >= spdm_context->local_context.slot_count) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -162,7 +162,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
 	if (request_size < sizeof(spdm_psk_exchange_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -171,7 +171,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 				   spdm_request->psk_hint_length +
 				   spdm_request->context_length +
 				   spdm_request->opaque_length) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -186,7 +186,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	status = spdm_process_opaque_data_supported_version_data(
 		spdm_context, spdm_request->opaque_length, ptr);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -217,7 +217,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	req_session_id = spdm_request->req_session_id;
 	rsp_session_id = spdm_allocate_rsp_session_id(spdm_context);
 	if (rsp_session_id == (INVALID_SESSION_ID & 0xFFFF)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -225,7 +225,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	session_id = (req_session_id << 16) | rsp_session_id;
 	session_info = spdm_assign_session_id(spdm_context, session_id, TRUE);
 	if (session_info == NULL) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
 			response_size, response);
 		return RETURN_SUCCESS;
@@ -246,13 +246,13 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		spdm_context, FALSE, spdm_request->header.param1, ptr);
 	if ((measurement_summary_hash_size == 0) &&
 		(spdm_request->header.param2 != SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH)) {
-		return spdm_generate_error_response(spdm_context,
+		return libspdm_generate_error_response(spdm_context,
 						SPDM_ERROR_CODE_INVALID_REQUEST,
 						0, response_size, response);
 	}
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -273,7 +273,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	status = spdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -283,7 +283,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 				       (uintn)ptr - (uintn)spdm_response);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -295,7 +295,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 					 th1_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -304,7 +304,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		session_info->secured_message_context, th1_hash_data);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -314,7 +314,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 						     ptr);
 	if (!result) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 			0, response_size, response);
 		return RETURN_SUCCESS;
@@ -322,7 +322,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 	status = spdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
 	if (RETURN_ERROR(status)) {
 		spdm_free_session_id(spdm_context, session_id);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -342,7 +342,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		status = spdm_calculate_th2_hash(spdm_context, session_info,
 						 FALSE, th2_hash_data);
 		if (RETURN_ERROR(status)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;
@@ -350,7 +350,7 @@ return_status spdm_get_response_psk_exchange(IN void *context,
 		status = spdm_generate_session_data_key(
 			session_info->secured_message_context, th2_hash_data);
 		if (RETURN_ERROR(status)) {
-			spdm_generate_error_response(
+			libspdm_generate_error_response(
 				spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
 				0, response_size, response);
 			return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -74,7 +74,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	}
 	session_id = spdm_context->last_spdm_request_session_id;
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
@@ -104,7 +104,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
 						spdm_request->header.request_response_code);
 
-	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
+	status = libspdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -133,7 +133,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
-	status = spdm_append_message_f(
+	status = libspdm_append_message_f(
 		spdm_context, session_info, FALSE,
 		(uint8 *)request + request_size - hmac_size,
 		hmac_size);
@@ -144,7 +144,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		return RETURN_SUCCESS;
 	}
 
-	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
+	status = libspdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -154,7 +154,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	}
 
 	DEBUG((DEBUG_INFO, "spdm_generate_session_data_key[%x]\n", session_id));
-	status = spdm_calculate_th2_hash(spdm_context, session_info, FALSE,
+	status = libspdm_calculate_th2_hash(spdm_context, session_info, FALSE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -53,21 +53,21 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		    spdm_context, FALSE,
 		    SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
 		    SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			SPDM_PSK_EXCHANGE, response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_context->connection_info.connection_state <
 	    SPDM_CONNECTION_STATE_NEGOTIATED) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
 					     0, response_size, response);
 		return RETURN_SUCCESS;
 	}
 
 	if (!spdm_context->last_spdm_request_session_id_valid) {
-		spdm_generate_error_response(context,
+		libspdm_generate_error_response(context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -76,7 +76,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	session_info =
 		spdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -84,7 +84,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	session_state = spdm_secured_message_get_session_state(
 		session_info->secured_message_context);
 	if (session_state != SPDM_SESSION_STATE_HANDSHAKING) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -95,7 +95,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		spdm_context->connection_info.algorithm.base_hash_algo);
 
 	if (request_size != sizeof(spdm_psk_finish_request_t) + hmac_size) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -107,7 +107,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, request,
 				       request_size - hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -128,7 +128,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		(uint8 *)request + sizeof(spdm_psk_finish_request_t),
 		hmac_size);
 	if (!result) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -138,7 +138,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 		(uint8 *)request + request_size - hmac_size,
 		hmac_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -147,7 +147,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	status = spdm_append_message_f(spdm_context, session_info, FALSE, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -157,7 +157,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	status = spdm_calculate_th2_hash(spdm_context, session_info, FALSE,
 					 th2_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -165,7 +165,7 @@ return_status spdm_get_response_psk_finish(IN void *context,
 	status = spdm_generate_session_data_key(
 		session_info->secured_message_context, th2_hash_data);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -167,7 +167,7 @@ return_status libspdm_process_request(IN void *context, OUT uint32 **session_id,
 	*session_id = message_session_id;
 
 	if (message_session_id != NULL) {
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *message_session_id);
 		if (session_info == NULL) {
 			return RETURN_UNSUPPORTED;
@@ -223,7 +223,7 @@ void spdm_set_session_state(IN spdm_context_t *spdm_context,
 	spdm_session_state_t old_session_state;
 
 	session_info =
-		spdm_get_session_info_via_session_id(spdm_context, session_id);
+		libspdm_get_session_info_via_session_id(spdm_context, session_id);
 	if (session_info == NULL) {
 		ASSERT(FALSE);
 		return;
@@ -358,7 +358,7 @@ return_status libspdm_build_response(IN void *context, IN uint32 *session_id,
 	}
 
 	if (session_id != NULL) {
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, *session_id);
 		if (session_info == NULL) {
 			ASSERT(FALSE);
@@ -449,7 +449,7 @@ return_status libspdm_build_response(IN void *context, IN uint32 *session_id,
 		case SPDM_END_SESSION_ACK:
 			spdm_set_session_state(spdm_context, *session_id,
 					       SPDM_SESSION_STATE_NOT_STARTED);
-			spdm_free_session_id(spdm_context, *session_id);
+			libspdm_free_session_id(spdm_context, *session_id);
 			break;
 		}
 	} else {

--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -45,7 +45,7 @@ return_status spdm_get_response_respond_if_ready(IN void *context,
 	}
 
 	if (request_size != sizeof(spdm_message_header_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -53,19 +53,19 @@ return_status spdm_get_response_respond_if_ready(IN void *context,
 
 	ASSERT(spdm_request->request_response_code == SPDM_RESPOND_IF_READY);
 	if (spdm_request->param1 != spdm_context->error_data.request_code) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_request->param1 == SPDM_RESPOND_IF_READY) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (spdm_request->param2 != spdm_context->error_data.token) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -75,7 +75,7 @@ return_status spdm_get_response_respond_if_ready(IN void *context,
 	get_response_func =
 		spdm_get_response_func_via_request_code(spdm_request->param1);
 	if (get_response_func == NULL) {
-		spdm_generate_error_response(
+		libspdm_generate_error_response(
 			spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
 			spdm_request->param1, response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -81,10 +81,10 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	//
 	// Cache
 	//
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
-	status = spdm_append_message_a(spdm_context, spdm_request,
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
+	status = libspdm_append_message_a(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
 		libspdm_generate_error_response(spdm_context,
@@ -93,7 +93,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 		return RETURN_SUCCESS;
 	}
 
-	spdm_reset_context(spdm_context);
+	libspdm_reset_context(spdm_context);
 
 	ASSERT(*response_size >= sizeof(spdm_version_response_mine_t));
 	*response_size =
@@ -118,10 +118,10 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	//
 	// Cache
 	//
-	status = spdm_append_message_a(spdm_context, spdm_response,
+	status = libspdm_append_message_a(spdm_context, spdm_response,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
-		spdm_reset_message_a(spdm_context);
+		libspdm_reset_message_a(spdm_context);
 		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -50,13 +50,13 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 				  SPDM_CONNECTION_STATE_NOT_STARTED);
 
 	if (spdm_request->header.spdm_version != SPDM_MESSAGE_VERSION_10) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
 	}
 	if (request_size != sizeof(spdm_get_version_request_t)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -87,7 +87,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 	status = spdm_append_message_a(spdm_context, spdm_request,
 				       spdm_request_size);
 	if (RETURN_ERROR(status)) {
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;
@@ -122,7 +122,7 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
 				       *response_size);
 	if (RETURN_ERROR(status)) {
 		spdm_reset_message_a(spdm_context);
-		spdm_generate_error_response(spdm_context,
+		libspdm_generate_error_response(spdm_context,
 					     SPDM_ERROR_CODE_UNSPECIFIED, 0,
 					     response_size, response);
 		return RETURN_SUCCESS;

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -135,7 +135,7 @@ return_status spdm_transport_mctp_encode_message(
 	transport_encode_message = mctp_encode_message;
 	if (session_id != NULL) {
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *session_id);
 		if (secured_message_context == NULL) {
 			return RETURN_UNSUPPORTED;
@@ -240,7 +240,7 @@ return_status spdm_transport_mctp_decode_message(
 
 	spdm_error.error_code = 0;
 	spdm_error.session_id = 0;
-	spdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
+	libspdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
 
 	spdm_secured_message_callbacks_t.version =
 		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
@@ -270,12 +270,12 @@ return_status spdm_transport_mctp_decode_message(
 		*session_id = SecuredMessageSessionId;
 
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *SecuredMessageSessionId);
 		if (secured_message_context == NULL) {
 			spdm_error.error_code = SPDM_ERROR_CODE_INVALID_SESSION;
 			spdm_error.session_id = *SecuredMessageSessionId;
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}
@@ -292,7 +292,7 @@ return_status spdm_transport_mctp_decode_message(
 			       "spdm_decode_secured_message - %p\n", status));
 			spdm_secured_message_get_last_spdm_error_struct(
 				secured_message_context, &spdm_error);
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
@@ -132,7 +132,7 @@ return_status spdm_transport_pci_doe_encode_message(
 	transport_encode_message = pci_doe_encode_message;
 	if (session_id != NULL) {
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *session_id);
 		if (secured_message_context == NULL) {
 			return RETURN_UNSUPPORTED;
@@ -217,7 +217,7 @@ return_status spdm_transport_pci_doe_decode_message(
 
 	spdm_error.error_code = 0;
 	spdm_error.session_id = 0;
-	spdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
+	libspdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
 
 	spdm_secured_message_callbacks_t.version =
 		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
@@ -248,12 +248,12 @@ return_status spdm_transport_pci_doe_decode_message(
 		*session_id = SecuredMessageSessionId;
 
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *SecuredMessageSessionId);
 		if (secured_message_context == NULL) {
 			spdm_error.error_code = SPDM_ERROR_CODE_INVALID_SESSION;
 			spdm_error.session_id = *SecuredMessageSessionId;
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}
@@ -269,7 +269,7 @@ return_status spdm_transport_pci_doe_decode_message(
 			       "spdm_decode_secured_message - %p\n", status));
 			spdm_secured_message_get_last_spdm_error_struct(
 				secured_message_context, &spdm_error);
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
@@ -25,17 +25,17 @@ uintn spdm_unit_test_group_setup(void **State)
 
 	spdm_test_context = m_spdm_test_context;
 	spdm_test_context->spdm_context =
-		(void *)malloc(spdm_get_context_size());
+		(void *)malloc(libspdm_get_context_size());
 	if (spdm_test_context->spdm_context == NULL) {
 		return (uintn)-1;
 	}
 	spdm_context = spdm_test_context->spdm_context;
 
-	spdm_init_context(spdm_context);
-	spdm_register_device_io_func(spdm_context,
+	libspdm_init_context(spdm_context);
+	libspdm_register_device_io_func(spdm_context,
 				     spdm_test_context->send_message,
 				     spdm_test_context->receive_message);
-	spdm_register_transport_layer_func(spdm_context,
+	libspdm_register_transport_layer_func(spdm_context,
 					   spdm_transport_test_encode_message,
 					   spdm_transport_test_decode_message);
 

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
@@ -26,8 +26,8 @@
 typedef struct {
 	uint32 signature;
 	boolean is_requester;
-	spdm_device_send_message_func send_message;
-	spdm_device_receive_message_func receive_message;
+	libspdm_device_send_message_func send_message;
+	libspdm_device_receive_message_func receive_message;
 	void *spdm_context;
 	void *test_buffer;
 	uintn test_buffer_size;

--- a/unit_test/spdm_transport_test_lib/common.c
+++ b/unit_test/spdm_transport_test_lib/common.c
@@ -135,7 +135,7 @@ return_status spdm_transport_test_encode_message(
 	transport_encode_message = test_encode_message;
 	if (session_id != NULL) {
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *session_id);
 		if (secured_message_context == NULL) {
 			return RETURN_UNSUPPORTED;
@@ -240,7 +240,7 @@ return_status spdm_transport_test_decode_message(
 
 	spdm_error.error_code = 0;
 	spdm_error.session_id = 0;
-	spdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
+	libspdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
 
 	spdm_secured_message_callbacks_t.version =
 		SPDM_SECURED_MESSAGE_CALLBACKS_VERSION;
@@ -270,12 +270,12 @@ return_status spdm_transport_test_decode_message(
 		*session_id = SecuredMessageSessionId;
 
 		secured_message_context =
-			spdm_get_secured_message_context_via_session_id(
+			libspdm_get_secured_message_context_via_session_id(
 				spdm_context, *SecuredMessageSessionId);
 		if (secured_message_context == NULL) {
 			spdm_error.error_code = SPDM_ERROR_CODE_INVALID_SESSION;
 			spdm_error.session_id = *SecuredMessageSessionId;
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}
@@ -292,7 +292,7 @@ return_status spdm_transport_test_decode_message(
 			       "spdm_decode_secured_message - %p\n", status));
 			spdm_secured_message_get_last_spdm_error_struct(
 				secured_message_context, &spdm_error);
-			spdm_set_last_spdm_error_struct(spdm_context,
+			libspdm_set_last_spdm_error_struct(spdm_context,
 							&spdm_error);
 			return RETURN_UNSUPPORTED;
 		}

--- a/unit_test/spdm_unit_test_common/common.c
+++ b/unit_test/spdm_unit_test_common/common.c
@@ -25,18 +25,18 @@ int spdm_unit_test_group_setup(void **state)
 
 	spdm_test_context = m_spdm_test_context;
 	spdm_test_context->spdm_context =
-		(void *)malloc(spdm_get_context_size());
+		(void *)malloc(libspdm_get_context_size());
 	if (spdm_test_context->spdm_context == NULL) {
 		return -1;
 	}
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0xFFFFFFFF;
 
-	spdm_init_context(spdm_context);
-	spdm_register_device_io_func(spdm_context,
+	libspdm_init_context(spdm_context);
+	libspdm_register_device_io_func(spdm_context,
 				     spdm_test_context->send_message,
 				     spdm_test_context->receive_message);
-	spdm_register_transport_layer_func(spdm_context,
+	libspdm_register_transport_layer_func(spdm_context,
 					   spdm_transport_test_encode_message,
 					   spdm_transport_test_decode_message);
 

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -57,8 +57,8 @@ extern uint16 m_use_key_schedule_algo;
 typedef struct {
 	uint32 signature;
 	boolean is_requester;
-	spdm_device_send_message_func send_message;
-	spdm_device_receive_message_func receive_message;
+	libspdm_device_send_message_func send_message;
+	libspdm_device_receive_message_func receive_message;
 	void *spdm_context;
 	uint32 case_id;
 } spdm_test_context_t;

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
@@ -10,7 +10,7 @@
   This function sends GET_DIGEST, GET_CERTIFICATE, CHALLENGE
   to authenticate the device.
 
-  This function is combination of spdm_get_digest, spdm_get_certificate, spdm_challenge.
+  This function is combination of libspdm_get_digest, libspdm_get_certificate, libspdm_challenge.
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  slot_mask                     The slots which deploy the CertificateChain.
@@ -37,13 +37,13 @@ spdm_authentication(IN void *context, OUT uint8 *slot_mask,
         status = RETURN_SUCCESS;
 
 	#if SPDM_ENABLE_CAPABILITY_CERT_CAP
-	status = spdm_get_digest(context, slot_mask, total_digest_buffer);
+	status = libspdm_get_digest(context, slot_mask, total_digest_buffer);
 	if (RETURN_ERROR(status)) {
 		return status;
 	}
 
 	if (slot_id != 0xFF) {
-		status = spdm_get_certificate(context, slot_id, cert_chain_size,
+		status = libspdm_get_certificate(context, slot_id, cert_chain_size,
 					      cert_chain);
 		if (RETURN_ERROR(status)) {
 			return status;
@@ -52,7 +52,7 @@ spdm_authentication(IN void *context, OUT uint8 *slot_mask,
 	#endif // SPDM_ENABLE_CAPABILITY_CERT_CAP
 
 	#if SPDM_ENABLE_CAPABILITY_CHAL_CAP
-	status = spdm_challenge(context, slot_id, measurement_hash_type,
+	status = libspdm_challenge(context, slot_id, measurement_hash_type,
 				measurement_hash);
 	if (RETURN_ERROR(status)) {
 		return status;

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
@@ -33,14 +33,14 @@ void *spdm_client_init(void)
 	uint32 data32;
 	boolean has_rsp_pub_cert;
 
-	spdm_context = (void *)allocate_pool(spdm_get_context_size());
+	spdm_context = (void *)allocate_pool(libspdm_get_context_size());
 	if (spdm_context == NULL) {
 		return NULL;
 	}
-	spdm_init_context(spdm_context);
-	spdm_register_device_io_func(spdm_context, SpdmRequesterSendMessage,
+	libspdm_init_context(spdm_context);
+	libspdm_register_device_io_func(spdm_context, SpdmRequesterSendMessage,
 				     SpdmRequesterReceiveMessage);
-	spdm_register_transport_layer_func(spdm_context,
+	libspdm_register_transport_layer_func(spdm_context,
 					   spdm_transport_mctp_encode_message,
 					   spdm_transport_mctp_decode_message);
 
@@ -49,7 +49,7 @@ void *spdm_client_init(void)
 	data8 = 0;
 	zero_mem(&parameter, sizeof(parameter));
 	parameter.location = SPDM_DATA_LOCATION_LOCAL;
-	spdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_CT_EXPONENT,
+	libspdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_CT_EXPONENT,
 		      &parameter, &data8, sizeof(data8));
 
 	data32 = /*SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP |
@@ -70,23 +70,23 @@ void *spdm_client_init(void)
 	} else {
 		data32 |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
 	}
-	spdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_FLAGS, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_FLAGS, &parameter,
 		      &data32, sizeof(data32));
 
 	data32 = SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048;
-	spdm_set_data(spdm_context, SPDM_DATA_BASE_ASYM_ALGO, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_BASE_ASYM_ALGO, &parameter,
 		      &data32, sizeof(data32));
 	data32 = SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
-	spdm_set_data(spdm_context, SPDM_DATA_BASE_HASH_ALGO, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_BASE_HASH_ALGO, &parameter,
 		      &data32, sizeof(data32));
 	data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048;
-	spdm_set_data(spdm_context, SPDM_DATA_DHE_NAME_GROUP, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_DHE_NAME_GROUP, &parameter,
 		      &data16, sizeof(data16));
 	data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
-	spdm_set_data(spdm_context, SPDM_DATA_AEAD_CIPHER_SUITE, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_AEAD_CIPHER_SUITE, &parameter,
 		      &data16, sizeof(data16));
 	data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
-	spdm_set_data(spdm_context, SPDM_DATA_KEY_SCHEDULE, &parameter, &data16,
+	libspdm_set_data(spdm_context, SPDM_DATA_KEY_SCHEDULE, &parameter, &data16,
 		      sizeof(data16));
 
 	status = libspdm_init_connection(spdm_context, FALSE);

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
@@ -89,9 +89,9 @@ void *spdm_client_init(void)
 	spdm_set_data(spdm_context, SPDM_DATA_KEY_SCHEDULE, &parameter, &data16,
 		      sizeof(data16));
 
-	status = spdm_init_connection(spdm_context, FALSE);
+	status = libspdm_init_connection(spdm_context, FALSE);
 	if (RETURN_ERROR(status)) {
-		DEBUG((DEBUG_ERROR, "spdm_init_connection - %r\n", status));
+		DEBUG((DEBUG_ERROR, "libspdm_init_connection - %r\n", status));
 		free_pool(spdm_context);
 		return NULL;
 	}

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_session.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_session.c
@@ -15,13 +15,13 @@ return_status do_session_via_spdm(IN void *spdm_context)
 
 	heartbeat_period = 0;
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_start_session(
+	status = libspdm_start_session(
 		spdm_context,
 		FALSE, // KeyExchange
 		SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0,
 		&session_id, &heartbeat_period, measurement_hash);
 	if (RETURN_ERROR(status)) {
-		DEBUG((DEBUG_ERROR, "spdm_start_session - %r\n", status));
+		DEBUG((DEBUG_ERROR, "libspdm_start_session - %r\n", status));
 		return status;
 	}
 
@@ -29,9 +29,9 @@ return_status do_session_via_spdm(IN void *spdm_context)
 	// TBD - Set key
 	//
 
-	status = spdm_stop_session(spdm_context, session_id, 0);
+	status = libspdm_stop_session(spdm_context, session_id, 0);
 	if (RETURN_ERROR(status)) {
-		DEBUG((DEBUG_ERROR, "spdm_stop_session - %r\n", status));
+		DEBUG((DEBUG_ERROR, "libspdm_stop_session - %r\n", status));
 		return status;
 	}
 

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
@@ -34,14 +34,14 @@ void *spdm_server_init(void)
 	boolean has_rsp_priv_key;
 	boolean has_req_pub_cert;
 
-	spdm_context = (void *)allocate_pool(spdm_get_context_size());
+	spdm_context = (void *)allocate_pool(libspdm_get_context_size());
 	if (spdm_context == NULL) {
 		return NULL;
 	}
-	spdm_init_context(spdm_context);
-	spdm_register_device_io_func(spdm_context, SpdmResponderSendMessage,
+	libspdm_init_context(spdm_context);
+	libspdm_register_device_io_func(spdm_context, SpdmResponderSendMessage,
 				     SpdmResponderReceiveMessage);
-	spdm_register_transport_layer_func(spdm_context,
+	libspdm_register_transport_layer_func(spdm_context,
 					   spdm_transport_mctp_encode_message,
 					   spdm_transport_mctp_decode_message);
 
@@ -52,7 +52,7 @@ void *spdm_server_init(void)
 	data8 = 0;
 	zero_mem(&parameter, sizeof(parameter));
 	parameter.location = SPDM_DATA_LOCATION_LOCAL;
-	spdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_CT_EXPONENT,
+	libspdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_CT_EXPONENT,
 		      &parameter, &data8, sizeof(data8));
 
 	data32 =
@@ -91,23 +91,23 @@ void *spdm_server_init(void)
 	} else {
 		data32 |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP;
 	}
-	spdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_FLAGS, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_CAPABILITY_FLAGS, &parameter,
 		      &data32, sizeof(data32));
 
 	data32 = SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048;
-	spdm_set_data(spdm_context, SPDM_DATA_BASE_ASYM_ALGO, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_BASE_ASYM_ALGO, &parameter,
 		      &data32, sizeof(data32));
 	data32 = SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
-	spdm_set_data(spdm_context, SPDM_DATA_BASE_HASH_ALGO, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_BASE_HASH_ALGO, &parameter,
 		      &data32, sizeof(data32));
 	data16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048;
-	spdm_set_data(spdm_context, SPDM_DATA_DHE_NAME_GROUP, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_DHE_NAME_GROUP, &parameter,
 		      &data16, sizeof(data16));
 	data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
-	spdm_set_data(spdm_context, SPDM_DATA_AEAD_CIPHER_SUITE, &parameter,
+	libspdm_set_data(spdm_context, SPDM_DATA_AEAD_CIPHER_SUITE, &parameter,
 		      &data16, sizeof(data16));
 	data16 = SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH;
-	spdm_set_data(spdm_context, SPDM_DATA_KEY_SCHEDULE, &parameter, &data16,
+	libspdm_set_data(spdm_context, SPDM_DATA_KEY_SCHEDULE, &parameter, &data16,
 		      sizeof(data16));
 
 	return spdm_context;

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_main.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_main.c
@@ -24,7 +24,7 @@ void spdm_dispatch(void)
 	}
 
 	while (TRUE) {
-		status = spdm_responder_dispatch_message(spdm_context);
+		status = libspdm_responder_dispatch_message(spdm_context);
 		if (status != RETURN_UNSUPPORTED) {
 			continue;
 		}

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -26,12 +26,12 @@ static void test_spdm_common_context_data_case1(void **state)
 	spdm_context = spdm_test_context->spdm_context;
 	spdm_test_context->case_id = 0x1;
 
-	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &data, sizeof(data));
 	assert_int_equal(status, RETURN_SUCCESS);
 
 	data_return_size = sizeof(return_data);
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &return_data, &data_return_size);
 	assert_int_equal(status, RETURN_SUCCESS);
 
@@ -43,7 +43,7 @@ static void test_spdm_common_context_data_case1(void **state)
 }
 
 /**
-  Test 2: Test failure paths of setting opaque data in context. spdm_set_data
+  Test 2: Test failure paths of setting opaque data in context. libspdm_set_data
   should fail when an invalid size is passed.
 **/
 static void test_spdm_common_context_data_case2(void **state)
@@ -66,7 +66,7 @@ static void test_spdm_common_context_data_case2(void **state)
 	 * changed after a failed set data.
 	 */
 	data_return_size = sizeof(current_return_data);
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &current_return_data, &data_return_size);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(data_return_size, sizeof(void*));
@@ -78,12 +78,12 @@ static void test_spdm_common_context_data_case2(void **state)
 	 * Set data with invalid size, it should fail. Read back to ensure that
 	 * no data was set.
 	 */
-	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &data, 500);
 	assert_int_equal(status, RETURN_INVALID_PARAMETER);
 
 	data_return_size = sizeof(return_data);
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &return_data, &data_return_size);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_ptr_equal(return_data, current_return_data);
@@ -94,7 +94,7 @@ static void test_spdm_common_context_data_case2(void **state)
 }
 
 /**
-  Test 3: Test failure paths of setting opaque data in context. spdm_set_data
+  Test 3: Test failure paths of setting opaque data in context. libspdm_set_data
   should fail when data contains NULL value.
 **/
 static void test_spdm_common_context_data_case3(void **state)
@@ -117,7 +117,7 @@ static void test_spdm_common_context_data_case3(void **state)
 	 * changed after a failed set data.
 	 */
 	data_return_size = sizeof(current_return_data);
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &current_return_data, &data_return_size);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_int_equal(data_return_size, sizeof(void*));
@@ -130,12 +130,12 @@ static void test_spdm_common_context_data_case3(void **state)
 	 * Set data with NULL data, it should fail. Read back to ensure that
 	 * no data was set.
 	 */
-	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &data, sizeof(void *));
 	assert_int_equal(status, RETURN_INVALID_PARAMETER);
 
 	data_return_size = sizeof(return_data);
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &return_data, &data_return_size);
 	assert_int_equal(status, RETURN_SUCCESS);
 	assert_ptr_equal(return_data, current_return_data);
@@ -147,7 +147,7 @@ static void test_spdm_common_context_data_case3(void **state)
 }
 
 /**
-  Test 4: Test failure paths of getting opaque data in context. spdm_get_data
+  Test 4: Test failure paths of getting opaque data in context. libspdm_get_data
   should fail when the size of buffer to get is too small.
 **/
 static void test_spdm_common_context_data_case4(void **state)
@@ -166,7 +166,7 @@ static void test_spdm_common_context_data_case4(void **state)
 	/*
 	 * Set data successfully.
 	 */
-	status = spdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &data, sizeof(void *));
 	assert_int_equal(status, RETURN_SUCCESS);
 
@@ -175,7 +175,7 @@ static void test_spdm_common_context_data_case4(void **state)
 	 * data size must return required buffer size.
 	 */
 	data_return_size = 4;
-	status = spdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+	status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
 			       NULL, &return_data, &data_return_size);
 	assert_int_equal(status, RETURN_BUFFER_TOO_SMALL);
 	assert_int_equal(data_return_size, sizeof(void*));

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -995,9 +995,9 @@ void test_spdm_requester_challenge_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1057,9 +1057,9 @@ void test_spdm_requester_challenge_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1117,9 +1117,9 @@ void test_spdm_requester_challenge_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1172,9 +1172,9 @@ void test_spdm_requester_challenge_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1227,9 +1227,9 @@ void test_spdm_requester_challenge_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1282,9 +1282,9 @@ void test_spdm_requester_challenge_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1335,9 +1335,9 @@ void test_spdm_requester_challenge_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1392,9 +1392,9 @@ void test_spdm_requester_challenge_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1448,9 +1448,9 @@ void test_spdm_requester_challenge_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
-	spdm_reset_message_b(spdm_context);
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_a(spdm_context);
+	libspdm_reset_message_b(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1497,9 +1497,9 @@ void test_spdm_requester_challenge_case10(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   // spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1539,9 +1539,9 @@ void test_spdm_requester_challenge_case11(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1579,9 +1579,9 @@ void test_spdm_requester_challenge_case12(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1620,9 +1620,9 @@ void test_spdm_requester_challenge_case13(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1660,9 +1660,9 @@ void test_spdm_requester_challenge_case14(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1701,9 +1701,9 @@ void test_spdm_requester_challenge_case15(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1748,9 +1748,9 @@ void test_spdm_requester_challenge_case16(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1795,9 +1795,9 @@ void test_spdm_requester_challenge_case17(void **state) {
   spdm_context->connection_info.capability.flags = 0;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1843,9 +1843,9 @@ void test_spdm_requester_challenge_case18(void **state) {
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP; //additional measurement capability
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1890,9 +1890,9 @@ void test_spdm_requester_challenge_case19(void **state) {
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP; //additional measurement capability
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
-  spdm_reset_message_a(spdm_context);
-  spdm_reset_message_b(spdm_context);
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_a(spdm_context);
+  libspdm_reset_message_b(spdm_context);
+  libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
   
@@ -1942,9 +1942,9 @@ void test_spdm_requester_challenge_case20(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_reset_message_a(spdm_context);
-    spdm_reset_message_b(spdm_context);
-    spdm_reset_message_c(spdm_context);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_b(spdm_context);
+    libspdm_reset_message_c(spdm_context);
 
     zero_mem (measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1011,7 +1011,7 @@ void test_spdm_requester_challenge_case1(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1073,7 +1073,7 @@ void test_spdm_requester_challenge_case2(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1133,7 +1133,7 @@ void test_spdm_requester_challenge_case3(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1188,7 +1188,7 @@ void test_spdm_requester_challenge_case4(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1243,7 +1243,7 @@ void test_spdm_requester_challenge_case5(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1298,7 +1298,7 @@ void test_spdm_requester_challenge_case6(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1351,7 +1351,7 @@ void test_spdm_requester_challenge_case7(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1408,7 +1408,7 @@ void test_spdm_requester_challenge_case8(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1464,7 +1464,7 @@ void test_spdm_requester_challenge_case9(void **state)
 		 data, data_size);
 
 	zero_mem(measurement_hash, sizeof(measurement_hash));
-	status = spdm_challenge(
+	status = libspdm_challenge(
 		spdm_context, 0,
 		SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
 		measurement_hash);
@@ -1509,7 +1509,7 @@ void test_spdm_requester_challenge_case10(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_UNSUPPORTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
   assert_int_equal (spdm_context->transcript.message_c.buffer_size, 0);
@@ -1551,7 +1551,7 @@ void test_spdm_requester_challenge_case11(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
   free(data);
 }
@@ -1591,7 +1591,7 @@ void test_spdm_requester_challenge_case12(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
   free(data);
 }
@@ -1632,7 +1632,7 @@ void test_spdm_requester_challenge_case13(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
   free(data);
 }
@@ -1672,7 +1672,7 @@ void test_spdm_requester_challenge_case14(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
   free(data);
 }
@@ -1713,7 +1713,7 @@ void test_spdm_requester_challenge_case15(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, MAX_SPDM_SLOT_COUNT, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, MAX_SPDM_SLOT_COUNT, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_INVALID_PARAMETER);;
   free(data);
 }
@@ -1760,7 +1760,7 @@ void test_spdm_requester_challenge_case16(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_SUCCESS);
   free(data);
 }
@@ -1807,7 +1807,7 @@ void test_spdm_requester_challenge_case17(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
   free(data);
 }
@@ -1855,7 +1855,7 @@ void test_spdm_requester_challenge_case18(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, measurement_hash);
   assert_int_equal (status, RETURN_SUCCESS);
 }
 
@@ -1902,7 +1902,7 @@ void test_spdm_requester_challenge_case19(void **state) {
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
   zero_mem (measurement_hash, sizeof(measurement_hash));
-  status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH, measurement_hash);
+  status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH, measurement_hash);
   assert_int_equal (status, RETURN_SUCCESS);
 }
 
@@ -1947,7 +1947,7 @@ void test_spdm_requester_challenge_case20(void **state) {
     spdm_reset_message_c(spdm_context);
 
     zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = spdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
+    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, measurement_hash);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -103,7 +103,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -136,7 +136,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -163,7 +163,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -190,7 +190,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -220,7 +220,7 @@ return_status spdm_requester_end_session_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index1++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -251,7 +251,7 @@ return_status spdm_requester_end_session_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -280,7 +280,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -312,7 +312,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -349,7 +349,7 @@ return_status spdm_requester_end_session_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index2++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -380,7 +380,7 @@ return_status spdm_requester_end_session_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -411,7 +411,7 @@ return_status spdm_requester_end_session_test_receive_message(
       spdm_response.header.param2 = 0;
 
       spdm_transport_test_encode_message (spdm_context, &session_id, FALSE, FALSE, sizeof(spdm_response), &spdm_response, response_size, response);
-      session_info = spdm_get_session_info_via_session_id (spdm_context, session_id);
+      session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
       ((spdm_secured_message_context_t*)(session_info->secured_message_context))->application_secret.response_data_sequence_number --;
     }
 
@@ -448,7 +448,7 @@ return_status spdm_requester_end_session_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -496,7 +496,7 @@ void test_spdm_requester_end_session_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -560,7 +560,7 @@ void test_spdm_requester_end_session_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -651,7 +651,7 @@ void test_spdm_requester_end_session_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -738,7 +738,7 @@ void test_spdm_requester_end_session_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -825,7 +825,7 @@ void test_spdm_requester_end_session_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -912,7 +912,7 @@ void test_spdm_requester_end_session_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1003,7 +1003,7 @@ void test_spdm_requester_end_session_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1092,7 +1092,7 @@ void test_spdm_requester_end_session_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1179,7 +1179,7 @@ void test_spdm_requester_end_session_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1274,7 +1274,7 @@ void test_spdm_requester_end_session_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_reset_message_a(spdm_context);
+    libspdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1337,7 +1337,7 @@ void test_spdm_requester_end_session_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -1286,7 +1286,7 @@ void test_spdm_requester_finish_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1362,7 +1362,7 @@ void test_spdm_requester_finish_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1441,7 +1441,7 @@ void test_spdm_requester_finish_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1516,7 +1516,7 @@ void test_spdm_requester_finish_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1591,7 +1591,7 @@ void test_spdm_requester_finish_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1667,7 +1667,7 @@ void test_spdm_requester_finish_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1747,7 +1747,7 @@ void test_spdm_requester_finish_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1824,7 +1824,7 @@ void test_spdm_requester_finish_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1900,7 +1900,7 @@ void test_spdm_requester_finish_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1987,7 +1987,7 @@ void test_spdm_requester_finish_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
     session_info = &spdm_context->session_info[0];
     spdm_session_info_init (spdm_context, session_info, session_id, FALSE);
@@ -2048,7 +2048,7 @@ void test_spdm_requester_finish_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2150,7 +2150,7 @@ void test_spdm_requester_finish_case12(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2227,7 +2227,7 @@ void test_spdm_requester_finish_case13(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2302,7 +2302,7 @@ void test_spdm_requester_finish_case14(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2378,7 +2378,7 @@ void test_spdm_requester_finish_case15(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2454,7 +2454,7 @@ void test_spdm_requester_finish_case16(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2545,7 +2545,7 @@ void test_spdm_requester_finish_case17(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2632,7 +2632,7 @@ void test_spdm_requester_finish_case18(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2720,7 +2720,7 @@ void test_spdm_requester_finish_case19(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -2808,7 +2808,7 @@ void test_spdm_requester_finish_case20(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -1137,7 +1137,7 @@ void test_spdm_requester_get_capabilities_case19(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1161,7 +1161,7 @@ void test_spdm_requester_get_capabilities_case20(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1185,7 +1185,7 @@ void test_spdm_requester_get_capabilities_case21(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1209,7 +1209,7 @@ void test_spdm_requester_get_capabilities_case22(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1233,7 +1233,7 @@ void test_spdm_requester_get_capabilities_case23(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1257,7 +1257,7 @@ void test_spdm_requester_get_capabilities_case24(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1281,7 +1281,7 @@ void test_spdm_requester_get_capabilities_case25(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1305,7 +1305,7 @@ void test_spdm_requester_get_capabilities_case26(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1329,7 +1329,7 @@ void test_spdm_requester_get_capabilities_case27(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1351,7 +1351,7 @@ void test_spdm_requester_get_capabilities_case28(void **state)
 	spdm_context->connection_info.version.minor_version = 1;
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->local_context.capability.ct_exponent = 0;
 	spdm_context->local_context.capability.flags =
@@ -1377,7 +1377,7 @@ void test_spdm_requester_get_capabilities_case29(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AFTER_VERSION;
-    spdm_reset_message_a(spdm_context);
+    libspdm_reset_message_a(spdm_context);
 
     status = spdm_get_capabilities (spdm_context);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1282,7 +1282,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1344,7 +1344,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
 #endif
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1401,7 +1401,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1452,7 +1452,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1503,7 +1503,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1556,7 +1556,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1612,7 +1612,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
@@ -1665,7 +1665,7 @@ void test_spdm_requester_get_certificate_case8(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	free(data);
@@ -1716,7 +1716,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1775,7 +1775,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1837,7 +1837,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1904,7 +1904,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1967,7 +1967,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2033,7 +2033,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate_choose_length(
+	status = libspdm_get_certificate_choose_length(
 		spdm_context, 0, get_cert_length, &cert_chain_size, cert_chain);
 	// It may fail because the spdm does not support too many messages.
 	//assert_int_equal (status, RETURN_SUCCESS);
@@ -2099,7 +2099,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	// It may fail because the spdm does not support too long message.
 	//assert_int_equal (status, RETURN_SUCCESS);
@@ -2160,7 +2160,7 @@ void test_spdm_requester_get_certificate_case16(void **state) {
 
     cert_chain_size = sizeof(cert_chain);
     zero_mem (cert_chain, sizeof(cert_chain));
-    status = spdm_get_certificate (spdm_context, 0, &cert_chain_size, cert_chain);
+    status = libspdm_get_certificate (spdm_context, 0, &cert_chain_size, cert_chain);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2225,7 +2225,7 @@ void test_spdm_requester_get_certificate_case17(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SUCCESS);
 	free(data);
@@ -2273,7 +2273,7 @@ void test_spdm_requester_get_certificate_case18(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 	free(data);
@@ -2329,7 +2329,7 @@ void test_spdm_requester_get_certificate_case19(void **state)
 
 	cert_chain_size = sizeof(cert_chain);
 	zero_mem(cert_chain, sizeof(cert_chain));
-	status = spdm_get_certificate(spdm_context, 0, &cert_chain_size,
+	status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
 				      cert_chain);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1276,7 +1276,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1334,7 +1334,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1395,7 +1395,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1446,7 +1446,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1497,7 +1497,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1550,7 +1550,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1606,7 +1606,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1659,7 +1659,7 @@ void test_spdm_requester_get_certificate_case8(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1710,7 +1710,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1769,7 +1769,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
 	spdm_context->local_context.peer_root_cert_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision = data;
 	spdm_context->local_context.peer_cert_chain_provision_size = data_size;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -1832,7 +1832,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 	cert_chain_size = sizeof(cert_chain);
@@ -1898,7 +1898,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 
@@ -1962,7 +1962,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 	cert_chain_size = sizeof(cert_chain);
@@ -2028,7 +2028,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 	cert_chain_size = sizeof(cert_chain);
@@ -2094,7 +2094,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 	cert_chain_size = sizeof(cert_chain);
@@ -2156,7 +2156,7 @@ void test_spdm_requester_get_certificate_case16(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AFTER_DIGESTS;
-    spdm_reset_message_b(spdm_context);
+    libspdm_reset_message_b(spdm_context);
 
     cert_chain_size = sizeof(cert_chain);
     zero_mem (cert_chain, sizeof(cert_chain));
@@ -2219,7 +2219,7 @@ void test_spdm_requester_get_certificate_case17(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -2267,7 +2267,7 @@ void test_spdm_requester_get_certificate_case18(void **state)
 	spdm_context->local_context.peer_root_cert_provision = root_cert;
 	spdm_context->local_context.peer_cert_chain_provision = NULL;
 	spdm_context->local_context.peer_cert_chain_provision_size = 0;
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 
@@ -2324,7 +2324,7 @@ void test_spdm_requester_get_certificate_case19(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
 	// Reseting message buffer
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	// Calculating expected number of messages received
 
 	cert_chain_size = sizeof(cert_chain);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -668,7 +668,7 @@ void test_spdm_requester_get_digests_case1(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -710,7 +710,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 #endif
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
@@ -755,7 +755,7 @@ void test_spdm_requester_get_digests_case3(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -793,7 +793,7 @@ void test_spdm_requester_get_digests_case4(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -831,7 +831,7 @@ void test_spdm_requester_get_digests_case5(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -870,7 +870,7 @@ void test_spdm_requester_get_digests_case6(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
@@ -914,7 +914,7 @@ void test_spdm_requester_get_digests_case7(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
@@ -955,7 +955,7 @@ void test_spdm_requester_get_digests_case8(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -991,7 +991,7 @@ void test_spdm_requester_get_digests_case9(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(
@@ -1034,7 +1034,7 @@ void test_spdm_requester_get_digests_case10(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -1072,7 +1072,7 @@ void test_spdm_requester_get_digests_case11(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1112,7 +1112,7 @@ void test_spdm_requester_get_digests_case12(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1151,7 +1151,7 @@ void test_spdm_requester_get_digests_case13(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1190,7 +1190,7 @@ void test_spdm_requester_get_digests_case14(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1233,7 +1233,7 @@ void test_spdm_requester_get_digests_case15(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -1275,7 +1275,7 @@ void test_spdm_requester_get_digests_case16(void **state)
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 #endif
 }
@@ -1311,7 +1311,7 @@ void test_spdm_requester_get_digests_case17(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 	assert_int_equal(spdm_context->error_state,
 			 SPDM_STATUS_ERROR_CERTIFICATE_FAILURE);
@@ -1349,7 +1349,7 @@ void test_spdm_requester_get_digests_case18(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1388,7 +1388,7 @@ void test_spdm_requester_get_digests_case19(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
 	assert_int_equal(spdm_context->error_state,
 			 SPDM_STATUS_ERROR_CERTIFICATE_FAILURE);
@@ -1426,7 +1426,7 @@ void test_spdm_requester_get_digests_case20(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1466,7 +1466,7 @@ void test_spdm_requester_get_digests_case21(void **state)
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
-		spdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+		libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1505,7 +1505,7 @@ void test_spdm_requester_get_digests_case22(void **state) {
     spdm_reset_message_b(spdm_context);
     
     zero_mem (total_digest_buffer, sizeof(total_digest_buffer));
-    status = spdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     // assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -664,7 +664,7 @@ void test_spdm_requester_get_digests_case1(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -702,7 +702,7 @@ void test_spdm_requester_get_digests_case2(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
@@ -751,7 +751,7 @@ void test_spdm_requester_get_digests_case3(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -789,7 +789,7 @@ void test_spdm_requester_get_digests_case4(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -827,7 +827,7 @@ void test_spdm_requester_get_digests_case5(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -866,7 +866,7 @@ void test_spdm_requester_get_digests_case6(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -910,7 +910,7 @@ void test_spdm_requester_get_digests_case7(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -951,7 +951,7 @@ void test_spdm_requester_get_digests_case8(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -987,7 +987,7 @@ void test_spdm_requester_get_digests_case9(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1030,7 +1030,7 @@ void test_spdm_requester_get_digests_case10(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1068,7 +1068,7 @@ void test_spdm_requester_get_digests_case11(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1108,7 +1108,7 @@ void test_spdm_requester_get_digests_case12(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1147,7 +1147,7 @@ void test_spdm_requester_get_digests_case13(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1186,7 +1186,7 @@ void test_spdm_requester_get_digests_case14(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1307,7 +1307,7 @@ void test_spdm_requester_get_digests_case17(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1345,7 +1345,7 @@ void test_spdm_requester_get_digests_case18(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1384,7 +1384,7 @@ void test_spdm_requester_get_digests_case19(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1422,7 +1422,7 @@ void test_spdm_requester_get_digests_case20(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1462,7 +1462,7 @@ void test_spdm_requester_get_digests_case21(void **state)
 		MAX_SPDM_MESSAGE_BUFFER_SIZE;
 	set_mem(m_local_certificate_chain, MAX_SPDM_MESSAGE_BUFFER_SIZE,
 		(uint8)(0xFF));
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 	status =
@@ -1502,7 +1502,7 @@ void test_spdm_requester_get_digests_case22(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_reset_message_b(spdm_context);
+    libspdm_reset_message_b(spdm_context);
     
     zero_mem (total_digest_buffer, sizeof(total_digest_buffer));
     status = libspdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -2572,7 +2572,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2628,7 +2628,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2684,7 +2684,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2740,7 +2740,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2796,7 +2796,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2852,7 +2852,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2908,7 +2908,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -2966,7 +2966,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3019,7 +3019,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3071,7 +3071,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
 		 data, data_size);
 	request_attribute = 0;
 
-	status = spdm_get_measurement(
+	status = libspdm_get_measurement(
 		spdm_context, NULL, request_attribute,
 		SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
 		0, &number_of_blocks, NULL, NULL);
@@ -3130,7 +3130,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3195,7 +3195,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3254,7 +3254,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3313,7 +3313,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3372,7 +3372,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3433,7 +3433,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 	for (int i = 0; i < sizeof(SlotIDs) / sizeof(SlotIDs[0]); i++) {
 		measurement_record_length = sizeof(measurement_record);
 		spdm_reset_message_m(spdm_context, NULL);
-		status = spdm_get_measurement(spdm_context, NULL,
+		status = libspdm_get_measurement(spdm_context, NULL,
 					      request_attribute, 1, SlotIDs[i],
 					      &number_of_block,
 					      &measurement_record_length,
@@ -3507,7 +3507,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
 		// i=0 => both number_of_blocks and measurement_record_length are non 0
 		// i=1 => only number_of_blocks is non 0
 		// i=2 => only is measurement_record_length is non 0
-		status = spdm_get_measurement(
+		status = libspdm_get_measurement(
 			spdm_context, NULL, request_attribute,
 			SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
 			0, &number_of_blocks, NULL, NULL);
@@ -3567,7 +3567,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3628,7 +3628,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3686,7 +3686,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3744,7 +3744,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3806,7 +3806,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 	measurement_record_length = sizeof(measurement_record);
 	for (NumberOfMessages = 1; NumberOfMessages <= TOTAL_MESSAGES;
 	     NumberOfMessages++) {
-		status = spdm_get_measurement(spdm_context, NULL,
+		status = libspdm_get_measurement(spdm_context, NULL,
 					      request_attribute, 1, 0,
 					      &number_of_block,
 					      &measurement_record_length,
@@ -3884,7 +3884,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -3949,7 +3949,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4009,7 +4009,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4068,7 +4068,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4128,7 +4128,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4190,7 +4190,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4250,7 +4250,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4313,7 +4313,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4378,7 +4378,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, NULL, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);
@@ -4439,7 +4439,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 	request_attribute = 0;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(
+	status = libspdm_get_measurement(
 		spdm_context, NULL, request_attribute,
 		SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_ALL_MEASUREMENTS,
 		0, &number_of_block, &measurement_record_length,
@@ -4498,7 +4498,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
     spdm_reset_message_m(spdm_context, NULL);
 
     measurement_record_length = sizeof(measurement_record);
-    status = spdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);
+    status = libspdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -4596,7 +4596,7 @@ void test_spdm_requester_get_measurements_case34(void **state)
 		SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE;
 
 	measurement_record_length = sizeof(measurement_record);
-	status = spdm_get_measurement(spdm_context, &session_id, request_attribute, 1,
+	status = libspdm_get_measurement(spdm_context, &session_id, request_attribute, 1,
 				      0, &number_of_block,
 				      &measurement_record_length,
 				      measurement_record);

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -377,7 +377,7 @@ return_status spdm_requester_get_measurements_test_send_message(
 		m_local_buffer_size = 0;
 		session_id = NULL;
 		app_message_size = sizeof(app_message);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, 0xFFFFFFFF);
 		message_size = spdm_test_get_measurement_request_size(
 			spdm_context, (uint8 *)request + header_size,
@@ -448,7 +448,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -532,7 +532,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -665,7 +665,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 			spdm_response->header.param1 = 0;
 			spdm_response->header.param2 = 0;
 			spdm_response->number_of_blocks = 1;
-			spdm_write_uint24(
+			libspdm_write_uint24(
 				spdm_response->measurement_record_length,
 				(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 					 spdm_get_measurement_hash_size(
@@ -816,7 +816,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 			spdm_response->header.param1 = 0;
 			spdm_response->header.param2 = 0;
 			spdm_response->number_of_blocks = 1;
-			spdm_write_uint24(
+			libspdm_write_uint24(
 				spdm_response->measurement_record_length,
 				(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 					 spdm_get_measurement_hash_size(
@@ -885,7 +885,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 4;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 0;
-		spdm_write_uint24(spdm_response->measurement_record_length, 0);
+		libspdm_write_uint24(spdm_response->measurement_record_length, 0);
 		
 		ptr = (uint8 *)spdm_response +
 		sizeof(spdm_measurements_response_t);
@@ -921,7 +921,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -990,7 +990,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1060,7 +1060,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1133,7 +1133,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1195,7 +1195,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1279,7 +1279,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = ALTERNATIVE_DEFAULT_SLOT_ID;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1353,7 +1353,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 					spdm_get_measurement_hash_size(
 						m_use_measurement_hash_algo);
 			spdm_response->number_of_blocks = 1;
-			spdm_write_uint24(
+			libspdm_write_uint24(
 				spdm_response->measurement_record_length,
 				(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 					 spdm_get_measurement_hash_size(
@@ -1375,7 +1375,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		} else if (sub_index0x11 == 1) {
 			temp_buf_size = sizeof(spdm_measurements_response_t);
 			spdm_response->number_of_blocks = 1;
-			spdm_write_uint24(
+			libspdm_write_uint24(
 				spdm_response->measurement_record_length, 0);
 		} else if (sub_index0x11 == 2) {
 			temp_buf_size = sizeof(spdm_measurements_response_t) +
@@ -1383,7 +1383,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 					spdm_get_measurement_hash_size(
 						m_use_measurement_hash_algo);
 			spdm_response->number_of_blocks = 0;
-			spdm_write_uint24(
+			libspdm_write_uint24(
 				spdm_response->measurement_record_length,
 				(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 					 spdm_get_measurement_hash_size(
@@ -1434,7 +1434,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = MAX_UINT8;
-		spdm_write_uint24(spdm_response->measurement_record_length,
+		libspdm_write_uint24(spdm_response->measurement_record_length,
 				  (uint32)(LARGE_MEASUREMENT_SIZE));
 		measurment_block = (void *)(spdm_response + 1);
 		set_mem(measurment_block, LARGE_MEASUREMENT_SIZE, 1);
@@ -1479,7 +1479,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1526,7 +1526,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1573,7 +1573,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1622,7 +1622,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1678,7 +1678,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1740,7 +1740,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1815,7 +1815,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -1909,7 +1909,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2002,7 +2002,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2093,7 +2093,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2171,7 +2171,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2234,7 +2234,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2297,7 +2297,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2464,7 +2464,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 		spdm_response->header.param1 = 0;
 		spdm_response->header.param2 = 0;
 		spdm_response->number_of_blocks = 1;
-		spdm_write_uint24(
+		libspdm_write_uint24(
 			spdm_response->measurement_record_length,
 			(uint32)(sizeof(spdm_measurement_block_dmtf_t) +
 				 spdm_get_measurement_hash_size(
@@ -2511,7 +2511,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
 						   FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2555,7 +2555,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2611,7 +2611,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2667,7 +2667,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2723,7 +2723,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2779,7 +2779,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2835,7 +2835,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2891,7 +2891,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -2949,7 +2949,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3002,7 +3002,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3056,7 +3056,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3114,7 +3114,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3178,7 +3178,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3237,7 +3237,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3296,7 +3296,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3355,7 +3355,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3432,7 +3432,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
 
 	for (int i = 0; i < sizeof(SlotIDs) / sizeof(SlotIDs[0]); i++) {
 		measurement_record_length = sizeof(measurement_record);
-		spdm_reset_message_m(spdm_context, NULL);
+		libspdm_reset_message_m(spdm_context, NULL);
 		status = libspdm_get_measurement(spdm_context, NULL,
 					      request_attribute, 1, SlotIDs[i],
 					      &number_of_block,
@@ -3488,7 +3488,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3551,7 +3551,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3612,7 +3612,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3670,7 +3670,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3728,7 +3728,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3788,7 +3788,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3868,7 +3868,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3933,7 +3933,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -3992,7 +3992,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4051,7 +4051,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4111,7 +4111,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4173,7 +4173,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4234,7 +4234,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4297,7 +4297,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4362,7 +4362,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4423,7 +4423,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->connection_info.algorithm.measurement_spec =
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
@@ -4495,7 +4495,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AUTHENTICATED;
-    spdm_reset_message_m(spdm_context, NULL);
+    libspdm_reset_message_m(spdm_context, NULL);
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -104,7 +104,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -137,7 +137,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -164,7 +164,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -191,7 +191,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -221,7 +221,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index1++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -252,7 +252,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -281,7 +281,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -313,7 +313,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -350,7 +350,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index2++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -381,7 +381,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -412,7 +412,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
       spdm_response.header.param2 = 0;
 
       spdm_transport_test_encode_message (spdm_context, &session_id, FALSE, FALSE, sizeof(spdm_response), &spdm_response, response_size, response);
-      session_info = spdm_get_session_info_via_session_id (spdm_context, session_id);
+      session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
       ((spdm_secured_message_context_t*)(session_info->secured_message_context))->application_secret.response_data_sequence_number --;
     }
 
@@ -449,7 +449,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -497,7 +497,7 @@ void test_spdm_requester_heartbeat_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -561,7 +561,7 @@ void test_spdm_requester_heartbeat_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -648,7 +648,7 @@ void test_spdm_requester_heartbeat_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -735,7 +735,7 @@ void test_spdm_requester_heartbeat_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -822,7 +822,7 @@ void test_spdm_requester_heartbeat_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -909,7 +909,7 @@ void test_spdm_requester_heartbeat_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -996,7 +996,7 @@ void test_spdm_requester_heartbeat_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1085,7 +1085,7 @@ void test_spdm_requester_heartbeat_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1172,7 +1172,7 @@ void test_spdm_requester_heartbeat_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1263,7 +1263,7 @@ void test_spdm_requester_heartbeat_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1326,7 +1326,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -524,7 +524,7 @@ void test_spdm_requester_heartbeat_case1(void **state)
 		session_info->secured_message_context,
 		SPDM_SESSION_STATE_ESTABLISHED);
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	free(data);
 }
@@ -611,7 +611,7 @@ void test_spdm_requester_heartbeat_case2(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 	free(data);
 }
@@ -698,7 +698,7 @@ void test_spdm_requester_heartbeat_case3(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
 	free(data);
 }
@@ -785,7 +785,7 @@ void test_spdm_requester_heartbeat_case4(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	free(data);
 }
@@ -872,7 +872,7 @@ void test_spdm_requester_heartbeat_case5(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
 	free(data);
 }
@@ -959,7 +959,7 @@ void test_spdm_requester_heartbeat_case6(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 	free(data);
 }
@@ -1046,7 +1046,7 @@ void test_spdm_requester_heartbeat_case7(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	assert_int_equal(spdm_context->connection_info.connection_state,
 			 SPDM_CONNECTION_STATE_NOT_STARTED);
@@ -1135,7 +1135,7 @@ void test_spdm_requester_heartbeat_case8(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
 	free(data);
 }
@@ -1222,7 +1222,7 @@ void test_spdm_requester_heartbeat_case9(void **state)
 						    ->secured_message_context))
 		->application_secret.response_data_sequence_number = 0;
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 	free(data);
 }
@@ -1275,7 +1275,7 @@ void test_spdm_requester_heartbeat_case10(void **state) {
     spdm_secured_message_set_response_data_salt (session_info->secured_message_context, m_dummy_salt_buffer, ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size);
     ((spdm_secured_message_context_t*)(session_info->secured_message_context))->application_secret.response_data_sequence_number = 0;
     
-    status = spdm_heartbeat (spdm_context, session_id); 
+    status = libspdm_heartbeat (spdm_context, session_id); 
     // assert_int_equal (status, RETURN_DEVICE_ERROR);
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
@@ -1388,7 +1388,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
 							spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
 
-	status = spdm_heartbeat(spdm_context, session_id);
+	status = libspdm_heartbeat(spdm_context, session_id);
 	assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -1137,7 +1137,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1188,7 +1188,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1244,7 +1244,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1295,7 +1295,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1346,7 +1346,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1397,7 +1397,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1453,7 +1453,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1506,7 +1506,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1557,7 +1557,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1617,7 +1617,7 @@ void test_spdm_requester_key_exchange_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_reset_message_a(spdm_context);
+    libspdm_reset_message_a(spdm_context);
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
@@ -1667,7 +1667,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -146,7 +146,7 @@ return_status spdm_requester_key_update_test_send_message(
 		session_id = 0xFFFFFFFF;
 		decoded_message_size = sizeof(decoded_message);
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -184,7 +184,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -225,7 +225,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -266,7 +266,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -307,7 +307,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -351,7 +351,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -401,7 +401,7 @@ return_status spdm_requester_key_update_test_send_message(
 		session_id = 0xFFFFFFFF;
 		decoded_message_size = sizeof(decoded_message);
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -439,7 +439,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -482,7 +482,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -524,7 +524,7 @@ return_status spdm_requester_key_update_test_send_message(
 		session_id = 0xFFFFFFFF;
 		decoded_message_size = sizeof(decoded_message);
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -559,7 +559,7 @@ return_status spdm_requester_key_update_test_send_message(
 		session_id = 0xFFFFFFFF;
 		decoded_message_size = sizeof(decoded_message);
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -597,7 +597,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -638,7 +638,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -679,7 +679,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -723,7 +723,7 @@ return_status spdm_requester_key_update_test_send_message(
 			session_id = 0xFFFFFFFF;
 			decoded_message_size = sizeof(decoded_message);
 
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -775,7 +775,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -816,7 +816,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -854,7 +854,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -882,7 +882,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -911,7 +911,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -985,7 +985,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1013,7 +1013,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1047,7 +1047,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1129,7 +1129,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1180,7 +1180,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1221,7 +1221,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1263,7 +1263,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1304,7 +1304,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1345,7 +1345,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1387,7 +1387,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1427,7 +1427,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1483,7 +1483,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1539,7 +1539,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1616,7 +1616,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1672,7 +1672,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1733,7 +1733,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1815,7 +1815,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_session_info_t    *session_info;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1890,7 +1890,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1936,7 +1936,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -1978,7 +1978,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2020,7 +2020,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
 		session_id = 0xFFFFFFFF;
 
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2066,7 +2066,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		uint64 curr_rsp_sequence_number;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2123,7 +2123,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		uint64 curr_rsp_sequence_number;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2181,7 +2181,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_secured_message_context_t *secured_message_context;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2286,7 +2286,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		uint64 curr_rsp_sequence_number;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2343,7 +2343,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		uint64 curr_rsp_sequence_number;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2403,7 +2403,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		spdm_secured_message_context_t *secured_message_context;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -2518,7 +2518,7 @@ return_status spdm_requester_key_update_test_receive_message(
 		uint64 curr_rsp_sequence_number;
 
 		session_id = 0xFFFFFFFF;
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -2618,7 +2618,7 @@ void test_spdm_requester_key_update_case1(void **state)
 		  m_rsp_secret_buffer, (uint8)(0xFF),
 		  m_req_secret_buffer, (uint8)(0xEE));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2662,7 +2662,7 @@ void test_spdm_requester_key_update_case2(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -2712,7 +2712,7 @@ void test_spdm_requester_key_update_case3(void **state)
 		  m_rsp_secret_buffer, (uint8)(0xFF),
 		  m_req_secret_buffer, (uint8)(0xEE));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -2751,7 +2751,7 @@ void test_spdm_requester_key_update_case4(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2800,7 +2800,7 @@ void test_spdm_requester_key_update_case5(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -2856,7 +2856,7 @@ void test_spdm_requester_key_update_case6(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -2904,7 +2904,7 @@ void test_spdm_requester_key_update_case7(void **state)
 		  m_rsp_secret_buffer, (uint8)(0xFF),
 		  m_req_secret_buffer, (uint8)(0xEE));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2946,7 +2946,7 @@ void test_spdm_requester_key_update_case8(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3002,7 +3002,7 @@ void test_spdm_requester_key_update_case9(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -3058,7 +3058,7 @@ void test_spdm_requester_key_update_case10(void **state)
 
 		//no keys are updated
 
-		status = spdm_key_update(
+		status = libspdm_key_update(
 			spdm_context, session_id, TRUE);
 
 		// assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -3134,7 +3134,7 @@ void test_spdm_requester_key_update_case11(void **state)
 					spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -3197,7 +3197,7 @@ void test_spdm_requester_key_update_case12(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -3246,7 +3246,7 @@ void test_spdm_requester_key_update_case13(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3301,7 +3301,7 @@ void test_spdm_requester_key_update_case14(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -3351,7 +3351,7 @@ void test_spdm_requester_key_update_case15(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3401,7 +3401,7 @@ void test_spdm_requester_key_update_case16(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3455,7 +3455,7 @@ void test_spdm_requester_key_update_case17(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3510,7 +3510,7 @@ void test_spdm_requester_key_update_case18(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -3566,7 +3566,7 @@ void test_spdm_requester_key_update_case19(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -3614,7 +3614,7 @@ void test_spdm_requester_key_update_case20(void **state)
 		  m_rsp_secret_buffer, (uint8)(0xFF),
 		  m_req_secret_buffer, (uint8)(0xEE));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3661,7 +3661,7 @@ void test_spdm_requester_key_update_case21(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3716,7 +3716,7 @@ void test_spdm_requester_key_update_case22(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -3777,7 +3777,7 @@ void test_spdm_requester_key_update_case23(void **state)
 			  sizeof(m_req_secret_buffer));
 		//response side *not* updated
 
-		status = spdm_key_update(
+		status = libspdm_key_update(
 			spdm_context, session_id, TRUE);
 
 		// assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -3847,7 +3847,7 @@ void test_spdm_requester_key_update_case24(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3902,7 +3902,7 @@ void test_spdm_requester_key_update_case25(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3957,7 +3957,7 @@ void test_spdm_requester_key_update_case26(void **state)
 		  sizeof(m_req_secret_buffer));
 	//response side *not* updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, TRUE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4015,7 +4015,7 @@ void test_spdm_requester_key_update_case27(void **state)
 		  m_rsp_secret_buffer, m_rsp_secret_buffer,
 		  sizeof(m_rsp_secret_buffer));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -4077,7 +4077,7 @@ void test_spdm_requester_key_update_case28(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4140,7 +4140,7 @@ void test_spdm_requester_key_update_case29(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -4213,7 +4213,7 @@ void test_spdm_requester_key_update_case30(void **state)
 		  m_rsp_secret_buffer, m_rsp_secret_buffer,
 		  sizeof(m_rsp_secret_buffer));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -4274,7 +4274,7 @@ void test_spdm_requester_key_update_case31(void **state)
 	my_last_rsp_sequence_number = secured_message_context
 			  ->application_secret.response_data_sequence_number;
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4329,7 +4329,7 @@ void test_spdm_requester_key_update_case32(void **state)
 
 	//no keys are updated
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4402,7 +4402,7 @@ void test_spdm_requester_key_update_case33(void **state)
 		  m_rsp_secret_buffer, m_rsp_secret_buffer,
 		  sizeof(m_rsp_secret_buffer));
 
-	status = spdm_key_update(
+	status = libspdm_key_update(
 		spdm_context, session_id, FALSE);
 
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -4471,7 +4471,7 @@ void test_spdm_requester_key_update_case34(void **state)
 
 		//no keys are updated
 
-		status = spdm_key_update(
+		status = libspdm_key_update(
 			spdm_context, session_id, FALSE);
 
 		// assert_int_equal (status, RETURN_DEVICE_ERROR);

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -964,7 +964,7 @@ void test_spdm_requester_negotiate_algorithms_case1(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -988,7 +988,7 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1014,7 +1014,7 @@ void test_spdm_requester_negotiate_algorithms_case3(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -1038,7 +1038,7 @@ void test_spdm_requester_negotiate_algorithms_case4(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1062,7 +1062,7 @@ void test_spdm_requester_negotiate_algorithms_case5(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -1086,7 +1086,7 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SUCCESS);
@@ -1112,7 +1112,7 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1138,7 +1138,7 @@ void test_spdm_requester_negotiate_algorithms_case8(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1159,7 +1159,7 @@ void test_spdm_requester_negotiate_algorithms_case9(void **state)
 		m_use_measurement_hash_algo;
 	spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 	spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1188,7 +1188,7 @@ void test_spdm_requester_negotiate_algorithms_case10(void **state)
 	spdm_context->connection_info.algorithm.base_hash_algo = 0;
 	spdm_context->connection_info.capability.flags |=
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1219,7 +1219,7 @@ void test_spdm_requester_negotiate_algorithms_case11(void **state)
 		SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
 	spdm_context->local_context.capability.flags |=
 		SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1245,7 +1245,7 @@ void test_spdm_requester_negotiate_algorithms_case12(void **state)
 	spdm_context->connection_info.algorithm.measurement_hash_algo = 0;
 	spdm_context->connection_info.algorithm.base_asym_algo = 0;
 	spdm_context->connection_info.algorithm.base_hash_algo = 0;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	status = spdm_negotiate_algorithms(spdm_context);
 	assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -1265,7 +1265,7 @@ void test_spdm_requester_negotiate_algorithms_case13(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1283,7 +1283,7 @@ void test_spdm_requester_negotiate_algorithms_case14(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1301,7 +1301,7 @@ void test_spdm_requester_negotiate_algorithms_case15(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1319,7 +1319,7 @@ void test_spdm_requester_negotiate_algorithms_case16(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1355,7 +1355,7 @@ void test_spdm_requester_negotiate_algorithms_case17(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1373,7 +1373,7 @@ void test_spdm_requester_negotiate_algorithms_case18(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1391,7 +1391,7 @@ void test_spdm_requester_negotiate_algorithms_case19(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1409,7 +1409,7 @@ void test_spdm_requester_negotiate_algorithms_case20(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1427,7 +1427,7 @@ void test_spdm_requester_negotiate_algorithms_case21(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_SECURITY_VIOLATION);
@@ -1445,7 +1445,7 @@ void test_spdm_requester_negotiate_algorithms_case22(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   status = spdm_negotiate_algorithms (spdm_context);
   assert_int_equal (status, RETURN_DEVICE_ERROR);
@@ -1466,7 +1466,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1509,7 +1509,7 @@ void test_spdm_requester_negotiate_algorithms_case24(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1549,7 +1549,7 @@ void test_spdm_requester_negotiate_algorithms_case25(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1589,7 +1589,7 @@ void test_spdm_requester_negotiate_algorithms_case26(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1629,7 +1629,7 @@ void test_spdm_requester_negotiate_algorithms_case27(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1669,7 +1669,7 @@ void test_spdm_requester_negotiate_algorithms_case28(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1709,7 +1709,7 @@ void test_spdm_requester_negotiate_algorithms_case29(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1749,7 +1749,7 @@ void test_spdm_requester_negotiate_algorithms_case30(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
@@ -1789,7 +1789,7 @@ void test_spdm_requester_negotiate_algorithms_case31(void **state) {
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -943,7 +943,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -998,7 +998,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1058,7 +1058,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1113,7 +1113,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1168,7 +1168,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1223,7 +1223,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1283,7 +1283,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1340,7 +1340,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1395,7 +1395,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =
@@ -1463,7 +1463,7 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_reset_message_a(spdm_context);
+    libspdm_reset_message_a(spdm_context);
   
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
@@ -1512,7 +1512,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.dhe_named_group =

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -122,7 +122,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -155,7 +155,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -182,7 +182,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -209,7 +209,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -239,7 +239,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index1++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -270,7 +270,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -299,7 +299,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -331,7 +331,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   sizeof(spdm_response),
 						   &spdm_response,
 						   response_size, response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -368,7 +368,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 				sizeof(spdm_response), &spdm_response,
 				response_size, response);
 			sub_index2++;
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -399,7 +399,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 				spdm_context, &session_id, FALSE, FALSE,
 				temp_buf_size, temp_buf, response_size,
 				response);
-			session_info = spdm_get_session_info_via_session_id(
+			session_info = libspdm_get_session_info_via_session_id(
 				spdm_context, session_id);
 			if (session_info == NULL) {
 				return RETURN_DEVICE_ERROR;
@@ -430,7 +430,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
       spdm_response.header.param2 = 0;
 
       spdm_transport_test_encode_message (spdm_context, &session_id, FALSE, FALSE, sizeof(spdm_response), &spdm_response, response_size, response);
-      session_info = spdm_get_session_info_via_session_id (spdm_context, session_id);
+      session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
       ((spdm_secured_message_context_t*)(session_info->secured_message_context))->handshake_secret.response_handshake_sequence_number --;
     }
 
@@ -467,7 +467,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -500,7 +500,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -533,7 +533,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -566,7 +566,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
 						   FALSE, FALSE, temp_buf_size,
 						   temp_buf, response_size,
 						   response);
-		session_info = spdm_get_session_info_via_session_id(
+		session_info = libspdm_get_session_info_via_session_id(
 			spdm_context, session_id);
 		if (session_info == NULL) {
 			return RETURN_DEVICE_ERROR;
@@ -619,7 +619,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -689,7 +689,7 @@ void test_spdm_requester_psk_finish_case2(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -786,7 +786,7 @@ void test_spdm_requester_psk_finish_case3(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -879,7 +879,7 @@ void test_spdm_requester_psk_finish_case4(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -972,7 +972,7 @@ void test_spdm_requester_psk_finish_case5(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1067,7 +1067,7 @@ void test_spdm_requester_psk_finish_case6(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1165,7 +1165,7 @@ void test_spdm_requester_psk_finish_case7(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1260,7 +1260,7 @@ void test_spdm_requester_psk_finish_case8(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1355,7 +1355,7 @@ void test_spdm_requester_psk_finish_case9(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;
 	spdm_context->connection_info.algorithm.base_asym_algo =
@@ -1459,7 +1459,7 @@ void test_spdm_requester_psk_finish_case10(void **state) {
   error_code = SPDM_ERROR_CODE_RESERVED_00;
   while(error_code <= 0xff) {
     spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_NEGOTIATED;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;
     session_info = &spdm_context->session_info[0];
@@ -1523,7 +1523,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
 	read_responder_public_certificate_chain(m_use_hash_algo,
 						m_use_asym_algo, &data,
 						&data_size, &hash, &hash_size);
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	spdm_context->connection_info.algorithm.base_hash_algo =
 		m_use_hash_algo;

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -948,7 +948,7 @@ void test_spdm_responder_algorithms_case7(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1003,7 +1003,7 @@ void test_spdm_responder_algorithms_case8(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1057,7 +1057,7 @@ void test_spdm_responder_algorithms_case9(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1111,7 +1111,7 @@ void test_spdm_responder_algorithms_case10(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1165,7 +1165,7 @@ void test_spdm_responder_algorithms_case11(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1219,7 +1219,7 @@ void test_spdm_responder_algorithms_case12(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1272,7 +1272,7 @@ void test_spdm_responder_algorithms_case13(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
@@ -1316,7 +1316,7 @@ void test_spdm_responder_algorithms_case14(void **state) {
   spdm_context->local_context.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   response_size = sizeof(response);
   status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request10_size, &m_spdm_negotiate_algorithm_request10, &response_size, response);
@@ -1346,7 +1346,7 @@ void test_spdm_responder_algorithms_case15(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1392,7 +1392,7 @@ void test_spdm_responder_algorithms_case16(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1447,7 +1447,7 @@ void test_spdm_responder_algorithms_case17(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1502,7 +1502,7 @@ void test_spdm_responder_algorithms_case18(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1553,7 +1553,7 @@ void test_spdm_responder_algorithms_case19(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
@@ -1617,7 +1617,7 @@ void test_spdm_responder_algorithms_case20(void **state) {
   spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
   spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_reset_message_a(spdm_context);
+  libspdm_reset_message_a(spdm_context);
 
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -952,7 +952,7 @@ void test_spdm_responder_capabilities_case18(void **state)
 	spdm_context->connection_info.connection_state =
 		SPDM_CONNECTION_STATE_AFTER_VERSION;
 
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 
 	response_size = sizeof(response);
 	status = spdm_get_response_capabilities(

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -399,7 +399,7 @@ void test_spdm_responder_certificate_case7(void **state)
 					MAX_SPDM_CERT_CHAIN_BLOCK_LEN);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		spdm_reset_message_b(spdm_context);
+		libspdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -480,7 +480,7 @@ void test_spdm_responder_certificate_case8(void **state)
 		m_spdm_get_certificate_request3.offset = test_offsets[i];
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		spdm_reset_message_b(spdm_context);
+		libspdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -589,7 +589,7 @@ void test_spdm_responder_certificate_case9(void **state)
 			m_spdm_get_certificate_request3.offset = test_sizes[j];
 
 			// reseting an internal buffer to avoid overflow and prevent tests to succeed
-			spdm_reset_message_b(spdm_context);
+			libspdm_reset_message_b(spdm_context);
 			response_size = sizeof(response);
 			status = spdm_get_response_certificate(
 				spdm_context,
@@ -705,7 +705,7 @@ void test_spdm_responder_certificate_case10(void **state)
 				m_spdm_get_certificate_request3.length);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		spdm_reset_message_b(spdm_context);
+		libspdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -816,7 +816,7 @@ void test_spdm_responder_certificate_case11(void **state)
 				m_spdm_get_certificate_request3.length);
 
 		// reseting an internal buffer to avoid overflow and prevent tests to succeed
-		spdm_reset_message_b(spdm_context);
+		libspdm_reset_message_b(spdm_context);
 		response_size = sizeof(response);
 		status = spdm_get_response_certificate(
 			spdm_context, m_spdm_get_certificate_request3_size,
@@ -909,7 +909,7 @@ void test_spdm_responder_certificate_case12(void **state)
 
 
 	// reseting an internal buffer to avoid overflow and prevent tests to succeed
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 
 	spdm_response = NULL;
 	for (uintn offset = 0; offset < data_size; offset++) {

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -91,7 +91,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =
 		spdm_context->transcript.message_m.max_buffer_size;
@@ -164,7 +164,7 @@ void test_spdm_responder_challenge_auth_case2(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -228,7 +228,7 @@ void test_spdm_responder_challenge_auth_case3(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -293,7 +293,7 @@ void test_spdm_responder_challenge_auth_case4(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -360,7 +360,7 @@ void test_spdm_responder_challenge_auth_case5(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -432,7 +432,7 @@ void test_spdm_responder_challenge_auth_case6(void **state)
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
 	spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-	spdm_reset_message_c(spdm_context);
+	libspdm_reset_message_c(spdm_context);
 
 	response_size = sizeof(response);
 	spdm_get_random_number(SPDM_NONCE_SIZE,
@@ -485,7 +485,7 @@ void test_spdm_responder_challenge_auth_case7(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -533,7 +533,7 @@ void test_spdm_responder_challenge_auth_case8(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -581,7 +581,7 @@ void test_spdm_responder_challenge_auth_case9(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[1] = data_size1;
   spdm_context->local_context.slot_count = 2;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -629,7 +629,7 @@ void test_spdm_responder_challenge_auth_case10(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -678,7 +678,7 @@ void test_spdm_responder_challenge_auth_case11(void **state) {
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 8;
   spdm_context->local_context.opaque_challenge_auth_rsp = m_opaque_challenge_auth_rsp;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -727,7 +727,7 @@ void test_spdm_responder_challenge_auth_case12(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -776,7 +776,7 @@ void test_spdm_responder_challenge_auth_case13(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
@@ -826,7 +826,7 @@ void test_spdm_responder_challenge_auth_case14(void **state) {
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
   spdm_context->local_context.slot_count = 1;
   spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-  spdm_reset_message_c(spdm_context);
+  libspdm_reset_message_c(spdm_context);
 
   response_size = sizeof(response);
   spdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -466,7 +466,7 @@ void test_spdm_responder_digests_case9(void **state)
 	spdm_context->local_context.slot_count = 0;
 
 	response_size = sizeof(response);
-	spdm_reset_message_b(spdm_context);
+	libspdm_reset_message_b(spdm_context);
 	status = spdm_get_response_digests(spdm_context,
 					   m_spdm_get_digests_request1_size,
 					   &m_spdm_get_digests_request1,

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -64,7 +64,7 @@ void test_spdm_responder_end_session_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -140,7 +140,7 @@ void test_spdm_responder_end_session_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -220,7 +220,7 @@ void test_spdm_responder_end_session_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -301,7 +301,7 @@ void test_spdm_responder_end_session_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -384,7 +384,7 @@ void test_spdm_responder_end_session_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -471,7 +471,7 @@ void test_spdm_responder_end_session_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -550,7 +550,7 @@ void test_spdm_responder_end_session_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -108,7 +108,7 @@ void test_spdm_responder_finish_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -216,7 +216,7 @@ void test_spdm_responder_finish_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -327,7 +327,7 @@ void test_spdm_responder_finish_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -441,7 +441,7 @@ void test_spdm_responder_finish_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -557,7 +557,7 @@ void test_spdm_responder_finish_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -679,7 +679,7 @@ void test_spdm_responder_finish_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -785,7 +785,7 @@ void test_spdm_responder_finish_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -924,7 +924,7 @@ void test_spdm_responder_finish_case8(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,
@@ -1061,7 +1061,7 @@ void test_spdm_responder_finish_case9(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1174,7 +1174,7 @@ void test_spdm_responder_finish_case10(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1281,7 +1281,7 @@ void test_spdm_responder_finish_case11(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1377,7 +1377,7 @@ void test_spdm_responder_finish_case12(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1480,7 +1480,7 @@ void test_spdm_responder_finish_case13(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1593,7 +1593,7 @@ void test_spdm_responder_finish_case14(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	session_id = 0xFFFFFFFF;
@@ -1713,7 +1713,7 @@ void test_spdm_responder_finish_case15(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,
@@ -1861,7 +1861,7 @@ void test_spdm_responder_finish_case16(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 1;
 	read_requester_public_certificate_chain(m_use_hash_algo,
 						m_use_req_asym_algo, &data2,

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -64,7 +64,7 @@ void test_spdm_responder_heartbeat_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -140,7 +140,7 @@ void test_spdm_responder_heartbeat_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -220,7 +220,7 @@ void test_spdm_responder_heartbeat_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -301,7 +301,7 @@ void test_spdm_responder_heartbeat_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -384,7 +384,7 @@ void test_spdm_responder_heartbeat_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -471,7 +471,7 @@ void test_spdm_responder_heartbeat_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -550,7 +550,7 @@ void test_spdm_responder_heartbeat_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -78,7 +78,7 @@ void test_spdm_responder_key_exchange_case1(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -157,7 +157,7 @@ void test_spdm_responder_key_exchange_case2(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -236,7 +236,7 @@ void test_spdm_responder_key_exchange_case3(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -316,7 +316,7 @@ void test_spdm_responder_key_exchange_case4(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -398,7 +398,7 @@ void test_spdm_responder_key_exchange_case5(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -484,7 +484,7 @@ void test_spdm_responder_key_exchange_case6(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 
 	spdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
@@ -562,7 +562,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
 	spdm_context->local_context.local_cert_chain_provision_size[0] =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 	spdm_context->transcript.message_m.buffer_size =

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -126,7 +126,7 @@ void test_spdm_responder_measurements_case1(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -181,7 +181,7 @@ void test_spdm_responder_measurements_case2(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -233,7 +233,7 @@ void test_spdm_responder_measurements_case3(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -286,7 +286,7 @@ void test_spdm_responder_measurements_case4(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -341,7 +341,7 @@ void test_spdm_responder_measurements_case5(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -401,7 +401,7 @@ void test_spdm_responder_measurements_case6(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -453,7 +453,7 @@ void test_spdm_responder_measurements_case7(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -507,7 +507,7 @@ void test_spdm_responder_measurements_case8(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -561,7 +561,7 @@ void test_spdm_responder_measurements_case9(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -612,7 +612,7 @@ void test_spdm_responder_measurements_case10(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -672,7 +672,7 @@ void test_spdm_responder_measurements_case11(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 +
@@ -732,7 +732,7 @@ void test_spdm_responder_measurements_case12(void **state)
 		m_use_measurement_spec;
 	spdm_context->connection_info.algorithm.measurement_hash_algo =
 		m_use_measurement_hash_algo;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -813,7 +813,7 @@ void test_spdm_responder_measurements_case13(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -883,7 +883,7 @@ void test_spdm_responder_measurements_case14(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -942,7 +942,7 @@ void test_spdm_responder_measurements_case15(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -997,7 +997,7 @@ void test_spdm_responder_measurements_case16(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1048,7 +1048,7 @@ void test_spdm_responder_measurements_case17(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	;
@@ -1107,7 +1107,7 @@ void test_spdm_responder_measurements_case18(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	read_responder_public_certificate_chain(m_use_hash_algo,
@@ -1179,7 +1179,7 @@ void test_spdm_responder_measurements_case19(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1233,7 +1233,7 @@ void test_spdm_responder_measurements_case20(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 	// measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16) + 0 + spdm_get_asym_signature_size (m_use_asym_algo);
@@ -1286,7 +1286,7 @@ void test_spdm_responder_measurements_case21(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -1341,7 +1341,7 @@ void test_spdm_responder_measurements_case22(void **state)
 	
 	spdm_context->connection_info.version.major_version = 1;
 	spdm_context->connection_info.version.minor_version = 1;
-	spdm_reset_message_m(spdm_context, NULL);
+	libspdm_reset_message_m(spdm_context, NULL);
 	spdm_context->local_context.opaque_measurement_rsp_size = 0;
 	spdm_context->local_context.opaque_measurement_rsp = NULL;
 

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -82,7 +82,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -175,7 +175,7 @@ void test_spdm_responder_psk_exchange_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -260,7 +260,7 @@ void test_spdm_responder_psk_exchange_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -346,7 +346,7 @@ void test_spdm_responder_psk_exchange_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -434,7 +434,7 @@ void test_spdm_responder_psk_exchange_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -526,7 +526,7 @@ void test_spdm_responder_psk_exchange_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));
@@ -610,7 +610,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
 		 sizeof(TEST_PSK_HINT_STRING));

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -97,7 +97,7 @@ void test_spdm_responder_psk_finish_case1(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -201,7 +201,7 @@ void test_spdm_responder_psk_finish_case2(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -308,7 +308,7 @@ void test_spdm_responder_psk_finish_case3(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -419,7 +419,7 @@ void test_spdm_responder_psk_finish_case4(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -532,7 +532,7 @@ void test_spdm_responder_psk_finish_case5(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -651,7 +651,7 @@ void test_spdm_responder_psk_finish_case6(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
@@ -754,7 +754,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
 	spdm_context->connection_info.local_used_cert_chain_buffer_size =
 		data_size1;
 	spdm_context->local_context.slot_count = 1;
-	spdm_reset_message_a(spdm_context);
+	libspdm_reset_message_a(spdm_context);
 	spdm_context->local_context.mut_auth_requested = 0;
 	zero_mem(m_local_psk_hint, 32);
 	copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -603,7 +603,7 @@ void test_spdm_responder_respond_if_ready_case5(void **state) {
   assert_int_equal (spdm_response->header.request_response_code, SPDM_KEY_EXCHANGE_RSP);
   assert_int_equal (spdm_response->rsp_session_id, 0xFFFF);
   free(data);
-  spdm_free_session_id (spdm_context, (0xFFFFFFFF));
+  libspdm_free_session_id (spdm_context, (0xFFFFFFFF));
 }
 
 #endif // SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
@@ -709,7 +709,7 @@ void test_spdm_responder_respond_if_ready_case6(void **state) {
   spdm_response = (void *)response;
   assert_int_equal (spdm_response->header.request_response_code, SPDM_FINISH_RSP);
   free(data);
-  spdm_free_session_id (spdm_context, (0xFFFFFFFF));
+  libspdm_free_session_id (spdm_context, (0xFFFFFFFF));
 }
 #endif // SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
@@ -799,7 +799,7 @@ void test_spdm_responder_respond_if_ready_case7(void **state) {
   assert_int_equal (spdm_response->header.request_response_code, SPDM_PSK_EXCHANGE_RSP);
   assert_int_equal (spdm_response->rsp_session_id, 0xFFFF);
   free(data);
-  spdm_free_session_id (spdm_context, (0xFFFFFFFF));
+  libspdm_free_session_id (spdm_context, (0xFFFFFFFF));
 }
 #endif // SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
@@ -902,7 +902,7 @@ void test_spdm_responder_respond_if_ready_case8(void **state) {
   spdm_response = (void *)response;
   assert_int_equal (spdm_response->header.request_response_code, SPDM_PSK_FINISH_RSP);
   free(data);
-  spdm_free_session_id (spdm_context, (0xFFFFFFFF));
+  libspdm_free_session_id (spdm_context, (0xFFFFFFFF));
 }
 #endif // SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 


### PR DESCRIPTION
Rename client-visible functions in spdm_common_lib.h, spdm_requester_lib.h, and spdm_responder_lib.h from spdm_ to libspdm_
@jyao1 this will break spdm-emu so perhaps wait before merging the pull request.

Signed-off by: Steven Bellock, sbellock@nvidia.com