### PR TITLE
Enhance C89 compatibility - remove Bit flags

### DIFF
--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -478,11 +478,6 @@ typedef struct {
     uint8_t SlotIDParam; /* BIT[0:3]=slot_id, BIT[4:7]=reserved*/
 } spdm_get_measurements_request_t;
 
-typedef struct {
-    uint8_t slot_id : 4;
-    uint8_t reserved : 4;
-} spdm_get_measurements_request_slot_id_parameter_t;
-
 
 /* SPDM GET_MEASUREMENTS request Attributes*/
 

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -224,11 +224,6 @@ typedef struct {
     /*uint32_t               alg_external[ext_alg_count];*/
 } spdm_negotiate_algorithms_struct_table_t;
 
-typedef struct {
-    uint8_t ext_alg_count : 4;
-    uint8_t fixed_alg_byte_count : 4;
-} spdm_negotiate_algorithms_struct_table_alg_count_t;
-
 #define SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE 2
 #define SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD 3
 #define SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG 4

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -524,11 +524,6 @@ typedef struct {
     /*uint8_t                                 hash_value[hash_size];*/
 } spdm_measurement_block_dmtf_t;
 
-typedef struct {
-    uint8_t Content : 7;
-    uint8_t presentation : 1;
-} SPDM_MEASUREMENTS_BLOCK_MEASUREMENT_TYPE;
-
 
 /* SPDM MEASUREMENTS block MeasurementValueType*/
 

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -453,12 +453,7 @@ typedef struct {
 #define SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH 1
 #define SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH 0xFF
 
-typedef struct {
-    uint8_t slot_id : 4;
-    uint8_t reserved : 3;
-    uint8_t basic_mut_auth_req : 1;
-} spdm_challenge_auth_response_attribute_t;
-
+#define SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_SLOT_ID_MASK 0xF
 #define SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ BIT7
 
 #define SPDM_CHALLENGE_AUTH_SIGN_CONTEXT "responder-challenge_auth signing"

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -475,7 +475,7 @@ typedef struct {
     /* param2 == measurement_operation*/
     uint8_t nonce[32];
     /* Below field is added in 1.1.*/
-    uint8_t SlotIDParam; /* BIT[0:3]=slot_id, BIT[4:7]=reserved*/
+    uint8_t slot_id_param; /* BIT[0:3]=slot_id, BIT[4:7]=reserved*/
 } spdm_get_measurements_request_t;
 
 

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -520,7 +520,7 @@ typedef struct {
 
 typedef struct {
     spdm_measurement_block_common_header_t measurement_block_common_header;
-    spdm_measurement_block_dmtf_header_t Measurement_block_dmtf_header;
+    spdm_measurement_block_dmtf_header_t measurement_block_dmtf_header;
     /*uint8_t                                 hash_value[hash_size];*/
 } spdm_measurement_block_dmtf_t;
 

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -109,13 +109,12 @@ typedef struct {
 
 
 /* SPDM VERSION structure*/
-
-typedef struct {
-    uint16_t alpha : 4;
-    uint16_t update_version_number : 4;
-    uint16_t minor_version : 4;
-    uint16_t major_version : 4;
-} spdm_version_number_t;
+/* bit[15:12] major_version */
+/* bit[11:8]  minor_version */
+/* bit[7:4]   update_version_number */
+/* bit[3:0]   alpha */
+typedef uint16_t spdm_version_number_t;
+#define SPDM_VERSION_NUMBER_SHIFT_BIT 8
 
 #define SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT "dmtf-spdm-v1.2.*"
 #define SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE (sizeof(SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT) - 1)

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -519,7 +519,7 @@ typedef struct {
 } spdm_measurement_block_dmtf_header_t;
 
 typedef struct {
-    spdm_measurement_block_common_header_t Measurement_block_common_header;
+    spdm_measurement_block_common_header_t measurement_block_common_header;
     spdm_measurement_block_dmtf_header_t Measurement_block_dmtf_header;
     /*uint8_t                                 hash_value[hash_size];*/
 } spdm_measurement_block_dmtf_t;

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1175,8 +1175,7 @@ return_status libspdm_append_message_m(IN void *context, IN void *session_info,
                     return RETURN_DEVICE_ERROR;
                 }
             }
-            if ((spdm_context->connection_info.version.major_version >= 2) ||
-                (spdm_context->connection_info.version.minor_version >= 2)) {
+            if ((spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
                 
                 /* Need append VCA since 1.2 script*/
                 
@@ -1209,8 +1208,7 @@ return_status libspdm_append_message_m(IN void *context, IN void *session_info,
                     return RETURN_DEVICE_ERROR;
                 }
             }
-            if ((spdm_context->connection_info.version.major_version >= 2) ||
-                (spdm_context->connection_info.version.minor_version >= 2)) {
+            if ((spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
                 
                 /* Need append VCA since 1.2 script*/
                 
@@ -1547,16 +1545,8 @@ return_status libspdm_append_message_f(IN void *context, IN void *session_info,
 boolean spdm_is_version_supported(IN spdm_context_t *spdm_context,
                   IN uint8_t version)
 {
-    uint8_t major_version;
-    uint8_t minor_version;
-
-    major_version = ((version >> 4) & 0xF);
-    minor_version = (version & 0xF);
-
-    if ((major_version ==
-            spdm_context->connection_info.version.major_version) &&
-        (minor_version ==
-            spdm_context->connection_info.version.minor_version)) {
+    if (version ==
+            (spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT)) {
         return TRUE;
     }
 
@@ -1572,8 +1562,7 @@ boolean spdm_is_version_supported(IN spdm_context_t *spdm_context,
 **/
 uint8_t spdm_get_connection_version(IN spdm_context_t *spdm_context)
 {
-    return (uint8_t)((spdm_context->connection_info.version.major_version << 4) |
-        spdm_context->connection_info.version.minor_version);
+    return (uint8_t)(spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
 /**
@@ -1748,31 +1737,13 @@ return_status libspdm_init_context(IN void *context)
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     spdm_context->current_token = 0;
     spdm_context->local_context.version.spdm_version_count = 3;
-    spdm_context->local_context.version.spdm_version[0].major_version = 1;
-    spdm_context->local_context.version.spdm_version[0].minor_version = 0;
-    spdm_context->local_context.version.spdm_version[0].alpha = 0;
-    spdm_context->local_context.version.spdm_version[0]
-        .update_version_number = 0;
-    spdm_context->local_context.version.spdm_version[1].major_version = 1;
-    spdm_context->local_context.version.spdm_version[1].minor_version = 1;
-    spdm_context->local_context.version.spdm_version[1].alpha = 0;
-    spdm_context->local_context.version.spdm_version[1]
-        .update_version_number = 0;
-    spdm_context->local_context.version.spdm_version[2].major_version = 1;
-    spdm_context->local_context.version.spdm_version[2].minor_version = 2;
-    spdm_context->local_context.version.spdm_version[2].alpha = 0;
-    spdm_context->local_context.version.spdm_version[2]
-        .update_version_number = 0;
+    spdm_context->local_context.version.spdm_version[0] = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[1] = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[2] = SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.secured_message_version.spdm_version_count =
         1;
-    spdm_context->local_context.secured_message_version.spdm_version[0]
-        .major_version = 1;
-    spdm_context->local_context.secured_message_version.spdm_version[0]
-        .minor_version = 1;
-    spdm_context->local_context.secured_message_version.spdm_version[0]
-        .alpha = 0;
-    spdm_context->local_context.secured_message_version.spdm_version[0]
-        .update_version_number = 0;
+    spdm_context->local_context.secured_message_version.spdm_version[0] = 
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->encap_context.certificate_chain_buffer.max_buffer_size =
         sizeof(spdm_context->encap_context.certificate_chain_buffer.buffer);
 
@@ -1855,6 +1826,5 @@ uintn libspdm_get_context_size(void)
 **/
 uint8_t spdm_get_version_from_version_number(IN spdm_version_number_t ver)
 {
-    return (uint8_t)(ver.major_version << 4 |
-                   ver.minor_version);
+    return (uint8_t)(ver >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -362,8 +362,7 @@ boolean spdm_calculate_l1l2(IN void *context, IN void *session_info,
     hash_size = libspdm_get_hash_size(
         spdm_context->connection_info.algorithm.base_hash_algo);
 
-    if ((spdm_context->connection_info.version.major_version >= 2) ||
-        (spdm_context->connection_info.version.minor_version >= 2)) {
+        if ((spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need append VCA since 1.2 script*/
         

--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -122,10 +122,7 @@ spdm_build_opaque_data_supported_version_data(IN spdm_context_t *spdm_context,
     opaque_element_support_version->version_count = 1;
 
     versions_list = (void *)(opaque_element_support_version + 1);
-    versions_list->alpha = 0;
-    versions_list->update_version_number = 0;
-    versions_list->minor_version = 1;
-    versions_list->major_version = 1;
+    versions_list[0] = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
     /* Zero Padding*/
     end = versions_list + 1;
@@ -195,8 +192,7 @@ spdm_process_opaque_data_supported_version_data(IN spdm_context_t *spdm_context,
         return RETURN_UNSUPPORTED;
     }
     versions_list = (void *)(opaque_element_support_version + 1);
-    if ((versions_list->minor_version != 1) ||
-        (versions_list->major_version != 1)) {
+    if ((versions_list[0] >> SPDM_VERSION_NUMBER_SHIFT_BIT) != SPDM_MESSAGE_VERSION_11) {
         return RETURN_UNSUPPORTED;
     }
 
@@ -264,10 +260,7 @@ spdm_build_opaque_data_version_selection_data(IN spdm_context_t *spdm_context,
         SECURED_MESSAGE_OPAQUE_ELEMENT_SMDATA_DATA_VERSION;
     OpaqueElementVersionSection->sm_data_id =
         SECURED_MESSAGE_OPAQUE_ELEMENT_SMDATA_ID_VERSION_SELECTION;
-    OpaqueElementVersionSection->selected_version.alpha = 0;
-    OpaqueElementVersionSection->selected_version.update_version_number = 0;
-    OpaqueElementVersionSection->selected_version.minor_version = 1;
-    OpaqueElementVersionSection->selected_version.major_version = 1;
+    OpaqueElementVersionSection->selected_version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
     /* Zero Padding*/
     end = OpaqueElementVersionSection + 1;
@@ -330,10 +323,8 @@ spdm_process_opaque_data_version_selection_data(IN spdm_context_t *spdm_context,
          SECURED_MESSAGE_OPAQUE_ELEMENT_SMDATA_DATA_VERSION) ||
         (OpaqueElementVersionSection->sm_data_id !=
          SECURED_MESSAGE_OPAQUE_ELEMENT_SMDATA_ID_VERSION_SELECTION) ||
-        (OpaqueElementVersionSection->selected_version.minor_version !=
-         1) ||
-        (OpaqueElementVersionSection->selected_version.major_version !=
-         1)) {
+        ((OpaqueElementVersionSection->selected_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) !=
+         SPDM_MESSAGE_VERSION_11)) {
         return RETURN_UNSUPPORTED;
     }
 

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -1524,8 +1524,7 @@ get_spdm_signing_context_string (
     uintn index;
 
     /* It is introduced in SPDM 1.2*/
-    ASSERT((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2));
+    ASSERT((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11);
 
     for (index = 0; index < ARRAY_SIZE(m_spdm_signing_context_str_table); index++) {
         if (m_spdm_signing_context_str_table[index].is_requester == is_requester &&
@@ -1557,12 +1556,11 @@ create_spdm_signing_context (
     char *context_str;
 
     /* It is introduced in SPDM 1.2*/
-    ASSERT((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2));
+    ASSERT((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11);
 
     /* So far, it only leaves 1 bytes for version*/
-    ASSERT((spdm_version.major_version < 10) &&
-        (spdm_version.minor_version < 10));
+    ASSERT((((spdm_version >> 12) & 0xF) < 10) &&
+        (((spdm_version >> 8) & 0xF) < 10));
 
     context_str = spdm_signing_context;
     for (index = 0; index < 4; index++) {
@@ -1571,8 +1569,8 @@ create_spdm_signing_context (
             SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT,
             SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE);
         /* patch the version*/
-        context_str[11] = (char8)('0' + spdm_version.major_version);
-        context_str[13] = (char8)('0' + spdm_version.minor_version);
+        context_str[11] = (char8)('0' + ((spdm_version >> 12) & 0xF));
+        context_str[13] = (char8)('0' + ((spdm_version >> 8) & 0xF));
         context_str[15] = (char8)('*');
         context_str += SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE;
     }
@@ -1965,8 +1963,7 @@ boolean libspdm_asym_verify(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2062,8 +2059,7 @@ boolean libspdm_asym_verify_hash(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2355,8 +2351,7 @@ boolean libspdm_asym_sign(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2456,8 +2451,7 @@ boolean libspdm_asym_sign_hash(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2658,8 +2652,7 @@ boolean libspdm_req_asym_verify(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2755,8 +2748,7 @@ boolean libspdm_req_asym_verify_hash(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -2909,8 +2901,7 @@ boolean libspdm_req_asym_sign(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -3010,8 +3001,7 @@ boolean libspdm_req_asym_sign_hash(
     param = NULL;
     param_size = 0;
 
-    if ((spdm_version.major_version >= 2) ||
-        (spdm_version.minor_version >= 2)) {
+    if ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11) {
         
         /* Need use SPDM 1.2 signing*/
         
@@ -3199,10 +3189,10 @@ void *libspdm_dhe_new(IN spdm_version_number_t spdm_version,
         copy_mem (spdm12_key_change_requester_context, SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT, SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT_SIZE);
         copy_mem (spdm12_key_change_responder_context, SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT, SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE);
         /* patch the version*/
-        spdm12_key_change_requester_context[25] = (char8)('0' + spdm_version.major_version);
-        spdm12_key_change_requester_context[27] = (char8)('0' + spdm_version.minor_version);
-        spdm12_key_change_responder_context[25] = (char8)('0' + spdm_version.major_version);
-        spdm12_key_change_responder_context[27] = (char8)('0' + spdm_version.minor_version);
+        spdm12_key_change_requester_context[25] = (char8)('0' + ((spdm_version >> 12) & 0xF));
+        spdm12_key_change_requester_context[27] = (char8)('0' + ((spdm_version >> 8) & 0xF));
+        spdm12_key_change_responder_context[25] = (char8)('0' + ((spdm_version >> 12) & 0xF));
+        spdm12_key_change_responder_context[27] = (char8)('0' + ((spdm_version >> 8) & 0xF));
 
         result = sm2_key_exchange_init (context, CRYPTO_NID_SM3_256,
             spdm12_key_change_requester_context, SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT_SIZE,

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -39,7 +39,7 @@ return_status spdm_get_encap_response_challenge_auth(
     uint8_t *ptr;
     uintn total_size;
     spdm_context_t *spdm_context;
-    spdm_challenge_auth_response_attribute_t auth_attribute;
+    uint8_t auth_attribute;
     return_status status;
 
     spdm_context = context;
@@ -91,10 +91,8 @@ return_status spdm_get_encap_response_challenge_auth(
 
     spdm_response->header.spdm_version = spdm_request->header.spdm_version;
     spdm_response->header.request_response_code = SPDM_CHALLENGE_AUTH;
-    auth_attribute.slot_id = (uint8_t)(slot_id & 0xF);
-    auth_attribute.reserved = 0;
-    auth_attribute.basic_mut_auth_req = 0;
-    spdm_response->header.param1 = *(uint8_t *)&auth_attribute;
+    auth_attribute = (uint8_t)(slot_id & 0xF);
+    spdm_response->header.param1 = auth_attribute;
     spdm_response->header.param2 = (1 << slot_id);
     if (slot_id == 0xFF) {
         spdm_response->header.param2 = 0;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -149,7 +149,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32_t *session_id
             spdm_request_size = sizeof(spdm_request);
         } else {
             spdm_request_size = sizeof(spdm_request) -
-                        sizeof(spdm_request.SlotIDParam);
+                        sizeof(spdm_request.slot_id_param);
         }
 
         if (requester_nonce_in == NULL) {
@@ -162,7 +162,7 @@ return_status try_spdm_get_measurement(IN void *context, IN uint32_t *session_id
         DEBUG((DEBUG_INFO, "ClientNonce - "));
         internal_dump_data(spdm_request.nonce, SPDM_NONCE_SIZE);
         DEBUG((DEBUG_INFO, "\n"));
-        spdm_request.SlotIDParam = slot_id_param;
+        spdm_request.slot_id_param = slot_id_param;
 
         if (requester_nonce != NULL) {
             copy_mem (requester_nonce, spdm_request.nonce, SPDM_NONCE_SIZE);

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -28,8 +28,7 @@ boolean spdm_check_request_version_compability(IN spdm_context_t *spdm_context, 
         local_ver = spdm_get_version_from_version_number(
                         spdm_context->local_context.version.spdm_version[index]);
         if (local_ver == version) {
-            spdm_context->connection_info.version.major_version = version >> 4;
-            spdm_context->connection_info.version.minor_version = version;
+            spdm_context->connection_info.version = version << SPDM_VERSION_NUMBER_SHIFT_BIT;
             return TRUE;
         }
     }

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -102,7 +102,7 @@ return_status spdm_process_encap_response_challenge_auth(
     void *opaque;
     void *signature;
     uintn signature_size;
-    spdm_challenge_auth_response_attribute_t auth_attribute;
+    uint8_t auth_attribute;
     return_status status;
 
     spdm_context->encap_context.error_state =
@@ -129,16 +129,16 @@ return_status spdm_process_encap_response_challenge_auth(
         return RETURN_DEVICE_ERROR;
     }
 
-    *(uint8_t *)&auth_attribute = spdm_response->header.param1;
+    auth_attribute = spdm_response->header.param1;
     if (spdm_context->encap_context.req_slot_id == 0xFF) {
-        if (auth_attribute.slot_id != 0xF) {
+        if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_SLOT_ID_MASK) != 0xF) {
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response->header.param2 != 0) {
             return RETURN_DEVICE_ERROR;
         }
     } else {
-        if (auth_attribute.slot_id !=
+        if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_SLOT_ID_MASK) !=
             spdm_context->encap_context.req_slot_id) {
             return RETURN_DEVICE_ERROR;
         }

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -339,7 +339,7 @@ return_status spdm_get_response_measurements(IN void *context,
             debug_measurements_block_size =
                 sizeof(spdm_measurement_block_dmtf_t) +
                 debug_measurement_block
-                    ->Measurement_block_dmtf_header
+                    ->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_size;
             debug_measurements_record_size += debug_measurements_block_size;
             debug_measurement_block =

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -211,14 +211,14 @@ return_status spdm_get_response_measurements(IN void *context,
         } else {
             if (request_size <
                 sizeof(spdm_get_measurements_request_t) -
-                    sizeof(spdm_request->SlotIDParam)) {
+                    sizeof(spdm_request->slot_id_param)) {
                 return libspdm_generate_error_response(
                     spdm_context,
                     SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                     response_size, response);
             }
             request_size = sizeof(spdm_get_measurements_request_t) -
-                       sizeof(spdm_request->SlotIDParam);
+                       sizeof(spdm_request->slot_id_param);
         }
     } else {
         if (request_size != sizeof(spdm_message_header_t)) {
@@ -389,7 +389,7 @@ return_status spdm_get_response_measurements(IN void *context,
         0) {
         if (spdm_response->header.spdm_version >=
             SPDM_MESSAGE_VERSION_11) {
-            slot_id_param = spdm_request->SlotIDParam;
+            slot_id_param = spdm_request->slot_id_param;
             if ((slot_id_param != 0xF) &&
                 (slot_id_param >=
                  spdm_context->local_context.slot_count)) {

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -204,9 +204,9 @@ return_status libspdm_measurement_collection(
         measurement_block = measurements;
 
         for (index = 1; index <= MEASUREMENT_BLOCK_NUMBER; index++) {
-            measurement_block->Measurement_block_common_header
+            measurement_block->measurement_block_common_header
                 .index = index;
-            measurement_block->Measurement_block_common_header
+            measurement_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
 
@@ -224,7 +224,7 @@ return_status libspdm_measurement_collection(
                     .dmtf_spec_measurement_value_size =
                     (uint16_t)hash_size;
 
-                measurement_block->Measurement_block_common_header
+                measurement_block->measurement_block_common_header
                     .measurement_size =
                     (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                          (uint16_t)hash_size);
@@ -251,7 +251,7 @@ return_status libspdm_measurement_collection(
                     .dmtf_spec_measurement_value_size =
                     (uint16_t)sizeof(data);
 
-                measurement_block->Measurement_block_common_header
+                measurement_block->measurement_block_common_header
                     .measurement_size =
                     (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                          (uint16_t)sizeof(data));
@@ -296,10 +296,10 @@ return_status libspdm_measurement_collection(
 
         measurement_block = measurements;
 
-        measurement_block->Measurement_block_common_header.index =
+        measurement_block->measurement_block_common_header.index =
             measurements_index;
 
-        measurement_block->Measurement_block_common_header
+        measurement_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
 
@@ -312,7 +312,7 @@ return_status libspdm_measurement_collection(
             measurement_block->Measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_size =
                 (uint16_t)hash_size;
-            measurement_block->Measurement_block_common_header
+            measurement_block->measurement_block_common_header
                 .measurement_size =
                 (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                      (uint16_t)hash_size);
@@ -333,7 +333,7 @@ return_status libspdm_measurement_collection(
                 .dmtf_spec_measurement_value_size =
                 (uint16_t)sizeof(data);
 
-            measurement_block->Measurement_block_common_header
+            measurement_block->measurement_block_common_header
                 .measurement_size =
                 (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                      (uint16_t)sizeof(data));
@@ -414,10 +414,10 @@ boolean libspdm_generate_measurement_summary_hash(
             measurment_block_size =
                 sizeof(spdm_measurement_block_common_header_t) +
                 cached_measurment_block
-                    ->Measurement_block_common_header
+                    ->measurement_block_common_header
                     .measurement_size;
             ASSERT(cached_measurment_block
-                       ->Measurement_block_common_header
+                       ->measurement_block_common_header
                        .measurement_size ==
                    sizeof(spdm_measurement_block_dmtf_header_t) +
                        cached_measurment_block
@@ -425,7 +425,7 @@ boolean libspdm_generate_measurement_summary_hash(
                            .dmtf_spec_measurement_value_size);
             measurment_data_size +=
                 cached_measurment_block
-                    ->Measurement_block_common_header
+                    ->measurement_block_common_header
                     .measurement_size;
             cached_measurment_block =
                 (void *)((uintn)cached_measurment_block +
@@ -442,7 +442,7 @@ boolean libspdm_generate_measurement_summary_hash(
             measurment_block_size =
                 sizeof(spdm_measurement_block_common_header_t) +
                 cached_measurment_block
-                    ->Measurement_block_common_header
+                    ->measurement_block_common_header
                     .measurement_size;
             /* filter unneeded data*/
             if (((measurement_summary_hash_type ==
@@ -462,12 +462,12 @@ boolean libspdm_generate_measurement_summary_hash(
                     &cached_measurment_block
                          ->Measurement_block_dmtf_header,
                     cached_measurment_block
-                        ->Measurement_block_common_header
+                        ->measurement_block_common_header
                         .measurement_size);
 
                 measurment_data_size +=
                     cached_measurment_block
-                        ->Measurement_block_common_header
+                        ->measurement_block_common_header
                         .measurement_size;
             }
             cached_measurment_block =

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -217,10 +217,10 @@ return_status libspdm_measurement_collection(
             if ((index < MEASUREMENT_BLOCK_NUMBER) &&
                 measurement_hash_algo !=
                     SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_RAW_BIT_STREAM_ONLY) {
-                measurement_block->Measurement_block_dmtf_header
+                measurement_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_type =
                     (index - 1);
-                measurement_block->Measurement_block_dmtf_header
+                measurement_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_size =
                     (uint16_t)hash_size;
 
@@ -243,11 +243,11 @@ return_status libspdm_measurement_collection(
                          hash_size);
 
             } else {
-                measurement_block->Measurement_block_dmtf_header
+                measurement_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_type =
                     (index - 1) |
                     SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM;
-                measurement_block->Measurement_block_dmtf_header
+                measurement_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_size =
                     (uint16_t)sizeof(data);
 
@@ -306,10 +306,10 @@ return_status libspdm_measurement_collection(
         if (measurements_index < MEASUREMENT_BLOCK_NUMBER &&
             measurement_hash_algo !=
                 SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_RAW_BIT_STREAM_ONLY) {
-            measurement_block->Measurement_block_dmtf_header
+            measurement_block->measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_type =
                 measurements_index - 1;
-            measurement_block->Measurement_block_dmtf_header
+            measurement_block->measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_size =
                 (uint16_t)hash_size;
             measurement_block->measurement_block_common_header
@@ -325,11 +325,11 @@ return_status libspdm_measurement_collection(
                 return RETURN_DEVICE_ERROR;
             }
         } else {
-            measurement_block->Measurement_block_dmtf_header
+            measurement_block->measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_type =
                 (measurements_index - 1) |
                 SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM;
-            measurement_block->Measurement_block_dmtf_header
+            measurement_block->measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_size =
                 (uint16_t)sizeof(data);
 
@@ -421,7 +421,7 @@ boolean libspdm_generate_measurement_summary_hash(
                        .measurement_size ==
                    sizeof(spdm_measurement_block_dmtf_header_t) +
                        cached_measurment_block
-                           ->Measurement_block_dmtf_header
+                           ->measurement_block_dmtf_header
                            .dmtf_spec_measurement_value_size);
             measurment_data_size +=
                 cached_measurment_block
@@ -448,19 +448,19 @@ boolean libspdm_generate_measurement_summary_hash(
             if (((measurement_summary_hash_type ==
                   SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH) &&
                  ((cached_measurment_block
-                       ->Measurement_block_dmtf_header
+                       ->measurement_block_dmtf_header
                        .dmtf_spec_measurement_value_type &
                    SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MASK) <
                   SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MEASUREMENT_MANIFEST)) ||
                 ((cached_measurment_block
-                      ->Measurement_block_dmtf_header
+                      ->measurement_block_dmtf_header
                       .dmtf_spec_measurement_value_type &
                   SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MASK) ==
                  SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_IMMUTABLE_ROM)) {
                 copy_mem(
                     &measurement_data[measurment_data_size],
                     &cached_measurment_block
-                         ->Measurement_block_dmtf_header,
+                         ->measurement_block_dmtf_header,
                     cached_measurment_block
                         ->measurement_block_common_header
                         .measurement_size);

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -66,8 +66,7 @@ void test_spdm_requester_challenge(void **State)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
@@ -40,8 +40,7 @@ void test_spdm_requester_encap_challenge(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
@@ -43,8 +43,7 @@ void test_spdm_responder_algorithms_case2(void **State)
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
@@ -65,8 +64,7 @@ void test_spdm_responder_algorithms_case3(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -95,8 +93,7 @@ void test_spdm_responder_algorithms_case4(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -137,8 +134,7 @@ void test_spdm_responder_algorithms_case5(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -169,8 +165,7 @@ void test_spdm_responder_algorithms_case6(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -201,8 +196,7 @@ void test_spdm_responder_algorithms_case7(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -232,8 +226,7 @@ void test_spdm_responder_algorithms_case8(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -262,8 +255,7 @@ void test_spdm_responder_algorithms_case9(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -290,8 +282,7 @@ void test_spdm_responder_algorithms_case12(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
     spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -320,8 +311,7 @@ void test_spdm_responder_algorithms_case10(void **State)
     spdm_context = spdm_test_context->spdm_context;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.algorithm.base_hash_algo = 0;
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -45,8 +45,7 @@ void test_spdm_responder_challenge_case1(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);
@@ -92,8 +91,7 @@ void test_spdm_responder_challenge_case2(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);
@@ -138,8 +136,7 @@ void test_spdm_responder_challenge_case3(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);
@@ -216,8 +213,7 @@ void test_spdm_responder_challenge_case5(void **State)
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP |
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP |
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);
@@ -266,8 +262,7 @@ void test_spdm_responder_challenge_case6(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
@@ -45,8 +45,7 @@ void test_spdm_responder_encap_challenge(void **State)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, NULL, NULL);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -46,8 +46,7 @@ void test_spdm_responder_respond_if_ready(void **State)
     spdm_context->connection_info.algorithm.base_hash_algo =
         m_use_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.local_cert_chain_provision[0] =
         m_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -96,7 +96,6 @@ return_status spdm_requester_challenge_test_receive_message(
     IN OUT void *response, IN uint64_t timeout)
 {
     spdm_test_context_t *spdm_test_context;
-    spdm_version_number_t spdm_version = {0, 0, 0, 1};
 
     spdm_test_context = get_spdm_test_context();
     switch (spdm_test_context->case_id) {
@@ -167,7 +166,8 @@ return_status spdm_requester_challenge_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_CHALLENGE_AUTH,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_CHALLENGE_AUTH,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -238,7 +238,8 @@ return_status spdm_requester_challenge_test_receive_message(
         libspdm_hash_all(m_use_hash_algo, m_local_buffer,
                   m_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_CHALLENGE_AUTH,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_CHALLENGE_AUTH,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -362,7 +363,8 @@ return_status spdm_requester_challenge_test_receive_message(
                       m_local_buffer_size, hash_data);
             sig_size =
                 libspdm_get_asym_signature_size(m_use_asym_algo);
-            libspdm_responder_data_sign(spdm_version, SPDM_CHALLENGE_AUTH,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                         SPDM_CHALLENGE_AUTH,
                          m_use_asym_algo,
                          m_use_hash_algo,
                          FALSE, m_local_buffer,
@@ -500,7 +502,8 @@ return_status spdm_requester_challenge_test_receive_message(
                       m_local_buffer_size, hash_data);
             sig_size =
                 libspdm_get_asym_signature_size(m_use_asym_algo);
-            libspdm_responder_data_sign(spdm_version, SPDM_CHALLENGE_AUTH,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                         SPDM_CHALLENGE_AUTH,
                          m_use_asym_algo,
                          m_use_hash_algo,
                          FALSE, m_local_buffer,
@@ -557,7 +560,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -624,7 +628,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -674,7 +679,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -724,7 +730,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -774,7 +781,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -826,7 +834,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -877,7 +886,8 @@ return_status spdm_requester_challenge_test_receive_message(
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     libspdm_hash_all (m_use_hash_algo, hash_data, libspdm_get_hash_size (m_use_hash_algo), hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, hash_data, libspdm_get_hash_size (m_use_hash_algo), Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -927,7 +937,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)Ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                    SPDM_CHALLENGE_AUTH,
                     m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, Ptr, &sig_size);
     Ptr += sig_size;
 
@@ -1003,7 +1014,8 @@ return_status spdm_requester_challenge_test_receive_message(
     m_local_buffer_size += ((uintn)ptr - (uintn)spdm_response);
     libspdm_hash_all (m_use_hash_algo, m_local_buffer, m_local_buffer_size, hash_data);
     sig_size = libspdm_get_asym_signature_size (m_use_asym_algo);
-    libspdm_responder_data_sign (spdm_version, SPDM_CHALLENGE_AUTH,
+    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+              SPDM_CHALLENGE_AUTH,
               m_use_asym_algo, m_use_hash_algo, FALSE, m_local_buffer, m_local_buffer_size, ptr, &sig_size);
     ptr += sig_size;
     spdm_transport_test_encode_message (spdm_context, NULL, FALSE, FALSE, temp_buf_size, temp_buf, response_size, response);
@@ -1050,8 +1062,7 @@ void test_spdm_requester_challenge_case1(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1112,8 +1123,7 @@ void test_spdm_requester_challenge_case2(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1172,8 +1182,7 @@ void test_spdm_requester_challenge_case3(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1227,8 +1236,7 @@ void test_spdm_requester_challenge_case4(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1282,8 +1290,7 @@ void test_spdm_requester_challenge_case5(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1337,8 +1344,7 @@ void test_spdm_requester_challenge_case6(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1390,8 +1396,7 @@ void test_spdm_requester_challenge_case7(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1447,8 +1452,7 @@ void test_spdm_requester_challenge_case8(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1503,8 +1507,7 @@ void test_spdm_requester_challenge_case9(void **state)
     spdm_context->connection_info.algorithm.base_asym_algo =
         m_use_asym_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size;
     copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
@@ -1550,8 +1553,7 @@ void test_spdm_requester_challenge_case10(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1592,8 +1594,7 @@ void test_spdm_requester_challenge_case11(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1632,8 +1633,7 @@ void test_spdm_requester_challenge_case12(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1673,8 +1673,7 @@ void test_spdm_requester_challenge_case13(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1713,8 +1712,7 @@ void test_spdm_requester_challenge_case14(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1754,8 +1752,7 @@ void test_spdm_requester_challenge_case15(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1801,8 +1798,7 @@ void test_spdm_requester_challenge_case16(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1848,8 +1844,7 @@ void test_spdm_requester_challenge_case17(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1896,8 +1891,7 @@ void test_spdm_requester_challenge_case18(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1943,8 +1937,7 @@ void test_spdm_requester_challenge_case19(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -1981,8 +1974,7 @@ void test_spdm_requester_challenge_case20(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
 
@@ -2045,8 +2037,7 @@ void test_spdm_requester_challenge_case21(void **state) {
   libspdm_reset_message_c(spdm_context);
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
   copy_mem (spdm_context->connection_info.peer_used_cert_chain_buffer, data, data_size);
   zero_mem (measurement_hash, sizeof(measurement_hash));

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -479,8 +479,7 @@ void test_spdm_requester_end_session_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -545,8 +544,7 @@ void test_spdm_requester_end_session_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -638,8 +636,7 @@ void test_spdm_requester_end_session_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -727,8 +724,7 @@ void test_spdm_requester_end_session_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -816,8 +812,7 @@ void test_spdm_requester_end_session_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -905,8 +900,7 @@ void test_spdm_requester_end_session_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -998,8 +992,7 @@ void test_spdm_requester_end_session_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1089,8 +1082,7 @@ void test_spdm_requester_end_session_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1178,8 +1170,7 @@ void test_spdm_requester_end_session_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1271,8 +1262,7 @@ void test_spdm_requester_end_session_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
@@ -1340,8 +1330,7 @@ void test_spdm_requester_end_session_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -1269,8 +1269,7 @@ void test_spdm_requester_finish_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1347,8 +1346,7 @@ void test_spdm_requester_finish_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1428,8 +1426,7 @@ void test_spdm_requester_finish_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -1505,8 +1502,7 @@ void test_spdm_requester_finish_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1582,8 +1578,7 @@ void test_spdm_requester_finish_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1660,8 +1655,7 @@ void test_spdm_requester_finish_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1742,8 +1736,7 @@ void test_spdm_requester_finish_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1821,8 +1814,7 @@ void test_spdm_requester_finish_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1899,8 +1891,7 @@ void test_spdm_requester_finish_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1983,8 +1974,7 @@ void test_spdm_requester_finish_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
@@ -2051,8 +2041,7 @@ void test_spdm_requester_finish_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2154,8 +2143,7 @@ void test_spdm_requester_finish_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags = 0;
@@ -2234,8 +2222,7 @@ void test_spdm_requester_finish_case13(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->connection_info.capability.flags |=
@@ -2311,8 +2298,7 @@ void test_spdm_requester_finish_case14(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2389,8 +2375,7 @@ void test_spdm_requester_finish_case15(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2467,8 +2452,7 @@ void test_spdm_requester_finish_case16(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x10;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2560,8 +2544,7 @@ void test_spdm_requester_finish_case17(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2649,8 +2632,7 @@ void test_spdm_requester_finish_case18(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2739,8 +2721,7 @@ void test_spdm_requester_finish_case19(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -2829,8 +2810,7 @@ void test_spdm_requester_finish_case20(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x14;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -752,8 +752,7 @@ void test_spdm_requester_get_capabilities_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -772,8 +771,7 @@ void test_spdm_requester_get_capabilities_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -803,8 +801,7 @@ void test_spdm_requester_get_capabilities_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
 
@@ -823,8 +820,7 @@ void test_spdm_requester_get_capabilities_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -843,8 +839,7 @@ void test_spdm_requester_get_capabilities_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -863,8 +858,7 @@ void test_spdm_requester_get_capabilities_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -887,8 +881,7 @@ void test_spdm_requester_get_capabilities_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -909,8 +902,7 @@ void test_spdm_requester_get_capabilities_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -929,8 +921,7 @@ void test_spdm_requester_get_capabilities_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -951,8 +942,7 @@ void test_spdm_requester_get_capabilities_case10(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xa;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -979,8 +969,7 @@ void test_spdm_requester_get_capabilities_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xb;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1008,8 +997,7 @@ void test_spdm_requester_get_capabilities_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xc;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1032,8 +1020,7 @@ void test_spdm_requester_get_capabilities_case13(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xd;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1052,8 +1039,7 @@ void test_spdm_requester_get_capabilities_case14(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xe;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1072,8 +1058,7 @@ void test_spdm_requester_get_capabilities_case15(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xf;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1092,8 +1077,7 @@ void test_spdm_requester_get_capabilities_case16(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x10;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1117,8 +1101,7 @@ void test_spdm_requester_get_capabilities_case17(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1140,8 +1123,7 @@ void test_spdm_requester_get_capabilities_case18(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
@@ -1163,8 +1145,7 @@ void test_spdm_requester_get_capabilities_case19(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1187,8 +1168,7 @@ void test_spdm_requester_get_capabilities_case20(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x14;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1211,8 +1191,7 @@ void test_spdm_requester_get_capabilities_case21(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x15;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1235,8 +1214,7 @@ void test_spdm_requester_get_capabilities_case22(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x16;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1259,8 +1237,7 @@ void test_spdm_requester_get_capabilities_case23(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x17;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1283,8 +1260,7 @@ void test_spdm_requester_get_capabilities_case24(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x18;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1307,8 +1283,7 @@ void test_spdm_requester_get_capabilities_case25(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x19;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1331,8 +1306,7 @@ void test_spdm_requester_get_capabilities_case26(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1a;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1355,8 +1329,7 @@ void test_spdm_requester_get_capabilities_case27(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1b;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1377,8 +1350,7 @@ void test_spdm_requester_get_capabilities_case28(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1c;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     libspdm_reset_message_a(spdm_context);
@@ -1399,8 +1371,7 @@ void test_spdm_requester_get_capabilities_case29(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1d;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.capability.ct_exponent = 0;
   spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG_VERSION_11;
 

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1261,8 +1261,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1317,8 +1316,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1384,8 +1382,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -1437,8 +1434,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1490,8 +1486,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1545,8 +1540,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1603,8 +1597,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1658,8 +1651,7 @@ void test_spdm_requester_get_certificate_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1711,8 +1703,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1772,8 +1763,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -1832,8 +1822,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
@@ -1897,8 +1886,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
@@ -1966,8 +1954,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
@@ -2034,8 +2021,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
@@ -2102,8 +2088,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
@@ -2172,8 +2157,7 @@ void test_spdm_requester_get_certificate_case16(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x10;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
   x509_get_cert_from_cert_chain((uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size,
@@ -2236,8 +2220,7 @@ void test_spdm_requester_get_certificate_case17(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -2286,8 +2269,7 @@ void test_spdm_requester_get_certificate_case18(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
     spdm_context->connection_info.capability.flags |=
@@ -2339,8 +2321,7 @@ void test_spdm_requester_get_certificate_case19(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     /* Setting SPDM context as the first steps of the protocol has been accomplished*/
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -652,8 +652,7 @@ void test_spdm_requester_get_digests_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -692,8 +691,7 @@ void test_spdm_requester_get_digests_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -743,8 +741,7 @@ void test_spdm_requester_get_digests_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -783,8 +780,7 @@ void test_spdm_requester_get_digests_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -823,8 +819,7 @@ void test_spdm_requester_get_digests_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -864,8 +859,7 @@ void test_spdm_requester_get_digests_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -910,8 +904,7 @@ void test_spdm_requester_get_digests_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -953,8 +946,7 @@ void test_spdm_requester_get_digests_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -991,8 +983,7 @@ void test_spdm_requester_get_digests_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1037,8 +1028,7 @@ void test_spdm_requester_get_digests_case10(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags = 0;
@@ -1076,8 +1066,7 @@ void test_spdm_requester_get_digests_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1118,8 +1107,7 @@ void test_spdm_requester_get_digests_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1159,8 +1147,7 @@ void test_spdm_requester_get_digests_case13(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1200,8 +1187,7 @@ void test_spdm_requester_get_digests_case14(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1242,8 +1228,7 @@ void test_spdm_requester_get_digests_case15(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1284,8 +1269,7 @@ void test_spdm_requester_get_digests_case16(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x10;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1327,8 +1311,7 @@ void test_spdm_requester_get_digests_case17(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1367,8 +1350,7 @@ void test_spdm_requester_get_digests_case18(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1408,8 +1390,7 @@ void test_spdm_requester_get_digests_case19(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1448,8 +1429,7 @@ void test_spdm_requester_get_digests_case20(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x14;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1490,8 +1470,7 @@ void test_spdm_requester_get_digests_case21(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x15;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1535,8 +1514,7 @@ void test_spdm_requester_get_digests_case22(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x16;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.peer_cert_chain_provision = m_local_certificate_chain;

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -47,11 +47,11 @@ uintn spdm_test_get_measurement_request_size(IN void *spdm_context,
         } else {
             if (buffer_size <
                 sizeof(spdm_get_measurements_request_t) -
-                    sizeof(spdm_request->SlotIDParam)) {
+                    sizeof(spdm_request->slot_id_param)) {
                 return buffer_size;
             }
             message_size = sizeof(spdm_get_measurements_request_t) -
-                       sizeof(spdm_request->SlotIDParam);
+                       sizeof(spdm_request->slot_id_param);
         }
     } else {
         /* already checked before if buffer_size < sizeof(spdm_message_header_t)*/

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -407,7 +407,6 @@ return_status spdm_requester_get_measurements_test_receive_message(
 {
     spdm_test_context_t *spdm_test_context;
     return_status status;
-    spdm_version_number_t spdm_version = {0, 0, 0, 1};
 
     spdm_test_context = get_spdm_test_context();
     switch (spdm_test_context->case_id) {
@@ -485,7 +484,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -569,7 +569,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -705,7 +706,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
             internal_dump_hex(m_local_buffer, m_local_buffer_size);
             sig_size =
                 libspdm_get_asym_signature_size(m_use_asym_algo);
-            libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                         SPDM_MEASUREMENTS,
                          m_use_asym_algo,
                          m_use_hash_algo,
                          FALSE, m_local_buffer,
@@ -856,7 +858,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
             internal_dump_hex(m_local_buffer, m_local_buffer_size);
             sig_size =
                 libspdm_get_asym_signature_size(m_use_asym_algo);
-            libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                         SPDM_MEASUREMENTS,
                          m_use_asym_algo,
                          m_use_hash_algo,
                          FALSE, m_local_buffer,
@@ -1232,7 +1235,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -1316,7 +1320,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -1856,7 +1861,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -1949,7 +1955,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
         DEBUG((DEBUG_INFO, "HashDataSize (0x%x):\n",
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -2042,7 +2049,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
         DEBUG((DEBUG_INFO, "HashDataSize (0x%x):\n",
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -2133,7 +2141,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
         DEBUG((DEBUG_INFO, "HashDataSize (0x%x):\n",
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -2501,7 +2510,8 @@ return_status spdm_requester_get_measurements_test_receive_message(
                libspdm_get_hash_size(m_use_hash_algo)));
         internal_dump_hex(m_local_buffer, m_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_use_asym_algo);
-        libspdm_responder_data_sign(spdm_version, SPDM_MEASUREMENTS,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_MEASUREMENTS,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, m_local_buffer, m_local_buffer_size,
                      ptr, &sig_size);
@@ -2548,8 +2558,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2606,8 +2615,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2664,8 +2672,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -2722,8 +2729,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2780,8 +2786,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2838,8 +2843,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2896,8 +2900,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -2956,8 +2959,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3011,8 +3013,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3067,8 +3068,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3127,8 +3127,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3191,8 +3190,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3250,8 +3248,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3309,8 +3306,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3368,8 +3364,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3428,8 +3423,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x10;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3501,8 +3495,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3564,8 +3557,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3625,8 +3617,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3683,8 +3674,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x14;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3741,8 +3731,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x15;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3801,8 +3790,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x16;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3881,8 +3869,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x17;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -3946,8 +3933,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x18;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4005,8 +3991,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x19;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4064,8 +4049,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1A;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4124,8 +4108,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1B;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4186,8 +4169,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1C;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4247,8 +4229,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1D;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4312,8 +4293,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1E;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4377,8 +4357,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1F;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
@@ -4440,8 +4419,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x20;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -458,10 +458,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -543,10 +543,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -677,10 +677,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                     libspdm_get_measurement_hash_size(
                         m_use_measurement_hash_algo),
                 1);
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_size = (uint16_t)(
                 sizeof(spdm_measurement_block_dmtf_header_t) +
                 libspdm_get_measurement_hash_size(
@@ -829,10 +829,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                     libspdm_get_measurement_hash_size(
                         m_use_measurement_hash_algo),
                 1);
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_size = (uint16_t)(
                 sizeof(spdm_measurement_block_dmtf_header_t) +
                 libspdm_get_measurement_hash_size(
@@ -935,10 +935,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1004,10 +1004,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1074,10 +1074,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1147,10 +1147,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1209,10 +1209,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1294,10 +1294,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1369,10 +1369,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                     libspdm_get_measurement_hash_size(
                         m_use_measurement_hash_algo),
                 1);
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_size = (uint16_t)(
                 sizeof(spdm_measurement_block_dmtf_header_t) +
                 libspdm_get_measurement_hash_size(
@@ -1399,10 +1399,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                     libspdm_get_measurement_hash_size(
                         m_use_measurement_hash_algo),
                 1);
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_size = (uint16_t)(
                 sizeof(spdm_measurement_block_dmtf_header_t) +
                 libspdm_get_measurement_hash_size(
@@ -1445,12 +1445,12 @@ return_status spdm_requester_get_measurements_test_receive_message(
         set_mem(measurment_block, LARGE_MEASUREMENT_SIZE, 1);
         for (count = 0; count < spdm_response->number_of_blocks;
              count++) {
-            measurment_block->Measurement_block_common_header.index =
+            measurment_block->measurement_block_common_header.index =
                 (uint8_t)(count + 1);
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_specification =
                 SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-            measurment_block->Measurement_block_common_header
+            measurment_block->measurement_block_common_header
                 .measurement_size = MAX_UINT16;
             temp_buf_size += (uintn)(
                 sizeof(spdm_measurement_block_common_header_t) +
@@ -1495,10 +1495,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header.index = 1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header.index = 1;
+        measurment_block->measurement_block_common_header
             .measurement_specification = BIT0 | BIT1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1542,10 +1542,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header.index = 1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header.index = 1;
+        measurment_block->measurement_block_common_header
             .measurement_specification = BIT2 | BIT1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1589,11 +1589,11 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header.index = 1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header.index = 1;
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             (uint8_t)(m_use_measurement_spec << 1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1638,10 +1638,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1694,10 +1694,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1756,10 +1756,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1831,10 +1831,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -1926,10 +1926,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2020,10 +2020,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2112,10 +2112,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2191,10 +2191,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2254,10 +2254,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2317,10 +2317,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2376,11 +2376,11 @@ return_status spdm_requester_get_measurements_test_receive_message(
                  libspdm_get_measurement_hash_size(
                      m_use_measurement_hash_algo)),
             1);
-        measurment_block->Measurement_block_common_header.index = 1;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header.index = 1;
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2390,11 +2390,11 @@ return_status spdm_requester_get_measurements_test_receive_message(
                  (sizeof(spdm_measurement_block_dmtf_t) +
                   libspdm_get_measurement_hash_size(
                       m_use_measurement_hash_algo)));
-        measurment_block->Measurement_block_common_header.index = 2;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header.index = 2;
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(
@@ -2484,10 +2484,10 @@ return_status spdm_requester_get_measurements_test_receive_message(
                 libspdm_get_measurement_hash_size(
                     m_use_measurement_hash_algo),
             1);
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_specification =
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->Measurement_block_common_header
+        measurment_block->measurement_block_common_header
             .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                  libspdm_get_measurement_hash_size(

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -79,10 +79,8 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 2;
-        spdm_response.version_number_entry[0].major_version = 1;
-        spdm_response.version_number_entry[0].minor_version = 0;
-        spdm_response.version_number_entry[1].major_version = 1;
-        spdm_response.version_number_entry[1].minor_version = 1;
+        spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -167,10 +165,8 @@ return_status spdm_requester_get_version_test_receive_message(
             spdm_response.header.param1 = 0;
             spdm_response.header.param2 = 0;
             spdm_response.version_number_entry_count = 2;
-            spdm_response.version_number_entry[0].major_version = 1;
-            spdm_response.version_number_entry[0].minor_version = 0;
-            spdm_response.version_number_entry[1].major_version = 1;
-            spdm_response.version_number_entry[1].minor_version = 1;
+            spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+            spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
             spdm_transport_test_encode_message(
                 spdm_context, NULL, FALSE, FALSE,
@@ -252,10 +248,8 @@ return_status spdm_requester_get_version_test_receive_message(
             spdm_response.header.param1 = 0;
             spdm_response.header.param2 = 0;
             spdm_response.version_number_entry_count = 2;
-            spdm_response.version_number_entry[0].major_version = 1;
-            spdm_response.version_number_entry[0].minor_version = 0;
-            spdm_response.version_number_entry[1].major_version = 1;
-            spdm_response.version_number_entry[1].minor_version = 1;
+            spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+            spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
             spdm_transport_test_encode_message(
                 spdm_context, NULL, FALSE, FALSE,
@@ -275,12 +269,9 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 2;
-        spdm_response.version_number_entry[0].major_version = 1;
-        spdm_response.version_number_entry[0].minor_version = 0;
-        spdm_response.version_number_entry[1].major_version = 1;
-        spdm_response.version_number_entry[1].minor_version = 1;
-        spdm_response.version_number_entry[2].major_version = 1;
-        spdm_response.version_number_entry[2].minor_version = 2;
+        spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[2] = 0x12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -298,10 +289,8 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 2;
-        spdm_response.version_number_entry[0].major_version = 10;
-        spdm_response.version_number_entry[0].minor_version = 0;
-        spdm_response.version_number_entry[1].major_version = 10;
-        spdm_response.version_number_entry[1].minor_version = 1;
+        spdm_response.version_number_entry[0] = 0xA0 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0xA1 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -319,10 +308,8 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 2;
-        spdm_response.version_number_entry[0].major_version = 1;
-        spdm_response.version_number_entry[0].minor_version = 0;
-        spdm_response.version_number_entry[1].major_version = 1;
-        spdm_response.version_number_entry[1].minor_version = 1;
+        spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -340,10 +327,8 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 2;
-        spdm_response.version_number_entry[0].major_version = 1;
-        spdm_response.version_number_entry[0].minor_version = 0;
-        spdm_response.version_number_entry[1].major_version = 1;
-        spdm_response.version_number_entry[1].minor_version = 1;
+        spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -389,17 +374,11 @@ return_status spdm_requester_get_version_test_receive_message(
         spdm_response.header.param1 = 0;
         spdm_response.header.param2 = 0;
         spdm_response.version_number_entry_count = 5;
-        spdm_response.version_number_entry[0].major_version = 4;
-        spdm_response.version_number_entry[0].minor_version = 2;
-        spdm_response.version_number_entry[1].major_version = 5;
-        spdm_response.version_number_entry[1].minor_version = 2;
-        spdm_response.version_number_entry[2].major_version = 1;
-        spdm_response.version_number_entry[2].minor_version = 2;
-        spdm_response.version_number_entry[3].major_version = 1;
-        spdm_response.version_number_entry[3].minor_version = 1;
-        spdm_response.version_number_entry[4].major_version = 1;
-        spdm_response.version_number_entry[4].minor_version = 0;
-
+        spdm_response.version_number_entry[0] = 0x42 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[1] = 0x52 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[2] = 0x12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[3] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_response.version_number_entry[4] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
         spdm_transport_test_encode_message(spdm_context, NULL, FALSE,
                            FALSE, sizeof(spdm_response),
@@ -717,22 +696,15 @@ void test_spdm_requester_get_version_case15(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
     spdm_context->local_context.version.spdm_version_count = 5;
-    spdm_context->local_context.version.spdm_version[0].major_version = 5;
-    spdm_context->local_context.version.spdm_version[0].minor_version = 5;
-    spdm_context->local_context.version.spdm_version[1].major_version = 4;
-    spdm_context->local_context.version.spdm_version[1].minor_version = 5;
-    spdm_context->local_context.version.spdm_version[2].major_version = 0;
-    spdm_context->local_context.version.spdm_version[2].minor_version = 9;
-    spdm_context->local_context.version.spdm_version[3].major_version = 1;
-    spdm_context->local_context.version.spdm_version[3].minor_version = 0;
-    spdm_context->local_context.version.spdm_version[4].major_version = 1;
-    spdm_context->local_context.version.spdm_version[4].minor_version = 1;
+    spdm_context->local_context.version.spdm_version[0] = 0x55 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[1] = 0x45 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[2] = 0x09 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[3] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[4] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     status = spdm_get_version(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
-        spdm_context->connection_info.version.major_version, 1);
-    assert_int_equal(
-        spdm_context->connection_info.version.minor_version, 1);
+        spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT, 0x11);
 }
 
 spdm_test_context_t mSpdmRequesterGetVersionTestContext = {

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -480,8 +480,7 @@ void test_spdm_requester_heartbeat_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -546,8 +545,7 @@ void test_spdm_requester_heartbeat_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -635,8 +633,7 @@ void test_spdm_requester_heartbeat_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -724,8 +721,7 @@ void test_spdm_requester_heartbeat_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -813,8 +809,7 @@ void test_spdm_requester_heartbeat_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -902,8 +897,7 @@ void test_spdm_requester_heartbeat_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -991,8 +985,7 @@ void test_spdm_requester_heartbeat_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1082,8 +1075,7 @@ void test_spdm_requester_heartbeat_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1171,8 +1163,7 @@ void test_spdm_requester_heartbeat_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1260,8 +1251,7 @@ void test_spdm_requester_heartbeat_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
@@ -1329,8 +1319,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -178,7 +178,6 @@ return_status spdm_requester_key_exchange_test_receive_message(
     IN OUT void *response, IN uint64_t timeout)
 {
     spdm_test_context_t *spdm_test_context;
-    spdm_version_number_t spdm_version = {0, 0, 1, 1};
 
     spdm_test_context = get_spdm_test_context();
     switch (spdm_test_context->case_id) {
@@ -252,7 +251,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
                        spdm_response->random_data);
         ptr = (void *)(spdm_response + 1);
-        dhe_context = libspdm_dhe_new(spdm_version, m_use_dhe_algo, TRUE);
+        dhe_context = libspdm_dhe_new(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, m_use_dhe_algo, TRUE);
         libspdm_dhe_generate_key(m_use_dhe_algo, dhe_context, ptr,
                       &dhe_key_size);
         final_key_size = sizeof(final_key);
@@ -291,7 +290,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_use_hash_algo, get_managed_buffer(&th_curr),
                   get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(spdm_version, SPDM_KEY_EXCHANGE_RSP,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_KEY_EXCHANGE_RSP,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, get_managed_buffer(&th_curr),
                      get_managed_buffer_size(&th_curr), ptr,
@@ -403,7 +403,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
                        spdm_response->random_data);
         ptr = (void *)(spdm_response + 1);
-        dhe_context = libspdm_dhe_new(spdm_version, m_use_dhe_algo, TRUE);
+        dhe_context = libspdm_dhe_new(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, m_use_dhe_algo, TRUE);
         libspdm_dhe_generate_key(m_use_dhe_algo, dhe_context, ptr,
                       &dhe_key_size);
         final_key_size = sizeof(final_key);
@@ -442,7 +442,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_use_hash_algo, get_managed_buffer(&th_curr),
                   get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(spdm_version, SPDM_KEY_EXCHANGE_RSP,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_KEY_EXCHANGE_RSP,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, get_managed_buffer(&th_curr),
                      get_managed_buffer_size(&th_curr), ptr,
@@ -604,7 +605,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
             libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
                            spdm_response->random_data);
             ptr = (void *)(spdm_response + 1);
-            dhe_context = libspdm_dhe_new(spdm_version, m_use_dhe_algo, TRUE);
+            dhe_context = libspdm_dhe_new(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, m_use_dhe_algo, TRUE);
             libspdm_dhe_generate_key(m_use_dhe_algo, dhe_context, ptr,
                           &dhe_key_size);
             final_key_size = sizeof(final_key);
@@ -650,7 +651,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
                       get_managed_buffer_size(&th_curr),
                       hash_data);
             free(data);
-            libspdm_responder_data_sign(spdm_version, SPDM_KEY_EXCHANGE_RSP,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                SPDM_KEY_EXCHANGE_RSP,
                 m_use_asym_algo, m_use_hash_algo,
                 FALSE, get_managed_buffer(&th_curr),
                 get_managed_buffer_size(&th_curr), ptr,
@@ -832,7 +834,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
             libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
                            spdm_response->random_data);
             ptr = (void *)(spdm_response + 1);
-            dhe_context = libspdm_dhe_new(spdm_version, m_use_dhe_algo, TRUE);
+            dhe_context = libspdm_dhe_new(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, m_use_dhe_algo, TRUE);
             libspdm_dhe_generate_key(m_use_dhe_algo, dhe_context, ptr,
                           &dhe_key_size);
             final_key_size = sizeof(final_key);
@@ -878,7 +880,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
                       get_managed_buffer_size(&th_curr),
                       hash_data);
             free(data);
-            libspdm_responder_data_sign(spdm_version, SPDM_KEY_EXCHANGE_RSP,
+            libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                SPDM_KEY_EXCHANGE_RSP,
                 m_use_asym_algo, m_use_hash_algo,
                 FALSE, get_managed_buffer(&th_curr),
                 get_managed_buffer_size(&th_curr), ptr,
@@ -1025,7 +1028,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE,
                        spdm_response->random_data);
         ptr = (void *)(spdm_response + 1);
-        dhe_context = libspdm_dhe_new(spdm_version, m_use_dhe_algo, TRUE);
+        dhe_context = libspdm_dhe_new(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, m_use_dhe_algo, TRUE);
         libspdm_dhe_generate_key(m_use_dhe_algo, dhe_context, ptr,
                       &dhe_key_size);
         final_key_size = sizeof(final_key);
@@ -1064,7 +1067,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_use_hash_algo, get_managed_buffer(&th_curr),
                   get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(spdm_version, SPDM_KEY_EXCHANGE_RSP,
+        libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                     SPDM_KEY_EXCHANGE_RSP,
                      m_use_asym_algo, m_use_hash_algo,
                      FALSE, get_managed_buffer(&th_curr),
                      get_managed_buffer_size(&th_curr), ptr,
@@ -1130,8 +1134,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1181,8 +1184,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1239,8 +1241,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -1292,8 +1293,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1345,8 +1345,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1398,8 +1397,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1456,8 +1454,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1511,8 +1508,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1564,8 +1560,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1622,8 +1617,7 @@ void test_spdm_requester_key_exchange_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
@@ -1678,8 +1672,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -2608,8 +2608,7 @@ void test_spdm_requester_key_update_case1(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2647,8 +2646,7 @@ void test_spdm_requester_key_update_case2(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2702,8 +2700,7 @@ void test_spdm_requester_key_update_case3(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2745,8 +2742,7 @@ void test_spdm_requester_key_update_case4(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2796,8 +2792,7 @@ void test_spdm_requester_key_update_case5(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2849,8 +2844,7 @@ void test_spdm_requester_key_update_case6(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2906,8 +2900,7 @@ void test_spdm_requester_key_update_case7(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -2948,8 +2941,7 @@ void test_spdm_requester_key_update_case8(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3001,8 +2993,7 @@ void test_spdm_requester_key_update_case9(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3062,8 +3053,7 @@ void test_spdm_requester_key_update_case10(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3125,8 +3115,7 @@ void test_spdm_requester_key_update_case11(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3201,8 +3190,7 @@ void test_spdm_requester_key_update_case12(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3258,8 +3246,7 @@ void test_spdm_requester_key_update_case13(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3310,8 +3297,7 @@ void test_spdm_requester_key_update_case14(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3367,8 +3353,7 @@ void test_spdm_requester_key_update_case15(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xF;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3419,8 +3404,7 @@ void test_spdm_requester_key_update_case16(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x10;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3470,8 +3454,7 @@ void test_spdm_requester_key_update_case17(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x11;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3527,8 +3510,7 @@ void test_spdm_requester_key_update_case18(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x12;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3585,8 +3567,7 @@ void test_spdm_requester_key_update_case19(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3642,8 +3623,7 @@ void test_spdm_requester_key_update_case20(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x14;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3684,8 +3664,7 @@ void test_spdm_requester_key_update_case21(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x15;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3741,8 +3720,7 @@ void test_spdm_requester_key_update_case22(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x16;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3802,8 +3780,7 @@ void test_spdm_requester_key_update_case23(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x17;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3876,8 +3853,7 @@ void test_spdm_requester_key_update_case24(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x18;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3933,8 +3909,7 @@ void test_spdm_requester_key_update_case25(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x19;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -3990,8 +3965,7 @@ void test_spdm_requester_key_update_case26(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1A;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4046,8 +4020,7 @@ void test_spdm_requester_key_update_case27(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1B;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4108,8 +4081,7 @@ void test_spdm_requester_key_update_case28(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1C;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4173,8 +4145,7 @@ void test_spdm_requester_key_update_case29(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1D;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4239,8 +4210,7 @@ void test_spdm_requester_key_update_case30(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1E;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4313,8 +4283,7 @@ void test_spdm_requester_key_update_case31(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1F;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4368,8 +4337,7 @@ void test_spdm_requester_key_update_case32(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x20;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4434,8 +4402,7 @@ void test_spdm_requester_key_update_case33(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x21;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 
@@ -4512,8 +4479,7 @@ void test_spdm_requester_key_update_case34(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x22;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_set_standard_key_update_test_state(
           spdm_context, &session_id);
 

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -958,8 +958,7 @@ void test_spdm_requester_negotiate_algorithms_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -984,8 +983,7 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1012,8 +1010,7 @@ void test_spdm_requester_negotiate_algorithms_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1038,8 +1035,7 @@ void test_spdm_requester_negotiate_algorithms_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1064,8 +1060,7 @@ void test_spdm_requester_negotiate_algorithms_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1090,8 +1085,7 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1118,8 +1112,7 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1146,8 +1139,7 @@ void test_spdm_requester_negotiate_algorithms_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1169,8 +1161,7 @@ void test_spdm_requester_negotiate_algorithms_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1195,8 +1186,7 @@ void test_spdm_requester_negotiate_algorithms_case10(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1226,8 +1216,7 @@ void test_spdm_requester_negotiate_algorithms_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1258,8 +1247,7 @@ void test_spdm_requester_negotiate_algorithms_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
     spdm_context->local_context.algorithm.measurement_hash_algo =
@@ -1285,8 +1273,7 @@ void test_spdm_requester_negotiate_algorithms_case13(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xD;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1305,8 +1292,7 @@ void test_spdm_requester_negotiate_algorithms_case14(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xE;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1325,8 +1311,7 @@ void test_spdm_requester_negotiate_algorithms_case15(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xF;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1345,8 +1330,7 @@ void test_spdm_requester_negotiate_algorithms_case16(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x10;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1365,8 +1349,7 @@ void test_spdm_requester_negotiate_algorithms_case17(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x11;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1385,8 +1368,7 @@ void test_spdm_requester_negotiate_algorithms_case18(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x12;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1405,8 +1387,7 @@ void test_spdm_requester_negotiate_algorithms_case19(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x13;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1425,8 +1406,7 @@ void test_spdm_requester_negotiate_algorithms_case20(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x14;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1445,8 +1425,7 @@ void test_spdm_requester_negotiate_algorithms_case21(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x15;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1465,8 +1444,7 @@ void test_spdm_requester_negotiate_algorithms_case22(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x16;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1486,8 +1464,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x17;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1529,8 +1506,7 @@ void test_spdm_requester_negotiate_algorithms_case24(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x18;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1569,8 +1545,7 @@ void test_spdm_requester_negotiate_algorithms_case25(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x19;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1609,8 +1584,7 @@ void test_spdm_requester_negotiate_algorithms_case26(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1A;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1649,8 +1623,7 @@ void test_spdm_requester_negotiate_algorithms_case27(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1B;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1689,8 +1662,7 @@ void test_spdm_requester_negotiate_algorithms_case28(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1C;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1729,8 +1701,7 @@ void test_spdm_requester_negotiate_algorithms_case29(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1D;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1769,8 +1740,7 @@ void test_spdm_requester_negotiate_algorithms_case30(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1E;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
@@ -1809,8 +1779,7 @@ void test_spdm_requester_negotiate_algorithms_case31(void **state) {
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0x1F;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
   spdm_context->local_context.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -167,7 +167,6 @@ return_status spdm_requester_psk_exchange_test_receive_message(
     IN OUT void *response, IN uint64_t timeout)
 {
     spdm_test_context_t *spdm_test_context;
-    spdm_version_number_t spdm_version = {0, 0, 1, 1};
 
     spdm_test_context = get_spdm_test_context();
     switch (spdm_test_context->case_id) {
@@ -266,7 +265,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
         zero_mem(m_local_psk_hint, 32);
         copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
              sizeof(TEST_PSK_HINT_STRING));
-        libspdm_psk_handshake_secret_hkdf_expand(spdm_version,
+        libspdm_psk_handshake_secret_hkdf_expand(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             m_use_hash_algo, m_local_psk_hint,
             sizeof(TEST_PSK_HINT_STRING), bin_str2, bin_str2_size,
             response_handshake_secret, hash_size);
@@ -381,7 +380,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
         zero_mem(m_local_psk_hint, 32);
         copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
              sizeof(TEST_PSK_HINT_STRING));
-        libspdm_psk_handshake_secret_hkdf_expand(spdm_version,
+        libspdm_psk_handshake_secret_hkdf_expand(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             m_use_hash_algo, m_local_psk_hint,
             sizeof(TEST_PSK_HINT_STRING), bin_str2, bin_str2_size,
             response_handshake_secret, hash_size);
@@ -553,7 +552,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
             zero_mem(m_local_psk_hint, 32);
             copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
                  sizeof(TEST_PSK_HINT_STRING));
-            libspdm_psk_handshake_secret_hkdf_expand(spdm_version,
+            libspdm_psk_handshake_secret_hkdf_expand(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 m_use_hash_algo, m_local_psk_hint,
                 sizeof(TEST_PSK_HINT_STRING), bin_str2,
                 bin_str2_size, response_handshake_secret,
@@ -742,7 +741,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
             zero_mem(m_local_psk_hint, 32);
             copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
                  sizeof(TEST_PSK_HINT_STRING));
-            libspdm_psk_handshake_secret_hkdf_expand(spdm_version,
+            libspdm_psk_handshake_secret_hkdf_expand(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 m_use_hash_algo, m_local_psk_hint,
                 sizeof(TEST_PSK_HINT_STRING), bin_str2,
                 bin_str2_size, response_handshake_secret,
@@ -890,7 +889,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
         zero_mem(m_local_psk_hint, 32);
         copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
              sizeof(TEST_PSK_HINT_STRING));
-        libspdm_psk_handshake_secret_hkdf_expand(spdm_version,
+        libspdm_psk_handshake_secret_hkdf_expand(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             m_use_hash_algo, m_local_psk_hint,
             sizeof(TEST_PSK_HINT_STRING), bin_str2, bin_str2_size,
             response_handshake_secret, hash_size);
@@ -934,8 +933,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -991,8 +989,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1053,8 +1050,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -1110,8 +1106,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1167,8 +1162,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1224,8 +1218,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1286,8 +1279,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1345,8 +1337,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1402,8 +1393,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1464,8 +1454,7 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, &hash, &hash_size);
@@ -1523,8 +1512,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -602,8 +602,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -674,8 +673,7 @@ void test_spdm_requester_psk_finish_case2(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -773,8 +771,7 @@ void test_spdm_requester_psk_finish_case3(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     spdm_context->connection_info.capability.flags |=
@@ -868,8 +865,7 @@ void test_spdm_requester_psk_finish_case4(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -963,8 +959,7 @@ void test_spdm_requester_psk_finish_case5(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1060,8 +1055,7 @@ void test_spdm_requester_psk_finish_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1160,8 +1154,7 @@ void test_spdm_requester_psk_finish_case7(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1257,8 +1250,7 @@ void test_spdm_requester_psk_finish_case8(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1354,8 +1346,7 @@ void test_spdm_requester_psk_finish_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1456,8 +1447,7 @@ void test_spdm_requester_psk_finish_case10(void **state) {
   spdm_test_context = *state;
   spdm_context = spdm_test_context->spdm_context;
   spdm_test_context->case_id = 0xA;
-  spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
   spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
@@ -1526,8 +1516,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -1647,8 +1636,7 @@ void test_spdm_requester_psk_finish_case12(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     /*no PSK capabilities*/
@@ -1743,8 +1731,7 @@ void test_spdm_requester_psk_finish_case13(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     /*no PSK capabilities*/
@@ -1840,8 +1827,7 @@ void test_spdm_requester_psk_finish_case14(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     /*no PSK capabilities*/

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -913,8 +913,7 @@ void test_spdm_responder_algorithms_case7(void **state) {
   spdm_test_context->case_id = 0x7;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -966,8 +965,7 @@ void test_spdm_responder_algorithms_case8(void **state) {
   spdm_test_context->case_id = 0x8;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1018,8 +1016,7 @@ void test_spdm_responder_algorithms_case9(void **state) {
   spdm_test_context->case_id = 0x9;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1070,8 +1067,7 @@ void test_spdm_responder_algorithms_case10(void **state) {
   spdm_test_context->case_id = 0xA;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1122,8 +1118,7 @@ void test_spdm_responder_algorithms_case11(void **state) {
   spdm_test_context->case_id = 0xB;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1174,8 +1169,7 @@ void test_spdm_responder_algorithms_case12(void **state) {
   spdm_test_context->case_id = 0xC;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1225,8 +1219,7 @@ void test_spdm_responder_algorithms_case13(void **state) {
   spdm_test_context->case_id = 0xD;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1271,8 +1264,7 @@ void test_spdm_responder_algorithms_case14(void **state) {
   spdm_test_context->case_id = 0xE;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 0;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
@@ -1295,8 +1287,7 @@ void test_spdm_responder_algorithms_case15(void **state) {
   spdm_test_context->case_id = 0xF;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1339,8 +1330,7 @@ void test_spdm_responder_algorithms_case16(void **state) {
   spdm_test_context->case_id = 0x10;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1392,8 +1382,7 @@ void test_spdm_responder_algorithms_case17(void **state) {
   spdm_test_context->case_id = 0x11;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1445,8 +1434,7 @@ void test_spdm_responder_algorithms_case18(void **state) {
   spdm_test_context->case_id = 0x12;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1494,8 +1482,7 @@ void test_spdm_responder_algorithms_case19(void **state) {
   spdm_test_context->case_id = 0x13;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
   spdm_context->local_context.algorithm.dhe_named_group = m_use_dhe_algo;
@@ -1548,8 +1535,7 @@ void test_spdm_responder_algorithms_case20(void **state) {
   spdm_test_context->case_id = 0x14;
   spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.algorithm.base_hash_algo =
       SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512 |
       SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -617,8 +617,7 @@ void test_spdm_responder_capabilities_case7(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
 
     response_size = sizeof(response);
     status = spdm_get_response_capabilities(

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -81,8 +81,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -154,8 +153,7 @@ void test_spdm_responder_challenge_auth_case2(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -218,8 +216,7 @@ void test_spdm_responder_challenge_auth_case3(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -283,8 +280,7 @@ void test_spdm_responder_challenge_auth_case4(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -350,8 +346,7 @@ void test_spdm_responder_challenge_auth_case5(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -422,8 +417,7 @@ void test_spdm_responder_challenge_auth_case6(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -478,8 +472,7 @@ void test_spdm_responder_challenge_auth_case7(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -526,8 +519,7 @@ void test_spdm_responder_challenge_auth_case8(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -574,8 +566,7 @@ void test_spdm_responder_challenge_auth_case9(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[1] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[1] = data_size1;
@@ -622,8 +613,7 @@ void test_spdm_responder_challenge_auth_case10(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -670,8 +660,7 @@ void test_spdm_responder_challenge_auth_case11(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -720,8 +709,7 @@ void test_spdm_responder_challenge_auth_case12(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -769,8 +757,7 @@ void test_spdm_responder_challenge_auth_case13(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
@@ -819,8 +806,7 @@ void test_spdm_responder_challenge_auth_case14(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data1, &data_size1, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data1;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -889,7 +889,6 @@ void test_spdm_responder_finish_case8(void **state)
     uint32_t hash_size;
     uint32_t hmac_size;
     uintn req_asym_signature_size;
-    spdm_version_number_t spdm_version = {0, 0, 1, 1};
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -975,7 +974,7 @@ void test_spdm_responder_finish_case8(void **state)
     append_managed_buffer(&th_curr, req_cert_buffer_hash, hash_size);
     append_managed_buffer(&th_curr, (uint8_t *)&m_spdm_finish_request3,
                   sizeof(spdm_finish_request_t));
-    libspdm_requester_data_sign(spdm_version, SPDM_FINISH,
+    libspdm_requester_data_sign(m_spdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
         m_use_req_asym_algo, m_use_hash_algo,
         FALSE, get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
         ptr, &req_asym_signature_size);
@@ -1678,7 +1677,6 @@ void test_spdm_responder_finish_case15(void **state)
     uint32_t hash_size;
     uint32_t hmac_size;
     uintn req_asym_signature_size;
-    spdm_version_number_t spdm_version = {0, 0, 1, 1};
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -1764,7 +1762,7 @@ void test_spdm_responder_finish_case15(void **state)
     append_managed_buffer(&th_curr, req_cert_buffer_hash, hash_size);
     append_managed_buffer(&th_curr, (uint8_t *)&m_spdm_finish_request3,
                   sizeof(spdm_finish_request_t));
-    libspdm_requester_data_sign(spdm_version, SPDM_FINISH,
+    libspdm_requester_data_sign(m_spdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
         m_use_req_asym_algo, m_use_hash_algo,
         FALSE, get_managed_buffer(&th_curr), get_managed_buffer_size(&th_curr),
         ptr, &req_asym_signature_size);
@@ -1826,7 +1824,6 @@ void test_spdm_responder_finish_case16(void **state)
     uint32_t hash_size;
     uint32_t hmac_size;
     uintn req_asym_signature_size;
-    spdm_version_number_t spdm_version = {0, 0, 1, 1};
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -1915,7 +1912,7 @@ void test_spdm_responder_finish_case16(void **state)
     /*randomize signature*/
     libspdm_hash_all(m_use_hash_algo, get_managed_buffer(&th_curr),
               get_managed_buffer_size(&th_curr), random_buffer);
-    libspdm_requester_data_sign(spdm_version, SPDM_FINISH,
+    libspdm_requester_data_sign(m_spdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
         m_use_req_asym_algo, m_use_hash_algo,
         FALSE, random_buffer, hash_size, ptr, &req_asym_signature_size);
     append_managed_buffer(&th_curr, ptr, req_asym_signature_size);

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -71,8 +71,7 @@ void test_spdm_responder_key_exchange_case1(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -152,8 +151,7 @@ void test_spdm_responder_key_exchange_case2(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -233,8 +231,7 @@ void test_spdm_responder_key_exchange_case3(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -315,8 +312,7 @@ void test_spdm_responder_key_exchange_case4(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -399,8 +395,7 @@ void test_spdm_responder_key_exchange_case5(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -487,8 +482,7 @@ void test_spdm_responder_key_exchange_case6(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);
@@ -567,8 +561,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
         m_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite =
         m_use_aead_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data1,
                         &data_size1, NULL, NULL);

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -787,11 +787,11 @@ void test_spdm_responder_measurements_case13(void **state)
 
     TestMsgSizes[0] =
         (uint16_t)(m_spdm_get_measurements_request9_size +
-             sizeof(m_spdm_get_measurements_request9.SlotIDParam) +
+             sizeof(m_spdm_get_measurements_request9.slot_id_param) +
              sizeof(m_spdm_get_measurements_request9.nonce));
     TestMsgSizes[1] =
         (uint16_t)(m_spdm_get_measurements_request9_size +
-             sizeof(m_spdm_get_measurements_request9.SlotIDParam));
+             sizeof(m_spdm_get_measurements_request9.slot_id_param));
     TestMsgSizes[2] =
         (uint16_t)(m_spdm_get_measurements_request9_size +
              sizeof(m_spdm_get_measurements_request9.nonce));
@@ -856,11 +856,11 @@ void test_spdm_responder_measurements_case14(void **state)
 
     TestMsgSizes[0] =
         (uint16_t)(m_spdm_get_measurements_request10_size -
-             sizeof(m_spdm_get_measurements_request10.SlotIDParam) -
+             sizeof(m_spdm_get_measurements_request10.slot_id_param) -
              sizeof(m_spdm_get_measurements_request10.nonce));
     TestMsgSizes[1] =
         (uint16_t)(m_spdm_get_measurements_request10_size -
-             sizeof(m_spdm_get_measurements_request10.SlotIDParam));
+             sizeof(m_spdm_get_measurements_request10.slot_id_param));
     TestMsgSizes[2] =
         (uint16_t)(m_spdm_get_measurements_request10_size -
              sizeof(m_spdm_get_measurements_request10.nonce));
@@ -1136,7 +1136,7 @@ void test_spdm_responder_measurements_case18(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
 #endif
-    assert_int_equal(m_spdm_get_measurements_request11.SlotIDParam,
+    assert_int_equal(m_spdm_get_measurements_request11.slot_id_param,
              spdm_response->header.param2);
 
     spdm_context->local_context.slot_count = 1;
@@ -1463,8 +1463,8 @@ spdm_test_context_t m_spdm_responder_measurements_test_context = {
 
 int spdm_responder_measurements_test_main(void)
 {
-    m_spdm_get_measurements_request11.SlotIDParam = SPDM_MAX_SLOT_COUNT - 1;
-    m_spdm_get_measurements_request12.SlotIDParam = SPDM_MAX_SLOT_COUNT + 1;
+    m_spdm_get_measurements_request11.slot_id_param = SPDM_MAX_SLOT_COUNT - 1;
+    m_spdm_get_measurements_request12.slot_id_param = SPDM_MAX_SLOT_COUNT + 1;
 
     const struct CMUnitTest spdm_responder_measurements_tests[] = {
         /* Success Case to get measurement number without signature*/

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -811,8 +811,7 @@ void test_spdm_responder_measurements_case13(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -881,8 +880,7 @@ void test_spdm_responder_measurements_case14(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -940,8 +938,7 @@ void test_spdm_responder_measurements_case15(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -995,8 +992,7 @@ void test_spdm_responder_measurements_case16(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1046,8 +1042,7 @@ void test_spdm_responder_measurements_case17(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1105,8 +1100,7 @@ void test_spdm_responder_measurements_case18(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1177,8 +1171,7 @@ void test_spdm_responder_measurements_case19(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1231,8 +1224,7 @@ void test_spdm_responder_measurements_case20(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1284,8 +1276,7 @@ void test_spdm_responder_measurements_case21(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1339,8 +1330,7 @@ void test_spdm_responder_measurements_case22(void **state)
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
 
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_reset_message_m(spdm_context, NULL);
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
@@ -1424,8 +1414,7 @@ void test_spdm_responder_measurements_case23(void **state)
         m_use_measurement_spec;
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_use_measurement_hash_algo;
-    spdm_context->connection_info.version.major_version = 1;
-    spdm_context->connection_info.version.minor_version = 0;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.opaque_measurement_rsp_size = 0;
     spdm_context->local_context.opaque_measurement_rsp = NULL;
     measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16_t) + 0 +

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -298,8 +298,7 @@ void test_spdm_responder_respond_if_ready_case1(void **state) {
   spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.local_cert_chain_provision[0] = m_local_certificate_chain;
   spdm_context->local_context.local_cert_chain_provision_size[0] = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
   set_mem (m_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, (uint8_t)(0xFF));
@@ -358,8 +357,7 @@ void test_spdm_responder_respond_if_ready_case2(void **state) {
   spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
   spdm_context->connection_info.algorithm.base_asym_algo = m_use_asym_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
@@ -423,8 +421,7 @@ void test_spdm_responder_respond_if_ready_case3(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
@@ -487,8 +484,7 @@ void test_spdm_responder_respond_if_ready_case4(void **state) {
   spdm_context->connection_info.algorithm.measurement_spec = m_use_measurement_spec;
   spdm_context->connection_info.algorithm.measurement_hash_algo = m_use_measurement_hash_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   spdm_context->local_context.opaque_measurement_rsp_size = 0;
   spdm_context->local_context.opaque_measurement_rsp = NULL;
 
@@ -555,8 +551,7 @@ void test_spdm_responder_respond_if_ready_case5(void **state) {
   spdm_context->connection_info.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->connection_info.algorithm.aead_cipher_suite = m_use_aead_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
@@ -653,8 +648,7 @@ void test_spdm_responder_respond_if_ready_case6(void **state) {
   spdm_context->connection_info.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->connection_info.algorithm.aead_cipher_suite = m_use_aead_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
@@ -749,8 +743,7 @@ void test_spdm_responder_respond_if_ready_case7(void **state) {
   spdm_context->connection_info.algorithm.aead_cipher_suite = m_use_aead_algo;
   spdm_context->connection_info.algorithm.key_schedule = m_use_key_schedule_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
@@ -845,8 +838,7 @@ void test_spdm_responder_respond_if_ready_case8(void **state) {
   spdm_context->connection_info.algorithm.dhe_named_group = m_use_dhe_algo;
   spdm_context->connection_info.algorithm.aead_cipher_suite = m_use_aead_algo;
 
-  spdm_context->connection_info.version.major_version = 1;
-  spdm_context->connection_info.version.minor_version = 1;
+  spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
   read_responder_public_certificate_chain (m_use_hash_algo, m_use_asym_algo, &data, &data_size, NULL, NULL);
   spdm_context->local_context.local_cert_chain_provision[0] = data;
   spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;


### PR DESCRIPTION
This PR removes bit flags definition in spdm.h, according to discussion in #457.

1) spdm_version_number_t - done
2) spdm_negotiate_algorithms_struct_table_alg_count_t - done
3) spdm_challenge_auth_response_attribute_t - done
4) spdm_get_measurements_request_slot_id_parameter_t - done
5) SPDM_MEASUREMENTS_BLOCK_MEASUREMENT_TYPE - done

PR for spdm_emu - https://github.com/DMTF/spdm-emu/pull/32
PR for spdm_dump - https://github.com/DMTF/spdm-dump/pull/12

