### PR TITLE
Change #include <> to #include ""

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -7,8 +7,8 @@
 #ifndef __SPDM_COMMON_LIB_INTERNAL_H__
 #define __SPDM_COMMON_LIB_INTERNAL_H__
 
-#include <library/spdm_common_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_common_lib.h"
+#include "library/spdm_secured_message_lib.h"
 
 #define INVALID_SESSION_ID 0
 

--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -7,8 +7,8 @@
 #ifndef __SPDM_REQUESTER_LIB_INTERNAL_H__
 #define __SPDM_REQUESTER_LIB_INTERNAL_H__
 
-#include <library/spdm_requester_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_requester_lib.h"
+#include "library/spdm_secured_message_lib.h"
 #include "internal/libspdm_common_lib.h"
 
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -7,8 +7,8 @@
 #ifndef __SPDM_RESPONDER_LIB_INTERNAL_H__
 #define __SPDM_RESPONDER_LIB_INTERNAL_H__
 
-#include <library/spdm_responder_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_responder_lib.h"
+#include "library/spdm_secured_message_lib.h"
 #include "internal/libspdm_common_lib.h"
 
 /**

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -7,7 +7,7 @@
 #ifndef __SPDM_SECURED_MESSAGE_LIB_INTERNAL_H__
 #define __SPDM_SECURED_MESSAGE_LIB_INTERNAL_H__
 
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_secured_message_lib.h"
 
 typedef struct {
     uint8_t dhe_secret[MAX_DHE_KEY_SIZE];

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -13,14 +13,14 @@
 #include LIBSPDM_CONFIG
 #endif
 
-#include <hal/base.h>
-#include <industry_standard/spdm.h>
-#include <hal/library/debuglib.h>
-#include <hal/library/memlib.h>
-#include <hal/library/cryptlib.h>
-#include <library/spdm_crypt_lib.h>
-#include <library/spdm_secured_message_lib.h>
-#include <library/spdm_device_secret_lib.h>
+#include "hal/base.h"
+#include "industry_standard/spdm.h"
+#include "hal/library/debuglib.h"
+#include "hal/library/memlib.h"
+#include "hal/library/cryptlib.h"
+#include "library/spdm_crypt_lib.h"
+#include "library/spdm_secured_message_lib.h"
+#include "library/spdm_device_secret_lib.h"
 
 //
 // Connection: When a host sends messgages to a device, they create a connection.

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -13,11 +13,11 @@
 #include LIBSPDM_CONFIG
 #endif
 
-#include <hal/base.h>
-#include <industry_standard/spdm.h>
-#include <hal/library/debuglib.h>
-#include <hal/library/memlib.h>
-#include <hal/library/cryptlib.h>
+#include "hal/base.h"
+#include "industry_standard/spdm.h"
+#include "hal/library/debuglib.h"
+#include "hal/library/memlib.h"
+#include "hal/library/cryptlib.h"
 
 #define MAX_DHE_KEY_SIZE 512
 #define MAX_ASYM_KEY_SIZE 512

--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -13,12 +13,12 @@
 #include LIBSPDM_CONFIG
 #endif
 
-#include <hal/base.h>
-#include <industry_standard/spdm.h>
-#include <hal/library/debuglib.h>
-#include <hal/library/memlib.h>
-#include <hal/library/cryptlib.h>
-#include <library/spdm_crypt_lib.h>
+#include "hal/base.h"
+#include "industry_standard/spdm.h"
+#include "hal/library/debuglib.h"
+#include "hal/library/memlib.h"
+#include "hal/library/cryptlib.h"
+#include "library/spdm_crypt_lib.h"
 
 /**
   Collect the device measurement.

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -7,7 +7,7 @@
 #ifndef __SPDM_REQUESTER_LIB_H__
 #define __SPDM_REQUESTER_LIB_H__
 
-#include <library/spdm_common_lib.h>
+#include "library/spdm_common_lib.h"
 
 /**
   Send an SPDM or an APP request to a device.

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -7,7 +7,7 @@
 #ifndef __SPDM_RESPONDER_LIB_H__
 #define __SPDM_RESPONDER_LIB_H__
 
-#include <library/spdm_common_lib.h>
+#include "library/spdm_common_lib.h"
 
 /**
   Process the SPDM or APP request and return the response.

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -13,14 +13,14 @@
 #include LIBSPDM_CONFIG
 #endif
 
-#include <hal/base.h>
-#include <industry_standard/spdm.h>
-#include <industry_standard/spdm_secured_message.h>
-#include <hal/library/debuglib.h>
-#include <hal/library/memlib.h>
-#include <hal/library/cryptlib.h>
-#include <library/spdm_crypt_lib.h>
-#include <library/spdm_device_secret_lib.h>
+#include "hal/base.h"
+#include "industry_standard/spdm.h"
+#include "industry_standard/spdm_secured_message.h"
+#include "hal/library/debuglib.h"
+#include "hal/library/memlib.h"
+#include "hal/library/cryptlib.h"
+#include "library/spdm_crypt_lib.h"
+#include "library/spdm_device_secret_lib.h"
 
 #define BIN_CONCAT_LABEL "spdm1.1 "
 #define BIN_STR_0_LABEL "derived"

--- a/include/library/spdm_transport_mctp_lib.h
+++ b/include/library/spdm_transport_mctp_lib.h
@@ -7,7 +7,7 @@
 #ifndef __SPDM_MCTP_TRANSPORT_LIB_H__
 #define __SPDM_MCTP_TRANSPORT_LIB_H__
 
-#include <library/spdm_common_lib.h>
+#include "library/spdm_common_lib.h"
 
 /**
   Encode an SPDM or APP message to a transport layer message.

--- a/include/library/spdm_transport_pcidoe_lib.h
+++ b/include/library/spdm_transport_pcidoe_lib.h
@@ -7,7 +7,7 @@
 #ifndef __PCI_DOE_TRANSPORT_LIB_H__
 #define __PCI_DOE_TRANSPORT_LIB_H__
 
-#include <library/spdm_common_lib.h>
+#include "library/spdm_common_lib.h"
 
 /**
   Encode an SPDM or APP message to a transport layer message.

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_crypt_lib.h>
+#include "library/spdm_crypt_lib.h"
 
 /**
   This function returns the SPDM hash algorithm size.

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_mctp_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_transport_mctp_lib.h"
+#include "library/spdm_secured_message_lib.h"
 
 /**
   Encode a normal message or secured message to a transport message.

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_mctp_lib.h>
-#include <industry_standard/mctp.h>
+#include "library/spdm_transport_mctp_lib.h"
+#include "industry_standard/mctp.h"
 
 #define MCTP_ALIGNMENT 1
 #define MCTP_SEQUENCE_NUMBER_COUNT 2

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_pcidoe_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_transport_pcidoe_lib.h"
+#include "library/spdm_secured_message_lib.h"
 
 /**
   Encode a normal message or secured message to a transport message.

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_pcidoe_lib.h>
-#include <industry_standard/pcidoe.h>
+#include "library/spdm_transport_pcidoe_lib.h"
+#include "industry_standard/pcidoe.h"
 
 #define PCI_DOE_ALIGNMENT 4
 #define PCI_DOE_SEQUENCE_NUMBER_COUNT 0

--- a/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
+++ b/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
@@ -12,10 +12,10 @@
 #define __INTERNAL_CRYPT_LIB_H__
 
 #include <base.h>
-#include <library/memlib.h>
-#include <library/malloclib.h>
-#include <library/debuglib.h>
-#include <library/cryptlib.h>
+#include "library/memlib.h"
+#include "library/malloclib.h"
+#include "library/debuglib.h"
+#include "library/cryptlib.h"
 #include <stdio.h>
 
 //

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -9,7 +9,7 @@
 **/
 
 #include "internal_crypt_lib.h"
