### PR TITLE
Add content_change in libspdm_get_measurement().

### DIFF
--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -260,6 +260,7 @@ return_status libspdm_challenge_ex(IN void *context, IN uint8_t slot_id,
   @param  request_attribute             The request attribute of the request message.
   @param  measurement_operation         The measurement operation of the request message.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  content_changed               The measurement content changed output param.
   @param  number_of_blocks               The number of blocks of the measurement record.
   @param  measurement_record_length      On input, indicate the size in bytes of the destination buffer to store the measurement record.
                                        On output, indicate the size in bytes of the measurement record.
@@ -273,6 +274,7 @@ return_status libspdm_get_measurement(IN void *spdm_context, IN uint32_t *sessio
                    IN uint8_t request_attribute,
                    IN uint8_t measurement_operation,
                    IN uint8_t slot_id,
+                   OUT uint8_t *content_changed,
                    OUT uint8_t *number_of_blocks,
                    IN OUT uint32_t *measurement_record_length,
                    OUT void *measurement_record);
@@ -290,6 +292,7 @@ return_status libspdm_get_measurement(IN void *spdm_context, IN uint32_t *sessio
   @param  request_attribute             The request attribute of the request message.
   @param  measurement_operation         The measurement operation of the request message.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  content_changed               The measurement content changed output param.
   @param  number_of_blocks               The number of blocks of the measurement record.
   @param  measurement_record_length      On input, indicate the size in bytes of the destination buffer to store the measurement record.
                                        On output, indicate the size in bytes of the measurement record.
@@ -305,11 +308,12 @@ return_status libspdm_get_measurement(IN void *spdm_context, IN uint32_t *sessio
 return_status libspdm_get_measurement_ex(IN void *context, IN uint32_t *session_id,
                    IN uint8_t request_attribute,
                    IN uint8_t measurement_operation,
-                   IN uint8_t slot_id_param,
+                   IN uint8_t slot_id,
+                   OUT uint8_t *content_changed,
                    OUT uint8_t *number_of_blocks,
                    IN OUT uint32_t *measurement_record_length,
                    OUT void *measurement_record,
-                 IN void *requester_nonce_in OPTIONAL,
+                   IN void *requester_nonce_in OPTIONAL,
                    OUT void *requester_nonce OPTIONAL,
                    OUT void *responder_nonce OPTIONAL);
 

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -36,6 +36,7 @@ typedef struct {
   @param  request_attribute             The request attribute of the request message.
   @param  measurement_operation         The measurement operation of the request message.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  content_changed               The measurement content changed output param.
   @param  number_of_blocks               The number of blocks of the measurement record.
   @param  measurement_record_length      On input, indicate the size in bytes of the destination buffer to store the measurement record.
                                        On output, indicate the size in bytes of the measurement record.
@@ -52,6 +53,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32_t *session_id
                        IN uint8_t request_attribute,
                        IN uint8_t measurement_operation,
                        IN uint8_t slot_id_param,
+                       OUT uint8_t *content_changed,
                        OUT uint8_t *number_of_blocks,
                        IN OUT uint32_t *measurement_record_length,
                        OUT void *measurement_record,
@@ -382,6 +384,9 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32_t *session_id
         }
     }
 
+    if (content_changed != NULL) {
+        *content_changed = 0;
+    }
     if (measurement_operation ==
         SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS) {
         *number_of_blocks = spdm_response.header.param1;
@@ -474,6 +479,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32_t *session_id
   @param  request_attribute             The request attribute of the request message.
   @param  measurement_operation         The measurement operation of the request message.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  content_changed               The measurement content changed output param.
   @param  number_of_blocks               The number of blocks of the measurement record.
   @param  measurement_record_length      On input, indicate the size in bytes of the destination buffer to store the measurement record.
                                        On output, indicate the size in bytes of the measurement record.
@@ -487,6 +493,7 @@ return_status libspdm_get_measurement(IN void *context, IN uint32_t *session_id,
                    IN uint8_t request_attribute,
                    IN uint8_t measurement_operation,
                    IN uint8_t slot_id_param,
+                   OUT uint8_t *content_changed,
                    OUT uint8_t *number_of_blocks,
                    IN OUT uint32_t *measurement_record_length,
                    OUT void *measurement_record)
@@ -500,7 +507,7 @@ return_status libspdm_get_measurement(IN void *context, IN uint32_t *session_id,
     do {
         status = try_spdm_get_measurement(
             spdm_context, session_id, request_attribute,
-            measurement_operation, slot_id_param, number_of_blocks,
+            measurement_operation, slot_id_param, content_changed, number_of_blocks,
             measurement_record_length, measurement_record, NULL, NULL, NULL);
         if (RETURN_NO_RESPONSE != status) {
             return status;
@@ -523,6 +530,7 @@ return_status libspdm_get_measurement(IN void *context, IN uint32_t *session_id,
   @param  request_attribute             The request attribute of the request message.
   @param  measurement_operation         The measurement operation of the request message.
   @param  slot_id                      The number of slot for the certificate chain.
+  @param  content_changed               The measurement content changed output param.
   @param  number_of_blocks               The number of blocks of the measurement record.
   @param  measurement_record_length      On input, indicate the size in bytes of the destination buffer to store the measurement record.
                                        On output, indicate the size in bytes of the measurement record.
@@ -539,6 +547,7 @@ return_status libspdm_get_measurement_ex(IN void *context, IN uint32_t *session_
                    IN uint8_t request_attribute,
                    IN uint8_t measurement_operation,
                    IN uint8_t slot_id_param,
+                   OUT uint8_t *content_changed,
                    OUT uint8_t *number_of_blocks,
                    IN OUT uint32_t *measurement_record_length,
                    OUT void *measurement_record,
@@ -554,7 +563,7 @@ return_status libspdm_get_measurement_ex(IN void *context, IN uint32_t *session_
     do {
         status = try_spdm_get_measurement(
             spdm_context, session_id, request_attribute,
-            measurement_operation, slot_id_param, number_of_blocks,
+            measurement_operation, slot_id_param, content_changed, number_of_blocks,
             measurement_record_length, measurement_record,
             requester_nonce_in,
             requester_nonce, responder_nonce);

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
@@ -76,7 +76,7 @@ void test_spdm_requester_get_measurement(void **State)
 
     measurement_record_length = sizeof(measurement_record);
     libspdm_get_measurement(spdm_context, NULL, request_attribute, 1, 0,
-                 &number_of_block, &measurement_record_length,
+                 NULL, &number_of_block, &measurement_record_length,
                  measurement_record);
 
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -2573,7 +2573,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2629,7 +2629,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -2685,7 +2685,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_UNSUPPORTED);
@@ -2741,7 +2741,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2797,7 +2797,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_NO_RESPONSE);
@@ -2853,7 +2853,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -2909,7 +2909,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -2967,7 +2967,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3020,7 +3020,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -3074,7 +3074,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
     status = libspdm_get_measurement(
         spdm_context, NULL, request_attribute,
         SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
-        0, &number_of_blocks, NULL, NULL);
+        0, NULL, &number_of_blocks, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(number_of_blocks, 4);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -3131,7 +3131,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -3196,7 +3196,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -3255,7 +3255,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -3314,7 +3314,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3373,7 +3373,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3435,7 +3435,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
         libspdm_reset_message_m(spdm_context, NULL);
         status = libspdm_get_measurement(spdm_context, NULL,
                           request_attribute, 1, SlotIDs[i],
-                          &number_of_block,
+                          NULL, &number_of_block,
                           &measurement_record_length,
                           measurement_record);
         if (SlotIDs[i] == ALTERNATIVE_DEFAULT_SLOT_ID) {
@@ -3510,7 +3510,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
         status = libspdm_get_measurement(
             spdm_context, NULL, request_attribute,
             SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS,
-            0, &number_of_blocks, NULL, NULL);
+            0, NULL, &number_of_blocks, NULL, NULL);
         assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         assert_int_equal(spdm_context->transcript.message_m.buffer_size,
@@ -3568,7 +3568,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -3629,7 +3629,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3687,7 +3687,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3745,7 +3745,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -3808,7 +3808,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
          NumberOfMessages++) {
         status = libspdm_get_measurement(spdm_context, NULL,
                           request_attribute, 1, 0,
-                          &number_of_block,
+                          NULL, &number_of_block,
                           &measurement_record_length,
                           measurement_record);
         /* It may fail due to transcript.message_m overflow*/
@@ -3885,7 +3885,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -3950,7 +3950,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -4010,7 +4010,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -4069,7 +4069,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4129,7 +4129,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4191,7 +4191,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
@@ -4251,7 +4251,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -4314,7 +4314,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -4379,7 +4379,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, NULL, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
@@ -4442,7 +4442,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
     status = libspdm_get_measurement(
         spdm_context, NULL, request_attribute,
         SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_ALL_MEASUREMENTS,
-        0, &number_of_block, &measurement_record_length,
+        0, NULL, &number_of_block, &measurement_record_length,
         measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -4498,7 +4498,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
     libspdm_reset_message_m(spdm_context, NULL);
 
     measurement_record_length = sizeof(measurement_record);
-    status = libspdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, &number_of_block, &measurement_record_length, measurement_record);
+    status = libspdm_get_measurement (spdm_context, NULL, request_attribute, 1, 0, NULL, &number_of_block, &measurement_record_length, measurement_record);
     /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
     ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -4597,7 +4597,7 @@ void test_spdm_requester_get_measurements_case34(void **state)
 
     measurement_record_length = sizeof(measurement_record);
     status = libspdm_get_measurement(spdm_context, &session_id, request_attribute, 1,
-                      0, &number_of_block,
+                      0, NULL, &number_of_block,
                       &measurement_record_length,
                       measurement_record);
     assert_int_equal(status, RETURN_SUCCESS);


### PR DESCRIPTION
This is for SPDM 1.2 compatibility.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>