### PR TITLE
Fix the hardcode for secured message binding version

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1027,4 +1027,14 @@ spdm_process_opaque_data_supported_version_data(IN spdm_context_t *spdm_context,
   @return the SPDMversion of the version number struct.
 **/
 uint8_t spdm_get_version_from_version_number(IN spdm_version_number_t ver);
+
+/**
+  Sort SPDMversion in descending order.
+
+  @param  spdm_context                A pointer to the SPDM context.
+  @param  ver_set                    A pointer to the version set.
+  @param  ver_num                    Version number.
+*/
+void spdm_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ver_num);
+
 #endif

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1037,4 +1037,20 @@ uint8_t spdm_get_version_from_version_number(IN spdm_version_number_t ver);
 */
 void spdm_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ver_num);
 
+/**
+  Negotiate SPDMversion for connection.
+  ver_set is the local version set of requester, res_ver_set is the version set of responder.
+
+  @param  common_version             A pointer to store the common version.
+  @param  req_ver_set                A pointer to the requester version set.
+  @param  req_ver_num                Version number of requester.
+  @param  res_ver_set                A pointer to the responder version set.
+  @param  res_ver_num                Version number of responder.
+
+  @retval TRUE                       Negotiation successfully, connect version be saved to common_version.
+  @retval FALSE                      Negotiation failed.
+*/
+boolean spdm_negotiate_connection_version(IN OUT spdm_version_number_t *common_version, IN spdm_version_number_t *req_ver_set, IN uintn req_ver_num,
+                                           IN spdm_version_number_t *res_ver_set, IN uintn res_ver_num);
+
 #endif

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1901,3 +1901,35 @@ uint8_t spdm_get_version_from_version_number(IN spdm_version_number_t ver)
 {
     return (uint8_t)(ver >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
+
+/**
+  Sort SPDMversion in descending order.
+
+  @param  spdm_context                A pointer to the SPDM context.
+  @param  ver_set                    A pointer to the version set.
+  @param  ver_num                    Version number.
+*/
+void spdm_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ver_num)
+{
+    uintn index;
+    uintn index_sort;
+    uintn index_max;
+    spdm_version_number_t version;
+
+    /* Select sort */
+    if (ver_num > 1) {
+        for (index_sort = 0; index_sort < ver_num; index_sort++) {
+            index_max = index_sort;
+            for (index = index_sort + 1; index < ver_num; index++) {
+                /* if ver_ser[index] higher than ver_set[index_max] */
+                if (ver_set[index] > ver_set[index_max]) {
+                    index_max = index;
+                }
+            }
+            /* swap ver_ser[index_min] and ver_set[index_sort] */
+            version = ver_set[index_sort];
+            ver_set[index_sort] = ver_set[index_max];
+            ver_set[index_max] = version;
+        }
+    }
+}

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1933,3 +1933,45 @@ void spdm_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ve
         }
     }
 }
+
+/**
+  Negotiate SPDMversion for connection.
+  ver_set is the local version set of requester, res_ver_set is the version set of responder.
+
+  @param  common_version             A pointer to store the common version.
+  @param  req_ver_set                A pointer to the requester version set.
+  @param  req_ver_num                Version number of requester.
+  @param  res_ver_set                A pointer to the responder version set.
+  @param  res_ver_num                Version number of responder.
+
+  @retval TRUE                       Negotiation successfully, connect version be saved to common_version.
+  @retval FALSE                      Negotiation failed.
+*/
+boolean spdm_negotiate_connection_version(IN OUT spdm_version_number_t *common_version, IN spdm_version_number_t *req_ver_set, IN uintn req_ver_num,
+                                           IN spdm_version_number_t *res_ver_set, IN uintn res_ver_num)
+{
+    uintn req_index;
+    uintn res_index;
+
+    if (req_ver_set == NULL || req_ver_num == 0 || res_ver_set == NULL || res_ver_num == 0) {
+        return FALSE;
+    }
+
+    /* Sort SPDMversion in descending order. */
+    spdm_version_number_sort(req_ver_set, req_ver_num);
+    spdm_version_number_sort(res_ver_set, res_ver_num);
+
+    /**
+      Find highest same version and make req_index point to it.
+      If not found, return FALSE.
+    **/
+    for (res_index = 0; res_index < res_ver_num; res_index ++) {
+        for (req_index = 0; req_index < req_ver_num; req_index ++) {
+            if (spdm_get_version_from_version_number(req_ver_set[req_index]) == spdm_get_version_from_version_number(res_ver_set[res_index])) {
+                *common_version = req_ver_set[req_index];
+                return TRUE;
+            }
+        }
+    }
+    return FALSE;
+}

--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -6,37 +6,6 @@
 
 #include "internal/libspdm_common_lib.h"
 
