### PR TITLE
Limit the test encoding buffer size to avoid assert.

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -24,6 +24,7 @@
 #define LIBSPDM_MAX_HASH_SIZE 64
 #define LIBSPDM_MAX_AEAD_KEY_SIZE 32
 #define LIBSPDM_MAX_AEAD_IV_SIZE 12
+#define LIBSPDM_MAX_AEAD_TAG_SIZE 16
 
 /**
   Allocates and initializes one HASH_CTX context for subsequent hash use.

--- a/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/spdm_encode_secured_message.c
+++ b/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/spdm_encode_secured_message.c
@@ -64,8 +64,21 @@ spdm_test_context_t m_spdm_transport_mctp_test_context = {
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)
 {
     void *State;
+    uintn record_header_max_size;
+    uintn aead_tag_max_size;
 
     setup_spdm_test_context(&m_spdm_transport_mctp_test_context);
+
+    /* limit the encoding buffer to avoid assert, because the input buffer is controlled by the the libspdm consumer. */
+    record_header_max_size = sizeof(spdm_secured_message_a_data_header1_t) +
+                             2 + /* MCTP_SEQUENCE_NUMBER_COUNT */
+                             sizeof(spdm_secured_message_a_data_header2_t) +
+                             sizeof(spdm_secured_message_cipher_header_t) +
+                             32; /* MCTP_MAX_RANDOM_NUMBER_COUNT */
+    aead_tag_max_size = LIBSPDM_MAX_AEAD_TAG_SIZE;
+    if (test_buffer_size > LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size) {
+        test_buffer_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size;
+    }
 
     m_spdm_transport_mctp_test_context.test_buffer = test_buffer;
     m_spdm_transport_mctp_test_context.test_buffer_size = test_buffer_size;

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_encode_message/transport_mctp_encode_message.c
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_encode_message/transport_mctp_encode_message.c
@@ -6,6 +6,7 @@
 
 #include "internal/libspdm_responder_lib.h"
 #include "spdm_transport_mctp_lib.h"
+#include "industry_standard/mctp.h"
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
 
@@ -46,8 +47,22 @@ spdm_test_context_t m_spdm_transport_mctp_test_context = {
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)
 {
     void *State;
+    uintn record_header_max_size;
+    uintn aead_tag_max_size;
 
     setup_spdm_test_context(&m_spdm_transport_mctp_test_context);
+
+    /* limit the encoding buffer to avoid assert, because the input buffer is controlled by the the libspdm consumer. */
+    record_header_max_size = sizeof(mctp_message_header_t) +
+                             sizeof(spdm_secured_message_a_data_header1_t) +
+                             2 + /* MCTP_SEQUENCE_NUMBER_COUNT */
+                             sizeof(spdm_secured_message_a_data_header2_t) +
+                             sizeof(spdm_secured_message_cipher_header_t) +
+                             32; /* MCTP_MAX_RANDOM_NUMBER_COUNT */
+    aead_tag_max_size = LIBSPDM_MAX_AEAD_TAG_SIZE;
+    if (test_buffer_size > LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size) {
+        test_buffer_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size;
+    }
 
     m_spdm_transport_mctp_test_context.test_buffer = test_buffer;
     m_spdm_transport_mctp_test_context.test_buffer_size = test_buffer_size;

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/spdm_transport_pci_doe_encode_message.c
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/spdm_transport_pci_doe_encode_message.c
@@ -6,6 +6,7 @@
 
 #include "internal/libspdm_responder_lib.h"
 #include "spdm_transport_pcidoe_lib.h"
+#include "industry_standard/pcidoe.h"
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
 
@@ -43,8 +44,22 @@ spdm_test_context_t m_spdm_transport_pci_doe_test_context = {
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)
 {
     void *State;
+    uintn record_header_max_size;
+    uintn aead_tag_max_size;
 
     setup_spdm_test_context(&m_spdm_transport_pci_doe_test_context);
+
+    /* limit the encoding buffer to avoid assert, because the input buffer is controlled by the the libspdm consumer. */
+    record_header_max_size = sizeof(pci_doe_data_object_header_t) +
+                             sizeof(spdm_secured_message_a_data_header1_t) +
+                             0 + /* PCI_DOE_SEQUENCE_NUMBER_COUNT */
+                             sizeof(spdm_secured_message_a_data_header2_t) +
+                             sizeof(spdm_secured_message_cipher_header_t) +
+                             0; /* PCI_DOE_MAX_RANDOM_NUMBER_COUNT */
+    aead_tag_max_size = LIBSPDM_MAX_AEAD_TAG_SIZE;
+    if (test_buffer_size > LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size) {
+        test_buffer_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE - record_header_max_size - aead_tag_max_size;
+    }
 
     m_spdm_transport_pci_doe_test_context.test_buffer = test_buffer;
     m_spdm_transport_pci_doe_test_context.test_buffer_size = test_buffer_size;


### PR DESCRIPTION
Fix #441
Fix #442
Fix #443

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>