### PR TITLE
Resolve warning in spdm_get_response_algorithms

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -406,6 +406,9 @@ return_status spdm_get_response_algorithms(IN void *context,
                     .key_schedule =
                     struct_table->alg_supported;
                 break;
+            default:
+                /* Unknown algorithm types do not need to be processed */
+                break;
             }
             ext_alg_count = struct_table->alg_count & 0xF;
             struct_table =


### PR DESCRIPTION
This change resolves the switch missing default case compilation warning
within the spdm_get_response_algorithms function.

SPDM specification 1.2.0 indicates:

 The algorithm structure table need be present only if the Responder
 supports that AlgType.

Based on this wording, we can silently skip over unsupportd algorithm
types.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>