### PR TITLE
Resolve switch missing default case warning

### DIFF
--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -1979,6 +1979,9 @@ boolean libspdm_asym_verify(
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, FALSE, &param_size);
             break;
+        default:
+            ASSERT(FALSE);
+            break;
         }
 
         create_spdm_signing_context (spdm_version, op_code, FALSE, spdm12_signing_context_with_hash);
@@ -2074,6 +2077,9 @@ boolean libspdm_asym_verify_hash(
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, FALSE, &param_size);
+            break;
+        default:
+            ASSERT(FALSE);
             break;
         }
 
@@ -2367,6 +2373,9 @@ boolean libspdm_asym_sign(
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, FALSE, &param_size);
             break;
+        default:
+            ASSERT(FALSE);
+            break;
         }
 
         create_spdm_signing_context (spdm_version, op_code, FALSE, spdm12_signing_context_with_hash);
@@ -2466,6 +2475,9 @@ boolean libspdm_asym_sign_hash(
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, FALSE, &param_size);
+            break;
+        default:
+            ASSERT(FALSE);
             break;
         }
 
@@ -2668,6 +2680,9 @@ boolean libspdm_req_asym_verify(
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, TRUE, &param_size);
             break;
+        default:
+            ASSERT(FALSE);
+            break;
         }
 
         create_spdm_signing_context (spdm_version, op_code, TRUE, spdm12_signing_context_with_hash);
@@ -2763,6 +2778,9 @@ boolean libspdm_req_asym_verify_hash(
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, TRUE, &param_size);
+            break;
+        default:
+            ASSERT(FALSE);
             break;
         }
 
@@ -2917,6 +2935,9 @@ boolean libspdm_req_asym_sign(
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, TRUE, &param_size);
             break;
+        default:
+            ASSERT(FALSE);
+            break;
         }
 
         create_spdm_signing_context (spdm_version, op_code, TRUE, spdm12_signing_context_with_hash);
@@ -3016,6 +3037,9 @@ boolean libspdm_req_asym_sign_hash(
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
             param = get_spdm_signing_context_string (spdm_version, op_code, TRUE, &param_size);
+            break;
+        default:
+            ASSERT(FALSE);
             break;
         }
 


### PR DESCRIPTION
This change resolves compile warnings within the libspdm_crypt_crypt.c
file which are not functionality equivalent as before.

For all cases it appears that the default case should never be hit so an
assertion is added to the default case to verify this.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>