### PR TITLE
Fix the bug for test_spdm_requester crashes with OpenSSL in Linux

### DIFF
--- a/os_stub/openssllib/include/crt_support.h
+++ b/os_stub/openssllib/include/crt_support.h
@@ -103,7 +103,7 @@
 typedef uintn size_t;
 typedef uintn u_int;
 typedef intn ssize_t;
-typedef int32 time_t;
+typedef intn time_t; /* time_t is 4 bytes for 32bit machine and 8 bytes for 64bit machine */ 
 typedef uint8 __uint8_t;
 typedef uint8 sa_family_t;
 typedef uint8 u_char;


### PR DESCRIPTION
Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>

Fix: #277 

Update the time_t type to ensure that:
time_t is 4 bytes for 32bit machine and 8 bytes for 64bit machine.


