### PR TITLE
Fixing return values for most spdm_hash* and spdm_hmac* functions

### DIFF
--- a/library/spdm_common_lib/CMakeLists.txt
+++ b/library/spdm_common_lib/CMakeLists.txt
@@ -5,7 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
 )
 
 SET(src_spdm_common_lib
-    #libspdm_com_context_data.c
+    libspdm_com_context_data.c
     libspdm_com_context_data_session.c
     libspdm_com_crypto_service.c
     libspdm_com_crypto_service_session.c

--- a/library/spdm_common_lib/CMakeLists.txt
+++ b/library/spdm_common_lib/CMakeLists.txt
@@ -5,7 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
 )
 
 SET(src_spdm_common_lib
-    libspdm_com_context_data.c
+    #libspdm_com_context_data.c
     libspdm_com_context_data_session.c
     libspdm_com_crypto_service.c
     libspdm_com_crypto_service_session.c

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -928,19 +928,43 @@ return_status libspdm_append_message_b(IN void *context, IN void *message,
     return append_managed_buffer(&spdm_context->transcript.message_b,
                      message, message_size);
 #else
-    if (spdm_context->transcript.digest_context_m1m2 == NULL) {
-        spdm_context->transcript.digest_context_m1m2 = spdm_hash_new (
-            spdm_context->connection_info.algorithm.base_hash_algo);
-        spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_m1m2);
-        spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_m1m2,
-            get_managed_buffer(&spdm_context->transcript.message_a),
-            get_managed_buffer_size(&spdm_context->transcript.message_a));
+    {
+        boolean result;
+
+        if (spdm_context->transcript.digest_context_m1m2 == NULL) {
+            spdm_context->transcript.digest_context_m1m2 = spdm_hash_new (
+                spdm_context->connection_info.algorithm.base_hash_algo);
+            if (spdm_context->transcript.digest_context_m1m2 == NULL) {
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_m1m2);
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_m1m2);
+                spdm_context->transcript.digest_context_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_m1m2,
+                get_managed_buffer(&spdm_context->transcript.message_a),
+                get_managed_buffer_size(&spdm_context->transcript.message_a));
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_m1m2);
+                spdm_context->transcript.digest_context_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+        }
+
+        result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->transcript.digest_context_m1m2, message, message_size);
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
+        }
+
+        return RETURN_SUCCESS;
     }
-    return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-        spdm_context->transcript.digest_context_m1m2, message, message_size) ?
-        RETURN_SUCCESS : RETURN_DEVICE_ERROR;
 #endif
 }
 
@@ -964,19 +988,43 @@ return_status libspdm_append_message_c(IN void *context, IN void *message,
     return append_managed_buffer(&spdm_context->transcript.message_c,
                      message, message_size);
 #else
-    if (spdm_context->transcript.digest_context_m1m2 == NULL) {
-        spdm_context->transcript.digest_context_m1m2 = spdm_hash_new (
-            spdm_context->connection_info.algorithm.base_hash_algo);
-        spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_m1m2);
-        spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_m1m2,
-            get_managed_buffer(&spdm_context->transcript.message_a),
-            get_managed_buffer_size(&spdm_context->transcript.message_a));
+    {
+        boolean result;
+
+        if (spdm_context->transcript.digest_context_m1m2 == NULL) {
+            spdm_context->transcript.digest_context_m1m2 = spdm_hash_new (
+                spdm_context->connection_info.algorithm.base_hash_algo);
+            if (spdm_context->transcript.digest_context_m1m2 == NULL) {
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_m1m2);
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_m1m2);
+                spdm_context->transcript.digest_context_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_m1m2,
+                get_managed_buffer(&spdm_context->transcript.message_a),
+                get_managed_buffer_size(&spdm_context->transcript.message_a));
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_m1m2);
+                spdm_context->transcript.digest_context_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+        }
+
+        result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->transcript.digest_context_m1m2, message, message_size);
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
+        }
+
+        return RETURN_SUCCESS;
     }
-    return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-        spdm_context->transcript.digest_context_m1m2, message, message_size) ?
-        RETURN_SUCCESS : RETURN_DEVICE_ERROR;
 #endif
 }
 