-#include <library/rnglib.h>
+#include "library/rnglib.h"
 
 /**
   Sets up the seed value for the pseudorandom number generator.

--- a/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
@@ -9,8 +9,8 @@
 **/
 
 #include <base.h>
-#include <library/debuglib.h>
-#include <library/memlib.h>
+#include "library/debuglib.h"
+#include "library/memlib.h"
 #include <stddef.h>
 
 int my_printf(const char *fmt, ...)

--- a/os_stub/cryptlib_mbedtls/sys_call/mem_allocation.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/mem_allocation.c
@@ -9,8 +9,8 @@
 **/
 
 #include <base.h>
-#include <library/debuglib.h>
-#include <library/malloclib.h>
+#include "library/debuglib.h"
+#include "library/malloclib.h"
 #include <stddef.h>
 
 //

--- a/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
@@ -9,7 +9,7 @@
 **/
 
 #include <base.h>
-#include <library/memlib.h>
+#include "library/memlib.h"
 #include <mbedtls/platform_time.h>
 
 struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt,

--- a/os_stub/cryptlib_null/internal_crypt_lib.h
+++ b/os_stub/cryptlib_null/internal_crypt_lib.h
@@ -12,9 +12,9 @@
 #define __INTERNAL_CRYPT_LIB_H__
 
 #include <base.h>
