### PR TITLE
Change the hard code to fix test_spdm_common error  and make the test case id correct

### DIFF
--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -174,7 +174,7 @@ static void test_spdm_common_context_data_case4(void **state)
      * Fail get data due to insufficient buffer for return value. returned
      * data size must return required buffer size.
      */
-    data_return_size = 4;
+    data_return_size = sizeof(void*) - 1;
     status = libspdm_get_data(spdm_context, LIBSPDM_DATA_APP_CONTEXT_DATA,
                    NULL, &return_data, &data_return_size);
     assert_int_equal(status, RETURN_BUFFER_TOO_SMALL);

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -58,7 +58,7 @@ static void test_spdm_common_context_data_case2(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x1;
+    spdm_test_context->case_id = 0x2;
 
     /**
      * Get current opaque data in context. May have been set in previous
@@ -109,7 +109,7 @@ static void test_spdm_common_context_data_case3(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x1;
+    spdm_test_context->case_id = 0x3;
 
     /**
      * Get current opaque data in context. May have been set in previous
@@ -161,7 +161,7 @@ static void test_spdm_common_context_data_case4(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x1;
+    spdm_test_context->case_id = 0x4;
 
     /*
      * Set data successfully.


### PR DESCRIPTION
Fix: #450 

Change the hard code to fix test_spdm_common unit test error.
Because the size of viod* is different on different machine, test_spdm_common unit test error is happen in ia32. Change the hard code to fix it.

Make the test case id correct.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>