@@ -1000,15 +1048,33 @@ return_status libspdm_append_message_mut_b(IN void *context, IN void *message,
     return append_managed_buffer(&spdm_context->transcript.message_mut_b,
                      message, message_size);
 #else
-    if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
-        spdm_context->transcript.digest_context_mut_m1m2 = spdm_hash_new (
-            spdm_context->connection_info.algorithm.base_hash_algo);
-        spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_mut_m1m2);
+    {
+        boolean result;
+
+        if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
+            spdm_context->transcript.digest_context_mut_m1m2 = spdm_hash_new (
+                spdm_context->connection_info.algorithm.base_hash_algo);
+            if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_mut_m1m2);
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_mut_m1m2);
+                spdm_context->transcript.digest_context_mut_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+        }
+
+        result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->transcript.digest_context_mut_m1m2, message, message_size);
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
+        }
+
+        return RETURN_SUCCESS;
     }
-    return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-        spdm_context->transcript.digest_context_mut_m1m2, message, message_size) ?
-        RETURN_SUCCESS : RETURN_DEVICE_ERROR;
 #endif
 }
 
@@ -1032,15 +1098,33 @@ return_status libspdm_append_message_mut_c(IN void *context, IN void *message,
     return append_managed_buffer(&spdm_context->transcript.message_mut_c,
                      message, message_size);
 #else
-    if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
-        spdm_context->transcript.digest_context_mut_m1m2 = spdm_hash_new (
-            spdm_context->connection_info.algorithm.base_hash_algo);
-        spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_mut_m1m2);
+    {
+        boolean result;
+
+        if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
+            spdm_context->transcript.digest_context_mut_m1m2 = spdm_hash_new (
+                spdm_context->connection_info.algorithm.base_hash_algo);
+            if (spdm_context->transcript.digest_context_mut_m1m2 == NULL) {
+                return RETURN_DEVICE_ERROR;
+            }
+            result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_mut_m1m2);
+            if (!result) {
+                spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_mut_m1m2);
+                spdm_context->transcript.digest_context_mut_m1m2 = NULL;
+                return RETURN_DEVICE_ERROR;
+            }
+        }
+
+        result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->transcript.digest_context_mut_m1m2, message, message_size);
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
+        }
+
+        return RETURN_SUCCESS;
     }
-    return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-        spdm_context->transcript.digest_context_mut_m1m2, message, message_size) ?
-        RETURN_SUCCESS : RETURN_DEVICE_ERROR;
 #endif
 }
 
@@ -1074,26 +1158,54 @@ return_status libspdm_append_message_m(IN void *context, IN void *session_info,
                                 message, message_size);
     }
 #else
-    if (spdm_session_info == NULL) {
-        if (spdm_context->transcript.digest_context_l1l2 == NULL) {
-            spdm_context->transcript.digest_context_l1l2 = spdm_hash_new (
-                spdm_context->connection_info.algorithm.base_hash_algo);
-            spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-                spdm_context->transcript.digest_context_l1l2);
+    {
+        boolean result;
+
+        if (spdm_session_info == NULL) {
+            if (spdm_context->transcript.digest_context_l1l2 == NULL) {
+                spdm_context->transcript.digest_context_l1l2 = spdm_hash_new (
+                    spdm_context->connection_info.algorithm.base_hash_algo);
+                if (spdm_context->transcript.digest_context_l1l2 == NULL) {
+                    return RETURN_DEVICE_ERROR;
+                }
+                result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_context->transcript.digest_context_l1l2);
+                if (!result) {
+                    spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                        spdm_context->transcript.digest_context_l1l2);
+                    spdm_context->transcript.digest_context_l1l2 = NULL;
+                    return RETURN_DEVICE_ERROR;
+                }
+            }
+            
+            result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_context->transcript.digest_context_l1l2, message, message_size);
+        } else {
+            if (spdm_session_info->session_transcript.digest_context_l1l2 == NULL) {
+                spdm_session_info->session_transcript.digest_context_l1l2 = spdm_hash_new (
+                    spdm_context->connection_info.algorithm.base_hash_algo);
+                if (spdm_session_info->session_transcript.digest_context_l1l2 == NULL) {
+                    return RETURN_DEVICE_ERROR;
+                }
+                result = spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
+                    spdm_session_info->session_transcript.digest_context_l1l2);
+                if (!result) {
+                    spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                        spdm_session_info->session_transcript.digest_context_l1l2);
+                    spdm_session_info->session_transcript.digest_context_l1l2 = NULL;
+                    return RETURN_DEVICE_ERROR;
+                }
+            }
+            
+            result = spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
+                spdm_session_info->session_transcript.digest_context_l1l2, message, message_size);
         }
