### PR TITLE
Rename OPAQUE_CONTEXT_DATA to APP_CONTEXT_DATA.

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -345,9 +345,9 @@ typedef struct {
     uint8_t retry_times;
 
     //
-    // Opaque context data for use by application
+    // App context data for use by application
     //
-    void *opaque_context_data_ptr;
+    void *app_context_data_ptr;
 
     //
     // Register for the last KEY_UPDATE token and operation (responder only)

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -112,10 +112,10 @@ typedef enum {
     SPDM_DATA_SESSION_MUT_AUTH_REQUESTED,
     SPDM_DATA_SESSION_END_SESSION_ATTRIBUTES,
     //
-    // Opaque data that can be used by the application
+    // App context data that can be used by the application
     // during callback functions such libspdm_device_send_message_func.
     //
-    SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    SPDM_DATA_APP_CONTEXT_DATA,
     //
     // MAX
     //

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -391,11 +391,11 @@ return_status libspdm_set_data(IN void *context, IN spdm_data_type_t data_type,
         }
         session_info->end_session_attributes = *(uint8_t *)data;
         break;
-    case SPDM_DATA_OPAQUE_CONTEXT_DATA:
+    case SPDM_DATA_APP_CONTEXT_DATA:
         if (data_size != sizeof(void *) || *(void **)data == NULL) {
             return RETURN_INVALID_PARAMETER;
         }
-        spdm_context->opaque_context_data_ptr = *(void **)data;
+        spdm_context->app_context_data_ptr = *(void **)data;
         break;
     default:
         return RETURN_UNSUPPORTED;
@@ -578,9 +578,9 @@ return_status libspdm_get_data(IN void *context, IN spdm_data_type_t data_type,
         target_data_size = sizeof(uint8_t);
         target_data = &session_info->end_session_attributes;
         break;
-    case SPDM_DATA_OPAQUE_CONTEXT_DATA:
+    case SPDM_DATA_APP_CONTEXT_DATA:
         target_data_size = sizeof(void *);
-        target_data = &spdm_context->opaque_context_data_ptr;
+        target_data = &spdm_context->app_context_data_ptr;
         break;
     default:
         return RETURN_UNSUPPORTED;

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -26,12 +26,12 @@ static void test_spdm_common_context_data_case1(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
 
-    status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_set_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &data, sizeof(data));
     assert_int_equal(status, RETURN_SUCCESS);
 
     data_return_size = sizeof(return_data);
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &return_data, &data_return_size);
     assert_int_equal(status, RETURN_SUCCESS);
 
@@ -66,7 +66,7 @@ static void test_spdm_common_context_data_case2(void **state)
      * changed after a failed set data.
      */
     data_return_size = sizeof(current_return_data);
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &current_return_data, &data_return_size);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(data_return_size, sizeof(void*));
@@ -78,12 +78,12 @@ static void test_spdm_common_context_data_case2(void **state)
      * Set data with invalid size, it should fail. Read back to ensure that
      * no data was set.
      */
-    status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_set_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &data, 500);
     assert_int_equal(status, RETURN_INVALID_PARAMETER);
 
     data_return_size = sizeof(return_data);
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &return_data, &data_return_size);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_ptr_equal(return_data, current_return_data);
@@ -117,7 +117,7 @@ static void test_spdm_common_context_data_case3(void **state)
      * changed after a failed set data.
      */
     data_return_size = sizeof(current_return_data);
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &current_return_data, &data_return_size);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(data_return_size, sizeof(void*));
@@ -130,12 +130,12 @@ static void test_spdm_common_context_data_case3(void **state)
      * Set data with NULL data, it should fail. Read back to ensure that
      * no data was set.
      */
-    status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_set_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &data, sizeof(void *));
     assert_int_equal(status, RETURN_INVALID_PARAMETER);
 
     data_return_size = sizeof(return_data);
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &return_data, &data_return_size);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_ptr_equal(return_data, current_return_data);
@@ -166,7 +166,7 @@ static void test_spdm_common_context_data_case4(void **state)
     /*
      * Set data successfully.
      */
-    status = libspdm_set_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_set_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &data, sizeof(void *));
     assert_int_equal(status, RETURN_SUCCESS);
 
@@ -175,7 +175,7 @@ static void test_spdm_common_context_data_case4(void **state)
      * data size must return required buffer size.
      */
     data_return_size = 4;
-    status = libspdm_get_data(spdm_context, SPDM_DATA_OPAQUE_CONTEXT_DATA,
+    status = libspdm_get_data(spdm_context, SPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &return_data, &data_return_size);
     assert_int_equal(status, RETURN_BUFFER_TOO_SMALL);
     assert_int_equal(data_return_size, sizeof(void*));


### PR DESCRIPTION
Fix #274.

The reason is that "opaque" is used in SPDM spec with special meaning.
Here we just need a pointer for application, not related to opaque in SPDM spec.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>