### PR TITLE
First batch of fixes for missing return value checks

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -112,10 +112,9 @@ return_status spdm_get_encap_response_challenge_auth(
     ptr = (void *)(spdm_response + 1);
     result = spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
     if (!result) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
     ptr += hash_size;
 

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -110,7 +110,13 @@ return_status spdm_get_encap_response_challenge_auth(
     }
 
     ptr = (void *)(spdm_response + 1);
-    spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
+    result = spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
+    if (!result) {
+        libspdm_generate_encap_error_response(
+            spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
+            response_size, response);
+        return RETURN_SUCCESS;
+    }
     ptr += hash_size;
 
     if(!spdm_get_random_number(SPDM_NONCE_SIZE, ptr)) {

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -38,6 +38,7 @@ return_status spdm_get_encap_response_digest(IN void *context,
     uint8_t *digest;
     spdm_context_t *spdm_context;
     return_status status;
+    boolean result;
 
     spdm_context = context;
     spdm_request = request;
@@ -92,8 +93,14 @@ return_status spdm_get_encap_response_digest(IN void *context,
             return RETURN_SUCCESS;
         }
         spdm_response->header.param2 |= (1 << index);
-        spdm_generate_cert_chain_hash(spdm_context, index,
+        result = spdm_generate_cert_chain_hash(spdm_context, index,
                           &digest[hash_size * index]);
+        if (!result) {
+            libspdm_generate_encap_error_response(
+                spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+            return RETURN_SUCCESS;
+        }
     }
     //
     // Cache

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -46,17 +46,15 @@ return_status spdm_get_encap_response_digest(IN void *context,
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, TRUE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP, 0)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_DIGESTS, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_get_digest_request_t)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -87,19 +85,17 @@ return_status spdm_get_encap_response_digest(IN void *context,
          index++) {
         if (spdm_context->local_context
                           .local_cert_chain_provision[index] == NULL) {
-            libspdm_generate_encap_error_response(
+            return libspdm_generate_encap_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
         spdm_response->header.param2 |= (1 << index);
         result = spdm_generate_cert_chain_hash(spdm_context, index,
                           &digest[hash_size * index]);
         if (!result) {
-            libspdm_generate_encap_error_response(
+            return libspdm_generate_encap_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
     //
@@ -108,19 +104,17 @@ return_status spdm_get_encap_response_digest(IN void *context,
     status = libspdm_append_message_mut_b(spdm_context, spdm_request,
                        request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_mut_b(spdm_context, spdm_response,
                        *response_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -138,9 +138,15 @@ return_status try_spdm_send_receive_key_exchange(
         return RETURN_DEVICE_ERROR;
     }
 
-    spdm_secured_message_dhe_generate_key(
+    result = spdm_secured_message_dhe_generate_key(
         spdm_context->connection_info.algorithm.dhe_named_group,
         dhe_context, ptr, &dhe_key_size);
+    if (!result) {
+        spdm_secured_message_dhe_free(
+            spdm_context->connection_info.algorithm.dhe_named_group,
+            dhe_context);
+        return RETURN_DEVICE_ERROR;
+    }
     DEBUG((DEBUG_INFO, "ClientKey (0x%x):\n", dhe_key_size));
     internal_dump_hex(ptr, dhe_key_size);
     ptr += dhe_key_size;

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -36,6 +36,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                   IN boolean single_direction, IN OUT boolean *key_updated)
 {
     return_status status;
+    return_status temp_status;
     spdm_key_update_request_t spdm_request;
     spdm_key_update_response_mine_t spdm_response;
     uintn spdm_response_size;
@@ -147,11 +148,12 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                     DEBUG((DEBUG_INFO,
                            "spdm_activate_update_session_data_key[%x] Responder old\n",
                            session_id));
-                    status = spdm_activate_update_session_data_key(
+                    temp_status = spdm_activate_update_session_data_key(
                         session_info->secured_message_context,
                         SPDM_KEY_UPDATE_ACTION_RESPONDER, FALSE);
-                    if (RETURN_ERROR(status)) {
-                        return status;
+                    // Try and return most relevant error
+                    if (RETURN_ERROR(temp_status)) {
+                        return temp_status;
                     }
                 }
                 return status;

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -101,9 +101,12 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             DEBUG((DEBUG_INFO,
                    "spdm_create_update_session_data_key[%x] Responder\n",
                    session_id));
-            spdm_create_update_session_data_key(
+            status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER);
+            if (RETURN_ERROR(status)) {
+                return status;
+            }
         }
 
         status = spdm_send_spdm_request(spdm_context, &session_id,
@@ -123,9 +126,12 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                 DEBUG((DEBUG_INFO,
                        "spdm_activate_update_session_data_key[%x] Responder old\n",
                        session_id));
-                spdm_activate_update_session_data_key(
+                status = spdm_activate_update_session_data_key(
                     session_info->secured_message_context,
                     SPDM_KEY_UPDATE_ACTION_RESPONDER, FALSE);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
             }
             return RETURN_DEVICE_ERROR;
         }
@@ -141,9 +147,12 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                     DEBUG((DEBUG_INFO,
                            "spdm_activate_update_session_data_key[%x] Responder old\n",
                            session_id));
-                    spdm_activate_update_session_data_key(
+                    status = spdm_activate_update_session_data_key(
                         session_info->secured_message_context,
                         SPDM_KEY_UPDATE_ACTION_RESPONDER, FALSE);
+                    if (RETURN_ERROR(status)) {
+                        return status;
+                    }
                 }
                 return status;
             }
@@ -157,9 +166,12 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                 DEBUG((DEBUG_INFO,
                        "spdm_activate_update_session_data_key[%x] Responder old\n",
                        session_id));
-                spdm_activate_update_session_data_key(
+                status = spdm_activate_update_session_data_key(
                     session_info->secured_message_context,
                     SPDM_KEY_UPDATE_ACTION_RESPONDER, FALSE);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
             }
             return RETURN_DEVICE_ERROR;
         }
@@ -168,23 +180,32 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             DEBUG((DEBUG_INFO,
                    "spdm_activate_update_session_data_key[%x] Responder new\n",
                    session_id, SPDM_KEY_UPDATE_ACTION_RESPONDER));
-            spdm_activate_update_session_data_key(
+            status = spdm_activate_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER, TRUE);
+            if (RETURN_ERROR(status)) {
+                return status;
+            }
         }
 
         DEBUG((DEBUG_INFO,
                "spdm_create_update_session_data_key[%x] Requester\n",
                session_id));
-        spdm_create_update_session_data_key(
+        status = spdm_create_update_session_data_key(
             session_info->secured_message_context,
             SPDM_KEY_UPDATE_ACTION_REQUESTER);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
         DEBUG((DEBUG_INFO,
                "spdm_activate_update_session_data_key[%x] Requester new\n",
                session_id));
-        spdm_activate_update_session_data_key(
+        status = spdm_activate_update_session_data_key(
             session_info->secured_message_context,
             SPDM_KEY_UPDATE_ACTION_REQUESTER, TRUE);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
     }
 
     *key_updated = TRUE;

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -43,6 +43,7 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
     spdm_session_info_t *session_info;
     uint8_t th2_hash_data[64];
     spdm_session_state_t session_state;
+    boolean result;
 
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, TRUE,
@@ -85,8 +86,11 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    spdm_generate_psk_exchange_req_hmac(spdm_context, session_info,
+    result = spdm_generate_psk_exchange_req_hmac(spdm_context, session_info,
                         spdm_request.verify_data);
+    if (!result) {
+        return RETURN_SECURITY_VIOLATION;
+    }
 
     status = libspdm_append_message_f(spdm_context, session_info, TRUE,
                        (uint8_t *)&spdm_request +

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -165,11 +165,19 @@ return_status spdm_get_response_challenge_auth(IN void *context,
     }
 
     ptr = (void *)(spdm_response + 1);
-    spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
+    result = spdm_generate_cert_chain_hash(spdm_context, slot_id, ptr);
+    if (!result) {
+        return libspdm_generate_error_response(spdm_context,
+                         SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                         response_size, response);
+    }
     ptr += hash_size;
 
-    if(!spdm_get_random_number(SPDM_NONCE_SIZE, ptr)) {
-        return RETURN_DEVICE_ERROR;
+    result = spdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    if (!result) {
+        return libspdm_generate_error_response(spdm_context,
+                         SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                         response_size, response);
     }
     ptr += SPDM_NONCE_SIZE;
 

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -39,6 +39,7 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
     uint8_t *digest;
     spdm_context_t *spdm_context;
     return_status status;
+    boolean result;
 
     spdm_context = context;
     spdm_request = request;
@@ -122,8 +123,13 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
             return RETURN_SUCCESS;
         }
         spdm_response->header.param2 |= (1 << index);
-        spdm_generate_cert_chain_hash(spdm_context, index,
+        result = spdm_generate_cert_chain_hash(spdm_context, index,
                           &digest[hash_size * index]);
+        if (!result) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
     }
     //
     // Cache

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -28,6 +28,7 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
     uint32_t session_id;
     spdm_session_info_t *session_info;
     spdm_session_state_t session_state;
+    return_status status;
 
     spdm_context->encap_context.last_encap_request_size = 0;
 
@@ -86,15 +87,21 @@ spdm_get_encap_request_key_update(IN spdm_context_t *spdm_context,
         DEBUG((DEBUG_INFO,
                "spdm_create_update_session_data_key[%x] Responder\n",
                session_id));
-        spdm_create_update_session_data_key(
+        status = spdm_create_update_session_data_key(
             session_info->secured_message_context,
             SPDM_KEY_UPDATE_ACTION_RESPONDER);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
         DEBUG((DEBUG_INFO,
                "spdm_activate_update_session_data_key[%x] Responder new\n",
                session_id));
-        spdm_activate_update_session_data_key(
+        status = spdm_activate_update_session_data_key(
             session_info->secured_message_context,
             SPDM_KEY_UPDATE_ACTION_RESPONDER, TRUE);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
     }
 
     copy_mem(&spdm_context->encap_context.last_encap_request_header,

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -36,6 +36,7 @@ return_status spdm_get_response_key_update(IN void *context,
     spdm_context_t *spdm_context;
     spdm_session_info_t *session_info;
     spdm_session_state_t session_state;
+    return_status status;
 
     spdm_context = context;
     spdm_request = request;
@@ -114,9 +115,12 @@ return_status spdm_get_response_key_update(IN void *context,
             DEBUG((DEBUG_INFO,
                    "spdm_create_update_session_data_key[%x] Requester\n",
                    session_id));
-            spdm_create_update_session_data_key(
+            status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER);
+            if (!status) {
+                return RETURN_UNSUPPORTED;
+            }
             break;
         case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS:
             if(prev_spdm_request->header.param1 ==
@@ -132,22 +136,30 @@ return_status spdm_get_response_key_update(IN void *context,
             DEBUG((DEBUG_INFO,
                    "spdm_create_update_session_data_key[%x] Requester\n",
                    session_id));
-            spdm_create_update_session_data_key(
+            status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER);
+            if (!status) {
+                return RETURN_UNSUPPORTED;
+            }
             DEBUG((DEBUG_INFO,
                    "spdm_create_update_session_data_key[%x] Responder\n",
                    session_id));
-            spdm_create_update_session_data_key(
+            status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER);
-
+            if (!status) {
+                return RETURN_UNSUPPORTED;
+            }
             DEBUG((DEBUG_INFO,
                    "spdm_activate_update_session_data_key[%x] Responder new\n",
                    session_id));
-            spdm_activate_update_session_data_key(
+            status = spdm_activate_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER, TRUE);
+            if (!status) {
+                return RETURN_UNSUPPORTED;
+            }
             break;
         case SPDM_KEY_UPDATE_OPERATIONS_TABLE_VERIFY_NEW_KEY:
             if(prev_spdm_request->header.param1 !=
@@ -162,9 +174,12 @@ return_status spdm_get_response_key_update(IN void *context,
             DEBUG((DEBUG_INFO,
                    "spdm_activate_update_session_data_key[%x] Requester new\n",
                    session_id));
-            spdm_activate_update_session_data_key(
+            status = spdm_activate_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER, TRUE);
+            if (!status) {
+                return RETURN_UNSUPPORTED;
+            }
             break;
         default:
             DEBUG((DEBUG_INFO, "espurious case\n"));

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -118,7 +118,7 @@ return_status spdm_get_response_key_update(IN void *context,
             status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER);
-            if (!status) {
+            if (RETURN_ERROR(status)) {
                 return RETURN_UNSUPPORTED;
             }
             break;
@@ -139,7 +139,7 @@ return_status spdm_get_response_key_update(IN void *context,
             status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER);
-            if (!status) {
+            if (RETURN_ERROR(status)) {
                 return RETURN_UNSUPPORTED;
             }
             DEBUG((DEBUG_INFO,
@@ -148,7 +148,7 @@ return_status spdm_get_response_key_update(IN void *context,
             status = spdm_create_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER);
-            if (!status) {
+            if (RETURN_ERROR(status)) {
                 return RETURN_UNSUPPORTED;
             }
             DEBUG((DEBUG_INFO,
@@ -157,7 +157,7 @@ return_status spdm_get_response_key_update(IN void *context,
             status = spdm_activate_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_RESPONDER, TRUE);
-            if (!status) {
+            if (RETURN_ERROR(status)) {
                 return RETURN_UNSUPPORTED;
             }
             break;
@@ -177,7 +177,7 @@ return_status spdm_get_response_key_update(IN void *context,
             status = spdm_activate_update_session_data_key(
                 session_info->secured_message_context,
                 SPDM_KEY_UPDATE_ACTION_REQUESTER, TRUE);
-            if (!status) {
+            if (RETURN_ERROR(status)) {
                 return RETURN_UNSUPPORTED;
             }
             break;

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -512,24 +512,29 @@ return_status spdm_decode_secured_message(
             //
             if ((is_requester && secured_message_context->requester_backup_valid) ||
                 ((!is_requester) && secured_message_context->responder_backup_valid)) {
-                spdm_activate_update_session_data_key(
+                status = spdm_activate_update_session_data_key(
                     secured_message_context,
                     is_requester ? SPDM_KEY_UPDATE_ACTION_REQUESTER : SPDM_KEY_UPDATE_ACTION_RESPONDER,
                     FALSE);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                } 
                 status = spdm_decode_secured_message(
                     spdm_secured_message_context, session_id,
                     is_requester, secured_message_size,
                     secured_message, app_message_size,
                     app_message, spdm_secured_message_callbacks_t);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
                 //
                 // Handle special case:
                 // If the responder returns SPDM_RESPOND_IF_READY error, the requester need activate backup key to parse the error.
                 // Then later the responder will return SUCCESS, the requester need activate new key.
                 // So we need restore the environment by spdm_create_update_session_data_key() again.
                 //
-                spdm_create_update_session_data_key (secured_message_context,
+                return spdm_create_update_session_data_key (secured_message_context,
                     is_requester ? SPDM_KEY_UPDATE_ACTION_REQUESTER : SPDM_KEY_UPDATE_ACTION_RESPONDER);
-                return status;
             }
 
             spdm_secured_message_set_last_spdm_error_struct(
@@ -602,24 +607,29 @@ return_status spdm_decode_secured_message(
             //
             if ((is_requester && secured_message_context->requester_backup_valid) ||
                 ((!is_requester) && secured_message_context->responder_backup_valid)) {
-                spdm_activate_update_session_data_key(
+                status = spdm_activate_update_session_data_key(
                     secured_message_context,
                     is_requester ? SPDM_KEY_UPDATE_ACTION_REQUESTER : SPDM_KEY_UPDATE_ACTION_RESPONDER,
                     FALSE);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
                 status = spdm_decode_secured_message(
                     spdm_secured_message_context, session_id,
                     is_requester, secured_message_size,
                     secured_message, app_message_size,
                     app_message, spdm_secured_message_callbacks_t);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
                 //
                 // Handle special case:
                 // If the responder returns SPDM_RESPOND_IF_READY error, the requester need activate backup key to parse the error.
                 // Then later the responder will return SUCCESS, the requester need activate new key.
                 // So we need restore the environment by spdm_create_update_session_data_key() again.
                 //
-                spdm_create_update_session_data_key (secured_message_context,
+                return spdm_create_update_session_data_key (secured_message_context,
                     is_requester ? SPDM_KEY_UPDATE_ACTION_REQUESTER : SPDM_KEY_UPDATE_ACTION_RESPONDER);
-                return status;
             }
 
             spdm_secured_message_set_last_spdm_error_struct(


### PR DESCRIPTION
First round of fixes for #75 .

Going to do these in batches since there's a lot of ground to cover.
This fixes (most) functions that had their return values not checked in:
- include/internal/libspdm_common_lib.h
- include/internal/libspdm_requester_lib.h
- include/internal/libspdm_responder_lib.h
- include/internal/libspdm_secured_message_lib.h
- include/library/spdm_secured_message_lib.h

There's a few omissions from the above two that I'll handle in a separate follow up:
- spdm_hmac_\*_with_\*_finished_key
- append_managed_buffer