### PR TITLE
Fixing missing return values for spdm_hash_all

### DIFF
--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -30,6 +30,7 @@ boolean libspdm_calculate_th_for_exchange(
     uint32_t hash_size;
     return_status status;
     large_managed_buffer_t th_curr;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -55,10 +56,13 @@ boolean libspdm_calculate_th_for_exchange(
     if (cert_chain_buffer != NULL) {
         DEBUG((DEBUG_INFO, "th_message_ct data :\n"));
         internal_dump_hex(cert_chain_buffer, cert_chain_buffer_size);
-        spdm_hash_all(
+        result = spdm_hash_all(
             spdm_context->connection_info.algorithm.base_hash_algo,
             cert_chain_buffer, cert_chain_buffer_size,
             cert_chain_buffer_hash);
+        if (!result) {
+            return FALSE;
+        }
         status = append_managed_buffer(&th_curr, cert_chain_buffer_hash,
                            hash_size);
         if (RETURN_ERROR(status)) {
@@ -212,6 +216,7 @@ boolean libspdm_calculate_th_for_finish(IN void *context,
     uint32_t hash_size;
     return_status status;
     large_managed_buffer_t th_curr;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -237,10 +242,13 @@ boolean libspdm_calculate_th_for_finish(IN void *context,
     if (cert_chain_buffer != NULL) {
         DEBUG((DEBUG_INFO, "th_message_ct data :\n"));
         internal_dump_hex(cert_chain_buffer, cert_chain_buffer_size);
-        spdm_hash_all(
+        result = spdm_hash_all(
             spdm_context->connection_info.algorithm.base_hash_algo,
             cert_chain_buffer, cert_chain_buffer_size,
             cert_chain_buffer_hash);
+        if (!result) {
+            return FALSE;
+        }
         status = append_managed_buffer(&th_curr, cert_chain_buffer_hash,
                            hash_size);
         if (RETURN_ERROR(status)) {
@@ -266,10 +274,13 @@ boolean libspdm_calculate_th_for_finish(IN void *context,
         DEBUG((DEBUG_INFO, "th_message_cm data :\n"));
         internal_dump_hex(mut_cert_chain_buffer,
                   mut_cert_chain_buffer_size);
-        spdm_hash_all(
+        result = spdm_hash_all(
             spdm_context->connection_info.algorithm.base_hash_algo,
             mut_cert_chain_buffer, mut_cert_chain_buffer_size,
             mut_cert_chain_buffer_hash);
+        if (!result) {
+            return FALSE;
+        }
         status = append_managed_buffer(&th_curr, mut_cert_chain_buffer_hash,
                            hash_size);
         if (RETURN_ERROR(status)) {
@@ -477,9 +488,14 @@ spdm_generate_key_exchange_rsp_signature(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    // debug only
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
-              th_curr_data, th_curr_data_size, hash_data);
+    // Debug code only - required for debug print of th_curr hash below
+    DEBUG_CODE(
+        if (!spdm_hash_all(
+                spdm_context->connection_info.algorithm.base_hash_algo,
+                th_curr_data, th_curr_data_size, hash_data)) {
+            return FALSE;
+        }
+    );
 #else
     result = libspdm_calculate_th_hash_for_exchange(
         spdm_context, session_info, &hash_size, hash_data);
@@ -621,9 +637,14 @@ boolean spdm_verify_key_exchange_rsp_signature(
         return FALSE;
     }
 
-    // debug only
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
-              th_curr_data, th_curr_data_size, hash_data);
+    // Debug code only - required for debug print of th_curr hash below
+    DEBUG_CODE(
+        if (!spdm_hash_all(
+                spdm_context->connection_info.algorithm.base_hash_algo,
+                th_curr_data, th_curr_data_size, hash_data)) {
+            return FALSE;
+        }
+    );
 #else
     result = libspdm_calculate_th_hash_for_exchange(
         spdm_context, session_info, &hash_size, hash_data);
@@ -810,9 +831,14 @@ boolean spdm_generate_finish_req_signature(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    // debug only
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
-              th_curr_data, th_curr_data_size, hash_data);
+    // Debug code only - required for debug print of th_curr below
+    DEBUG_CODE(
+        if (!spdm_hash_all(
+                spdm_context->connection_info.algorithm.base_hash_algo,
+                th_curr_data, th_curr_data_size, hash_data)) {
+            return FALSE;
+        }
+    );
 #else
     result = libspdm_calculate_th_hash_for_finish(
         spdm_context, session_info, &hash_size, hash_data);
@@ -981,9 +1007,14 @@ boolean spdm_verify_finish_req_signature(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    // debug only
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
-              th_curr_data, th_curr_data_size, hash_data);
+    // Debug code only - required for debug print of th_curr below
+    DEBUG_CODE(
+        if (!spdm_hash_all(
+                spdm_context->connection_info.algorithm.base_hash_algo,
+                th_curr_data, th_curr_data_size, hash_data)) {
+            return FALSE;
+        }
+    );
 #else
     result = libspdm_calculate_th_hash_for_finish(
         spdm_context, session_info, &hash_size, hash_data);
@@ -1577,8 +1608,11 @@ return_status libspdm_calculate_th1_hash(IN void *context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+    result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
               th_curr_data, th_curr_data_size, th1_hash_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hash_for_exchange(
         spdm_context, session_info, &hash_size, th1_hash_data);
@@ -1679,8 +1713,11 @@ return_status libspdm_calculate_th2_hash(IN void *context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
+    result = spdm_hash_all(spdm_context->connection_info.algorithm.base_hash_algo,
               th_curr_data, th_curr_data_size, th2_hash_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hash_for_finish(
         spdm_context, session_info, &hash_size, th2_hash_data);

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -2966,6 +2966,7 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32_t base_hash_algo,
     uint8_t calc_root_cert_hash[MAX_HASH_SIZE];
     uint8_t *leaf_cert_buffer;
     uintn leaf_cert_buffer_size;
+    boolean result;
 
     hash_size = spdm_get_hash_size(base_hash_algo);
 
@@ -2994,8 +2995,11 @@ boolean spdm_verify_certificate_chain_buffer(IN uint32_t base_hash_algo,
     }
 
     if (spdm_is_root_certificate(first_cert_buffer, first_cert_buffer_size)) {
-        spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
+        result = spdm_hash_all(base_hash_algo, first_cert_buffer, first_cert_buffer_size,
                 calc_root_cert_hash);
+        if (!result) {
+            return FALSE;
+        }
         if (const_compare_mem((uint8_t *)cert_chain_buffer + sizeof(spdm_cert_chain_t),
                 calc_root_cert_hash, hash_size) != 0) {
             DEBUG((DEBUG_INFO,

--- a/os_stub/spdm_device_secret_lib_sample/cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/cert.c
@@ -92,8 +92,13 @@ boolean read_responder_root_public_certificate(IN uint32_t base_hash_algo,
     cert_chain->length = (uint16_t)cert_chain_size;
     cert_chain->reserved = 0;
 
-    spdm_hash_all(base_hash_algo, file_data, file_size,
+    res = spdm_hash_all(base_hash_algo, file_data, file_size,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 
@@ -179,8 +184,13 @@ boolean read_requester_root_public_certificate(IN uint32_t base_hash_algo,
     }
     cert_chain->length = (uint16_t)cert_chain_size;
     cert_chain->reserved = 0;
-    spdm_hash_all(base_hash_algo, file_data, file_size,
+    res = spdm_hash_all(base_hash_algo, file_data, file_size,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 
@@ -284,8 +294,13 @@ boolean read_responder_public_certificate_chain(
         return res;
     }
 
-    spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+    res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 
@@ -389,8 +404,13 @@ boolean read_requester_public_certificate_chain(
         return res;
     }
 
-    spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+    res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 
@@ -461,8 +481,13 @@ boolean read_responder_root_public_certificate_by_size(
     cert_chain->length = (uint16_t)cert_chain_size;
     cert_chain->reserved = 0;
 
-    spdm_hash_all(base_hash_algo, file_data, file_size,
+    res = spdm_hash_all(base_hash_algo, file_data, file_size,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 
@@ -553,8 +578,13 @@ boolean read_responder_public_certificate_chain_by_size(
         return res;
     }
 
-    spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
+    res = spdm_hash_all(base_hash_algo, root_cert, root_cert_len,
               (uint8_t *)(cert_chain + 1));
+    if (!res) {
+        free(file_data);
+        free(cert_chain);
+        return res;
+    }
     copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
          file_data, file_size);
 

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -140,6 +140,7 @@ return_status spdm_measurement_collection(
     uint8_t index;
     uint8_t data[MEASUREMENT_MANIFEST_SIZE];
     uintn total_size_needed;
+    boolean result;
 
     ASSERT(measurement_specification ==
            SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF);
@@ -210,10 +211,13 @@ return_status spdm_measurement_collection(
                     (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                          (uint16_t)hash_size);
 
-                spdm_measurement_hash_all(
+                result = spdm_measurement_hash_all(
                     measurement_hash_algo, data,
                     sizeof(data),
                     (void *)(measurement_block + 1));
+                if (!result) {
+                    return RETURN_DEVICE_ERROR;
+                }
 
                 measurement_block =
                     (void *)((uint8_t *)measurement_block +
@@ -296,10 +300,12 @@ return_status spdm_measurement_collection(
                      (uint16_t)hash_size);
 
             // Hash directly to buffer after measurement block.
-            spdm_measurement_hash_all(
+            result = spdm_measurement_hash_all(
                 measurement_hash_algo, data, sizeof(data),
                 (void *)(measurement_block + 1));
-
+            if (!result) {
+                return RETURN_DEVICE_ERROR;
+            }
         } else {
             measurement_block->Measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_type =
@@ -356,6 +362,7 @@ boolean spdm_generate_measurement_summary_hash(
     uint8_t device_measurement_count;
     uintn device_measurement_size;
     return_status status;
+    boolean result;
 
     switch (measurement_summary_hash_type) {
     case SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH:
@@ -450,8 +457,11 @@ boolean spdm_generate_measurement_summary_hash(
                      measurment_block_size);
         }
 
-        spdm_hash_all(base_hash_algo, measurement_data,
+        result = spdm_hash_all(base_hash_algo, measurement_data,
                   measurment_data_size, measurement_summary_hash);
+        if (!result) {
+            return FALSE;
+        }
         break;
     default:
         return FALSE;


### PR DESCRIPTION
Addresses #75

Fixes missing return values for spdm_hash_all. For certain usages of spdm_hash_all, which were only meant for debug code, gated the usage behind DEBUG_CODE macro to ensure the functions wouldn't be called in Release builds.

Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>