### PR TITLE
Add SPDM_ERROR_CODE_DECRYPT_ERROR handle for requester

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -387,8 +387,10 @@ return_status libspdm_send_receive_data(IN void *context, IN uint32_t *session_i
 {
     return_status status;
     spdm_context_t *spdm_context;
+    spdm_error_response_t *spdm_response;
 
     spdm_context = context;
+    spdm_response = response;
 
     status = libspdm_send_request(spdm_context, session_id, is_app_message,
                                   request_size, request);
@@ -400,6 +402,14 @@ return_status libspdm_send_receive_data(IN void *context, IN uint32_t *session_i
                                       response_size, response);
     if (RETURN_ERROR(status)) {
         return RETURN_DEVICE_ERROR;
+    }
+
+    if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        if ((spdm_response->header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) &&
+            (session_id != NULL)) {
+            libspdm_free_session_id(spdm_context, *session_id);
+            return RETURN_SECURITY_VIOLATION;
+        }
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -90,6 +90,10 @@ return_status try_spdm_send_receive_end_session(IN spdm_context_t *spdm_context,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
+        if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            libspdm_free_session_id(spdm_context, session_id);
+            return RETURN_SECURITY_VIOLATION;
+        }
         status = spdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_END_SESSION, SPDM_END_SESSION_ACK,

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -189,6 +189,10 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
         goto error;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
+        if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            status = RETURN_SECURITY_VIOLATION;
+            goto error;
+        }
         if (spdm_response.header.param1 != SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
             libspdm_reset_message_f (spdm_context, session_info);
         }

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -87,6 +87,10 @@ return_status try_spdm_heartbeat(IN void *context, IN uint32_t session_id)
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
+        if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            libspdm_free_session_id(spdm_context, session_id);
+            return RETURN_SECURITY_VIOLATION;
+        }
         status = spdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_HEARTBEAT, SPDM_HEARTBEAT_ACK,

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -134,6 +134,10 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response.header.request_response_code == SPDM_ERROR) {
+            if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+                libspdm_free_session_id(spdm_context, session_id);
+                return RETURN_SECURITY_VIOLATION;
+            }
             status = spdm_handle_error_response_main(
                 spdm_context, &session_id,
                 &spdm_response_size, &spdm_response,
@@ -242,6 +246,10 @@ return_status try_spdm_key_update(IN void *context, IN uint32_t session_id,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
+        if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            libspdm_free_session_id(spdm_context, session_id);
+            return RETURN_SECURITY_VIOLATION;
+        }
         status = spdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -132,6 +132,10 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
         goto error;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
+        if (spdm_response.header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            status = RETURN_SECURITY_VIOLATION;
+            goto error;
+        }
         status = spdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -159,6 +159,14 @@ return_status spdm_process_encap_response_key_update(
     if (spdm_response->header.spdm_version != spdm_get_connection_version (spdm_context)) {
         return RETURN_DEVICE_ERROR;
     }
+
+    if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        if (spdm_response->header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            libspdm_free_session_id(spdm_context, session_id);
+            return RETURN_SECURITY_VIOLATION;
+        }
+    }
+
     if ((spdm_response_size != sizeof(spdm_key_update_response_t)) ||
         (spdm_response->header.request_response_code !=
          SPDM_KEY_UPDATE_ACK) ||

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -66,6 +66,8 @@ return_status spdm_requester_end_session_test_send_message(
         return RETURN_SUCCESS;
     case 0xB:
         return RETURN_SUCCESS;
+    case 0xC:
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -462,6 +464,33 @@ return_status spdm_requester_end_session_test_receive_message(
         ->application_secret.response_data_sequence_number--;
     }
         return RETURN_SUCCESS;
+    case 0xC: {
+        spdm_error_response_t spdm_response;
+        uint32_t session_id;
+        spdm_session_info_t *session_info;
+
+        session_id = 0xFFFFFFFF;
+        spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response.header.request_response_code = SPDM_ERROR;
+        spdm_response.header.param1 = SPDM_ERROR_CODE_DECRYPT_ERROR;
+        spdm_response.header.param2 = 0;
+
+        spdm_transport_test_encode_message(spdm_context, &session_id,
+                                           false, false,
+                                           sizeof(spdm_response),
+                                           &spdm_response,
+                                           response_size, response);
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context, session_id);
+        if (session_info == NULL) {
+            return RETURN_DEVICE_ERROR;
+        }
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->application_secret.response_data_sequence_number--;
+    }
+        return RETURN_SUCCESS;
+
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -1345,7 +1374,11 @@ void test_spdm_requester_end_session_case10(void **state) {
 
         status = spdm_send_receive_end_session (spdm_context, session_id, 0);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
-        ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+        if(error_code != SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+        } else {
+            ASSERT_INT_EQUAL_CASE (status, RETURN_SECURITY_VIOLATION, error_code);
+        }
 
         error_code++;
         if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
@@ -1476,6 +1509,103 @@ void test_spdm_requester_end_session_case11(void **state)
     free(data);
 }
 
+/**
+ * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
+ * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
+ **/
+void test_spdm_requester_end_session_case12(void **state)
+{
+    return_status status;
+    spdm_test_context_t *spdm_test_context;
+    spdm_context_t *spdm_context;
+    uint32_t session_id;
+    void *data;
+    uintn data_size;
+    void *hash;
+    uintn hash_size;
+    spdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xC;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    read_responder_public_certificate_chain(m_use_hash_algo,
+                                            m_use_asym_algo, &data,
+                                            &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_use_aead_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+             data, data_size);
+#endif
+    zero_mem(m_local_psk_hint, 32);
+    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+             sizeof(TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    spdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+    set_mem(m_dummy_key_buffer,
+            ((spdm_secured_message_context_t
+              *)(session_info->secured_message_context))
+            ->aead_key_size,
+            (uint8_t)(0xFF));
+    spdm_secured_message_set_response_data_encryption_key(
+        session_info->secured_message_context, m_dummy_key_buffer,
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->aead_key_size);
+    set_mem(m_dummy_salt_buffer,
+            ((spdm_secured_message_context_t
+              *)(session_info->secured_message_context))
+            ->aead_iv_size,
+            (uint8_t)(0xFF));
+    spdm_secured_message_set_response_data_salt(
+        session_info->secured_message_context, m_dummy_salt_buffer,
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->aead_iv_size);
+    ((spdm_secured_message_context_t *)(session_info
+                                        ->secured_message_context))
+    ->application_secret.response_data_sequence_number = 0;
+
+    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+    assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
+
+    free(data);
+}
+
 spdm_test_context_t m_spdm_requester_end_session_test_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -1508,6 +1638,8 @@ int spdm_requester_end_session_test_main(void)
         cmocka_unit_test(test_spdm_requester_end_session_case10),
         /* Buffer reset*/
         cmocka_unit_test(test_spdm_requester_end_session_case11),
+        /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
+        cmocka_unit_test(test_spdm_requester_end_session_case12),
     };
 
     setup_spdm_test_context(&m_spdm_requester_end_session_test_context);

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -67,6 +67,8 @@ return_status spdm_requester_heartbeat_test_send_message(IN void *spdm_context,
         return RETURN_SUCCESS;
     case 0xB:
         return RETURN_SUCCESS;
+    case 0xC:
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -463,6 +465,34 @@ return_status spdm_requester_heartbeat_test_receive_message(
         ->application_secret.response_data_sequence_number--;
     }
         return RETURN_SUCCESS;
+
+    case 0xC: {
+        spdm_error_response_t spdm_response;
+        uint32_t session_id;
+        spdm_session_info_t *session_info;
+
+        session_id = 0xFFFFFFFF;
+        spdm_response.header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response.header.request_response_code = SPDM_ERROR;
+        spdm_response.header.param1 = SPDM_ERROR_CODE_DECRYPT_ERROR;
+        spdm_response.header.param2 = 0;
+
+        spdm_transport_test_encode_message(spdm_context, &session_id,
+                                           false, false,
+                                           sizeof(spdm_response),
+                                           &spdm_response,
+                                           response_size, response);
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context, session_id);
+        if (session_info == NULL) {
+            return RETURN_DEVICE_ERROR;
+        }
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->application_secret.response_data_sequence_number--;
+    }
+        return RETURN_SUCCESS;
+
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -1335,7 +1365,11 @@ void test_spdm_requester_heartbeat_case10(void **state) {
 
         status = libspdm_heartbeat (spdm_context, session_id);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
-        ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+        if(error_code != SPDM_ERROR_CODE_DECRYPT_ERROR) {
+            ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+        } else {
+            ASSERT_INT_EQUAL_CASE (status, RETURN_SECURITY_VIOLATION, error_code);
+        }
 
         error_code++;
         if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
@@ -1462,6 +1496,103 @@ void test_spdm_requester_heartbeat_case11(void **state)
     free(data);
 }
 
+/**
+ * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
+ * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
+ **/
+void test_spdm_requester_heartbeat_case12(void **state)
+{
+    return_status status;
+    spdm_test_context_t *spdm_test_context;
+    spdm_context_t *spdm_context;
+    uint32_t session_id;
+    void *data;
+    uintn data_size;
+    void *hash;
+    uintn hash_size;
+    spdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xC;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    read_responder_public_certificate_chain(m_use_hash_algo,
+                                            m_use_asym_algo, &data,
+                                            &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_use_aead_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+             data, data_size);
+#endif
+    zero_mem(m_local_psk_hint, 32);
+    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
+             sizeof(TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    spdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+    set_mem(m_dummy_key_buffer,
+            ((spdm_secured_message_context_t
+              *)(session_info->secured_message_context))
+            ->aead_key_size,
+            (uint8_t)(0xFF));
+    spdm_secured_message_set_response_data_encryption_key(
+        session_info->secured_message_context, m_dummy_key_buffer,
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->aead_key_size);
+    set_mem(m_dummy_salt_buffer,
+            ((spdm_secured_message_context_t
+              *)(session_info->secured_message_context))
+            ->aead_iv_size,
+            (uint8_t)(0xFF));
+    spdm_secured_message_set_response_data_salt(
+        session_info->secured_message_context, m_dummy_salt_buffer,
+        ((spdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->aead_iv_size);
+    ((spdm_secured_message_context_t *)(session_info
+                                        ->secured_message_context))
+    ->application_secret.response_data_sequence_number = 0;
+
+    status = libspdm_heartbeat(spdm_context, session_id);
+    assert_int_equal(status, RETURN_SECURITY_VIOLATION);
+    assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
+
+    free(data);
+}
+
 spdm_test_context_t m_spdm_requester_heartbeat_test_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -1494,7 +1625,8 @@ int spdm_requester_heartbeat_test_main(void)
         cmocka_unit_test(test_spdm_requester_heartbeat_case10),
         /* Buffer reset*/
         cmocka_unit_test(test_spdm_requester_heartbeat_case11),
-
+        /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
+        cmocka_unit_test(test_spdm_requester_heartbeat_case12),
     };
 
     setup_spdm_test_context(&m_spdm_requester_heartbeat_test_context);


### PR DESCRIPTION
Fix: #488

For handshake and application phase:
If ErrorCode = DecryptError, the session shall immediately terminate and proceed to session termination.


Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>