-        return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_context->transcript.digest_context_l1l2, message, message_size) ?
-            RETURN_SUCCESS : RETURN_DEVICE_ERROR;
-    } else {
-        if (spdm_session_info->session_transcript.digest_context_l1l2 == NULL) {
-            spdm_session_info->session_transcript.digest_context_l1l2 = spdm_hash_new (
-                spdm_context->connection_info.algorithm.base_hash_algo);
-            spdm_hash_init (spdm_context->connection_info.algorithm.base_hash_algo,
-                spdm_session_info->session_transcript.digest_context_l1l2);
+
+        if (!result) {
+            return RETURN_DEVICE_ERROR;
         }
-        return spdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
-            spdm_session_info->session_transcript.digest_context_l1l2, message, message_size) ?
-            RETURN_SUCCESS : RETURN_DEVICE_ERROR;
+
+        return RETURN_SUCCESS;
     }
 #endif
 }
@@ -1149,10 +1261,13 @@ return_status libspdm_append_message_k(IN void *context, IN void *session_info,
                 }
                 hash_size = spdm_get_hash_size(
                     spdm_context->connection_info.algorithm.base_hash_algo);
-                spdm_hash_all(
+                result = spdm_hash_all(
                     spdm_context->connection_info.algorithm.base_hash_algo,
                     cert_chain_buffer, cert_chain_buffer_size,
                     cert_chain_buffer_hash);
+                if (!result) {
+                    return FALSE;
+                }
             }
         }
 
