### PR TITLE
fix the openssl build fail issue with AFL in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
     elseif(TOOLCHAIN STREQUAL "AFL")
         SET(CMAKE_C_COMPILER afl-gcc)
-        SET(CMAKE_C_FLAGS "-g -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -maccumulate-outgoing-args -mno-red-zone -Wno-address -fpie -fno-asynchronous-unwind-tables -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare")
+        SET(CMAKE_C_FLAGS "-std=c99 -g -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -maccumulate-outgoing-args -mno-red-zone -Wno-address -fpie -fno-asynchronous-unwind-tables -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare")
         if(GCOV STREQUAL "ON")
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
         endif()


### PR DESCRIPTION
Fix the openssl build fail issue with AFL in Linux.
Fix: #331