### PR TITLE
Add _Static_assert support for C89 and C99

### DIFF
--- a/include/hal/base.h
+++ b/include/hal/base.h
@@ -645,6 +645,10 @@ typedef uintn *BASE_LIST;
 #define STATIC_ASSERT(expression, message)
 #elif _MSC_EXTENSIONS
 #define STATIC_ASSERT static_assert
+#elif !defined(_Static_assert)
+#define STATIC_ASSERT(expression, message) \
+    extern int (*__Static_assert_function (void)) \
+        [!!sizeof (struct { int __error_if_negative: (expression) ? 2 : -1; })]
 #else
 #define STATIC_ASSERT _Static_assert
 #endif


### PR DESCRIPTION
_Static_assert was only introduced in C11, this implementation
which I have taken from glibc:
https://patchwork.ozlabs.org/project/glibc/patch/54D40347.3020508@cs.ucla.edu/
allows usage of _Static_assert on earlier compliers.

This change partially addresses the C89 compatibility brought up in #454

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>