### PR TITLE
Add a check when callback function drop the response

### DIFF
--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -33,6 +33,8 @@
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ * @retval RETURN_UNSUPPORTED           Just ignore this message: return UNSUPPORTED and clear response_size.
+ *                                      Continue the dispatch without send response.
  **/
 typedef return_status (*libspdm_get_response_func)(
     IN void *spdm_context, IN uint32_t *session_id, IN bool is_app_message,
@@ -87,6 +89,8 @@ return_status libspdm_process_request(IN void *spdm_context,
  *
  * @retval RETURN_SUCCESS               The SPDM response is sent successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is sent to the device.
+ * @retval RETURN_UNSUPPORTED           Just ignore this message: return UNSUPPORTED and clear response_size.
+ *                                      Continue the dispatch without send response.
  **/
 return_status libspdm_build_response(IN void *spdm_context, IN uint32_t *session_id,
                                      IN bool is_app_message,

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -301,6 +301,8 @@ void spdm_set_connection_state(IN spdm_context_t *spdm_context,
  *
  * @retval RETURN_SUCCESS               The SPDM response is sent successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is sent to the device.
+ * @retval RETURN_UNSUPPORTED           Just ignore this message: return UNSUPPORTED and clear response_size.
+ *                                      Continue the dispatch without send response.
  **/
 return_status libspdm_build_response(IN void *context, IN uint32_t *session_id,
                                      IN bool is_app_message,
@@ -422,6 +424,14 @@ return_status libspdm_build_response(IN void *context, IN uint32_t *session_id,
             status = RETURN_NOT_FOUND;
         }
     }
+    /* if return the status: Responder drop the response
+     * just ignore this message
+     * return UNSUPPORTED and clear response_size to continue the dispatch without send response.*/
+    if((my_response_size == 0) && (status == RETURN_UNSUPPORTED)) {
+        *response_size = 0;
+        return RETURN_UNSUPPORTED;
+    }
+
     if (RETURN_ERROR(status)) {
         status = libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,


### PR DESCRIPTION
Fix: #490 

When the callback function drop the response, the return response_size is 0.
And the return status is RETURN_UNSUPPORTED.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>