### PR TITLE
Change all "openspdm" to "libspdm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@
 
    Free and Open Source Developers European Meeting 2021 - [openspdm](https://fosdem.org/2021/schedule/event/firmware_uoifaaffsdc/)
 
-2) openspdm library threat model:
+2) libspdm library threat model:
 
    The user guide can be found at [threat_model](https://github.com/DMTF/libspdm/blob/main/doc/threat_model.md)
 
-3) openspdm library design:
+3) libspdm library design:
 
    The detailed design can be found at [design](https://github.com/DMTF/libspdm/blob/main/doc/design.md)
 
-4) openspdm user guide:
+4) libspdm user guide:
 
    The user guide can be found at [user_guide](https://github.com/DMTF/libspdm/blob/main/doc/user_guide.md)
 
@@ -197,7 +197,7 @@ Example cmake commands: (Note the `..` at the end of the cmake command).
 
 ### Other Test
 
-  openspdm also supports other test such as code coverage, fuzzing, symbolic execution, model checker.
+  libspdm also supports other test such as code coverage, fuzzing, symbolic execution, model checker.
 
   Please refer to [test](https://github.com/DMTF/libspdm/blob/main/doc/test.md) for detail. 
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -1,4 +1,4 @@
-# openspdm library design.
+# libspdm library design.
 
 1. Use static linking (Library) when there is one instance that can be linked to the device.
    For example, crypto engine.
@@ -100,7 +100,7 @@
 
    These APIs send and receive transport layer messages to or from a SPDM device.
 
-9) [spdm_lib_config.h](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_lib_config.h) provides the configuration to the openspdm library.
+9) [spdm_lib_config.h](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_lib_config.h) provides the configuration to the libspdm library.
 
 10) SPDM library depends upon the [HAL library](https://github.com/DMTF/libspdm/tree/main/include/hal).
 

--- a/doc/test.md
+++ b/doc/test.md
@@ -1,6 +1,6 @@
-# Test in openspdm
+# Test in libspdm
 
-Besides spdm_emu and UnitTest introduced in readme, openspdm also supports some other tests.
+Besides spdm_emu and UnitTest introduced in readme, libspdm also supports some other tests.
 
 ## Prerequisit
 
@@ -85,13 +85,13 @@ For riscv64: `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
    Install Perl [ActivePerl 5.26](https://www.activestate.com/products/perl/downloads/).
 
    Build cases.
-   Goto openspdm/Build/\<TARGET>_\<TOOLCHAIN>/\<ARCH>. mkdir log and cd log.
+   Goto libspdm/Build/\<TARGET>_\<TOOLCHAIN>/\<ARCH>. mkdir log and cd log.
 
    Run all tests and generate log file :
    `%DRIO_PATH%\<bin64|bin32>\drrun.exe -c %DRIO_PATH%\tools\<lib64|lib32>\release\drcov.dll -- <test_app>`
    
    Generate coverage data with filter :
-   `%DRIO_PATH%\tools\<bin64|bin32>\drcov2lcov.exe -dir . -src_filter openspdm`
+   `%DRIO_PATH%\tools\<bin64|bin32>\drcov2lcov.exe -dir . -src_filter libspdm`
    
    Generate coverage report :
    `perl %DRIO_PATH%\tools\<bin64|bin32>\genhtml coverage.info`
@@ -113,7 +113,7 @@ For riscv64: `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
    make
    ```
 
-   Goto openspdm/Build/\<TARGET>_\<TOOLCHAIN>/\<ARCH>. mkdir log and cd log.
+   Goto libspdm/Build/\<TARGET>_\<TOOLCHAIN>/\<ARCH>. mkdir log and cd log.
 
    Run all tests.
 
@@ -325,9 +325,9 @@ For riscv64: `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
 
    Build cases with CBMC toolchain:
 
-   For Windowns, open visual studio 2019 command prompt at openspdm dir and build it with CBMC toolchain `-DARCH=ia32 -DTOOLCHAIN=LIBFUZZER`. (Use x86 command prompt for ARCH=ia32 only)
+   For Windowns, open visual studio 2019 command prompt at libspdm dir and build it with CBMC toolchain `-DARCH=ia32 -DTOOLCHAIN=LIBFUZZER`. (Use x86 command prompt for ARCH=ia32 only)
 
-   For Linux, open command prompt at openspdm dir and build it with CBMC toolchain `-DARCH=x64 -DTOOLCHAIN=CBMC`. (ARCH=x64 only)
+   For Linux, open command prompt at libspdm dir and build it with CBMC toolchain `-DARCH=x64 -DTOOLCHAIN=CBMC`. (ARCH=x64 only)
 
    The output binary is created by the [goto-cc](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/goto-cc.md).
 
@@ -349,12 +349,12 @@ For riscv64: `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
    set KW_ROOT=%KW_HOME%\<version>\projects_root
    set KW_TABLE_ROOT=%KW_HOME%\Tables
    set KW_CONFIG=%KW_ROOT%\projects\workspace\rules\analysis_profile.pconf
-   set KW_PROJECT_NAME=openspdm
+   set KW_PROJECT_NAME=libspdm
    ```
 
    Run CMAKE to generate makefile.
 
-   Build openspdm with Klocwork :
+   Build libspdm with Klocwork :
    ```
    kwinject --output %KW_ROOT%\%KW_PROJECT_NAME%.out nmake
    ```

--- a/doc/threat_model.md
+++ b/doc/threat_model.md
@@ -1,4 +1,4 @@
-# openspdm threat model.
+# libspdm threat model.
 
 ## Trust Domain
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -38,7 +38,7 @@ Please refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF
    ```
 
    1.2, register the device io functions and transport layer functions.
-   The openspdm provides the default [spdm_transport_mctp_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_mctp_lib.h) and [spdm_transport_pcidoe_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_pcidoe_lib.h).
+   The libspdm provides the default [spdm_transport_mctp_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_mctp_lib.h) and [spdm_transport_pcidoe_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_pcidoe_lib.h).
    The SPDM device driver need provide device IO send/receive function.
 
    ```
@@ -230,7 +230,7 @@ Please refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF
    ```
 
    1.2, register the device io functions and transport layer functions.
-   The openspdm provides the default [spdm_transport_mctp_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_mctp_lib.h) and [spdm_transport_pcidoe_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_pcidoe_lib.h).
+   The libspdm provides the default [spdm_transport_mctp_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_mctp_lib.h) and [spdm_transport_pcidoe_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_pcidoe_lib.h).
    The SPDM device driver need provide device IO send/receive function.
 
    ```


### PR DESCRIPTION
Fix: #46 
Change most instances of "openspdm" to "libspdm".
Make the the code meaning clearly.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>