-#include <library/debuglib.h>
-#include <library/memlib.h>
-#include <library/cryptlib.h>
+#include "library/debuglib.h"
+#include "library/memlib.h"
+#include "library/cryptlib.h"
 
 typedef uintn size_t;
 

--- a/os_stub/cryptlib_openssl/internal_crypt_lib.h
+++ b/os_stub/cryptlib_openssl/internal_crypt_lib.h
@@ -15,10 +15,10 @@
 #undef _WIN64
 
 #include <base.h>
-#include <library/memlib.h>
-#include <library/malloclib.h>
-#include <library/debuglib.h>
-#include <library/cryptlib.h>
+#include "library/memlib.h"
+#include "library/malloclib.h"
+#include "library/debuglib.h"
+#include "library/cryptlib.h"
 
 #include "crt_support.h"
 

--- a/os_stub/cryptlib_openssl/sys_call/crt_wrapper_host.c
+++ b/os_stub/cryptlib_openssl/sys_call/crt_wrapper_host.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 #include <base.h>
-#include <library/debuglib.h>
+#include "library/debuglib.h"
 #include <openssl/bio.h>
 
 /* Convert character to lowercase */

--- a/os_stub/debuglib/debuglib.c
+++ b/os_stub/debuglib/debuglib.c
@@ -12,7 +12,7 @@
 #include <assert.h>
 #include <stdarg.h>
 
-#include <library/debuglib.h>
+#include "library/debuglib.h"
 
 //
 // Define the maximum debug and assert message length that this library supports

--- a/os_stub/openssllib/include/arpa/inet.h
+++ b/os_stub/openssllib/include/arpa/inet.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/arpa/nameser.h
+++ b/os_stub/openssllib/include/arpa/nameser.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/assert.h
+++ b/os_stub/openssllib/include/assert.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/crt_support.h
+++ b/os_stub/openssllib/include/crt_support.h
@@ -13,8 +13,8 @@
 #define __CRT_LIB_SUPPORT_H__
 
 #include <base.h>
-#include <library/memlib.h>
-#include <library/debuglib.h>
+#include "library/memlib.h"
+#include "library/debuglib.h"
 
 #define OPENSSLDIR ""
 #define ENGINESDIR ""

