### PR TITLE
Add dhe_context check for NULL pointer return

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -132,6 +132,10 @@ return_status try_spdm_send_receive_key_exchange(
 		spdm_context->connection_info.algorithm.dhe_named_group);
 	dhe_context = spdm_secured_message_dhe_new(
 		spdm_context->connection_info.algorithm.dhe_named_group);
+	if (dhe_context == NULL) {
+		return RETURN_DEVICE_ERROR;
+	}
+
 	spdm_secured_message_dhe_generate_key(
 		spdm_context->connection_info.algorithm.dhe_named_group,
 		dhe_context, ptr, &dhe_key_size);


### PR DESCRIPTION
Fix: #290 

'dhe_context' should be checked whether it is a NULL Pointer before subsequent using

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>