@@ -1312,10 +1427,13 @@ return_status libspdm_append_message_f(IN void *context, IN void *session_info,
 
                 hash_size = spdm_get_hash_size(
                     spdm_context->connection_info.algorithm.base_hash_algo);
-                spdm_hash_all(
+                result = spdm_hash_all(
                     spdm_context->connection_info.algorithm.base_hash_algo,
                     mut_cert_chain_buffer, mut_cert_chain_buffer_size,
                     mut_cert_chain_buffer_hash);
+                if (!result) {
+                    return RETURN_DEVICE_ERROR;
+                }
             }
 
             //

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -297,6 +297,7 @@ boolean spdm_calculate_m1m2_hash(IN void *context, IN boolean is_mut,
 {
     spdm_context_t *spdm_context;
     uint32_t hash_size;
+    boolean result;
 
     spdm_context = context;
 
@@ -304,15 +305,21 @@ boolean spdm_calculate_m1m2_hash(IN void *context, IN boolean is_mut,
         spdm_context->connection_info.algorithm.base_hash_algo);
 
     if (is_mut) {
-        spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+        result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_context->transcript.digest_context_mut_m1m2, m1m2_hash);
+        if (!result) {
+            return FALSE;
+        }
         DEBUG((DEBUG_INFO, "m1m2 Mut hash - "));
         internal_dump_data(m1m2_hash, hash_size);
         DEBUG((DEBUG_INFO, "\n"));
 
     } else {
-        spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+        result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_context->transcript.digest_context_m1m2, m1m2_hash);
+        if (!result) {
+            return FALSE;
+        }
         DEBUG((DEBUG_INFO, "m1m2 hash - "));
         internal_dump_data(m1m2_hash, hash_size);
         DEBUG((DEBUG_INFO, "\n"));
@@ -401,6 +408,7 @@ boolean spdm_calculate_l1l2_hash(IN void *context, IN void *session_info,
 {
     spdm_context_t *spdm_context;
     spdm_session_info_t *spdm_session_info;
+    boolean result;
 
     uint32_t hash_size;
 
@@ -411,12 +419,15 @@ boolean spdm_calculate_l1l2_hash(IN void *context, IN void *session_info,
         spdm_context->connection_info.algorithm.base_hash_algo);
 
     if (spdm_session_info == NULL) {
-        spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+        result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_context->transcript.digest_context_l1l2, l1l2_hash);
     } else {
         DEBUG((DEBUG_INFO, "use message_m in session :\n"));
-        spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+        result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_session_info->session_transcript.digest_context_l1l2, l1l2_hash);
+    }
+    if (!result) {
+        return FALSE;
     }
     DEBUG((DEBUG_INFO, "l1l2 hash - "));
     internal_dump_data(l1l2_hash, hash_size);

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -109,6 +109,7 @@ boolean libspdm_calculate_th_hash_for_exchange(
     spdm_session_info_t *session_info;
     uint32_t hash_size;
     void *digest_context_th;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -121,11 +122,21 @@ boolean libspdm_calculate_th_hash_for_exchange(
     // duplicate the th context, because we still need use original context to continue.
     digest_context_th = spdm_hash_new (
         spdm_context->connection_info.algorithm.base_hash_algo);
-    spdm_hash_duplicate (spdm_context->connection_info.algorithm.base_hash_algo,
+    if (digest_context_th == NULL) {
+        return FALSE;
+    }
+    result = spdm_hash_duplicate (spdm_context->connection_info.algorithm.base_hash_algo,
         session_info->session_transcript.digest_context_th, digest_context_th);
-    spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+    if (!result) {
+        spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo, digest_context_th);
+        return FALSE;
+    }
+    result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
         digest_context_th, th_hash_buffer);
     spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo, digest_context_th);
+    if (!result) {
+        return FALSE;
+    }
 
     *th_hash_buffer_size = hash_size;
 
@@ -152,6 +163,7 @@ boolean libspdm_calculate_th_hmac_for_exchange_rsp(
     uint32_t hash_size;
     void *hmac_context_th;
     return_status status;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -173,11 +185,21 @@ boolean libspdm_calculate_th_hmac_for_exchange_rsp(
 
     // duplicate the th context, because we still need use original context to continue.
     hmac_context_th = spdm_hmac_new_with_response_finished_key (secured_message_context);
-    spdm_hmac_duplicate_with_response_finished_key (secured_message_context,
+    if (hmac_context_th == NULL) {
+        return FALSE;
+    }
+    result = spdm_hmac_duplicate_with_response_finished_key (secured_message_context,
         session_info->session_transcript.hmac_rsp_context_th, hmac_context_th);
-    spdm_hmac_final_with_response_finished_key (secured_message_context,
+    if (!result) {
+        spdm_hmac_free_with_response_finished_key (secured_message_context, hmac_context_th);
+        return FALSE;
+    }
+    result = spdm_hmac_final_with_response_finished_key (secured_message_context,
         hmac_context_th, th_hmac_buffer);
     spdm_hmac_free_with_response_finished_key (secured_message_context, hmac_context_th);
+    if (!result) {
+        return FALSE;
+    }
 
     *th_hmac_buffer_size = hash_size;
 
@@ -328,6 +350,7 @@ boolean libspdm_calculate_th_hash_for_finish(IN void *context,
     spdm_session_info_t *session_info;
     uint32_t hash_size;
     void *digest_context_th;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -340,11 +363,21 @@ boolean libspdm_calculate_th_hash_for_finish(IN void *context,
     // duplicate the th context, because we still need use original context to continue.
     digest_context_th = spdm_hash_new (
         spdm_context->connection_info.algorithm.base_hash_algo);
-    spdm_hash_duplicate (spdm_context->connection_info.algorithm.base_hash_algo,
+    if (digest_context_th == NULL) {
+        return FALSE;
+    }
+    result = spdm_hash_duplicate (spdm_context->connection_info.algorithm.base_hash_algo,
         session_info->session_transcript.digest_context_th, digest_context_th);
-    spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
+    if (!result) {
+        spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo, digest_context_th);
+        return FALSE;
+    }
+    result = spdm_hash_final (spdm_context->connection_info.algorithm.base_hash_algo,
         digest_context_th, th_hash_buffer);
     spdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo, digest_context_th);
+    if (!result) {
+        return FALSE;
+    }
 
     *th_hash_buffer_size = hash_size;
 
@@ -371,6 +404,7 @@ boolean libspdm_calculate_th_hmac_for_finish_rsp(IN void *context,
     void *secured_message_context;
     uint32_t hash_size;
     void *hmac_context_th;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -385,11 +419,21 @@ boolean libspdm_calculate_th_hmac_for_finish_rsp(IN void *context,
 
     // duplicate the th context, because we still need use original context to continue.
     hmac_context_th = spdm_hmac_new_with_response_finished_key (secured_message_context);
-    spdm_hmac_duplicate_with_response_finished_key (secured_message_context,
+    if (hmac_context_th == NULL) {
+        return FALSE;
+    }
+    result = spdm_hmac_duplicate_with_response_finished_key (secured_message_context,
         session_info->session_transcript.hmac_rsp_context_th, hmac_context_th);
-    spdm_hmac_final_with_response_finished_key (secured_message_context,
+    if (!result) {
+        spdm_hmac_free_with_response_finished_key (secured_message_context, hmac_context_th);
+        return FALSE;
+    }
+    result = spdm_hmac_final_with_response_finished_key (secured_message_context,
         hmac_context_th, th_hmac_buffer);
     spdm_hmac_free_with_response_finished_key (secured_message_context, hmac_context_th);
+    if (!result) {
+        return FALSE;
+    }
 
     *th_hmac_buffer_size = hash_size;
 
@@ -416,6 +460,7 @@ boolean libspdm_calculate_th_hmac_for_finish_req(IN void *context,
     void *secured_message_context;
     uint32_t hash_size;
     void *hmac_context_th;
+    boolean result;
 
     spdm_context = context;
     session_info = spdm_session_info;
@@ -430,11 +475,21 @@ boolean libspdm_calculate_th_hmac_for_finish_req(IN void *context,
 
     // duplicate the th context, because we still need use original context to continue.
     hmac_context_th = spdm_hmac_new_with_request_finished_key (secured_message_context);
-    spdm_hmac_duplicate_with_request_finished_key (secured_message_context,
+    if (hmac_context_th == NULL) {
+        return FALSE;
+    }
+    result = spdm_hmac_duplicate_with_request_finished_key (secured_message_context,
         session_info->session_transcript.hmac_req_context_th, hmac_context_th);
-    spdm_hmac_final_with_request_finished_key (secured_message_context,
+    if (!result) {
+        spdm_hmac_free_with_request_finished_key (secured_message_context, hmac_context_th);
+        return FALSE;
+    }
+    result = spdm_hmac_final_with_request_finished_key (secured_message_context,
         hmac_context_th, th_hmac_buffer);
     spdm_hmac_free_with_request_finished_key (secured_message_context, hmac_context_th);
+    if (!result) {
+        return FALSE;
+    }
 
     *th_hmac_buffer_size = hash_size;
 
@@ -571,9 +626,12 @@ spdm_generate_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_exchange_rsp(
         spdm_context, session_info, FALSE, &hash_size, hmac_data);
@@ -752,9 +810,12 @@ boolean spdm_verify_key_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, calc_hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_exchange_rsp(
         spdm_context, session_info, TRUE, &hash_size, calc_hmac_data);
@@ -929,9 +990,12 @@ boolean spdm_generate_finish_req_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_request_finished_key(
+    result = spdm_hmac_all_with_request_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, calc_hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_req(
         spdm_context, session_info, &hash_size, calc_hmac_data);
@@ -1138,9 +1202,12 @@ boolean spdm_verify_finish_req_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_request_finished_key(
+    result = spdm_hmac_all_with_request_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_req(
         spdm_context, session_info, &hash_size, hmac_data);
@@ -1217,9 +1284,12 @@ boolean spdm_generate_finish_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_rsp(
         spdm_context, session_info, &hash_size, hmac_data);
@@ -1295,9 +1365,12 @@ boolean spdm_verify_finish_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, calc_hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_rsp(
         spdm_context, session_info, &hash_size, calc_hmac_data);
@@ -1353,9 +1426,12 @@ spdm_generate_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_exchange_rsp(
         spdm_context, session_info, FALSE, &hash_size, hmac_data);
@@ -1409,9 +1485,12 @@ boolean spdm_verify_psk_exchange_rsp_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_response_finished_key(
+    result = spdm_hmac_all_with_response_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, calc_hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_exchange_rsp(
         spdm_context, session_info, TRUE, &hash_size, calc_hmac_data);
@@ -1468,9 +1547,12 @@ spdm_generate_psk_exchange_req_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_request_finished_key(
+    result = spdm_hmac_all_with_request_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, calc_hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_req(
         spdm_context, session_info, &hash_size, calc_hmac_data);
@@ -1523,9 +1605,12 @@ boolean spdm_verify_psk_finish_req_hmac(IN spdm_context_t *spdm_context,
         return FALSE;
     }
 
-    spdm_hmac_all_with_request_finished_key(
+    result = spdm_hmac_all_with_request_finished_key(
         session_info->secured_message_context, th_curr_data,
         th_curr_data_size, hmac_data);
+    if (!result) {
+        return FALSE;
+    }
 #else
     result = libspdm_calculate_th_hmac_for_finish_req(
         spdm_context, session_info, &hash_size, hmac_data);


### PR DESCRIPTION
Addresses #75.

Addresses most remaining functions - these functions use allocated contexts heavily, so have to be more careful when checking for and handling error, so that we do not unintentionally disrupt state.

Note: I did NOT address the libspdm_append_message_k and libspdm_append_message_f buffers yet. These functions are not written in a way to handle errors gracefully. If we fail at any point during these functions, the message hashes and buffers can enter an unrecoverable state. The changes required to gracefully handle this error would need close care when reviewing, and so I will defer it to a later PR. This probably deserves its own issue.


Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>