### PR TITLE
Resolve copy_mem discards qualifiers compile warning

### DIFF
--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -31,10 +31,10 @@ void *copy_mem(OUT void *destination_buffer, IN const void *source_buffer,
            IN uintn length)
 {
     volatile uint8_t *pointer_dst;
-    volatile uint8_t *pointer_src;
+    const volatile uint8_t *pointer_src;
 
     pointer_dst = (uint8_t *)destination_buffer;
-    pointer_src = (uint8_t *)source_buffer;
+    pointer_src = (const uint8_t *)source_buffer;
     while (length-- != 0) {
         *(pointer_dst++) = *(pointer_src++);
     }


### PR DESCRIPTION
Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>