### PR TITLE
Add CI for format check and mbedtls build check

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,11 +6,31 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    #Changes to the following files do not trigger deployment
+    paths-ignore:
+     - README.md
+     - 'os_stub/openssllib/openssl/**'
+     - 'os_stub/mbedtlslib/mbedtls/**'
+     - 'unit_test/cmockalib/cmocka/**'
 
 env:
   BUILD_TYPE: Release
 
 jobs:
+  format_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        # If any *.c *.h file(except:mbedtls/openssl/cmocka) have Tab, the check will the wrong.
+      - name: Check code format
+        run: |
+          if [grep -rn "	" * --include=*.c --include=*.h --exclude-dir={os_stub/mbedtlslib/mbedtls,os_stub/openssllib/openssl,unit_test/cmockalib/cmocka}];
+          then exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,33 @@ jobs:
           then exit 1
           fi
 
-  build:
+  mbedtls_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=mbedtls ..
+          make copy_sample_key
+          make -j2
+
+      - name: Test Requester
+        run: |
+          cd build/bin
+          ./test_spdm_requester
+
+      - name: Test Responder
+        run: |
+          cd build/bin
+          ./test_spdm_responder
+
+  openssl_build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Add format check for later patch:
If the later patch include Tab, the check will not pass.
And the check will skip on openssl/mbedtls/cmocka/README.

Add build with mbedtls :
Add mbedtls build to CI check.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>