### PR TITLE
Enhance C89 compatibility.

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -48,19 +48,19 @@
 #define LIBSPDM_STATUS_ERROR_NO_MUTUAL_AUTH (LIBSPDM_STATUS_ERROR + 0x41)
 
 typedef enum {
-    
+
     /* SPDM parameter*/
-    
+
     LIBSPDM_DATA_SPDM_VERSION,
     LIBSPDM_DATA_SECURED_MESSAGE_VERSION,
-    
+
     /* SPDM capability*/
-    
+
     LIBSPDM_DATA_CAPABILITY_FLAGS,
     LIBSPDM_DATA_CAPABILITY_CT_EXPONENT,
-    
+
     /* SPDM algorithm setting*/
-    
+
     LIBSPDM_DATA_MEASUREMENT_SPEC,
     LIBSPDM_DATA_MEASUREMENT_HASH_ALGO,
     LIBSPDM_DATA_BASE_ASYM_ALGO,
@@ -69,17 +69,17 @@ typedef enum {
     LIBSPDM_DATA_AEAD_CIPHER_SUITE,
     LIBSPDM_DATA_REQ_BASE_ASYM_ALG,
     LIBSPDM_DATA_KEY_SCHEDULE,
-    
+
     /* Connection State*/
-    
+
     LIBSPDM_DATA_CONNECTION_STATE,
-    
+
     /* response_state*/
-    
+
     LIBSPDM_DATA_RESPONSE_STATE,
-    
+
     /* Certificate info*/
-    
+
     LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN,
     LIBSPDM_DATA_LOCAL_SLOT_COUNT,
     LIBSPDM_DATA_PEER_PUBLIC_ROOT_CERT,
@@ -87,39 +87,39 @@ typedef enum {
     LIBSPDM_DATA_BASIC_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_HEARTBEAT_PERIOD,
-    
+
     /* Negotiated result*/
-    
+
     LIBSPDM_DATA_LOCAL_USED_CERT_CHAIN_BUFFER,
     LIBSPDM_DATA_PEER_USED_CERT_CHAIN_BUFFER,
-    
+
     /* Pre-shared key Hint*/
     /* If PSK is present, then PSK_EXCHANGE is used.*/
     /* Otherwise, the KEY_EXCHANGE is used.*/
-    
+
     LIBSPDM_DATA_PSK_HINT,
-    
+
     /* SessionData*/
-    
+
     LIBSPDM_DATA_SESSION_USE_PSK,
     LIBSPDM_DATA_SESSION_MUT_AUTH_REQUESTED,
     LIBSPDM_DATA_SESSION_END_SESSION_ATTRIBUTES,
-    
+
     /* App context data that can be used by the application*/
     /* during callback functions such libspdm_device_send_message_func.*/
-    
+
     LIBSPDM_DATA_APP_CONTEXT_DATA,
-    
+
     /* MAX*/
-    
-    LIBSPDM_DATA_MAX,
+
+    LIBSPDM_DATA_MAX
 } libspdm_data_type_t;
 
 typedef enum {
     LIBSPDM_DATA_LOCATION_LOCAL,
     LIBSPDM_DATA_LOCATION_CONNECTION,
     LIBSPDM_DATA_LOCATION_SESSION,
-    LIBSPDM_DATA_LOCATION_MAX,
+    LIBSPDM_DATA_LOCATION_MAX
 } libspdm_data_location_t;
 
 typedef struct {
@@ -132,65 +132,65 @@ typedef struct {
 } libspdm_data_parameter_t;
 
 typedef enum {
-    
+
     /* Before GET_VERSION/VERSION*/
-    
+
     LIBSPDM_CONNECTION_STATE_NOT_STARTED,
-    
+
     /* After GET_VERSION/VERSION*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_VERSION,
-    
+
     /* After GET_CAPABILITIES/CAPABILITIES*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES,
-    
+
     /* After NEGOTIATE_ALGORITHMS/ALGORITHMS*/
-    
+
     LIBSPDM_CONNECTION_STATE_NEGOTIATED,
-    
+
     /* After GET_DIGESTS/DIGESTS*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS,
-    
+
     /* After GET_CERTIFICATE/CERTIFICATE*/
-    
+
     LIBSPDM_CONNECTION_STATE_AFTER_CERTIFICATE,
-    
+
     /* After CHALLENGE/CHALLENGE_AUTH, and ENCAP CALLENGE/CHALLENG_AUTH if MUT_AUTH is enabled.*/
-    
+
     LIBSPDM_CONNECTION_STATE_AUTHENTICATED,
-    
+
     /* MAX*/
-    
-    LIBSPDM_CONNECTION_STATE_MAX,
+
+    LIBSPDM_CONNECTION_STATE_MAX
 } libspdm_connection_state_t;
 
 typedef enum {
-    
+
     /* Normal response.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NORMAL,
-    
+
     /* Other component is busy.*/
-    
+
     LIBSPDM_RESPONSE_STATE_BUSY,
-    
+
     /* Hardware is not ready.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NOT_READY,
-    
+
     /* Firmware Update is done. Need resync.*/
-    
+
     LIBSPDM_RESPONSE_STATE_NEED_RESYNC,
-    
+
     /* Processing Encapsulated message.*/
-    
+
     LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP,
-    
+
     /* MAX*/
-    
-    LIBSPDM_RESPONSE_STATE_MAX,
+
+    LIBSPDM_RESPONSE_STATE_MAX
 } libspdm_response_state_t;
 
 /**

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -26,27 +26,27 @@ typedef enum {
     LIBSPDM_SESSION_TYPE_NONE,
     LIBSPDM_SESSION_TYPE_MAC_ONLY,
     LIBSPDM_SESSION_TYPE_ENC_MAC,
-    LIBSPDM_SESSION_TYPE_MAX,
+    LIBSPDM_SESSION_TYPE_MAX
 } libspdm_session_type_t;
 
 typedef enum {
-    
+
     /* Before send KEY_EXCHANGE/PSK_EXCHANGE*/
     /* or after END_SESSION*/
-    
+
     LIBSPDM_SESSION_STATE_NOT_STARTED,
-    
+
     /* After send KEY_EXHCNAGE, before send FINISH*/
-    
+
     LIBSPDM_SESSION_STATE_HANDSHAKING,
-    
+
     /* After send FINISH, before END_SESSION*/
-    
+
     LIBSPDM_SESSION_STATE_ESTABLISHED,
-    
+
     /* MAX*/
-    
-    LIBSPDM_SESSION_STATE_MAX,
+
+    LIBSPDM_SESSION_STATE_MAX
 } libspdm_session_state_t;
 
 /**
@@ -521,7 +521,7 @@ libspdm_generate_session_data_key(IN void *spdm_secured_message_context,
 typedef enum {
     LIBSPDM_KEY_UPDATE_ACTION_REQUESTER,
     LIBSPDM_KEY_UPDATE_ACTION_RESPONDER,
-    LIBSPDM_KEY_UPDATE_ACTION_MAX,
+    LIBSPDM_KEY_UPDATE_ACTION_MAX
 } libspdm_key_update_action_t;
 
 /**


### PR DESCRIPTION
The last element in an enum cannot have a trailing comma; that was introduced in C99.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>