### PR TITLE
Enhance C89 compatibility.

### DIFF
--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -110,10 +110,10 @@ typedef struct {
 /* SPDM VERSION structure*/
 
 typedef struct {
-    uint16_t alpha : 4;
-    uint16_t update_version_number : 4;
-    uint16_t minor_version : 4;
-    uint16_t major_version : 4;
+    unsigned int alpha : 4;
+    unsigned int update_version_number : 4;
+    unsigned int minor_version : 4;
+    unsigned int major_version : 4;
 } spdm_version_number_t;
 
 
@@ -222,8 +222,8 @@ typedef struct {
 } spdm_negotiate_algorithms_struct_table_t;
 
 typedef struct {
-    uint8_t ext_alg_count : 4;
-    uint8_t fixed_alg_byte_count : 4;
+    unsigned int ext_alg_count : 4;
+    unsigned int fixed_alg_byte_count : 4;
 } spdm_negotiate_algorithms_struct_table_alg_count_t;
 
 #define SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE 2
@@ -381,23 +381,23 @@ typedef struct {
 } spdm_certificate_response_t;
 
 typedef struct {
-    
+
     /* Total length of the certificate chain, in bytes,*/
     /* including all fields in this table.*/
-    
+
     uint16_t length;
     uint16_t reserved;
-    
+
     /* digest of the Root Certificate.*/
     /* Note that Root Certificate is ASN.1 DER-encoded for this digest.*/
     /* The hash size is determined by the SPDM device.*/
-    
+
     /*uint8_t    root_hash[hash_size];*/
-    
+
     /* One or more ASN.1 DER-encoded X509v3 certificates where the first certificate is signed by the Root*/
     /* Certificate or is the Root Certificate itself and each subsequent certificate is signed by the preceding*/
     /* certificate. The last certificate is the Leaf Certificate.*/
-    
+
     /*uint8_t    certificates[length - 4 - hash_size];*/
 } spdm_cert_chain_t;
 
@@ -434,9 +434,9 @@ typedef struct {
 #define SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH 0xFF
 
 typedef struct {
-    uint8_t slot_id : 4;
-    uint8_t reserved : 3;
-    uint8_t basic_mut_auth_req : 1;
+    unsigned int slot_id : 4;
+    unsigned int reserved : 3;
+    unsigned int basic_mut_auth_req : 1;
 } spdm_challenge_auth_response_attribute_t;
 
 #define SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ BIT7
@@ -454,8 +454,8 @@ typedef struct {
 } spdm_get_measurements_request_t;
 
 typedef struct {
-    uint8_t slot_id : 4;
-    uint8_t reserved : 4;
+    unsigned int slot_id : 4;
+    unsigned int reserved : 4;
 } spdm_get_measurements_request_slot_id_parameter_t;
 
 
@@ -500,8 +500,8 @@ typedef struct {
 } spdm_measurement_block_dmtf_t;
 
 typedef struct {
-    uint8_t Content : 7;
-    uint8_t presentation : 1;
+    unsigned int Content : 7;
+    unsigned int presentation : 1;
 } SPDM_MEASUREMENTS_BLOCK_MEASUREMENT_TYPE;
 
 

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -619,10 +619,8 @@ void spdm_init_mut_auth_encap_state(IN spdm_context_t *spdm_context,
   This function initializes the basic_mut_auth encapsulated state.
 
   @param  spdm_context                  A pointer to the SPDM context.
-  @param  basic_mut_auth_requested        Indicate of the mut_auth_requested through CHALLENG response.
 **/
-void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
-                      IN uint8_t basic_mut_auth_requested);
+void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context);
 
 /**
   This function handles the encap error response.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -48,19 +48,19 @@
 #define LIBSPDM_STATUS_ERROR_NO_MUTUAL_AUTH (LIBSPDM_STATUS_ERROR + 0x41)
 
 typedef enum {
-    
+
     /* SPDM parameter*/
-    
+
     LIBSPDM_DATA_SPDM_VERSION,
     LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
-    
+
     /* SPDM capability*/
-    
+
     LIBSPDM_DATA_CAPABILITY_FLAGS,
     LIBSPDM_DATA_CAPABILITY_CT_EXPONENT,
-    
+
     /* SPDM algorithm setting*/
-    
+
     LIBSPDM_DATA_MEASUREMENT_SPEC,
     LIBSPDM_DATA_MEASUREMENT_HASH_ALGO,
     LIBSPDM_DATA_BASE_ASYM_ALGO,
@@ -69,17 +69,17 @@ typedef enum {
     LIBSPDM_DATA_AEAD_CIPHER_SUITE,
     LIBSPDM_DATA_REQ_BASE_ASYM_ALG,
     LIBSPDM_DATA_KEY_SCHEDULE,
-    
+
     /* Connection State*/
-    
+
     LIBSPDM_DATA_CONNECTION_STATE,
-    
+
     /* response_state*/
-    
+
     LIBSPDM_DATA_RESPONSE_STATE,
-    
+
     /* Certificate info*/
-    
+
     LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN,
     LIBSPDM_DATA_LOCAL_SLOT_COUNT,
     LIBSPDM_DATA_PEER_PUBLIC_ROOT_CERT,
@@ -87,39 +87,39 @@ typedef enum {
     LIBSPDM_DATA_BASIC_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_HEARTBEAT_PERIOD,
-    
+
     /* Negotiated result*/
-    
+
     LIBSPDM_DATA_LOCAL_USED_CERT_CHAIN_BUFFER,
     LIBSPDM_DATA_PEER_USED_CERT_CHAIN_BUFFER,
-    
+
     /* Pre-shared key Hint*/
     /* If PSK is present, then PSK_EXCHANGE is used.*/
     /* Otherwise, the KEY_EXCHANGE is used.*/
-    
+
     LIBSPDM_DATA_PSK_HINT,
-    
+
     /* SessionData*/
-    
+
     LIBSPDM_DATA_SESSION_USE_PSK,
     LIBSPDM_DATA_SESSION_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_SESSION_END_SESSION_ATTRIBUTES,
-    
+
     /* App context data that can be used by the application*/
     /* during callback functions such libspdm_device_send_message_func.*/
-    
+
     LIBSPDM_DATA_APP_CONTEXT_DATA,
-    
+
     /* MAX*/
-    
-    LIBSPDM_DATA_MAX,
+
+    LIBSPDM_DATA_MAX
 } libspdm_data_type_t;
 
 typedef enum {
     LIBSPDM_DATA_LOCATION_LOCAL,
     LIBSPDM_DATA_LOCATION_CONNECTION,
     LIBSPDM_DATA_LOCATION_SESSION,
-    LIBSPDM_DATA_LOCATION_MAX,
+    LIBSPDM_DATA_LOCATION_MAX
 } libspdm_data_location_t;
 
 typedef struct {
@@ -132,65 +132,65 @@ typedef struct {
 } libspdm_data_parameter_t;
 
 typedef enum {
-    
+
     /* Before GET_VERSION/VERSION*/
-    
+
     LIBSPDM_CONNECTION_STATE_NOT_STARTED,
-    
+
     /* After GET_VERSION/VERSION*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_VERSION,
-    
+
     /* After GET_CAPABILITIES/CAPABILITIES*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES,
-    
+
     /* After NEGOTIATE_ALGORITHMS/ALGORITHMS*/
-    
+
     LIBSPDM_CONNECTION_STATE_NEGOTIATED,
-    
+
     /* After GET_DIGESTS/DIGESTS*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS,
-    
+
     /* After GET_CERTIFICATE/CERTIFICATE*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_CERTIFICATE,
-    
+
     /* After CHALLENGE/CHALLENGE_AUTH, and ENCAP CALLENGE/CHALLENG_AUTH if MUT_AUTH is enabled.*/
-    
+
     LIBSPDM_CONNECTION_STATE_AUTHENTICATED,
-    
+
     /* MAX*/
-    
-    LIBSPDM_CONNECTION_STATE_MAX,
+
+    LIBSPDM_CONNECTION_STATE_MAX
 } libspdm_connection_state_t;
 
 typedef enum {
-    
+
     /* Normal response.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NORMAL,
-    
+
     /* Other component is busy.*/
-    
+
     LIBSPDM_RESPONSE_STATE_BUSY,
-    
+
     /* Hardware is not ready.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NOT_READY,
-    
+
     /* Firmware Update is done. Need resync.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NEED_RESYNC,
-    
+
     /* Processing Encapsulated message.*/
-    
+
     LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP,
-    
+
     /* MAX*/
-    
-    LIBSPDM_RESPONSE_STATE_MAX,
+
+    LIBSPDM_RESPONSE_STATE_MAX
 } libspdm_response_state_t;
 
 /**

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -26,27 +26,27 @@ typedef enum {
     LIBSPDM_SESSION_TYPE_NONE,
     LIBSPDM_SESSION_TYPE_MAC_ONLY,
     LIBSPDM_SESSION_TYPE_ENC_MAC,
-    LIBSPDM_SESSION_TYPE_MAX,
+    LIBSPDM_SESSION_TYPE_MAX
 } libspdm_session_type_t;
 
 typedef enum {
-    
+
     /* Before send KEY_EXCHANGE/PSK_EXCHANGE*/
     /* or after END_SESSION*/
-    
+
     LIBSPDM_SESSION_STATE_NOT_STARTED,
-    
+
     /* After send KEY_EXHCNAGE, before send FINISH*/
-    
+
     LIBSPDM_SESSION_STATE_HANDSHAKING,
-    
+
     /* After send FINISH, before END_SESSION*/
-    
+
     LIBSPDM_SESSION_STATE_ESTABLISHED,
-    
+
     /* MAX*/
-    
-    LIBSPDM_SESSION_STATE_MAX,
+
+    LIBSPDM_SESSION_STATE_MAX
 } libspdm_session_state_t;
 
 /**
@@ -517,7 +517,7 @@ libspdm_generate_session_data_key(IN void *spdm_secured_message_context,
 typedef enum {
     LIBSPDM_KEY_UPDATE_ACTION_REQUESTER,
     LIBSPDM_KEY_UPDATE_ACTION_RESPONDER,
-    LIBSPDM_KEY_UPDATE_ACTION_MAX,
+    LIBSPDM_KEY_UPDATE_ACTION_MAX
 } libspdm_key_update_action_t;
 
 /**

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -151,8 +151,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
                 spdm_context->local_context.basic_mut_auth_requested;
         }
         if (auth_attribute.basic_mut_auth_req != 0) {
-            spdm_init_basic_mut_auth_encap_state(
-                context, auth_attribute.basic_mut_auth_req);
+            spdm_init_basic_mut_auth_encap_state(context);
         }
     }
 
@@ -211,9 +210,9 @@ return_status spdm_get_response_challenge_auth(IN void *context,
          spdm_context->local_context.opaque_challenge_auth_rsp_size);
     ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
 
-    
+
     /* Calc Sign*/
-    
+
     status = libspdm_append_message_c(spdm_context, spdm_request,
                        spdm_request_size);
     if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -202,19 +202,19 @@ void spdm_init_mut_auth_encap_state(IN spdm_context_t *spdm_context,
     spdm_context->encap_context.certificate_chain_buffer.buffer_size = 0;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP;
 
-    
+
     /* Clear Cache*/
-    
+
     libspdm_reset_message_mut_b(spdm_context);
     libspdm_reset_message_mut_c(spdm_context);
 
-    
+
     /* Possible Sequence:*/
     /* 2. Session Mutual Auth: (spdm_context->last_spdm_request_session_id_valid)*/
     /*    2.1 GET_DIGEST/GET_CERTIFICATE (spdm_context->encap_context.req_slot_id != 0xFF)*/
     /*    2.2 GET_DIGEST (spdm_context->encap_context.req_slot_id == 0xFF)*/
     /*    2.3 N/A (SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP)*/
-    
+
     zero_mem(spdm_context->encap_context.request_op_code_sequence,
          sizeof(spdm_context->encap_context.request_op_code_sequence));
     /* Session Mutual Auth*/
@@ -242,10 +242,8 @@ void spdm_init_mut_auth_encap_state(IN spdm_context_t *spdm_context,
   This function initializes the basic_mut_auth encapsulated state.
 
   @param  spdm_context                  A pointer to the SPDM context.
-  @param  basic_mut_auth_requested        Indicate of the mut_auth_requested through CHALLENG response.
 **/
-void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
-                      IN uint8_t basic_mut_auth_requested)
+void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context)
 {
     spdm_context->encap_context.error_state = 0;
     spdm_context->encap_context.current_request_op_code = 0x00;
@@ -256,19 +254,19 @@ void spdm_init_basic_mut_auth_encap_state(IN spdm_context_t *spdm_context,
     spdm_context->encap_context.certificate_chain_buffer.buffer_size = 0;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP;
 
-    
+
     /* Clear Cache*/
-    
+
     libspdm_reset_message_mut_b(spdm_context);
     libspdm_reset_message_mut_c(spdm_context);
 
-    
+
     /* Possible Sequence:*/
     /* 1. Basic Mutual Auth:*/
     /*    1.1 GET_DIGEST/GET_CERTIFICATE/CHALLENGE (spdm_context->encap_context.req_slot_id != 0xFF)*/
     /*    1.2 GET_DIGEST/CHALLENGE (spdm_context->encap_context.req_slot_id == 0xFF)*/
     /*    1.3 CHALLENGE (SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP)*/
-    
+
     zero_mem(spdm_context->encap_context.request_op_code_sequence,
          sizeof(spdm_context->encap_context.request_op_code_sequence));
     /* Basic Mutual Auth*/
@@ -565,9 +563,9 @@ return_status spdm_get_response_encapsulated_response_ack(
 return_status spdm_handle_encap_error_response_main(
     IN spdm_context_t *spdm_context, IN uint8_t error_code)
 {
-    
+
     /* According to "Timing Specification for SPDM messages", RESPONSE_NOT_READY is only for responder.*/
     /* RESPONSE_NOT_READY should not be sent by requester. No need to check it.*/
-    
+
     return RETURN_DEVICE_ERROR;
 }


### PR DESCRIPTION
The last element in an enum cannot have a trailing comma; that was introduced in C99. The bit-field type must be either unsigned int or signed int.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>