### PR TITLE
Adjust clangformat to use spaces only, 4 space indentation, 100 colum…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,9 +34,9 @@ BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 80
+ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
-ContinuationIndentWidth: 8
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat: false
@@ -46,7 +46,7 @@ IncludeCategories:
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
-IndentWidth: 8
+IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
@@ -77,7 +77,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Cpp03
-TabWidth: 8
-UseTab: Always
+TabWidth: 4
+UseTab: Never
 ...
 


### PR DESCRIPTION
…n limit.

Needed to adjust clangformat to match new 4 space indentation and 100 column limits.

Visual studio will use clangformat on copy/paste operations and was trying to insert tabs back.

Signed-off-by: Kong, Richard <richard.kong@intel.com>