### PR TITLE
Add check version for mutual function and add missing check in spdm_requester_lib

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -53,6 +53,9 @@ return_status spdm_requester_respond_if_ready(IN spdm_context_t *spdm_context,
     if (*response_size < sizeof(spdm_message_header_t)) {
         return RETURN_DEVICE_ERROR;
     }
+    if (spdm_response->spdm_version != spdm_request.header.spdm_version) {
+        return RETURN_DEVICE_ERROR;
+    }
     if (spdm_response->request_response_code != expected_response_code) {
         return RETURN_DEVICE_ERROR;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -114,6 +114,9 @@ return_status spdm_process_encap_response_challenge_auth(
     if (spdm_response_size < sizeof(spdm_message_header_t)) {
         return RETURN_DEVICE_ERROR;
     }
+    if (spdm_response->header.spdm_version != spdm_get_connection_version (spdm_context)) {
+        return RETURN_DEVICE_ERROR;
+    }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
         status = spdm_handle_encap_error_response_main(
             spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -102,6 +102,9 @@ return_status spdm_process_encap_response_certificate(
     if (spdm_response_size < sizeof(spdm_message_header_t)) {
         return RETURN_DEVICE_ERROR;
     }
+    if (spdm_response->header.spdm_version != spdm_get_connection_version (spdm_context)) {
+        return RETURN_DEVICE_ERROR;
+    }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
         status = spdm_handle_encap_error_response_main(
             spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
@@ -98,6 +98,9 @@ return_status spdm_process_encap_response_digest(
     if (spdm_response_size < sizeof(spdm_message_header_t)) {
         return RETURN_DEVICE_ERROR;
     }
+    if (spdm_response->header.spdm_version != spdm_get_connection_version (spdm_context)) {
+        return RETURN_DEVICE_ERROR;
+    }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
         status = spdm_handle_encap_error_response_main(
             spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -156,6 +156,9 @@ return_status spdm_process_encap_response_key_update(
     spdm_response = encap_response;
     spdm_response_size = encap_response_size;
 
+    if (spdm_response->header.spdm_version != spdm_get_connection_version (spdm_context)) {
+        return RETURN_DEVICE_ERROR;
+    }
     if ((spdm_response_size != sizeof(spdm_key_update_response_t)) ||
         (spdm_response->header.request_response_code !=
          SPDM_KEY_UPDATE_ACK) ||


### PR DESCRIPTION
Fix: #402 

Add check version for mutual function in spdm_responder_lib.

Add missing check the SPDM Version filed of response message in spdm_requester_lib.