### PR TITLE
Restore LIBFUZZER's "Function Implicit Declaration"

### DIFF
--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.c
@@ -8,6 +8,7 @@
 #include "hal/base.h"
 #include "hal/library/memlib.h"
 #include "toolchain_harness.h"
+#include "library/malloclib.h"
 
 #ifdef TEST_WITH_LIBFUZZER
 #include <stdint.h>


### PR DESCRIPTION
Fix : #513 
Signed-off-by: Xiaohanjlll <hanx.xiao@intel.com>