### PR TITLE
Additional return value checks fixed

### DIFF
--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -527,9 +527,9 @@ spdm_generate_session_data_key(IN void *spdm_secured_message_context,
                    IN uint8_t *th2_hash_data);
 
 typedef enum {
-    SPDM_KEY_UPDATE_ACTION_REQUESTER = 0x1,
-    SPDM_KEY_UPDATE_ACTION_RESPONDER = 0x2,
-    SPDM_KEY_UPDATE_ACTION_ALL = 0x3,
+    SPDM_KEY_UPDATE_ACTION_REQUESTER,
+    SPDM_KEY_UPDATE_ACTION_RESPONDER,
+    SPDM_KEY_UPDATE_ACTION_MAX,
 } spdm_key_update_action_t;
 
 /**

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -1152,7 +1152,7 @@ uint32_t spdm_get_asym_signature_size(IN uint32_t base_asym_algo)
 
   @return asymmetric GET_PUBLIC_KEY_FROM_X509 function
 **/
-asym_get_public_key_from_x509_func __attribute__((warn_unused_result))
+asym_get_public_key_from_x509_func
 get_spdm_asym_get_public_key_from_x509(IN uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
@@ -1432,7 +1432,7 @@ boolean spdm_asym_verify_hash(
 
   @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
 **/
-asym_get_private_key_from_pem_func __attribute__((warn_unused_result))
+asym_get_private_key_from_pem_func
 get_spdm_asym_get_private_key_from_pem(IN uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
@@ -1654,7 +1654,7 @@ uint32_t spdm_get_req_asym_signature_size(IN uint16_t req_base_asym_alg)
 
   @return requester asymmetric GET_PUBLIC_KEY_FROM_X509 function
 **/
-asym_get_public_key_from_x509_func __attribute__((warn_unused_result))
+asym_get_public_key_from_x509_func
 get_spdm_req_asym_get_public_key_from_x509(IN uint16_t req_base_asym_alg)
 {
     return get_spdm_asym_get_public_key_from_x509(req_base_asym_alg);
@@ -1842,7 +1842,7 @@ boolean spdm_req_asym_verify_hash(
 
   @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
 **/
-asym_get_private_key_from_pem_func __attribute__((warn_unused_result))
+asym_get_private_key_from_pem_func
 get_spdm_req_asym_get_private_key_from_pem(IN uint16_t req_base_asym_alg)
 {
     return get_spdm_asym_get_private_key_from_pem(req_base_asym_alg);
@@ -2852,7 +2852,7 @@ return_status spdm_get_dmtf_subject_alt_name_from_bytes(
                                    name_buffer_size parameter.
   @retval RETURN_UNSUPPORTED       The operation is not supported.
 **/
-return_status __attribute__((warn_unused_result))
+return_status
 spdm_get_dmtf_subject_alt_name(IN const uint8_t *cert, IN intn cert_size,
                    OUT char8 *name_buffer,
                    OPTIONAL IN OUT uintn *name_buffer_size,

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -1152,7 +1152,7 @@ uint32_t spdm_get_asym_signature_size(IN uint32_t base_asym_algo)
 
   @return asymmetric GET_PUBLIC_KEY_FROM_X509 function
 **/
-asym_get_public_key_from_x509_func
+asym_get_public_key_from_x509_func __attribute__((warn_unused_result))
 get_spdm_asym_get_public_key_from_x509(IN uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
@@ -1432,7 +1432,7 @@ boolean spdm_asym_verify_hash(
 
   @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
 **/
-asym_get_private_key_from_pem_func
+asym_get_private_key_from_pem_func __attribute__((warn_unused_result))
 get_spdm_asym_get_private_key_from_pem(IN uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
@@ -1654,7 +1654,7 @@ uint32_t spdm_get_req_asym_signature_size(IN uint16_t req_base_asym_alg)
 
   @return requester asymmetric GET_PUBLIC_KEY_FROM_X509 function
 **/
-asym_get_public_key_from_x509_func
+asym_get_public_key_from_x509_func __attribute__((warn_unused_result))
 get_spdm_req_asym_get_public_key_from_x509(IN uint16_t req_base_asym_alg)
 {
     return get_spdm_asym_get_public_key_from_x509(req_base_asym_alg);
@@ -1842,7 +1842,7 @@ boolean spdm_req_asym_verify_hash(
 
   @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
 **/
-asym_get_private_key_from_pem_func
+asym_get_private_key_from_pem_func __attribute__((warn_unused_result))
 get_spdm_req_asym_get_private_key_from_pem(IN uint16_t req_base_asym_alg)
 {
     return get_spdm_asym_get_private_key_from_pem(req_base_asym_alg);
@@ -2852,7 +2852,7 @@ return_status spdm_get_dmtf_subject_alt_name_from_bytes(
                                    name_buffer_size parameter.
   @retval RETURN_UNSUPPORTED       The operation is not supported.
 **/
-return_status
+return_status __attribute__((warn_unused_result))
 spdm_get_dmtf_subject_alt_name(IN const uint8_t *cert, IN intn cert_size,
                    OUT char8 *name_buffer,
                    OPTIONAL IN OUT uintn *name_buffer_size,
@@ -2998,6 +2998,8 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32_t base_hash_algo,
         result = spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
                 calc_root_cert_hash);
         if (!result) {
+            DEBUG((DEBUG_INFO,
+                "!!! VerifyCertificateChainBuffer - FAIL (hash calculation fail) !!!\n"));
             return FALSE;
         }
         if (const_compare_mem((uint8_t *)cert_chain_buffer + sizeof(spdm_cert_chain_t),

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -40,7 +40,6 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
     spdm_key_update_request_t spdm_request;
     spdm_key_update_response_mine_t spdm_response;
     uintn spdm_response_size;
-    spdm_key_update_action_t action;
     spdm_context_t *spdm_context;
     spdm_session_info_t *session_info;
     spdm_session_state_t session_state;
@@ -69,12 +68,6 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
         return RETURN_UNSUPPORTED;
     }
 
-    if (single_direction) {
-        action = SPDM_KEY_UPDATE_ACTION_REQUESTER;
-    } else {
-        action = SPDM_KEY_UPDATE_ACTION_ALL;
-    }
-
     spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
                                         SPDM_KEY_UPDATE);
 
@@ -97,8 +90,8 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             return RETURN_DEVICE_ERROR;
         }
 
-        // Create new key
-        if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+        // If updating both, create new responder key
+        if (!single_direction) {
             DEBUG((DEBUG_INFO,
                    "spdm_create_update_session_data_key[%x] Responder\n",
                    session_id));
@@ -123,7 +116,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
 
         if (RETURN_ERROR(status) ||
             spdm_response_size < sizeof(spdm_message_header_t)) {
-            if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+            if (!single_direction) {
                 DEBUG((DEBUG_INFO,
                        "spdm_activate_update_session_data_key[%x] Responder old\n",
                        session_id));
@@ -144,7 +137,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
                 SPDM_KEY_UPDATE, SPDM_KEY_UPDATE_ACK,
                 sizeof(spdm_key_update_response_mine_t));
             if (RETURN_ERROR(status)) {
-                if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+                if (!single_direction) {
                     DEBUG((DEBUG_INFO,
                            "spdm_activate_update_session_data_key[%x] Responder old\n",
                            session_id));
@@ -164,7 +157,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             SPDM_KEY_UPDATE_ACK) ||
             (spdm_response.header.param1 != spdm_request.header.param1) ||
             (spdm_response.header.param2 != spdm_request.header.param2)) {
-            if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+            if (!single_direction) {
                 DEBUG((DEBUG_INFO,
                        "spdm_activate_update_session_data_key[%x] Responder old\n",
                        session_id));
@@ -178,7 +171,7 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             return RETURN_DEVICE_ERROR;
         }
 
-        if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+        if (!single_direction) {
             DEBUG((DEBUG_INFO,
                    "spdm_activate_update_session_data_key[%x] Responder new\n",
                    session_id, SPDM_KEY_UPDATE_ACTION_RESPONDER));

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -306,29 +306,38 @@ spdm_generate_session_handshake_key(IN void *spdm_secured_message_context,
                hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    spdm_generate_finished_key(
+    status = spdm_generate_finished_key(
         secured_message_context,
         secured_message_context->handshake_secret
             .request_handshake_secret,
         secured_message_context->handshake_secret.request_finished_key);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
 
-    spdm_generate_finished_key(
+    status = spdm_generate_finished_key(
         secured_message_context,
         secured_message_context->handshake_secret
             .response_handshake_secret,
         secured_message_context->handshake_secret.response_finished_key);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
 
-    spdm_generate_aead_key_and_iv(secured_message_context,
+    status = spdm_generate_aead_key_and_iv(secured_message_context,
                       secured_message_context->handshake_secret
                           .request_handshake_secret,
                       secured_message_context->handshake_secret
                           .request_handshake_encryption_key,
                       secured_message_context->handshake_secret
                           .request_handshake_salt);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
     secured_message_context->handshake_secret
         .request_handshake_sequence_number = 0;
 
-    spdm_generate_aead_key_and_iv(
+    status = spdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->handshake_secret
             .response_handshake_secret,
@@ -336,12 +345,15 @@ spdm_generate_session_handshake_key(IN void *spdm_secured_message_context,
             .response_handshake_encryption_key,
         secured_message_context->handshake_secret
             .response_handshake_salt);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
     secured_message_context->handshake_secret
         .response_handshake_sequence_number = 0;
 
     zero_mem(secured_message_context->master_secret.dhe_secret,
         MAX_DHE_KEY_SIZE);
-    
+   
     secured_message_context->finished_key_ready = TRUE;
     return RETURN_SUCCESS;
 }
@@ -513,21 +525,27 @@ spdm_generate_session_data_key(IN void *spdm_secured_message_context,
         hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    spdm_generate_aead_key_and_iv(
+    status = spdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->application_secret.request_data_secret,
         secured_message_context->application_secret
             .request_data_encryption_key,
         secured_message_context->application_secret.request_data_salt);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
     secured_message_context->application_secret
         .request_data_sequence_number = 0;
 
-    spdm_generate_aead_key_and_iv(
+    status = spdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->application_secret.response_data_secret,
         secured_message_context->application_secret
             .response_data_encryption_key,
         secured_message_context->application_secret.response_data_salt);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
     secured_message_context->application_secret
         .response_data_sequence_number = 0;
 
@@ -562,6 +580,9 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                  NULL, (uint16_t)hash_size, hash_size, bin_str9,
                  &bin_str9_size);
     ASSERT_RETURN_ERROR(status);
+    if (RETURN_ERROR(status)) {
+        return status;
+    }
     DEBUG((DEBUG_INFO, "bin_str9 (0x%x):\n", bin_str9_size));
     internal_dump_hex(bin_str9, bin_str9_size);
 
@@ -595,6 +616,9 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                 .request_data_secret,
             hash_size);
         ASSERT(ret_val);
+        if (!ret_val) {
+            return RETURN_DEVICE_ERROR;
+        }
         DEBUG((DEBUG_INFO, "RequestDataSecretUpdate (0x%x) - ",
                hash_size));
         internal_dump_data(secured_message_context->application_secret
@@ -602,7 +626,7 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                    hash_size);
         DEBUG((DEBUG_INFO, "\n"));
 
-        spdm_generate_aead_key_and_iv(
+        status = spdm_generate_aead_key_and_iv(
             secured_message_context,
             secured_message_context->application_secret
                 .request_data_secret,
@@ -610,6 +634,9 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                 .request_data_encryption_key,
             secured_message_context->application_secret
                 .request_data_salt);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
         secured_message_context->application_secret
             .request_data_sequence_number = 0;
 
@@ -646,6 +673,9 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                 .response_data_secret,
             hash_size);
         ASSERT(ret_val);
+        if (!ret_val) {
+            return RETURN_DEVICE_ERROR;
+        }
         DEBUG((DEBUG_INFO, "ResponseDataSecretUpdate (0x%x) - ",
                hash_size));
         internal_dump_data(secured_message_context->application_secret
@@ -653,7 +683,7 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                    hash_size);
         DEBUG((DEBUG_INFO, "\n"));
 
-        spdm_generate_aead_key_and_iv(
+        status = spdm_generate_aead_key_and_iv(
             secured_message_context,
             secured_message_context->application_secret
                 .response_data_secret,
@@ -661,6 +691,9 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
                 .response_data_encryption_key,
             secured_message_context->application_secret
                 .response_data_salt);
+        if (RETURN_ERROR(status)) {
+            return status;
+        }
         secured_message_context->application_secret
             .response_data_sequence_number = 0;
 
@@ -857,7 +890,7 @@ boolean spdm_hmac_init_with_request_finished_key(
   @retval TRUE   HMAC context copy succeeded.
   @retval FALSE  HMAC context copy failed.
 **/
-boolean spdm_hmac_duplicate_with_request_finished_key(
+boolean  spdm_hmac_duplicate_with_request_finished_key(
     IN void *spdm_secured_message_context,
     IN const void *hmac_ctx, OUT void *new_hmac_ctx)
 {
@@ -880,7 +913,7 @@ boolean spdm_hmac_duplicate_with_request_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean spdm_hmac_update_with_request_finished_key(
+boolean  spdm_hmac_update_with_request_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx, IN const void *data,
     IN uintn data_size)
@@ -903,7 +936,7 @@ boolean spdm_hmac_update_with_request_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean spdm_hmac_final_with_request_finished_key(
+boolean  spdm_hmac_final_with_request_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx,  OUT uint8_t *hmac_value)
 {
@@ -982,7 +1015,7 @@ void spdm_hmac_free_with_response_finished_key(
   @retval TRUE   The key is set successfully.
   @retval FALSE  The key is set unsuccessfully.
 **/
-boolean spdm_hmac_init_with_response_finished_key(
+boolean  spdm_hmac_init_with_response_finished_key(
     IN void *spdm_secured_message_context, OUT void *hmac_ctx)
 {
     spdm_secured_message_context_t *secured_message_context;
@@ -1004,7 +1037,7 @@ boolean spdm_hmac_init_with_response_finished_key(
   @retval TRUE   HMAC context copy succeeded.
   @retval FALSE  HMAC context copy failed.
 **/
-boolean spdm_hmac_duplicate_with_response_finished_key(
+boolean  spdm_hmac_duplicate_with_response_finished_key(
     IN void *spdm_secured_message_context,
     IN const void *hmac_ctx, OUT void *new_hmac_ctx)
 {
@@ -1027,7 +1060,7 @@ boolean spdm_hmac_duplicate_with_response_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean spdm_hmac_update_with_response_finished_key(
+boolean  spdm_hmac_update_with_response_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx, IN const void *data,
     IN uintn data_size)
@@ -1050,7 +1083,7 @@ boolean spdm_hmac_update_with_response_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean spdm_hmac_final_with_response_finished_key(
+boolean  spdm_hmac_final_with_response_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx,  OUT uint8_t *hmac_value)
 {
@@ -1073,7 +1106,7 @@ boolean spdm_hmac_final_with_response_finished_key(
   @retval TRUE   HMAC computation succeeded.
   @retval FALSE  HMAC computation failed.
 **/
-boolean spdm_hmac_all_with_response_finished_key(
+boolean  spdm_hmac_all_with_response_finished_key(
     IN void *spdm_secured_message_context, IN const void *data,
     IN uintn data_size, OUT uint8_t *hmac_value)
 {

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -890,7 +890,7 @@ boolean spdm_hmac_init_with_request_finished_key(
   @retval TRUE   HMAC context copy succeeded.
   @retval FALSE  HMAC context copy failed.
 **/
-boolean  spdm_hmac_duplicate_with_request_finished_key(
+boolean spdm_hmac_duplicate_with_request_finished_key(
     IN void *spdm_secured_message_context,
     IN const void *hmac_ctx, OUT void *new_hmac_ctx)
 {
@@ -913,7 +913,7 @@ boolean  spdm_hmac_duplicate_with_request_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean  spdm_hmac_update_with_request_finished_key(
+boolean spdm_hmac_update_with_request_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx, IN const void *data,
     IN uintn data_size)
@@ -936,7 +936,7 @@ boolean  spdm_hmac_update_with_request_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean  spdm_hmac_final_with_request_finished_key(
+boolean spdm_hmac_final_with_request_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx,  OUT uint8_t *hmac_value)
 {
@@ -1015,7 +1015,7 @@ void spdm_hmac_free_with_response_finished_key(
   @retval TRUE   The key is set successfully.
   @retval FALSE  The key is set unsuccessfully.
 **/
-boolean  spdm_hmac_init_with_response_finished_key(
+boolean spdm_hmac_init_with_response_finished_key(
     IN void *spdm_secured_message_context, OUT void *hmac_ctx)
 {
     spdm_secured_message_context_t *secured_message_context;
@@ -1037,7 +1037,7 @@ boolean  spdm_hmac_init_with_response_finished_key(
   @retval TRUE   HMAC context copy succeeded.
   @retval FALSE  HMAC context copy failed.
 **/
-boolean  spdm_hmac_duplicate_with_response_finished_key(
+boolean spdm_hmac_duplicate_with_response_finished_key(
     IN void *spdm_secured_message_context,
     IN const void *hmac_ctx, OUT void *new_hmac_ctx)
 {
@@ -1060,7 +1060,7 @@ boolean  spdm_hmac_duplicate_with_response_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean  spdm_hmac_update_with_response_finished_key(
+boolean spdm_hmac_update_with_response_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx, IN const void *data,
     IN uintn data_size)
@@ -1083,7 +1083,7 @@ boolean  spdm_hmac_update_with_response_finished_key(
   @retval TRUE   HMAC data digest succeeded.
   @retval FALSE  HMAC data digest failed.
 **/
-boolean  spdm_hmac_final_with_response_finished_key(
+boolean spdm_hmac_final_with_response_finished_key(
     IN void *spdm_secured_message_context,
     OUT void *hmac_ctx,  OUT uint8_t *hmac_value)
 {
@@ -1106,7 +1106,7 @@ boolean  spdm_hmac_final_with_response_finished_key(
   @retval TRUE   HMAC computation succeeded.
   @retval FALSE  HMAC computation failed.
 **/
-boolean  spdm_hmac_all_with_response_finished_key(
+boolean spdm_hmac_all_with_response_finished_key(
     IN void *spdm_secured_message_context, IN const void *data,
     IN uintn data_size, OUT uint8_t *hmac_value)
 {

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -586,7 +586,7 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
     DEBUG((DEBUG_INFO, "bin_str9 (0x%x):\n", bin_str9_size));
     internal_dump_hex(bin_str9, bin_str9_size);
 
-    if ((action & SPDM_KEY_UPDATE_ACTION_REQUESTER) != 0) {
+    if (action == SPDM_KEY_UPDATE_ACTION_REQUESTER) {
         copy_mem(&secured_message_context->application_secret_backup
                   .request_data_secret,
              &secured_message_context->application_secret
@@ -641,9 +641,7 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
             .request_data_sequence_number = 0;
 
         secured_message_context->requester_backup_valid = TRUE;
-    }
-
-    if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+    } else if (action == SPDM_KEY_UPDATE_ACTION_RESPONDER) {
         copy_mem(&secured_message_context->application_secret_backup
                   .response_data_secret,
              &secured_message_context->application_secret
@@ -698,7 +696,10 @@ spdm_create_update_session_data_key(IN void *spdm_secured_message_context,
             .response_data_sequence_number = 0;
 
         secured_message_context->responder_backup_valid = TRUE;
+    } else {
+        return RETURN_INVALID_PARAMETER;
     }
+
     return RETURN_SUCCESS;
 }
 
@@ -741,7 +742,7 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
     secured_message_context = spdm_secured_message_context;
 
     if (!use_new_key) {
-        if (((action & SPDM_KEY_UPDATE_ACTION_REQUESTER) != 0) &&
+        if ((action == SPDM_KEY_UPDATE_ACTION_REQUESTER) &&
             secured_message_context->requester_backup_valid) {
             copy_mem(&secured_message_context->application_secret
                       .request_data_secret,
@@ -766,8 +767,7 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
                 secured_message_context
                     ->application_secret_backup
                     .request_data_sequence_number;
-        }
-        if (((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) &&
+        } else if ((action == SPDM_KEY_UPDATE_ACTION_RESPONDER) &&
             secured_message_context->responder_backup_valid) {
             copy_mem(&secured_message_context->application_secret
                       .response_data_secret,
@@ -795,7 +795,7 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
         }
     }
 
-    if ((action & SPDM_KEY_UPDATE_ACTION_REQUESTER) != 0) {
+    if (action == SPDM_KEY_UPDATE_ACTION_REQUESTER) {
         zero_mem(&secured_message_context->application_secret_backup
                   .request_data_secret,
              MAX_HASH_SIZE);
@@ -808,8 +808,7 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
         secured_message_context->application_secret_backup
             .request_data_sequence_number = 0;
         secured_message_context->requester_backup_valid = FALSE;
-    }
-    if ((action & SPDM_KEY_UPDATE_ACTION_RESPONDER) != 0) {
+    } else if (action == SPDM_KEY_UPDATE_ACTION_RESPONDER) {
         zero_mem(&secured_message_context->application_secret_backup
                   .response_data_secret,
              MAX_HASH_SIZE);
@@ -823,6 +822,7 @@ spdm_activate_update_session_data_key(IN void *spdm_secured_message_context,
             .response_data_sequence_number = 0;
         secured_message_context->responder_backup_valid = FALSE;
     }
+
     return RETURN_SUCCESS;
 }
 


### PR DESCRIPTION
Addresses #75 

The purpose of this PR was to fix any missing return value checks for functions that may not have declarations in header files. This is so that they were not overlooked when doing the large swaths of checking via adding __attribute__((warn_unused_result)) to every function declaration. This didn't catch many/any functions that were only defined internally, but did provide a few warnings for other functions declared in headers we haven't gotten do yet.

Also updates the spdm_create_update_session_data_key and spdm_activate_update_session_data_key to be single operation. With error checks, these could fail halfway and have halfway completed result, which is a pain to deal with. Changing to single operation at a time, to try and prevent.