### PR TITLE
Resolve switch missing default case warning

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -462,6 +462,9 @@ return_status libspdm_build_response(IN void *context, IN uint32_t *session_id,
                            LIBSPDM_SESSION_STATE_NOT_STARTED);
             libspdm_free_session_id(spdm_context, *session_id);
             break;
+        default:
+            /* No session state update needed */
+            break;
         }
     } else {
         switch (spdm_response->request_response_code) {
@@ -475,6 +478,9 @@ return_status libspdm_build_response(IN void *context, IN uint32_t *session_id,
                     spdm_context->latest_session_id,
                     LIBSPDM_SESSION_STATE_ESTABLISHED);
             }
+            break;
+        default:
+            /* No session state update needed */
             break;
         }
     }


### PR DESCRIPTION
This change is functionality equivalent to previous code and only
addresses compile warnings regarding missing default case in switch
statement.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>