### PR TITLE
Add session_policy to libspdm_start_session().

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -92,8 +92,9 @@ return_status spdm_negotiate_algorithms(IN spdm_context_t *spdm_context);
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the KEY_EXCHANGE request.
   @param  slot_id                      slot_id to the KEY_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the KEY_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
   @param  req_slot_id_param               req_slot_id_param from the KEY_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the KEY_EXCHANGE_RSP response.
 
@@ -104,7 +105,7 @@ return_status spdm_negotiate_algorithms(IN spdm_context_t *spdm_context);
 
 return_status spdm_send_receive_key_exchange(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
-    IN uint8_t slot_id, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
+    IN uint8_t slot_id, IN uint8_t session_policy, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT uint8_t *req_slot_id_param, OUT void *measurement_hash);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
@@ -115,8 +116,9 @@ return_status spdm_send_receive_key_exchange(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the KEY_EXCHANGE request.
   @param  slot_id                      slot_id to the KEY_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the KEY_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
   @param  req_slot_id_param               req_slot_id_param from the KEY_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the KEY_EXCHANGE_RSP response.
   @param  requester_random_in           A buffer to hold the requester random (32 bytes) as input, if not NULL.
@@ -130,7 +132,7 @@ return_status spdm_send_receive_key_exchange(
 
 return_status spdm_send_receive_key_exchange_ex(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
-    IN uint8_t slot_id, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
+    IN uint8_t slot_id, IN uint8_t session_policy, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT uint8_t *req_slot_id_param, OUT void *measurement_hash,
     IN void *requester_random_in OPTIONAL,
     OUT void *requester_random OPTIONAL,
@@ -157,8 +159,9 @@ return_status spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the PSK_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the PSK_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the PSK_EXCHANGE_RSP response.
 
   @retval RETURN_SUCCESS               The PSK_EXCHANGE is sent and the PSK_EXCHANGE_RSP is received.
@@ -167,7 +170,7 @@ return_status spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
 return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
-                         IN uint8_t measurement_hash_type,
+                         IN uint8_t measurement_hash_type, IN uint8_t session_policy,
                          OUT uint32_t *session_id,
                          OUT uint8_t *heartbeat_period,
                          OUT void *measurement_hash);
@@ -179,8 +182,9 @@ return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the PSK_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the PSK_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the PSK_EXCHANGE_RSP response.
   @param  requester_context_in          A buffer to hold the requester context as input, if not NULL.
   @param  requester_context_in_size     The size of requester_context_in.
@@ -200,7 +204,7 @@ return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
 return_status spdm_send_receive_psk_exchange_ex(IN spdm_context_t *spdm_context,
-                         IN uint8_t measurement_hash_type,
+                         IN uint8_t measurement_hash_type, IN uint8_t session_policy,
                          OUT uint32_t *session_id,
                          OUT uint8_t *heartbeat_period,
                          OUT void *measurement_hash,

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -325,6 +325,7 @@ return_status libspdm_get_measurement_ex(IN void *context, IN uint32_t *session_
                                        TRUE means to use PSK_EXCHANGE/PSK_FINISH to start a session.
   @param  measurement_hash_type          The type of the measurement hash.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  session_policy               The policy for the session.
   @param  session_id                    The session ID of the session.
   @param  heartbeat_period              The heartbeat period for the session.
   @param  measurement_hash              A pointer to a destination buffer to store the measurement hash.
@@ -335,7 +336,9 @@ return_status libspdm_get_measurement_ex(IN void *context, IN uint32_t *session_
 **/
 return_status libspdm_start_session(IN void *spdm_context, IN boolean use_psk,
                  IN uint8_t measurement_hash_type,
-                 IN uint8_t slot_id, OUT uint32_t *session_id,
+                 IN uint8_t slot_id,
+                 IN uint8_t session_policy,
+                 OUT uint32_t *session_id,
                  OUT uint8_t *heartbeat_period,
                  OUT void *measurement_hash);
 
@@ -351,6 +354,7 @@ return_status libspdm_start_session(IN void *spdm_context, IN boolean use_psk,
                                        TRUE means to use PSK_EXCHANGE/PSK_FINISH to start a session.
   @param  measurement_hash_type          The type of the measurement hash.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  session_policy               The policy for the session.
   @param  session_id                    The session ID of the session.
   @param  heartbeat_period              The heartbeat period for the session.
   @param  measurement_hash              A pointer to a destination buffer to store the measurement hash.
@@ -376,7 +380,9 @@ return_status libspdm_start_session(IN void *spdm_context, IN boolean use_psk,
 **/
 return_status libspdm_start_session_ex(IN void *spdm_context, IN boolean use_psk,
                  IN uint8_t measurement_hash_type,
-                 IN uint8_t slot_id, OUT uint32_t *session_id,
+                 IN uint8_t slot_id,
+                 IN uint8_t session_policy,
+                 OUT uint32_t *session_id,
                  OUT uint8_t *heartbeat_period,
                  OUT void *measurement_hash,
                  IN void *requester_random_in OPTIONAL,

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -56,6 +56,7 @@ return_status libspdm_init_connection(IN void *context,
                                        TRUE means to use PSK_EXCHANGE/PSK_FINISH to start a session.
   @param  measurement_hash_type          The type of the measurement hash.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  session_policy               The policy for the session.
   @param  session_id                    The session ID of the session.
   @param  heartbeat_period              The heartbeat period for the session.
   @param  measurement_hash              A pointer to a destination buffer to store the measurement hash.
@@ -66,7 +67,9 @@ return_status libspdm_init_connection(IN void *context,
 **/
 return_status libspdm_start_session(IN void *context, IN boolean use_psk,
                  IN uint8_t measurement_hash_type,
-                 IN uint8_t slot_id, OUT uint32_t *session_id,
+                 IN uint8_t slot_id,
+                 IN uint8_t session_policy,
+                 OUT uint32_t *session_id,
                  OUT uint8_t *heartbeat_period,
                  OUT void *measurement_hash)
 {
@@ -84,7 +87,7 @@ return_status libspdm_start_session(IN void *context, IN boolean use_psk,
     if (!use_psk) {
         #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
         status = spdm_send_receive_key_exchange(
-            spdm_context, measurement_hash_type, slot_id,
+            spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, &req_slot_id_param,
             measurement_hash);
         if (RETURN_ERROR(status)) {
@@ -141,7 +144,7 @@ return_status libspdm_start_session(IN void *context, IN boolean use_psk,
     } else {
         #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
         status = spdm_send_receive_psk_exchange(
-            spdm_context, measurement_hash_type, session_id,
+            spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash);
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO,
@@ -178,6 +181,7 @@ return_status libspdm_start_session(IN void *context, IN boolean use_psk,
   @param  measurement_hash_type          The type of the measurement hash.
   @param  slot_id                      The number of slot for the certificate chain.
   @param  session_id                    The session ID of the session.
+  @param  session_policy               The policy for the session.
   @param  heartbeat_period              The heartbeat period for the session.
   @param  measurement_hash              A pointer to a destination buffer to store the measurement hash.
   @param  requester_random_in           A buffer to hold the requester random as input, if not NULL.
@@ -202,7 +206,9 @@ return_status libspdm_start_session(IN void *context, IN boolean use_psk,
 **/
 return_status libspdm_start_session_ex(IN void *context, IN boolean use_psk,
                  IN uint8_t measurement_hash_type,
-                 IN uint8_t slot_id, OUT uint32_t *session_id,
+                 IN uint8_t slot_id,
+                 IN uint8_t session_policy,
+                 OUT uint32_t *session_id,
                  OUT uint8_t *heartbeat_period,
                  OUT void *measurement_hash,
                  IN void *requester_random_in OPTIONAL,
@@ -229,7 +235,7 @@ return_status libspdm_start_session_ex(IN void *context, IN boolean use_psk,
         ASSERT (requester_random_size == NULL || *requester_random_size == SPDM_RANDOM_DATA_SIZE);
         ASSERT (responder_random_size == NULL || *responder_random_size == SPDM_RANDOM_DATA_SIZE);
         status = spdm_send_receive_key_exchange_ex(
-            spdm_context, measurement_hash_type, slot_id,
+            spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, &req_slot_id_param,
             measurement_hash, requester_random_in,
             requester_random, responder_random);
@@ -287,7 +293,7 @@ return_status libspdm_start_session_ex(IN void *context, IN boolean use_psk,
     } else {
         #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
         status = spdm_send_receive_psk_exchange_ex(
-            spdm_context, measurement_hash_type, session_id,
+            spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             requester_random_in, requester_random_in_size,
             requester_random, requester_random_size,

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -42,8 +42,9 @@ typedef struct {
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the KEY_EXCHANGE request.
   @param  slot_id                      slot_id to the KEY_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the KEY_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
   @param  req_slot_id_param               req_slot_id_param from the KEY_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the KEY_EXCHANGE_RSP response.
   @param  requester_random_in           A buffer to hold the requester random (32 bytes) as input, if not NULL.
@@ -55,7 +56,7 @@ typedef struct {
 **/
 return_status try_spdm_send_receive_key_exchange(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
-    IN uint8_t slot_id, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
+    IN uint8_t slot_id, IN uint8_t session_policy, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT uint8_t *req_slot_id_param, OUT void *measurement_hash,
     IN void *requester_random_in OPTIONAL,
     OUT void *requester_random OPTIONAL,
@@ -477,8 +478,9 @@ return_status try_spdm_send_receive_key_exchange(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the KEY_EXCHANGE request.
   @param  slot_id                      slot_id to the KEY_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the KEY_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
   @param  req_slot_id_param               req_slot_id_param from the KEY_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the KEY_EXCHANGE_RSP response.
 
@@ -487,7 +489,7 @@ return_status try_spdm_send_receive_key_exchange(
 **/
 return_status spdm_send_receive_key_exchange(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
-    IN uint8_t slot_id, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
+    IN uint8_t slot_id, IN uint8_t session_policy, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT uint8_t *req_slot_id_param, OUT void *measurement_hash)
 {
     uintn retry;
@@ -496,7 +498,7 @@ return_status spdm_send_receive_key_exchange(
     retry = spdm_context->retry_times;
     do {
         status = try_spdm_send_receive_key_exchange(
-            spdm_context, measurement_hash_type, slot_id,
+            spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, NULL, NULL, NULL);
         if (RETURN_NO_RESPONSE != status) {
@@ -513,8 +515,9 @@ return_status spdm_send_receive_key_exchange(
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the KEY_EXCHANGE request.
   @param  slot_id                      slot_id to the KEY_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the KEY_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the KEY_EXCHANGE_RSP response.
   @param  req_slot_id_param               req_slot_id_param from the KEY_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the KEY_EXCHANGE_RSP response.
   @param  requester_random_in           A buffer to hold the requester random (32 bytes) as input, if not NULL.
@@ -526,7 +529,7 @@ return_status spdm_send_receive_key_exchange(
 **/
 return_status spdm_send_receive_key_exchange_ex(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
-    IN uint8_t slot_id, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
+    IN uint8_t slot_id, IN uint8_t session_policy, OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT uint8_t *req_slot_id_param, OUT void *measurement_hash,
     IN void *requester_random_in OPTIONAL,
     OUT void *requester_random OPTIONAL,
@@ -538,7 +541,7 @@ return_status spdm_send_receive_key_exchange_ex(
     retry = spdm_context->retry_times;
     do {
         status = try_spdm_send_receive_key_exchange(
-            spdm_context, measurement_hash_type, slot_id,
+            spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, requester_random_in,
             requester_random, responder_random);

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -40,8 +40,9 @@ typedef struct {
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the PSK_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the PSK_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the PSK_EXCHANGE_RSP response.
   @param  requester_context_in          A buffer to hold the requester context as input, if not NULL.
   @param  requester_context_in_size     The size of requester_context_in.
@@ -60,6 +61,7 @@ typedef struct {
 **/
 return_status try_spdm_send_receive_psk_exchange(
     IN spdm_context_t *spdm_context, IN uint8_t measurement_hash_type,
+    IN uint8_t session_policy,
     OUT uint32_t *session_id, OUT uint8_t *heartbeat_period,
     OUT void *measurement_hash,
     IN void *requester_context_in OPTIONAL,
@@ -381,8 +383,9 @@ return_status try_spdm_send_receive_psk_exchange(
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the PSK_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the PSK_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the PSK_EXCHANGE_RSP response.
 
   @retval RETURN_SUCCESS               The PSK_EXCHANGE is sent and the PSK_EXCHANGE_RSP is received.
@@ -390,6 +393,7 @@ return_status try_spdm_send_receive_psk_exchange(
 **/
 return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
                          IN uint8_t measurement_hash_type,
+                         IN uint8_t session_policy,
                          OUT uint32_t *session_id,
                          OUT uint8_t *heartbeat_period,
                          OUT void *measurement_hash)
@@ -400,7 +404,7 @@ return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
     retry = spdm_context->retry_times;
     do {
         status = try_spdm_send_receive_psk_exchange(
-            spdm_context, measurement_hash_type, session_id,
+            spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             NULL, 0, NULL, NULL, NULL, NULL);
         if (RETURN_NO_RESPONSE != status) {
@@ -416,8 +420,9 @@ return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
 
   @param  spdm_context                  A pointer to the SPDM context.
   @param  measurement_hash_type          measurement_hash_type to the PSK_EXCHANGE request.
-  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
+  @param  session_policy               The policy for the session.
   @param  session_id                    session_id from the PSK_EXCHANGE_RSP response.
+  @param  heartbeat_period              heartbeat_period from the PSK_EXCHANGE_RSP response.
   @param  measurement_hash              measurement_hash from the PSK_EXCHANGE_RSP response.
   @param  requester_context_in          A buffer to hold the requester context as input, if not NULL.
   @param  requester_context_in_size     The size of requester_context_in.
@@ -436,6 +441,7 @@ return_status spdm_send_receive_psk_exchange(IN spdm_context_t *spdm_context,
 **/
 return_status spdm_send_receive_psk_exchange_ex(IN spdm_context_t *spdm_context,
                          IN uint8_t measurement_hash_type,
+                         IN uint8_t session_policy,
                          OUT uint32_t *session_id,
                          OUT uint8_t *heartbeat_period,
                          OUT void *measurement_hash,
@@ -452,7 +458,7 @@ return_status spdm_send_receive_psk_exchange_ex(IN spdm_context_t *spdm_context,
     retry = spdm_context->retry_times;
     do {
         status = try_spdm_send_receive_psk_exchange(
-            spdm_context, measurement_hash_type, session_id,
+            spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             requester_context_in, requester_context_in_size,
             requester_context, requester_context_size,

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -79,7 +79,7 @@ void test_spdm_requester_key_exchange(void **State)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -119,7 +119,7 @@ void test_spdm_requester_psk_exchange(void **State)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
 }
 

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_session.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_session.c
@@ -18,7 +18,7 @@ return_status do_session_via_spdm(IN void *spdm_context)
     status = libspdm_start_session(
         spdm_context,
         FALSE, /* KeyExchange*/
-        SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, 0,
         &session_id, &heartbeat_period, measurement_hash);
     if (RETURN_ERROR(status)) {
         DEBUG((DEBUG_ERROR, "libspdm_start_session - %r\n", status));

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -1155,7 +1155,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -1206,7 +1206,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1262,7 +1262,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -1313,7 +1313,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1364,7 +1364,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -1415,7 +1415,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1471,7 +1471,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1524,7 +1524,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -1575,7 +1575,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1622,7 +1622,7 @@ void test_spdm_requester_key_exchange_case10(void **state) {
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange (spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-               0, &session_id, &heartbeat_period, &slot_id_param, measurement_hash);
+               0, 0, &session_id, &heartbeat_period, &slot_id_param, measurement_hash);
     /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
@@ -1697,7 +1697,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_key_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
         measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -967,7 +967,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
@@ -1022,7 +1022,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(session_id, 0xFFFFFFFF);
@@ -1082,7 +1082,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
@@ -1137,7 +1137,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
@@ -1192,7 +1192,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_NO_RESPONSE);
     free(data);
@@ -1247,7 +1247,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(session_id, 0xFFFEFFFE);
@@ -1307,7 +1307,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
@@ -1364,7 +1364,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
@@ -1419,7 +1419,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(session_id, 0xFFFDFFFD);
@@ -1467,7 +1467,7 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange (spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = spdm_send_receive_psk_exchange (spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
              &session_id, &heartbeat_period, measurement_hash);
     /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
@@ -1548,7 +1548,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
     zero_mem(measurement_hash, sizeof(measurement_hash));
     status = spdm_send_receive_psk_exchange(
         spdm_context,
-        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, &session_id,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(session_id, 0xFFFFFFFF);


### PR DESCRIPTION
This is for SPDM 1.2 compatibility.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>