### PR TITLE
Adding missing return value checks for cryptlib.h file.

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -277,8 +277,11 @@ void libspdm_set_last_spdm_error_struct(IN void *spdm_context,
   The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
+
+  @retval RETURN_SUCCESS       context is initialized.
+  @retval RETURN_DEVICE_ERROR  context initialization failed.
 */
-void libspdm_init_context(IN void *spdm_context);
+return_status libspdm_init_context(IN void *context);
 
 /**
   Reset an SPDM context.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1553,8 +1553,11 @@ void libspdm_set_last_spdm_error_struct(IN void *context,
   The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
 
   @param  spdm_context                  A pointer to the SPDM context.
+
+  @retval RETURN_SUCCESS       context is initialized.
+  @retval RETURN_DEVICE_ERROR  context initialization failed.
 */
-void libspdm_init_context(IN void *context)
+return_status libspdm_init_context(IN void *context)
 {
     spdm_context_t *spdm_context;
     void *secured_message_context;
@@ -1616,8 +1619,15 @@ void libspdm_init_context(IN void *context)
                 .secured_message_context);
     }
 
-    random_seed(NULL, 0);
-    return;
+    //
+    // The random_seed function may or may not be implemented.
+    // If unimplemented, the stub should always return success.
+    // 
+    if (!random_seed(NULL, 0)) {
+        return RETURN_DEVICE_ERROR;
+    }
+    
+    return RETURN_SUCCESS;
 }
 
 /**

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -547,10 +547,15 @@ boolean spdm_verify_peer_cert_chain_buffer(IN spdm_context_t *spdm_context,
             return FALSE;
         }
 
-        x509_get_cert_from_cert_chain(
+        result = x509_get_cert_from_cert_chain(
             (uint8_t *)cert_chain_buffer + sizeof(spdm_cert_chain_t) + root_cert_hash_size,
             cert_chain_buffer_size - sizeof(spdm_cert_chain_t) - root_cert_hash_size,
             0, &received_root_cert, &received_root_cert_size);
+        if (!result) {
+            DEBUG((DEBUG_INFO,
+                "!!! verify_peer_cert_chain_buffer - FAIL (cert retrieval fail) !!!\n"));
+            return FALSE;
+        }
         if (spdm_is_root_certificate(received_root_cert, received_root_cert_size)) {
             if (const_compare_mem(received_root_cert, root_cert, root_cert_size) != 0) {
                 DEBUG((DEBUG_INFO,

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -2702,6 +2702,7 @@ boolean spdm_is_root_certificate(IN const uint8_t *cert, IN uintn cert_size)
     uintn issuer_name_len;
     uint8_t subject_name[MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE];
     uintn subject_name_len;
+    boolean result;
 
     if (cert == NULL || cert_size == 0) {
         return FALSE;
@@ -2709,11 +2710,17 @@ boolean spdm_is_root_certificate(IN const uint8_t *cert, IN uintn cert_size)
 
     // 1. issuer_name
     issuer_name_len = MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
-    x509_get_issuer_name(cert, cert_size, issuer_name, &issuer_name_len);
+    result = x509_get_issuer_name(cert, cert_size, issuer_name, &issuer_name_len);
+    if (!result) {
+        return FALSE;
+    }
 
     // 2. subject_name
     subject_name_len = MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
-    x509_get_subject_name(cert, cert_size, subject_name, &subject_name_len);
+    result = x509_get_subject_name(cert, cert_size, subject_name, &subject_name_len);
+    if (!result) {
+        return FALSE;
+    }
 
     if (issuer_name_len != subject_name_len) {
         return FALSE;

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -30,8 +30,6 @@ void spdm_secured_message_init_context(IN void *spdm_secured_message_context)
     secured_message_context = spdm_secured_message_context;
     zero_mem(secured_message_context,
          sizeof(spdm_secured_message_context_t));
-
-    random_seed(NULL, 0);
 }
 
 /**

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -179,7 +179,11 @@ return_status spdm_encode_secured_message(
                      ->get_max_random_number_count();
         if (max_rand_count != 0) {
             rand_count = 0;
-            random_bytes((uint8_t *)&rand_count, sizeof(rand_count));
+            result = spdm_get_random_number(sizeof(rand_count),
+                (uint8_t *)&rand_count);
+            if (!result) {
+                return RETURN_DEVICE_ERROR;
+            }
             rand_count = (uint8_t)((rand_count % max_rand_count) + 1);
         } else {
             rand_count = 0;
@@ -212,11 +216,13 @@ return_status spdm_encode_secured_message(
         enc_msg_header->application_data_length =
             (uint16_t)app_message_size;
         copy_mem(enc_msg_header + 1, app_message, app_message_size);
-        random_bytes(
+        result = spdm_get_random_number(rand_count,
             (uint8_t *)enc_msg_header +
                 sizeof(spdm_secured_message_cipher_header_t) +
-                app_message_size,
-            rand_count);
+                app_message_size);
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
+        }
         zero_mem((uint8_t *)enc_msg_header + plain_text_size,
              aead_pad_size);
 

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -74,7 +74,12 @@ boolean random_bytes(OUT uint8_t *output, IN uintn size)
 
 int myrand(void *rng_state, unsigned char *output, size_t len)
 {
-    random_bytes(output, len);
+    boolean result = random_bytes(output, len);
 
-    return 0;
+    //
+    // The MbedTLS function f_rng, which myrand implements, is not
+    // documented well. From looking at code: zero is considered success,
+    // while non-zero return value is considered failure.
+    //
+    return result ? 0 : -1;
 }

--- a/os_stub/cryptlib_null/rand/rand.c
+++ b/os_stub/cryptlib_null/rand/rand.c
@@ -50,10 +50,3 @@ boolean random_bytes(OUT uint8_t *output, IN uintn size)
 {
     return TRUE;
 }
-
-int myrand(void *rng_state, unsigned char *output, size_t len)
-{
-    random_bytes(output, len);
-
-    return 0;
-}


### PR DESCRIPTION
Addresses #75 in part.

Additionally: 
- Modifies libspdm_init_context to have a return value. Required as it calls random_seed(), which can fail.
- Removes random_seed from spdm_secured_message_init_context - presuming this is OK as we already seed RNG in libspdm_init_context. If we need to seed everytime we init the secured message context - there is a very wide cascading effect of functions we need to modify to have return values.
- Changes some direct calls of random_bytes to spdm_get_random_number.

Signed-off-by: Timothy <tandrewprinz@nvidia.com>