### PR TITLE
Add rnglib_null to support size calculation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,6 +617,7 @@ endif()
     ADD_SUBDIRECTORY(unit_test/test_size/cryptstublib_dummy)
     ADD_SUBDIRECTORY(unit_test/test_size/intrinsiclib)
     ADD_SUBDIRECTORY(unit_test/test_size/malloclib_null)
+    ADD_SUBDIRECTORY(unit_test/test_size/rnglib_null)
 
     if(NOT TOOLCHAIN STREQUAL "LIBFUZZER")
     ADD_SUBDIRECTORY(unit_test/test_spdm_common)

--- a/unit_test/test_size/rnglib_null/CMakeLists.txt
+++ b/unit_test/test_size/rnglib_null/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.6)
+
+INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
+                    ${LIBSPDM_DIR}/include/hal
+                    ${LIBSPDM_DIR}/include/hal/${ARCH}
+)
+
+SET(src_rnglib_null
+    rnglib.c
+)
+
+ADD_LIBRARY(rnglib_null STATIC ${src_rnglib_null})

--- a/unit_test/test_size/rnglib_null/rnglib.c
+++ b/unit_test/test_size/rnglib_null/rnglib.c
@@ -1,0 +1,21 @@
+/**
+    Copyright Notice:
+    Copyright 2021 DMTF. All rights reserved.
+    License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+**/
+
+#include <base.h>
+
+/**
+  Generates a 64-bit random number.
+
+  @param[out] rand_data     buffer pointer to store the 64-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+boolean get_random_number_64(OUT uint64_t *rand_data)
+{
+    return TRUE;
+}

--- a/unit_test/test_size/test_size_of_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_size/test_size_of_spdm_requester/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(test_size_of_spdm_requester_LIBRARY
 #    cryptstublib_dummy
 #    ${CRYPTO_LIB_PATHS}
 #    cryptlib_${CRYPTO}
+#    rnglib_null
     cryptlib_null
     malloclib_null
     spdm_crypt_lib
@@ -46,6 +47,7 @@ if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
 #                   $<TARGET_OBJECTS:cryptstublib_dummy>
 #                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
 #                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+#                   $<TARGET_OBJECTS:rnglib_null>
                    $<TARGET_OBJECTS:cryptlib_null>
                    $<TARGET_OBJECTS:malloclib_null>
                    $<TARGET_OBJECTS:spdm_crypt_lib>

--- a/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(test_size_of_spdm_responder_LIBRARY
 #    cryptstublib_dummy
 #    ${CRYPTO_LIB_PATHS}
 #    cryptlib_${CRYPTO}
+#    rnglib_null
     cryptlib_null
     malloclib_null
     spdm_crypt_lib
@@ -44,6 +45,7 @@ if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
 #                   $<TARGET_OBJECTS:cryptstublib_dummy>
 #                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
 #                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+#                   $<TARGET_OBJECTS:rnglib_null>
                    $<TARGET_OBJECTS:cryptlib_null>
                    $<TARGET_OBJECTS:malloclib_null>
                    $<TARGET_OBJECTS:spdm_crypt_lib>


### PR DESCRIPTION
It is commented by default.
It will be used to calculate size with real cryptolib used such as mbedtls.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>