### PR TITLE
Resolve compile warning for libspdm_get_dmtf_subject_alt_name_from_bytes

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1251,7 +1251,7 @@ boolean libspdm_is_root_certificate(IN const uint8_t *cert, IN uintn cert_size);
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status libspdm_get_dmtf_subject_alt_name_from_bytes(
-    IN const uint8_t *buffer, IN intn len, OUT char *name_buffer,
+    IN uint8_t *buffer, IN intn len, OUT char *name_buffer,
     OPTIONAL IN OUT uintn *name_buffer_size, OUT uint8_t *oid,
     OPTIONAL IN OUT uintn *oid_size);
 

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -4124,7 +4124,7 @@ static const uint8_t m_oid_subject_alt_name[] = { 0x55, 0x1D, 0x11 };
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status libspdm_get_dmtf_subject_alt_name_from_bytes(
-    IN const uint8_t *buffer, IN intn len, OUT char *name_buffer,
+    IN uint8_t *buffer, IN intn len, OUT char *name_buffer,
     OPTIONAL IN OUT uintn *name_buffer_size, OUT uint8_t *oid,
     OPTIONAL IN OUT uintn *oid_size)
 {
@@ -4134,7 +4134,7 @@ return_status libspdm_get_dmtf_subject_alt_name_from_bytes(
     int32_t ret;
 
     length = (int32_t)len;
-    ptr = (uint8_t *)buffer;
+    ptr = buffer;
     obj_len = 0;
 
     /* Sequence*/
@@ -4245,7 +4245,7 @@ libspdm_get_dmtf_subject_alt_name(IN const uint8_t *cert, IN intn cert_size,
     }
 
     return libspdm_get_dmtf_subject_alt_name_from_bytes(
-        (const uint8_t *)name_buffer, *name_buffer_size, name_buffer,
+        (uint8_t *)name_buffer, *name_buffer_size, name_buffer,
         name_buffer_size, oid, oid_size);
 }
 


### PR DESCRIPTION
This change resolves the "cast discards qualifiers from pointer target
type" warning for libspdm_get_dmtf_subject_alt_name_from_bytes by
removing the const qualifier from the input buffer.

The mbedtls mbedtls_asn1_get_len function requires the buffer to not be
constant which forces this lack of const up the stack.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>