### PR TITLE
[spdm_requester_lib] fixed potential buffer overflow

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -110,7 +110,7 @@ boolean spdm_negotiate_connection_version(IN OUT void *context, IN spdm_version_
         req_version = spdm_get_version_from_version_number(req_ver_set[req_index]);
         res_index = 0;
         res_version = spdm_get_version_from_version_number(res_ver_set[res_index]);
-        while (res_index < res_ver_num && res_version > req_version) {
+        while (res_index < res_ver_num - 1 && res_version > req_version) {
             res_index++;
             res_version = spdm_get_version_from_version_number(res_ver_set[res_index]);
         }


### PR DESCRIPTION
In function `spdm_negotiate_connection_version` there is a potential buffer overflow (line 115) where the indexing variable (`res_index`) is incremented before the array access.

This bug was found by ESBMC as a part of our work of applying formal verification to libspdm.