### PR TITLE
Fix test_spdm_responder_algorithms fuzzing test case issue.

### DIFF
--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
@@ -277,7 +277,27 @@ void test_spdm_responder_algorithms_case9(void **State)
 
     spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer, &response_size, response);
+}
 
+void test_spdm_responder_algorithms_case12(void **State)
+{
+    spdm_test_context_t *spdm_test_context;
+    spdm_context_t *spdm_context;
+    uintn response_size;
+    uint8_t response[MAX_SPDM_MESSAGE_BUFFER_SIZE];
+    response_size = sizeof(response);
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.connection_state = SPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->connection_info.version.major_version = 1;
+    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_use_key_schedule_algo;
     spdm_context->connection_info.algorithm.measurement_spec =
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
     spdm_context->connection_info.algorithm.measurement_hash_algo =


### PR DESCRIPTION
test_spdm_responder_algorithms_case9 call spdm_get_response_algorithms function twice, so divide it into two cases.
Fix: #394
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>