--- a/os_stub/openssllib/include/ctype.h
+++ b/os_stub/openssllib/include/ctype.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/errno.h
+++ b/os_stub/openssllib/include/errno.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/limits.h
+++ b/os_stub/openssllib/include/limits.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/memory.h
+++ b/os_stub/openssllib/include/memory.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/netinet/in.h
+++ b/os_stub/openssllib/include/netinet/in.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/stdarg.h
+++ b/os_stub/openssllib/include/stdarg.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/stdatomic.h
+++ b/os_stub/openssllib/include/stdatomic.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/stddef.h
+++ b/os_stub/openssllib/include/stddef.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/stdio.h
+++ b/os_stub/openssllib/include/stdio.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/stdlib.h
+++ b/os_stub/openssllib/include/stdlib.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/string.h
+++ b/os_stub/openssllib/include/string.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/strings.h
+++ b/os_stub/openssllib/include/strings.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/param.h
+++ b/os_stub/openssllib/include/sys/param.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/shm.h
+++ b/os_stub/openssllib/include/sys/shm.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/socket.h
+++ b/os_stub/openssllib/include/sys/socket.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/syscall.h
+++ b/os_stub/openssllib/include/sys/syscall.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/time.h
+++ b/os_stub/openssllib/include/sys/time.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/types.h
+++ b/os_stub/openssllib/include/sys/types.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/sys/utsname.h
+++ b/os_stub/openssllib/include/sys/utsname.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/syslog.h
+++ b/os_stub/openssllib/include/syslog.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/time.h
+++ b/os_stub/openssllib/include/time.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/include/unistd.h
+++ b/os_stub/openssllib/include/unistd.h
@@ -4,4 +4,4 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <crt_support.h>
+#include "crt_support.h"

--- a/os_stub/openssllib/rand_pool.c
+++ b/os_stub/openssllib/rand_pool.c
@@ -8,7 +8,7 @@
 #include <openssl/aes.h>
 
 #include <base.h>
-#include <library/rnglib.h>
+#include "library/rnglib.h"
 
 /**
   Calls RandomNumber64 to fill

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -9,7 +9,7 @@
   It follows the SPDM Specification.
 **/
 
-#include <library/spdm_device_secret_lib.h>
+#include "library/spdm_device_secret_lib.h"
 
 /**
   Collect the device measurement.

--- a/os_stub/spdm_device_secret_lib_sample/cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/cert.c
@@ -20,7 +20,7 @@
 
 #undef NULL
 #include <base.h>
-#include <library/memlib.h>
+#include "library/memlib.h"
 #include "spdm_device_secret_lib_internal.h"
 
 boolean read_responder_root_public_certificate(IN uint32_t base_hash_algo,

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -20,7 +20,7 @@
 
 #undef NULL
 #include <base.h>
-#include <library/memlib.h>
+#include "library/memlib.h"
 #include "spdm_device_secret_lib_internal.h"
 
 boolean read_responder_private_certificate(IN uint32_t base_asym_algo,

--- a/os_stub/spdm_device_secret_lib_sample/spdm_device_secret_lib_internal.h
+++ b/os_stub/spdm_device_secret_lib_sample/spdm_device_secret_lib_internal.h
@@ -12,7 +12,7 @@
 #ifndef __SPDM_DEVICE_SECRET_LIB_INTERNAL_H__
 #define __SPDM_DEVICE_SECRET_LIB_INTERNAL_H__
 
-#include <library/spdm_device_secret_lib.h>
+#include "library/spdm_device_secret_lib.h"
 
 #define MEASUREMENT_BLOCK_NUMBER 5
 #define MEASUREMENT_MANIFEST_SIZE 128

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
@@ -16,14 +16,14 @@
 #include <stdio.h>
 
 #undef NULL
-#include <hal/base.h>
-#include <hal/library/memlib.h>
-#include <library/spdm_requester_lib.h>
-#include <library/spdm_responder_lib.h>
-#include <library/spdm_common_lib.h>
-#include <library/spdm_transport_test_lib.h>
-#include <internal/libspdm_common_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "hal/base.h"
+#include "hal/library/memlib.h"
+#include "library/spdm_requester_lib.h"
+#include "library/spdm_responder_lib.h"
+#include "library/spdm_common_lib.h"
+#include "library/spdm_transport_test_lib.h"
+#include "internal/libspdm_common_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 extern uint8_t m_use_measurement_spec;
 extern uint32_t m_use_measurement_hash_algo;

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
@@ -5,8 +5,8 @@
 **/
 
 #undef NULL
