### PR TITLE
fix the warning implicit declaration of function 'allocate_zero_pool'…

### DIFF
--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
@@ -8,6 +8,7 @@
 #include "hal/base.h"
 #include "hal/library/memlib.h"
 #include "toolchain_harness.h"
+#include "library/malloclib.h"
 
 #ifdef TEST_WITH_LIBFUZZER
 #include <stdint.h>

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_key_update/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_key_update/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_finish/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_finish/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/CMakeLists.txt
@@ -4,6 +4,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/CMakeLists.txt
@@ -4,6 +4,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/CMakeLists.txt
@@ -4,6 +4,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/CMakeLists.txt
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/CMakeLists.txt
@@ -7,6 +7,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_requester/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_capabilities/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_capabilities/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/CMakeLists.txt
@@ -9,6 +9,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_digests/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_digests/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
+                    ${LIBSPDM_DIR}/os_stub/include
 
 )
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
                     ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_version/CMakeLists.txt
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_version/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_responder/test_spdm_re
                     ${LIBSPDM_DIR}/include/hal/${ARCH}
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_secured_message/test_spdm_decode_secured_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_secured_message/test_spdm_decode_secured_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_secured_message/test_s
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_secured_message/test_s
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_decode_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_decode_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_transport/test_spdm_tr
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_encode_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_mctp_encode_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_transport/test_spdm_tr
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_decode_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_decode_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_transport/test_spdm_tr
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/CMakeLists.txt
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/fuzzing/test_transport/test_spdm_tr
                     ${LIBSPDM_DIR}/include/library
                     ${LIBSPDM_DIR}/unit_test/include
                     ${LIBSPDM_DIR}/unit_test/fuzzing/spdm_unit_fuzzing_common
+                    ${LIBSPDM_DIR}/os_stub/include
 )
 
 if(TOOLCHAIN STREQUAL "KLEE")


### PR DESCRIPTION
… when building with toolchain LIBFUZZER on linux

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>