### PR TITLE
Fix missing return statuses in requester, responder, and common library functions.

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -722,10 +722,8 @@ void *libspdm_assign_session_id(IN void *spdm_context, IN uint32_t session_id,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  session_id                    The SPDM session ID.
-
-  @return freed session info assicated with this session ID.
 **/
-void *libspdm_free_session_id(IN void *spdm_context, IN uint32_t session_id);
+void libspdm_free_session_id(IN void *spdm_context, IN uint32_t session_id);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*
@@ -947,6 +945,6 @@ uint32_t libspdm_read_uint24(IN uint8_t *buffer);
 
   @return The 24-bit value to write to buffer.
 **/
-uint32_t libspdm_write_uint24(IN uint8_t *buffer, IN uint32_t value);
+void libspdm_write_uint24(IN uint8_t *buffer, IN uint32_t value);
 
 #endif

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1270,6 +1270,7 @@ return_status libspdm_append_message_f(IN void *context, IN void *session_info,
         uint8_t mut_cert_chain_buffer_hash[MAX_HASH_SIZE];
         uint32_t hash_size;
         boolean finished_key_ready;
+        return_status status;
 
         spdm_context = context;
         secured_message_context = spdm_session_info->secured_message_context;
@@ -1287,7 +1288,10 @@ return_status libspdm_append_message_f(IN void *context, IN void *session_info,
             if (spdm_session_info->session_transcript.digest_context_th == NULL ||
                 spdm_session_info->session_transcript.hmac_rsp_context_th == NULL ||
                 spdm_session_info->session_transcript.hmac_req_context_th == NULL) {
-                libspdm_append_message_k (context, session_info, is_requester, NULL, 0);
+                status = libspdm_append_message_k (context, session_info, is_requester, NULL, 0);
+                if (RETURN_ERROR(status)) {
+                    return status;
+                }
             }
 
             if (!spdm_session_info->use_psk && spdm_session_info->mut_auth_requested) {

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -259,10 +259,8 @@ uint16_t spdm_allocate_rsp_session_id(IN spdm_context_t *spdm_context)
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  session_id                    The SPDM session ID.
-
-  @return freed session info assicated with this session ID.
 **/
-void *libspdm_free_session_id(IN void *context, IN uint32_t session_id)
+void libspdm_free_session_id(IN void *context, IN uint32_t session_id)
 {
     spdm_context_t *spdm_context;
     spdm_session_info_t *session_info;
@@ -274,7 +272,7 @@ void *libspdm_free_session_id(IN void *context, IN uint32_t session_id)
         DEBUG((DEBUG_ERROR,
                "libspdm_free_session_id - Invalid session_id\n"));
         ASSERT(FALSE);
-        return NULL;
+        return;
     }
 
     session_info = spdm_context->session_info;
@@ -283,11 +281,11 @@ void *libspdm_free_session_id(IN void *context, IN uint32_t session_id)
             spdm_session_info_init(spdm_context,
                            &session_info[index],
                            INVALID_SESSION_ID, FALSE);
-            return &session_info[index];
+            return;
         }
     }
 
     DEBUG((DEBUG_ERROR, "libspdm_free_session_id - MAX session_id\n"));
     ASSERT(FALSE);
-    return NULL;
+    return;
 }

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -147,6 +147,7 @@ boolean libspdm_calculate_th_hmac_for_exchange_rsp(
     void *secured_message_context;
     uint32_t hash_size;
     void *hmac_context_th;
+    return_status status;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -159,7 +160,10 @@ boolean libspdm_calculate_th_hmac_for_exchange_rsp(
 
     if (session_info->session_transcript.hmac_rsp_context_th == NULL) {
         // trigger message_k to initialize hmac context after finished_key is ready.
-        libspdm_append_message_k (context, spdm_session_info, is_requester, NULL, 0);
+        status = libspdm_append_message_k (context, spdm_session_info, is_requester, NULL, 0);
+        if (RETURN_ERROR(status)) {
+            return FALSE;
+        }
         ASSERT(session_info->session_transcript.hmac_rsp_context_th != NULL);
     }
 

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -80,15 +80,13 @@ uint32_t libspdm_read_uint24(IN uint8_t *buffer)
 
   @param  buffer  The pointer to a 24-bit value that may be unaligned.
   @param  value   24-bit value to write to buffer.
-
-  @return The 24-bit value to write to buffer.
 **/
-uint32_t libspdm_write_uint24(IN uint8_t *buffer, IN uint32_t value)
+void libspdm_write_uint24(IN uint8_t *buffer, IN uint32_t value)
 {
     buffer[0] = (uint8_t)(value & 0xFF);
     buffer[1] = (uint8_t)((value >> 8) & 0xFF);
     buffer[2] = (uint8_t)((value >> 16) & 0xFF);
-    return value;
+    return;
 }
 
 /**

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -46,34 +46,30 @@ return_status spdm_get_encap_response_certificate(IN void *context,
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, TRUE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP, 0)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_CERTIFICATE, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_get_certificate_request_t)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     slot_id = spdm_request->header.param1;
 
     if (slot_id >= spdm_context->local_context.slot_count) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (spdm_context->local_context
                       .local_cert_chain_provision[slot_id] == NULL) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
             0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     offset = spdm_request->offset;
@@ -84,10 +80,9 @@ return_status spdm_get_encap_response_certificate(IN void *context,
 
     if (offset >= spdm_context->local_context
                   .local_cert_chain_provision_size[slot_id]) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if ((uintn)(offset + length) >
@@ -131,19 +126,17 @@ return_status spdm_get_encap_response_certificate(IN void *context,
     status = libspdm_append_message_mut_b(spdm_context, spdm_request,
                        request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_mut_b(spdm_context, spdm_response,
                        *response_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -48,27 +48,24 @@ return_status spdm_get_encap_response_challenge_auth(
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, TRUE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP, 0)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_CHALLENGE, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_challenge_request_t)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     slot_id = spdm_request->header.param1;
 
     if ((slot_id != 0xFF) &&
         (slot_id >= spdm_context->local_context.slot_count)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -138,28 +135,25 @@ return_status spdm_get_encap_response_challenge_auth(
     status = libspdm_append_message_mut_c(spdm_context, spdm_request,
                        request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_mut_c(spdm_context, spdm_response,
                        (uintn)ptr - (uintn)spdm_response);
     if (RETURN_ERROR(status)) {
         libspdm_reset_message_mut_c(spdm_context);
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
     result =
         spdm_generate_challenge_auth_signature(spdm_context, TRUE, ptr);
     if (!result) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
             0, response_size, response);
-        return RETURN_SUCCESS;
     }
     ptr += signature_size;
 

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -61,7 +61,7 @@ return_status spdm_get_encap_response_key_update(IN void *context,
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);
-   }
+    }
     session_state = spdm_secured_message_get_session_state(
         session_info->secured_message_context);
     if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -96,7 +96,7 @@ return_status SpdmProcessEncapsulatedRequest(IN spdm_context_t *spdm_context,
 
     spdm_requester = encap_request;
     if (encap_request_size < sizeof(spdm_message_header_t)) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             spdm_requester->request_response_code,
             encap_response_size, encap_response);
@@ -117,7 +117,7 @@ return_status SpdmProcessEncapsulatedRequest(IN spdm_context_t *spdm_context,
         status = RETURN_NOT_FOUND;
     }
     if (status != RETURN_SUCCESS) {
-        libspdm_generate_encap_error_response(
+        return libspdm_generate_encap_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             spdm_requester->request_response_code,
             encap_response_size, encap_response);

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -202,17 +202,15 @@ return_status spdm_get_response_algorithms(IN void *context,
     }
     if (spdm_context->connection_info.connection_state !=
         SPDM_CONNECTION_STATE_AFTER_CAPABILITIES) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size < sizeof(spdm_negotiate_algorithms_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (request_size <
         sizeof(spdm_negotiate_algorithms_request_t) +
@@ -220,10 +218,9 @@ return_status spdm_get_response_algorithms(IN void *context,
             sizeof(uint32_t) * spdm_request->ext_hash_count +
             sizeof(spdm_negotiate_algorithms_common_struct_table_t) *
                 spdm_request->header.param1) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     struct_table = (void *)((uintn)spdm_request +
                 sizeof(spdm_negotiate_algorithms_request_t) +
@@ -233,40 +230,36 @@ return_status spdm_get_response_algorithms(IN void *context,
         for (index = 0; index < spdm_request->header.param1; index++) {
             if ((uintn)spdm_request + request_size <
                 (uintn)struct_table) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             if ((uintn)spdm_request + request_size -
                     (uintn)struct_table <
                 sizeof(spdm_negotiate_algorithms_common_struct_table_t)) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             fixed_alg_size = (struct_table->alg_count >> 4) & 0xF;
             ext_alg_count = struct_table->alg_count & 0xF;
             ext_alg_total_count += ext_alg_count;
             if (fixed_alg_size != 2) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             if ((uintn)spdm_request + request_size -
                     (uintn)struct_table -
                     sizeof(spdm_negotiate_algorithms_common_struct_table_t) <
                 sizeof(uint32_t) * ext_alg_count) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             struct_table =
                 (void *)((uintn)struct_table +
@@ -435,28 +428,25 @@ return_status spdm_get_response_algorithms(IN void *context,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP)) {
         if (spdm_context->connection_info.algorithm.measurement_spec !=
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
         algo_size = spdm_get_measurement_hash_size(
             spdm_context->connection_info.algorithm
                 .measurement_hash_algo);
         if (algo_size == 0) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
     algo_size = spdm_get_hash_size(
         spdm_context->connection_info.algorithm.base_hash_algo);
     if (algo_size == 0) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_is_capabilities_flag_supported(
             spdm_context, FALSE, 0,
@@ -464,10 +454,9 @@ return_status spdm_get_response_algorithms(IN void *context,
         algo_size = spdm_get_asym_signature_size(
             spdm_context->connection_info.algorithm.base_asym_algo);
         if (algo_size == 0) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
@@ -489,11 +478,10 @@ return_status spdm_get_response_algorithms(IN void *context,
                 spdm_context->connection_info.algorithm
                     .dhe_named_group);
             if (algo_size == 0) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
         }
         if (spdm_is_capabilities_flag_supported(
@@ -508,11 +496,10 @@ return_status spdm_get_response_algorithms(IN void *context,
                 spdm_context->connection_info.algorithm
                     .aead_cipher_suite);
             if (algo_size == 0) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
         }
         if (spdm_is_capabilities_flag_supported(
@@ -523,11 +510,10 @@ return_status spdm_get_response_algorithms(IN void *context,
                 spdm_context->connection_info.algorithm
                     .req_base_asym_alg);
             if (algo_size == 0) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
         }
         if (spdm_is_capabilities_flag_supported(
@@ -553,19 +539,17 @@ return_status spdm_get_response_algorithms(IN void *context,
     status = libspdm_append_message_a(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_a(spdm_context, spdm_response,
                        *response_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_set_connection_state(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -164,42 +164,37 @@ return_status spdm_get_response_capabilities(IN void *context,
     }
     if (spdm_context->connection_info.connection_state !=
         SPDM_CONNECTION_STATE_AFTER_VERSION) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (!spdm_check_request_version_compability(
             spdm_context, spdm_request->header.spdm_version)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (spdm_is_version_supported(spdm_context, SPDM_MESSAGE_VERSION_11)) {
         if (request_size != sizeof(spdm_get_capabilities_request)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     } else {
         if (request_size != sizeof(spdm_message_header_t)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
     if (!spdm_check_request_flag_compability(
             spdm_request->flags, spdm_request->header.spdm_version)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     spdm_request_size = request_size;
 
@@ -228,19 +223,17 @@ return_status spdm_get_response_capabilities(IN void *context,
     status = libspdm_append_message_a(spdm_context, spdm_request,
                   spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                         SPDM_ERROR_CODE_UNSPECIFIED, 0,
                         response_size, response);
-        return RETURN_SUCCESS;
     }
     status = libspdm_append_message_a(spdm_context,
                   spdm_response, *response_size);
 
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                         SPDM_ERROR_CODE_UNSPECIFIED, 0,
                         response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_11) {
         spdm_context->connection_info.capability.ct_exponent =

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -55,43 +55,38 @@ return_status spdm_get_response_certificate(IN void *context,
          SPDM_CONNECTION_STATE_AFTER_DIGESTS) &&
         (spdm_context->connection_info.connection_state !=
          SPDM_CONNECTION_STATE_AFTER_CERTIFICATE)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, FALSE, 0,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_CERTIFICATE, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_get_certificate_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     spdm_request_size = request_size;
 
     slot_id = spdm_request->header.param1;
 
     if (slot_id >= spdm_context->local_context.slot_count) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (spdm_context->local_context
                       .local_cert_chain_provision[slot_id] == NULL) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
             0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     offset = spdm_request->offset;
@@ -102,10 +97,9 @@ return_status spdm_get_response_certificate(IN void *context,
 
     if (offset >= spdm_context->local_context
                   .local_cert_chain_provision_size[slot_id]) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -149,19 +143,17 @@ return_status spdm_get_response_certificate(IN void *context,
     status = libspdm_append_message_b(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_b(spdm_context, spdm_response,
                        *response_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_set_connection_state(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -217,10 +217,9 @@ return_status spdm_get_response_challenge_auth(IN void *context,
     status = libspdm_append_message_c(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_c(spdm_context, spdm_response,

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -53,24 +53,21 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, FALSE, 0,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_DIGESTS, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->connection_info.connection_state !=
         SPDM_CONNECTION_STATE_NEGOTIATED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_get_digest_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -86,10 +83,9 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
         }
     }
     if (no_local_cert_chain) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_DIGESTS, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     hash_size = spdm_get_hash_size(
@@ -117,10 +113,9 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
          index++) {
         if (spdm_context->local_context
                           .local_cert_chain_provision[index] == NULL) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
         spdm_response->header.param2 |= (1 << index);
         result = spdm_generate_cert_chain_hash(spdm_context, index,
@@ -137,19 +132,17 @@ return_status spdm_get_response_digests(IN void *context, IN uintn request_size,
     status = libspdm_append_message_b(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     status = libspdm_append_message_b(spdm_context, spdm_response,
                        *response_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_set_connection_state(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -360,20 +360,18 @@ return_status spdm_get_response_encapsulated_request(
             spdm_context, FALSE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_ENCAPSULATED_REQUEST, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->response_state !=
         SPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
         if (spdm_context->response_state ==
             SPDM_RESPONSE_STATE_NORMAL) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_SUCCESS;
         }
         return spdm_responder_handle_response_state(
             spdm_context,
@@ -382,10 +380,9 @@ return_status spdm_get_response_encapsulated_request(
     }
 
     if (request_size != sizeof(spdm_get_encapsulated_request_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -407,11 +404,10 @@ return_status spdm_get_response_encapsulated_request(
     status = spdm_process_encapsulated_response(
         context, 0, NULL, &encap_request_size, encap_request);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
             response_size, response);
         spdm_context->response_state = SPDM_RESPONSE_STATE_NORMAL;
-        return RETURN_SUCCESS;
     }
     *response_size = sizeof(spdm_encapsulated_request_response_t) +
              encap_request_size;
@@ -462,21 +458,19 @@ return_status spdm_get_response_encapsulated_response_ack(
             spdm_context, FALSE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_DELIVER_ENCAPSULATED_RESPONSE, response_size,
             response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->response_state !=
         SPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
         if (spdm_context->response_state ==
             SPDM_RESPONSE_STATE_NORMAL) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_SUCCESS;
         }
         return spdm_responder_handle_response_state(
             spdm_context,
@@ -486,20 +480,18 @@ return_status spdm_get_response_encapsulated_response_ack(
 
     if (request_size <=
         sizeof(spdm_deliver_encapsulated_response_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_request_size = request_size;
 
     if (spdm_request->header.param1 !=
         spdm_context->encap_context.request_id) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     encap_response = (spdm_request + 1);
@@ -523,10 +515,9 @@ return_status spdm_get_response_encapsulated_response_ack(
                  sizeof(spdm_encapsulated_response_ack_response_t);
     encap_request = spdm_response + 1;
     if (encap_response_size < sizeof(spdm_message_header_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -536,11 +527,10 @@ return_status spdm_get_response_encapsulated_response_ack(
         context, encap_response_size, encap_response,
         &encap_request_size, encap_request);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
             response_size, response);
         spdm_context->response_state = SPDM_RESPONSE_STATE_NORMAL;
-        return RETURN_SUCCESS;
     }
 
     *response_size = sizeof(spdm_encapsulated_response_ack_response_t) +

--- a/library/spdm_responder_lib/libspdm_rsp_end_session.c
+++ b/library/spdm_responder_lib/libspdm_rsp_end_session.c
@@ -46,40 +46,35 @@ return_status spdm_get_response_end_session(IN void *context,
     }
     if (spdm_context->connection_info.connection_state <
         SPDM_CONNECTION_STATE_NEGOTIATED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (!spdm_context->last_spdm_request_session_id_valid) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_info = libspdm_get_session_info_via_session_id(
         spdm_context, spdm_context->last_spdm_request_session_id);
     if (session_info == NULL) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_state = spdm_secured_message_get_session_state(
         session_info->secured_message_context);
     if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_end_session_request_t)) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, session_info,

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -28,18 +28,21 @@ return_status spdm_responder_handle_response_state(IN void *context,
                            OUT void *response)
 {
     spdm_context_t *spdm_context;
+    return_status status;
 
     spdm_context = context;
     switch (spdm_context->response_state) {
     case SPDM_RESPONSE_STATE_BUSY:
-        libspdm_generate_error_response(spdm_context, SPDM_ERROR_CODE_BUSY,
+        return libspdm_generate_error_response(spdm_context, SPDM_ERROR_CODE_BUSY,
                          0, response_size, response);
         // NOTE: Need to reset status to Normal in up level
-        return RETURN_SUCCESS;
     case SPDM_RESPONSE_STATE_NEED_RESYNC:
-        libspdm_generate_error_response(spdm_context,
+        status = libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_REQUEST_RESYNCH, 0,
                          response_size, response);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
         // NOTE: Need to let SPDM_VERSION reset the State
         spdm_set_connection_state(spdm_context,
                       SPDM_CONNECTION_STATE_NOT_STARTED);
@@ -57,19 +60,17 @@ return_status spdm_responder_handle_response_state(IN void *context,
             spdm_context->error_data.request_code = request_code;
             spdm_context->error_data.token = spdm_context->current_token++;
         }
-        libspdm_generate_extended_error_response(
+        return libspdm_generate_extended_error_response(
             spdm_context, SPDM_ERROR_CODE_RESPONSE_NOT_READY, 0,
             sizeof(spdm_error_data_response_not_ready_t),
             (uint8_t *)(void *)&spdm_context->error_data,
             response_size, response);
         // NOTE: Need to reset status to Normal in up level
-        return RETURN_SUCCESS;
     case SPDM_RESPONSE_STATE_PROCESSING_ENCAP:
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_REQUEST_IN_FLIGHT,
                          0, response_size, response);
         // NOTE: Need let SPDM_ENCAPSULATED_RESPONSE_ACK reset the State
-        return RETURN_SUCCESS;
     default:
         return RETURN_SUCCESS;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -48,47 +48,41 @@ return_status spdm_get_response_heartbeat(IN void *context,
             spdm_context, FALSE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->connection_info.connection_state <
         SPDM_CONNECTION_STATE_NEGOTIATED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (!spdm_context->last_spdm_request_session_id_valid) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_info = libspdm_get_session_info_via_session_id(
         spdm_context, spdm_context->last_spdm_request_session_id);
     if (session_info == NULL) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_state = spdm_secured_message_get_session_state(
         session_info->secured_message_context);
     if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_heartbeat_request_t)) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, session_info,

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -51,48 +51,42 @@ return_status spdm_get_response_key_update(IN void *context,
             spdm_context, FALSE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_KEY_UPDATE, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->connection_info.connection_state <
         SPDM_CONNECTION_STATE_NEGOTIATED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (!spdm_context->last_spdm_request_session_id_valid) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_id = spdm_context->last_spdm_request_session_id;
     session_info =
         libspdm_get_session_info_via_session_id(spdm_context, session_id);
     if (session_info == NULL) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     session_state = spdm_secured_message_get_session_state(
         session_info->secured_message_context);
     if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if (request_size != sizeof(spdm_key_update_request_t)) {
-        libspdm_generate_error_response(context,
+        return libspdm_generate_error_response(context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     prev_spdm_request = (spdm_key_update_request_t *) 
@@ -106,10 +100,9 @@ return_status spdm_get_response_key_update(IN void *context,
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY ||
                  prev_spdm_request->header.param1 ==
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-                libspdm_generate_error_response(context,
+                return libspdm_generate_error_response(context,
                                  SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                  response_size, response);
-                return RETURN_SUCCESS;
             }
 
             DEBUG((DEBUG_INFO,
@@ -127,10 +120,9 @@ return_status spdm_get_response_key_update(IN void *context,
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY ||
                  prev_spdm_request->header.param1 ==
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-                libspdm_generate_error_response(context,
+                return libspdm_generate_error_response(context,
                                  SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                  response_size, response);
-                return RETURN_SUCCESS;
             }
 
             DEBUG((DEBUG_INFO,
@@ -166,10 +158,9 @@ return_status spdm_get_response_key_update(IN void *context,
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY &&
                 prev_spdm_request->header.param1 !=
                       SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS) {
-                libspdm_generate_error_response(context,
+                return libspdm_generate_error_response(context,
                                  SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                  response_size, response);
-                return RETURN_SUCCESS;
             }
             DEBUG((DEBUG_INFO,
                    "spdm_activate_update_session_data_key[%x] Requester new\n",
@@ -183,10 +174,9 @@ return_status spdm_get_response_key_update(IN void *context,
             break;
         default:
             DEBUG((DEBUG_INFO, "espurious case\n"));
-            libspdm_generate_error_response(context,
+            return libspdm_generate_error_response(context,
                              SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                              response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -156,48 +156,43 @@ return_status spdm_get_response_measurements(IN void *context,
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, FALSE, 0,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_GET_MEASUREMENTS, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (!spdm_context->last_spdm_request_session_id_valid) {
         if (spdm_context->connection_info.connection_state <
             SPDM_CONNECTION_STATE_AUTHENTICATED) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_SUCCESS;
         }
         session_info = NULL;
     } else {
         if (spdm_context->connection_info.connection_state <
             SPDM_CONNECTION_STATE_NEGOTIATED) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_SUCCESS;
         }
         session_info = libspdm_get_session_info_via_session_id(
             spdm_context,
             spdm_context->last_spdm_request_session_id);
         if (session_info == NULL) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_SUCCESS;
         }
         session_state = spdm_secured_message_get_session_state(
             session_info->secured_message_context);
         if (session_state != SPDM_SESSION_STATE_ESTABLISHED) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
-            return RETURN_UNSUPPORTED;
         }
     }
 
@@ -207,32 +202,29 @@ return_status spdm_get_response_measurements(IN void *context,
                           SPDM_MESSAGE_VERSION_11)) {
             if (request_size <
                 sizeof(spdm_get_measurements_request_t)) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             request_size = sizeof(spdm_get_measurements_request_t);
         } else {
             if (request_size <
                 sizeof(spdm_get_measurements_request_t) -
                     sizeof(spdm_request->SlotIDParam)) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             request_size = sizeof(spdm_get_measurements_request_t) -
                        sizeof(spdm_request->SlotIDParam);
         }
     } else {
         if (request_size != sizeof(spdm_message_header_t)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
@@ -242,10 +234,9 @@ return_status spdm_get_response_measurements(IN void *context,
         if (!spdm_is_capabilities_flag_supported(
                 spdm_context, FALSE, 0,
                 SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
@@ -286,10 +277,9 @@ return_status spdm_get_response_measurements(IN void *context,
     if (measurements_size > spdm_response_size) {
         measurements_size -= spdm_response_size;
     } else {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED,
                          0, response_size, response);
-        return RETURN_BUFFER_TOO_SMALL;
     }
 
     measurements = (uint8_t*)response + sizeof(spdm_measurements_response_t);
@@ -307,16 +297,14 @@ return_status spdm_get_response_measurements(IN void *context,
     if (RETURN_ERROR(status)) {
 
         if (status == RETURN_NOT_FOUND) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
         else {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
@@ -417,11 +405,10 @@ return_status spdm_get_response_measurements(IN void *context,
             if ((slot_id_param != 0xF) &&
                 (slot_id_param >=
                  spdm_context->local_context.slot_count)) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
-                return RETURN_SUCCESS;
             }
             spdm_response->header.param2 = slot_id_param;
         }
@@ -439,10 +426,9 @@ return_status spdm_get_response_measurements(IN void *context,
             spdm_context, session_info, spdm_request,
             request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                         SPDM_ERROR_CODE_UNSPECIFIED, 0,
                         response_size, response);
-        return RETURN_SUCCESS;
     }
 
     if ((spdm_request->header.param1 &
@@ -453,13 +439,13 @@ return_status spdm_get_response_measurements(IN void *context,
             spdm_context, session_info, spdm_response,
             spdm_response_size);
         if (!ret) {
-            libspdm_generate_error_response(
+            status = libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNSPECIFIED,
                 SPDM_GET_MEASUREMENTS,
                 response_size, response);
             libspdm_reset_message_m(spdm_context, session_info);
-            return RETURN_SUCCESS;
+            return status;
         }
         //reset
         libspdm_reset_message_m(spdm_context, session_info);
@@ -467,11 +453,11 @@ return_status spdm_get_response_measurements(IN void *context,
         status = libspdm_append_message_m(spdm_context, session_info, spdm_response,
                            *response_size);
         if (RETURN_ERROR(status)) {
-            libspdm_generate_error_response(
+            status = libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
             libspdm_reset_message_m(spdm_context, session_info);
-            return RETURN_SUCCESS;
+            return status;
         }
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -66,17 +66,15 @@ return_status spdm_get_response_psk_exchange(IN void *context,
             spdm_context, FALSE,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_PSK_EXCHANGE, response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_context->connection_info.connection_state <
         SPDM_CONNECTION_STATE_NEGOTIATED) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                          0, response_size, response);
-        return RETURN_SUCCESS;
     }
 
     {
@@ -87,41 +85,37 @@ return_status spdm_get_response_psk_exchange(IN void *context,
             if (spdm_context->connection_info.algorithm
                     .measurement_spec !=
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
                     SPDM_PSK_EXCHANGE, response_size,
                     response);
-                return RETURN_SUCCESS;
             }
             algo_size = spdm_get_measurement_hash_size(
                 spdm_context->connection_info.algorithm
                     .measurement_hash_algo);
             if (algo_size == 0) {
-                libspdm_generate_error_response(
+                return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
                     SPDM_PSK_EXCHANGE, response_size,
                     response);
-                return RETURN_SUCCESS;
             }
         }
         algo_size = spdm_get_hash_size(
             spdm_context->connection_info.algorithm.base_hash_algo);
         if (algo_size == 0) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
                 SPDM_PSK_EXCHANGE, response_size, response);
-            return RETURN_SUCCESS;
         }
         if (spdm_context->connection_info.algorithm.key_schedule !=
             SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
                 SPDM_PSK_EXCHANGE, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
 
@@ -133,27 +127,24 @@ return_status spdm_get_response_psk_exchange(IN void *context,
             SPDM_STATUS_SUCCESS) {
             DEBUG((DEBUG_INFO,
                    "spdm_get_response_psk_exchange fail due to Mutual Auth fail\n"));
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
     }
     if (!spdm_is_capabilities_flag_supported(
             spdm_context, FALSE,
             0, SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) &&
             spdm_request->header.param1 > 0) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             SPDM_PSK_EXCHANGE, response_size, response);
-        return RETURN_SUCCESS;
     }
     slot_id = spdm_request->header.param2;
     if (slot_id >= spdm_context->local_context.slot_count) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     measurement_summary_hash_size = spdm_get_measurement_summary_hash_size(
@@ -162,19 +153,17 @@ return_status spdm_get_response_psk_exchange(IN void *context,
         spdm_context->connection_info.algorithm.base_hash_algo);
 
     if (request_size < sizeof(spdm_psk_exchange_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (request_size < sizeof(spdm_psk_exchange_request_t) +
                    spdm_request->psk_hint_length +
                    spdm_request->context_length +
                    spdm_request->opaque_length) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     request_size = sizeof(spdm_psk_exchange_request_t) +
                spdm_request->psk_hint_length +
@@ -186,10 +175,9 @@ return_status spdm_get_response_psk_exchange(IN void *context,
     status = spdm_process_opaque_data_supported_version_data(
         spdm_context, spdm_request->opaque_length, ptr);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     opaque_psk_exchange_rsp_size =
@@ -217,18 +205,16 @@ return_status spdm_get_response_psk_exchange(IN void *context,
     req_session_id = spdm_request->req_session_id;
     rsp_session_id = spdm_allocate_rsp_session_id(spdm_context);
     if (rsp_session_id == (INVALID_SESSION_ID & 0xFFFF)) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
     session_id = (req_session_id << 16) | rsp_session_id;
     session_info = libspdm_assign_session_id(spdm_context, session_id, TRUE);
     if (session_info == NULL) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_SESSION_LIMIT_EXCEEDED, 0,
             response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_reset_message_buffer_via_request_code(spdm_context, NULL,
@@ -266,10 +252,9 @@ return_status spdm_get_response_psk_exchange(IN void *context,
     }
     if (!result) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     ptr += measurement_summary_hash_size;
 
@@ -289,20 +274,18 @@ return_status spdm_get_response_psk_exchange(IN void *context,
     status = libspdm_append_message_k(spdm_context, session_info, FALSE, request, request_size);
     if (RETURN_ERROR(status)) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     
     status = libspdm_append_message_k(spdm_context, session_info, FALSE, spdm_response,
                        (uintn)ptr - (uintn)spdm_response);
     if (RETURN_ERROR(status)) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     DEBUG((DEBUG_INFO, "spdm_generate_session_handshake_key[%x]\n",
@@ -311,37 +294,33 @@ return_status spdm_get_response_psk_exchange(IN void *context,
                      th1_hash_data);
     if (RETURN_ERROR(status)) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     status = spdm_generate_session_handshake_key(
         session_info->secured_message_context, th1_hash_data);
     if (RETURN_ERROR(status)) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     result = spdm_generate_psk_exchange_rsp_hmac(spdm_context, session_info,
                              ptr);
     if (!result) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
             0, response_size, response);
-        return RETURN_SUCCESS;
     }
     status = libspdm_append_message_k(spdm_context, session_info, FALSE, ptr, hmac_size);
     if (RETURN_ERROR(status)) {
         libspdm_free_session_id(spdm_context, session_id);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     ptr += hmac_size;
 
@@ -358,18 +337,16 @@ return_status spdm_get_response_psk_exchange(IN void *context,
         status = libspdm_calculate_th2_hash(spdm_context, session_info,
                          FALSE, th2_hash_data);
         if (RETURN_ERROR(status)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
         status = spdm_generate_session_data_key(
             session_info->secured_message_context, th2_hash_data);
         if (RETURN_ERROR(status)) {
-            libspdm_generate_error_response(
+            return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
                 0, response_size, response);
-            return RETURN_SUCCESS;
         }
 
         spdm_set_session_state(spdm_context, session_id,

--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -45,40 +45,35 @@ return_status spdm_get_response_respond_if_ready(IN void *context,
     }
 
     if (request_size != sizeof(spdm_message_header_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     ASSERT(spdm_request->request_response_code == SPDM_RESPOND_IF_READY);
     if (spdm_request->param1 != spdm_context->error_data.request_code) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_request->param1 == SPDM_RESPOND_IF_READY) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (spdm_request->param2 != spdm_context->error_data.token) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     get_response_func = NULL;
     get_response_func =
         spdm_get_response_func_via_request_code(spdm_request->param1);
     if (get_response_func == NULL) {
-        libspdm_generate_error_response(
+        return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
             spdm_request->param1, response_size, response);
-        return RETURN_SUCCESS;
     }
     status = get_response_func(spdm_context,
                    spdm_context->cache_spdm_request_size,

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -50,16 +50,14 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
                   SPDM_CONNECTION_STATE_NOT_STARTED);
 
     if (spdm_request->header.spdm_version != SPDM_MESSAGE_VERSION_10) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if (request_size != sizeof(spdm_get_version_request_t)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
     if ((spdm_context->response_state == SPDM_RESPONSE_STATE_NEED_RESYNC) ||
         (spdm_context->response_state ==
@@ -87,10 +85,9 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
     status = libspdm_append_message_a(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     libspdm_reset_context(spdm_context);
@@ -122,10 +119,9 @@ return_status spdm_get_response_version(IN void *context, IN uintn request_size,
                        *response_size);
     if (RETURN_ERROR(status)) {
         libspdm_reset_message_a(spdm_context);
-        libspdm_generate_error_response(spdm_context,
+        return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_UNSPECIFIED, 0,
                          response_size, response);
-        return RETURN_SUCCESS;
     }
 
     spdm_set_connection_state(spdm_context,


### PR DESCRIPTION
Partially addresses #75.

Adds missing return status checks to functions defined in:
- include/library/spdm_common_lib.h
- include/library/spdm_device_secret_lib.h (none missing)
- include/library/spdm_requester_lib.h
- include/library/spdm_responder_lib.h

Also changes libspdm_free_session_id and libspdm_write_uint24 to no longer have return values - as there wasn't any usage of them, and doesn't seem like the return value was necessary (free functions typically don't return anything, write_uint24 return isn't needed).