-/**
-  Sort SPDMversion in descending order.
-
-  @param  spdm_context                A pointer to the SPDM context.
-  @param  ver_set                    A pointer to the version set.
-  @param  ver_num                    Version number.
-*/
-void spdm_secured_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ver_num)
-{
-    uintn index;
-    uintn index_sort;
-    uintn index_max;
-    spdm_version_number_t version;
-
-    /* Select sort */
-    if (ver_num > 1) {
-        for (index_sort = 0; index_sort < ver_num; index_sort++) {
-            index_max = index_sort;
-            for (index = index_sort + 1; index < ver_num; index++) {
-                /* if ver_ser[index] higher than ver_set[index_max] */
-                if (ver_set[index] > ver_set[index_max]) {
-                    index_max = index;
-                }
-            }
-            /* swap ver_ser[index_min] and ver_set[index_sort] */
-            version = ver_set[index_sort];
-            ver_set[index_sort] = ver_set[index_max];
-            ver_set[index_max] = version;
-        }
-    }
-}
 
 /**
   Return the size in bytes of opaque data version selection.
@@ -261,8 +230,8 @@ spdm_process_opaque_data_supported_version_data(IN spdm_context_t *spdm_context,
     }
     versions_list = (void *)(opaque_element_support_version + 1);
 
-    spdm_secured_version_number_sort(versions_list, spdm_context->local_context.secured_message_version.spdm_version_count);
-    spdm_secured_version_number_sort(spdm_context->local_context.secured_message_version.spdm_version, spdm_context->local_context.secured_message_version.spdm_version_count);
+    spdm_version_number_sort(versions_list, spdm_context->local_context.secured_message_version.spdm_version_count);
+    spdm_version_number_sort(spdm_context->local_context.secured_message_version.spdm_version, spdm_context->local_context.secured_message_version.spdm_version_count);
 
     for (secured_message_version_index = 0;
         secured_message_version_index < spdm_context->local_context.secured_message_version.spdm_version_count;

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -17,57 +17,6 @@ typedef struct {
 
 
 /**
-  Compare SPDMversion feild of spdm_version_number_t.
-
-  @param  spdm_context                A pointer to the SPDM context.
-  @param  first_ver                    First version number.
-  @param  seccond_ver                Second version number.
-
-  @retval TRUE                        First version is higher than seccond version.
-  @retval FALSE                        First version is not higher than seccond version.
-*/
-boolean spdm_version_number_compare(IN spdm_version_number_t first_ver, IN spdm_version_number_t seccond_ver)
-{
-    uint8_t first_version;
-    uint8_t seccond_version;
-
-    first_version = spdm_get_version_from_version_number(first_ver);
-    seccond_version = spdm_get_version_from_version_number(seccond_ver);
-    return (first_version > seccond_version);
-}
-
-/**
-  Sort SPDMversion in descending order.
-
-  @param  spdm_context                A pointer to the SPDM context.
-  @param  ver_set                    A pointer to the version set.
-  @param  ver_num                    Version number.
-*/
-void spdm_version_number_sort(IN OUT spdm_version_number_t *ver_set, IN uintn ver_num)
-{
-    uintn index;
-    uintn index_sort;
-    uintn index_max;
-    spdm_version_number_t version;
-
-    /* Select sort */
-    if (ver_num > 1) {
-        for (index_sort = 0; index_sort < ver_num; index_sort++) {
-            index_max = index_sort;
-            for (index = index_sort + 1; index < ver_num; index++) {
-                /* if ver_ser[index] higher than ver_set[index_max] */
-                if (spdm_version_number_compare(ver_set[index], ver_set[index_max])) {
-                    index_max = index;
-                }
-            }
-            /* swap ver_ser[index_min] and ver_set[index_sort] */
-            version = ver_set[index_sort];
-            ver_set[index_sort] = ver_set[index_max];
-            ver_set[index_max] = version;
-        }
-    }
-}
-/**
   Negotiate SPDMversion for connection.
   ver_set is the local version set of requester, res_ver_set is the version set of responder.
 

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -215,6 +215,8 @@ return_status spdm_requester_key_exchange_test_receive_message(
         uint8_t temp_buf[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
         uintn temp_buf_size;
 
+        ((spdm_context_t *)spdm_context)->connection_info.secured_message_version =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
         ((spdm_context_t *)spdm_context)
             ->connection_info.algorithm.base_asym_algo =
             m_use_asym_algo;
@@ -1191,6 +1193,9 @@ void test_spdm_requester_key_exchange_case2(void **state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, &hash, &hash_size);

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -195,6 +195,8 @@ return_status spdm_requester_psk_exchange_test_receive_message(
         uint8_t temp_buf[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
         uintn temp_buf_size;
 
+        ((spdm_context_t *)spdm_context)->connection_info.secured_message_version =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
         ((spdm_context_t *)spdm_context)
             ->connection_info.algorithm.base_asym_algo =
             m_use_asym_algo;
@@ -996,6 +998,9 @@ void test_spdm_requester_psk_exchange_case2(void **state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     read_responder_public_certificate_chain(m_use_hash_algo,
                         m_use_asym_algo, &data,
                         &data_size, &hash, &hash_size);


### PR DESCRIPTION
Fix: #480 

Sort for secured message binding version.
Find the first match version in loop.

Fix the hardcode for secured message binding version.

Make sort function consistent and remove sort function to common lib.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>