### PR TITLE
Resolve compile warning for x509_get_extension_data

### DIFF
--- a/include/hal/library/cryptlib.h
+++ b/include/hal/library/cryptlib.h
@@ -2692,7 +2692,7 @@ return_status x509_get_signature_algorithm(IN const uint8_t *cert,
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status x509_get_extension_data(IN const uint8_t *cert, IN uintn cert_size,
-                                      IN uint8_t *oid, IN uintn oid_size,
+                                      IN const uint8_t *oid, IN uintn oid_size,
                                       OUT uint8_t *extension_data,
                                       IN OUT uintn *extension_data_size);
 

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -4225,7 +4225,7 @@ libspdm_get_dmtf_subject_alt_name(IN const uint8_t *cert, IN intn cert_size,
 
     extension_data_size = 0;
     status = x509_get_extension_data(cert, cert_size,
-                                     (uint8_t *)m_oid_subject_alt_name,
+                                     m_oid_subject_alt_name,
                                      sizeof(m_oid_subject_alt_name), NULL,
                                      &extension_data_size);
     if (status != RETURN_BUFFER_TOO_SMALL) {
@@ -4237,7 +4237,7 @@ libspdm_get_dmtf_subject_alt_name(IN const uint8_t *cert, IN intn cert_size,
     }
     status =
         x509_get_extension_data(cert, cert_size,
-                                (uint8_t *)m_oid_subject_alt_name,
+                                m_oid_subject_alt_name,
                                 sizeof(m_oid_subject_alt_name),
                                 (uint8_t *)name_buffer, name_buffer_size);
     if (RETURN_ERROR(status)) {

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -1079,7 +1079,7 @@ cleanup:
  *
  **/
 static return_status
-internal_x509_find_extension_data(uint8_t *start, uint8_t *end, uint8_t *oid,
+internal_x509_find_extension_data(uint8_t *start, uint8_t *end, const uint8_t *oid,
                                   uintn oid_size, uint8_t **find_extension_data,
                                   uintn *find_extension_data_len)
 {
@@ -1168,7 +1168,7 @@ internal_x509_find_extension_data(uint8_t *start, uint8_t *end, uint8_t *oid,
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status x509_get_extension_data(IN const uint8_t *cert, IN uintn cert_size,
-                                      IN uint8_t *oid, IN uintn oid_size,
+                                      IN const uint8_t *oid, IN uintn oid_size,
                                       OUT uint8_t *extension_data,
                                       IN OUT uintn *extension_data_size)
 {

--- a/os_stub/cryptlib_null/pk/x509.c
+++ b/os_stub/cryptlib_null/pk/x509.c
@@ -579,7 +579,7 @@ return_status x509_get_signature_algorithm(IN const uint8_t *cert,
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status x509_get_extension_data(IN const uint8_t *cert, IN uintn cert_size,
-                                      IN uint8_t *oid, IN uintn oid_size,
+                                      IN const uint8_t *oid, IN uintn oid_size,
                                       OUT uint8_t *extension_data,
                                       IN OUT uintn *extension_data_size)
 {

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1303,7 +1303,7 @@ done:
  * @retval RETURN_UNSUPPORTED       The operation is not supported.
  **/
 return_status x509_get_extension_data(IN const uint8_t *cert, IN uintn cert_size,
-                                      IN uint8_t *oid, IN uintn oid_size,
+                                      IN const uint8_t *oid, IN uintn oid_size,
                                       OUT uint8_t *extension_data,
                                       IN OUT uintn *extension_data_size)
 {
@@ -1425,7 +1425,7 @@ return_status x509_get_extended_key_usage(IN const uint8_t *cert,
 {
     return_status status;
     status = x509_get_extension_data(cert, cert_size,
-                                     (uint8_t *)m_oid_ext_key_usage,
+                                     m_oid_ext_key_usage,
                                      sizeof(m_oid_ext_key_usage), usage,
                                      usage_size);
     return status;

--- a/unit_test/test_crypt/x509_verify.c
+++ b/unit_test/test_crypt/x509_verify.c
@@ -321,7 +321,7 @@ return_status validate_crypt_x509(char *Path, uintn len)
     asn1_buffer_len = 1024;
     zero_mem(asn1_buffer, asn1_buffer_len);
     ret = x509_get_extension_data(test_end_cert, test_end_cert_len,
-                                  (uint8_t *)m_oid_subject_alt_name,
+                                  m_oid_subject_alt_name,
                                   sizeof(m_oid_subject_alt_name),
                                   asn1_buffer, &asn1_buffer_len);
     if (RETURN_ERROR(ret)) {


### PR DESCRIPTION
This change resolves the "cast discards qualifiers from pointer target
type" for  x509_get_extension_data function by marking the oid filed as
a pointer to const.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>