### PR TITLE
Update ia32 build on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -mcmodel=small")
     elseif(ARCH STREQUAL "ia32")
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32" )
     endif()
 
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Download and install [LLVM9](http://releases.llvm.org/download.html#9.0.0). Ensu
    ```
 
 ### Linux Builds
+    If ia32 builds on 64 bit Linux machine, need install `sudo apt-get install gcc-multilib`.
 General build steps: (Note the `..` at the end of the cmake command). 
   
    ```


### PR DESCRIPTION
Fix : #280 

Add description for README : how to build ia32 on 64bit linux machine.
Update CMakeLists to fix error : build error with Openssl for ia32 in Linux. 
