### PR TITLE
Address pointer-to-int-cast warnings on 32-bit architectures

### DIFF
--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -310,7 +310,7 @@ void test_spdm_verify_peer_cert_chain_buffer_case6(void **state)
     spdm_context->local_context.peer_root_cert_provision[0] = root_cert;
     result = spdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor, &trust_anchor_size);
     assert_int_equal (result, TRUE);
-    assert_int_equal (trust_anchor, root_cert);
+    assert_ptr_equal (trust_anchor, root_cert);
 
     free(data);
     free(data_test);
@@ -394,14 +394,14 @@ void test_spdm_verify_peer_cert_chain_buffer_case7(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT / 2 - 1] = root_cert;
     result = spdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor, &trust_anchor_size);
     assert_int_equal (result, TRUE);
-    assert_int_equal (trust_anchor, root_cert);
+    assert_ptr_equal (trust_anchor, root_cert);
 
     /*case: there is no match root cert in the middle*/
     spdm_context->local_context.peer_root_cert_provision_size[LIBSPDM_MAX_ROOT_CERT_SUPPORT / 4] =root_cert_size;
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT / 4] = root_cert;
     result = spdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor, &trust_anchor_size);
     assert_int_equal (result, TRUE);
-    assert_int_equal (trust_anchor, root_cert);
+    assert_ptr_equal (trust_anchor, root_cert);
 
     free(data);
     free(data_test);
@@ -480,7 +480,7 @@ void test_spdm_verify_peer_cert_chain_buffer_case8(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT - 1] = root_cert;
     result = spdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor, &trust_anchor_size);
     assert_int_equal (result, TRUE);
-    assert_int_equal (trust_anchor, root_cert);
+    assert_ptr_equal (trust_anchor, root_cert);
 
     /*case: there is no match root cert in the middle*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT; root_cert_index ++) {
@@ -491,7 +491,7 @@ void test_spdm_verify_peer_cert_chain_buffer_case8(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT / 2] = root_cert;
     result = spdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor, &trust_anchor_size);
     assert_int_equal (result, TRUE);
-    assert_int_equal (trust_anchor, root_cert);
+    assert_ptr_equal (trust_anchor, root_cert);
 
     free(data);
     free(data_test);
@@ -540,7 +540,7 @@ static void test_libspdm_set_data_case9(void **state)
                    NULL, root_cert, root_cert_size);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (spdm_context->local_context.peer_root_cert_provision_size[0], root_cert_size);
-    assert_int_equal (spdm_context->local_context.peer_root_cert_provision[0], root_cert);
+    assert_ptr_equal (spdm_context->local_context.peer_root_cert_provision[0], root_cert);
 
     /*case: there is full root cert*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT;root_cert_index ++) {


### PR DESCRIPTION
Minor change to address pointer-to-integer cast warnings on 32-bit architectures within spdm_common unit tests (observed with GCC for ARMv7 originally, and also on IA32).

> error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
note: in expansion of macro 'assert_int_equal'
note: in expansion of macro 'cast_to_uintmax_type'

uintmax_t should be large enough to hold a 32-bit pointer, but depending on the platform can be of a different underlying type. There was already an `assert_ptr_equal()` handy which first converts the pointers to the `uintptr_t` integral type.

Possibly related to the comment in https://github.com/DMTF/libspdm/pull/550 regarding additional CI configurations.