### PR TITLE
Remove unnecessary assert for request_response_code

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -50,7 +50,6 @@ return_status spdm_get_response_respond_if_ready(IN void *context,
                          response_size, response);
     }
 
-    ASSERT(spdm_request->request_response_code == SPDM_RESPOND_IF_READY);
     if (spdm_request->param1 != spdm_context->error_data.request_code) {
         return libspdm_generate_error_response(spdm_context,
                          SPDM_ERROR_CODE_INVALID_REQUEST, 0,


### PR DESCRIPTION
Fix #421

This is dispatch function.
Following same pattern, we should either add ASSERT for all, or not add ASSERT for all.
Since no other functions are using ASSERT, we remove it here.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>