-#include <hal/base.h>
-#include <hal/library/memlib.h>
+#include "hal/base.h"
+#include "hal/library/memlib.h"
 #include "toolchain_harness.h"
 
 #ifdef TEST_WITH_LIBFUZZER

--- a/unit_test/fuzzing/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_spdm_requester_challenge/challenge.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_requester_encap_certificate/encap_certificate.c
+++ b/unit_test/fuzzing/test_spdm_requester_encap_certificate/encap_certificate.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
+++ b/unit_test/fuzzing/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_requester_encap_digests/encap_digests.c
+++ b/unit_test/fuzzing/test_spdm_requester_encap_digests/encap_digests.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_requester_encap_key_update/encap_key_update.c
+++ b/unit_test/fuzzing/test_spdm_requester_encap_key_update/encap_key_update.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 static void

--- a/unit_test/fuzzing/test_spdm_requester_end_session/end_session.c
+++ b/unit_test/fuzzing/test_spdm_requester_end_session/end_session.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 static uint8_t m_local_psk_hint[32];

--- a/unit_test/fuzzing/test_spdm_requester_finish/finish.c
+++ b/unit_test/fuzzing/test_spdm_requester_finish/finish.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_get_capabilities/get_capabilities.c
+++ b/unit_test/fuzzing/test_spdm_requester_get_capabilities/get_capabilities.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_get_certificate/get_certificate.c
+++ b/unit_test/fuzzing/test_spdm_requester_get_certificate/get_certificate.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_get_digests/get_digests.c
+++ b/unit_test/fuzzing/test_spdm_requester_get_digests/get_digests.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_get_measurements/get_measurements.c
+++ b/unit_test/fuzzing/test_spdm_requester_get_measurements/get_measurements.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_get_version/get_version.c
+++ b/unit_test/fuzzing/test_spdm_requester_get_version/get_version.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_heartbeat/heartbeat.c
+++ b/unit_test/fuzzing/test_spdm_requester_heartbeat/heartbeat.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 static uint8_t m_local_psk_hint[32];
 static uint8_t m_dummy_key_buffer[MAX_AEAD_KEY_SIZE];

