### PR TITLE
Add a plocicy to control send DECRYPT_ERROR or drop request silently

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -376,6 +376,13 @@ typedef struct {
      * or secured SPDM transport message.
      **/
     uint8_t request_response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
+    /**
+     * The BIT0 control to generate SPDM_ERROR_CODE_DECRYPT_ERROR response or drop the request silently.
+     * If the BIT0 is not set, generate SPDM_ERROR_CODE_DECRYPT_ERROR response.
+     * If the BIT0 set, drop the request silently.
+     **/
+    uint8_t handle_error_return_policy;
 } spdm_context_t;
 
 /**

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -115,6 +115,13 @@ typedef enum {
 
     LIBSPDM_DATA_APP_CONTEXT_DATA,
 
+    /**
+     * The LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY BIT0 control to generate SPDM_ERROR_CODE_DECRYPT_ERROR response or drop the request silently.
+     * If the BIT0 is not set, generate SPDM_ERROR_CODE_DECRYPT_ERROR response.
+     * If the BIT0 set, drop the request silently.
+     **/
+    LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY,
+
     /* MAX*/
 
     LIBSPDM_DATA_MAX

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -483,6 +483,12 @@ return_status libspdm_set_data(IN void *context, IN libspdm_data_type_t data_typ
         }
         spdm_context->app_context_data_ptr = *(void **)data;
         break;
+    case LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY:
+        if (data_size != sizeof(uint8_t)) {
+            return RETURN_INVALID_PARAMETER;
+        }
+        spdm_context->handle_error_return_policy = *(uint8_t *)data;
+        break;
     default:
         return RETURN_UNSUPPORTED;
         break;
@@ -699,6 +705,10 @@ return_status libspdm_get_data(IN void *context, IN libspdm_data_type_t data_typ
     case LIBSPDM_DATA_APP_CONTEXT_DATA:
         target_data_size = sizeof(void *);
         target_data = &spdm_context->app_context_data_ptr;
+        break;
+    case LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY:
+        target_data_size = sizeof(uint8_t);
+        target_data = &spdm_context->handle_error_return_policy;
         break;
     default:
         return RETURN_UNSUPPORTED;

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -167,9 +167,18 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
             (uint8_t *)request + sizeof(spdm_finish_request_t),
             signature_size);
         if (!result) {
-            return libspdm_generate_error_response(
-                spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
-                response_size, response);
+            if((spdm_context->handle_error_return_policy & BIT0) == 0) {
+                return libspdm_generate_error_response(
+                    spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
+                    response_size, response);
+            } else {
+                /**
+                 * just ignore this message
+                 * return UNSUPPORTED and clear response_size to continue the dispatch without send response.
+                 **/
+                *response_size = 0;
+                return RETURN_UNSUPPORTED;
+            }
         }
         status = libspdm_append_message_f(
             spdm_context, session_info, false,
@@ -188,9 +197,18 @@ return_status spdm_get_response_finish(IN void *context, IN uintn request_size,
         sizeof(spdm_finish_request_t),
         hmac_size);
     if (!result) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
-                                               response_size, response);
+        if((spdm_context->handle_error_return_policy & BIT0) == 0) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
+                response_size, response);
+        } else {
+            /**
+             * just ignore this message
+             * return UNSUPPORTED and clear response_size to continue the dispatch without send response
+             **/
+            *response_size = 0;
+            return RETURN_UNSUPPORTED;
+        }
     }
 
     status = libspdm_append_message_f(spdm_context, session_info, false,

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -126,9 +126,18 @@ return_status spdm_get_response_psk_finish(IN void *context,
         (uint8_t *)request + sizeof(spdm_psk_finish_request_t),
         hmac_size);
     if (!result) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
-                                               response_size, response);
+        if((spdm_context->handle_error_return_policy & BIT0) == 0) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
+                response_size, response);
+        } else {
+            /**
+             * just ignore this message
+             * return UNSUPPORTED and clear response_size to continue the dispatch without send response
+             **/
+            *response_size = 0;
+            return RETURN_UNSUPPORTED;
+        }
     }
     status = libspdm_append_message_f(
         spdm_context, session_info, false,

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -331,14 +331,26 @@ return_status libspdm_build_response(IN void *context, IN uint32_t *session_id,
         switch (spdm_context->last_spdm_error.error_code) {
         case SPDM_ERROR_CODE_DECRYPT_ERROR:
             /* session ID is valid. Use it to encrypt the error message.*/
-            status = libspdm_generate_error_response(
-                spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
-                &my_response_size, my_response);
+            if((spdm_context->handle_error_return_policy & BIT0) == 0) {
+                status = libspdm_generate_error_response(
+                    spdm_context, SPDM_ERROR_CODE_DECRYPT_ERROR, 0,
+                    response_size, response);
+            } else {
+                /**
+                 * just ignore this message
+                 * return UNSUPPORTED and clear response_size to continue the dispatch without send response
+                 **/
+                *response_size = 0;
+                status = RETURN_UNSUPPORTED;
+            }
             break;
         case SPDM_ERROR_CODE_INVALID_SESSION:
-            /* don't use session ID, because we dont know which right session ID should be used.
+            /**
+             * don't use session ID, because we dont know which right session ID should be used.
              * just ignore this message
-             * return UNSUPPORTED to continue the dispatch without send response.*/
+             * return UNSUPPORTED and clear response_size to continue the dispatch without send response
+             **/
+            *response_size = 0;
             status = RETURN_UNSUPPORTED;
             break;
         default:


### PR DESCRIPTION
Fix: #489

Add error_return_policy to control send DECRYPT_ERROR or drop request.
If the handle_error_return_policy BIT0 set, drop the request silently.


Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>