--- a/unit_test/fuzzing/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_spdm_requester_key_exchange/key_exchange.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_requester_key_update/key_update.c
+++ b/unit_test/fuzzing/test_spdm_requester_key_update/key_update.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 static void
 spdm_set_standard_key_update_test_state(IN OUT spdm_context_t *spdm_context,

--- a/unit_test/fuzzing/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
+++ b/unit_test/fuzzing/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_requester_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_requester_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 static uint8_t m_local_psk_hint[32];
 

--- a/unit_test/fuzzing/test_spdm_requester_psk_finish/psk_finish.c
+++ b/unit_test/fuzzing/test_spdm_requester_psk_finish/psk_finish.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_requester_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_requester_lib.h"
 
 
 static void spdm_secured_message_set_dummy_finished_key(

--- a/unit_test/fuzzing/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_spdm_responder_algorithms/algorithms.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_capabilities/capabilities.c
+++ b/unit_test/fuzzing/test_spdm_responder_capabilities/capabilities.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_certificate/certificate.c
+++ b/unit_test/fuzzing/test_spdm_responder_certificate/certificate.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_digests/digests.c
+++ b/unit_test/fuzzing/test_spdm_responder_digests/digests.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_encap_challenge/encap_challenge.c
+++ b/unit_test/fuzzing/test_spdm_responder_encap_challenge/encap_challenge.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
+++ b/unit_test/fuzzing/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_responder_encap_get_digests/encap_get_digests.c
+++ b/unit_test/fuzzing/test_spdm_responder_encap_get_digests/encap_get_digests.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_responder_encap_key_update/encap_key_update.c
+++ b/unit_test/fuzzing/test_spdm_responder_encap_key_update/encap_key_update.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 static void

--- a/unit_test/fuzzing/test_spdm_responder_end_session/end_session.c
+++ b/unit_test/fuzzing/test_spdm_responder_end_session/end_session.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 uintn get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "internal/libspdm_responder_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_spdm_responder_if_ready/respond_if_ready.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 #define MY_TEST_TOKEN 0x30

--- a/unit_test/fuzzing/test_spdm_responder_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_spdm_responder_key_exchange/key_exchange.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_key_update/key_update.c
+++ b/unit_test/fuzzing/test_spdm_responder_key_update/key_update.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 
 static void

--- a/unit_test/fuzzing/test_spdm_responder_measurements/measurements.c
+++ b/unit_test/fuzzing/test_spdm_responder_measurements/measurements.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 typedef struct {
     spdm_message_header_t header;

--- a/unit_test/fuzzing/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -6,8 +6,8 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <spdm_device_secret_lib_internal.h>
-#include <internal/libspdm_responder_lib.h>
+#include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_spdm_responder_version/version.c
+++ b/unit_test/fuzzing/test_spdm_responder_version/version.c
@@ -6,7 +6,7 @@
 
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 uintn get_max_buffer_size(void)
 {

--- a/unit_test/include/library/spdm_transport_test_lib.h
+++ b/unit_test/include/library/spdm_transport_test_lib.h
@@ -7,7 +7,7 @@
 #ifndef __SPDM_TEST_TRANSPORT_LIB_H__
 #define __SPDM_TEST_TRANSPORT_LIB_H__
 
-#include <library/spdm_common_lib.h>
+#include "library/spdm_common_lib.h"
 
 #define TEST_MESSAGE_TYPE_SPDM 0x01
 #define TEST_MESSAGE_TYPE_SECURED_TEST 0x02

--- a/unit_test/spdm_transport_test_lib/common.c
+++ b/unit_test/spdm_transport_test_lib/common.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_test_lib.h>
-#include <library/spdm_secured_message_lib.h>
+#include "library/spdm_transport_test_lib.h"
+#include "library/spdm_secured_message_lib.h"
 
 /**
   Encode a normal message or secured message to a transport message.

--- a/unit_test/spdm_transport_test_lib/test.c
+++ b/unit_test/spdm_transport_test_lib/test.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <library/spdm_transport_test_lib.h>
+#include "library/spdm_transport_test_lib.h"
 
 #define TEST_ALIGNMENT 4
 #define TEST_SEQUENCE_NUMBER_COUNT 2

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -18,13 +18,13 @@
 #include <string.h>
 
 #undef NULL
-#include <hal/base.h>
-#include <hal/library/memlib.h>
-#include <library/spdm_requester_lib.h>
-#include <library/spdm_responder_lib.h>
-#include <library/spdm_transport_test_lib.h>
-#include <internal/libspdm_common_lib.h>
-#include <spdm_device_secret_lib_internal.h>
+#include "hal/base.h"
+#include "hal/library/memlib.h"
+#include "library/spdm_requester_lib.h"
+#include "library/spdm_responder_lib.h"
+#include "library/spdm_transport_test_lib.h"
+#include "internal/libspdm_common_lib.h"
+#include "spdm_device_secret_lib_internal.h"
 
 extern uint8_t m_use_measurement_spec;
 extern uint32_t m_use_measurement_hash_algo;

--- a/unit_test/test_crypt/test_crypt.h
+++ b/unit_test/test_crypt/test_crypt.h
@@ -16,12 +16,12 @@
 #include <assert.h>
 #undef NULL
 
-#include <hal/base.h>
+#include "hal/base.h"
 
-#include <hal/library/debuglib.h>
-#include <hal/library/memlib.h>
-#include <library/malloclib.h>
-#include <hal/library/cryptlib.h>
+#include "hal/library/debuglib.h"
+#include "hal/library/memlib.h"
+#include "library/malloclib.h"
+#include "hal/library/cryptlib.h"
 
 boolean read_input_file(IN char8 *file_name, OUT void **file_data,
             OUT uintn *file_size);

--- a/unit_test/test_size/cryptstublib_dummy/rand_dummy.c
+++ b/unit_test/test_size/cryptstublib_dummy/rand_dummy.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
-#include <hal/library/debuglib.h>
+#include "hal/base.h"
+#include "hal/library/debuglib.h"
 
 int rand()
 {

--- a/unit_test/test_size/cryptstublib_dummy/timeclock_dummy.c
+++ b/unit_test/test_size/cryptstublib_dummy/timeclock_dummy.c
@@ -4,8 +4,8 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
-#include <hal/library/debuglib.h>
+#include "hal/base.h"
+#include "hal/library/debuglib.h"
 
 typedef int time_t;
 

--- a/unit_test/test_size/intrinsiclib/copy_mem.c
+++ b/unit_test/test_size/intrinsiclib/copy_mem.c
@@ -8,8 +8,8 @@
   Intrinsic Memory Routines Wrapper Implementation.
 **/
 
-#include <hal/base.h>
-#include <hal/library/memlib.h>
+#include "hal/base.h"
+#include "hal/library/memlib.h"
 
 #if defined(__clang__) && !defined(__APPLE__)
 

--- a/unit_test/test_size/intrinsiclib/ia32/math_div_s64x64.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_div_s64x64.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 int64_t div_s64x64_remainder(IN int64_t dividend, IN int64_t divisor,
              OUT int64_t *remainder OPTIONAL);

--- a/unit_test/test_size/intrinsiclib/ia32/math_div_s64x64_remainder.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_div_s64x64_remainder.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 uint64_t internal_math_div_rem_u64x64(IN uint64_t dividend, IN uint64_t divisor,
                 OUT uint64_t *remainder OPTIONAL);

--- a/unit_test/test_size/intrinsiclib/ia32/math_div_u64x64.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_div_u64x64.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 uint64_t div_u64x64_remainder(IN uint64_t dividend, IN uint64_t divisor,
               OUT uint64_t *remainder OPTIONAL);

--- a/unit_test/test_size/intrinsiclib/ia32/math_div_u64x64_remainder.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_div_u64x64_remainder.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 uint64_t internal_math_div_rem_u64x32(IN uint64_t dividend, IN uint32_t divisor,
                 OUT uint32_t *remainder)

--- a/unit_test/test_size/intrinsiclib/ia32/math_mult_s64x64.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_mult_s64x64.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 uint64_t internal_math_mult_u64x64(IN uint64_t multiplicand, IN uint64_t multiplier)
 {

--- a/unit_test/test_size/intrinsiclib/ia32/math_remainder_s64x64.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_remainder_s64x64.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 int64_t div_s64x64_remainder(IN int64_t dividend, IN int64_t divisor,
              OUT int64_t *remainder OPTIONAL);

--- a/unit_test/test_size/intrinsiclib/ia32/math_remainder_u64x64.c
+++ b/unit_test/test_size/intrinsiclib/ia32/math_remainder_u64x64.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 uint64_t div_u64x64_remainder(IN uint64_t dividend, IN uint64_t divisor,
               OUT uint64_t *remainder OPTIONAL);

--- a/unit_test/test_size/intrinsiclib/memory_intrinsics.c
+++ b/unit_test/test_size/intrinsiclib/memory_intrinsics.c
@@ -8,8 +8,8 @@
   Intrinsic Memory Routines Wrapper Implementation.
 **/
 
-#include <hal/base.h>
-#include <hal/library/memlib.h>
+#include "hal/base.h"
+#include "hal/library/memlib.h"
 
 typedef uintn size_t;
 

--- a/unit_test/test_size/malloclib_null/malloclib.c
+++ b/unit_test/test_size/malloclib_null/malloclib.c
@@ -4,7 +4,7 @@
     License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
 **/
 
-#include <hal/base.h>
+#include "hal/base.h"
 
 void *allocate_pool(IN uintn AllocationSize)
 {

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester.h
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester.h
@@ -7,10 +7,10 @@
 #ifndef __SPDM_REQUESTER_H__
 #define __SPDM_REQUESTER_H__
 
-#include <hal/base.h>
-#include <library/spdm_requester_lib.h>
-#include <library/spdm_transport_mctp_lib.h>
-#include <library/malloclib.h>
+#include "hal/base.h"
+#include "library/spdm_requester_lib.h"
+#include "library/spdm_transport_mctp_lib.h"
+#include "library/malloclib.h"
 
 return_status do_authentication_via_spdm(IN void *spdm_context);
 

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder.h
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder.h
@@ -7,10 +7,10 @@
 #ifndef __SPDM_RESPONDER_H__
 #define __SPDM_RESPONDER_H__
 
-#include <hal/base.h>
-#include <library/spdm_responder_lib.h>
-#include <library/spdm_transport_mctp_lib.h>
-#include <library/malloclib.h>
+#include "hal/base.h"
+#include "library/spdm_responder_lib.h"
+#include "library/spdm_transport_mctp_lib.h"
+#include "library/malloclib.h"
 
 void *spdm_server_init(void);
 

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 static const uint32_t opaque_data = 0xDEADBEEF;
 

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CHAL_CAP
 

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 static uint8_t m_local_psk_hint[32];
 static uint8_t m_dummy_key_buffer[MAX_AEAD_KEY_SIZE];

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #define DEFAULT_CAPABILITY_FLAG                                                \
     (SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP |                        \

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CERT_CAP
 

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CERT_CAP
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #pragma pack(1)
 typedef struct {

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 static uint8_t m_local_psk_hint[32];
 static uint8_t m_dummy_key_buffer[MAX_AEAD_KEY_SIZE];

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 static uint8_t my_last_token;
 static uint8_t my_last_rsp_enc_key[MAX_AEAD_KEY_SIZE];

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #pragma pack(1)
 typedef struct {

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_requester_lib.h>
+#include "internal/libspdm_requester_lib.h"
 
 int spdm_requester_get_version_test_main(void);
 int spdm_requester_get_capabilities_test_main(void);

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #pragma pack(1)
 typedef struct {

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 spdm_get_capabilities_request m_spdm_get_capabilities_request1 = {
     {

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CERT_CAP
 

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CHAL_CAP
 

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_CERT_CAP
 

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 spdm_end_session_request_t m_spdm_end_session_request1 = {
     { SPDM_MESSAGE_VERSION_11, SPDM_END_SESSION, 0, 0 }

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #pragma pack(1)
 

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 spdm_heartbeat_request_t m_spdm_heartbeat_request1 = {
     { SPDM_MESSAGE_VERSION_11, SPDM_HEARTBEAT, 0, 0 }

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/unit_test/test_spdm_responder/key_update.c
+++ b/unit_test/test_spdm_responder/key_update.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 spdm_key_update_request_t m_spdm_key_update_request1 = {
     { SPDM_MESSAGE_VERSION_11, SPDM_KEY_UPDATE,

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_MEAS_CAP
 

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #if SPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -5,8 +5,8 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #pragma pack(1)
 

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -8,8 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
-#include <internal/libspdm_secured_message_lib.h>
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #define MY_TEST_TOKEN            0x30
 #define MY_WRONG_TEST_TOKEN      0x2F

--- a/unit_test/test_spdm_responder/test_spdm_responder.c
+++ b/unit_test/test_spdm_responder/test_spdm_responder.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 int spdm_responder_version_test_main(void);
 int spdm_responder_capabilities_test_main(void);

--- a/unit_test/test_spdm_responder/version.c
+++ b/unit_test/test_spdm_responder/version.c
@@ -5,7 +5,7 @@
 **/
 
 #include "spdm_unit_test.h"
-#include <internal/libspdm_responder_lib.h>
+#include "internal/libspdm_responder_lib.h"
 
 #define DEFAULT_SPDM_VERSION_ENTRY_COUNT 2
 


### PR DESCRIPTION
Fix: #283 
Change #include <> to #include "".
General headers provided by the system, compiler, or standard library go in <> and libspdm's files would go in "".

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>