### PR TITLE
Proposal for copy_mem_s function that adds the destination size as parameter.

### DIFF
--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -40,7 +40,7 @@
  *
  * @return   0 on success. non-zero on error.
  *
-**/
+ **/
 int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len);
 
 int copy_mem(OUT void* dst_buf, IN const void* src_buf, IN uintn len);

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -21,15 +21,16 @@
  * This function copies "len" bytes from "src_buf" to "dst_buf".
  *
  * Asserts and returns a non-zero value if any of the following are true:
- *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
+ *   1) "src_buf" or "dst_buf" are NULL.
  *   2) "src_buf" and "dst_buf" overlap.
  *   3) "len" is greater than "dst_len".
  *   4) "len" or "dst_len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
  *   5) "len" or "dst_len" is greater than (MAX_ADDRESS - "src_buf" + 1).
  *   6) "len" or "dst_len" is greater than (SIZE_MAX >> 1).
  *
- * In case of error, the "dst_buf" is left unmodifed. This behavior is different
- * than memcopy_s, which zeros the "dst_buf" if "dst_buf" is valid.
+ * In case of error, the "dst_buf" is left unmodifed.
+ * This behavior is different than C11 memcopy_s, which zeros the "dst_buf"
+ * if there is a runtime violation.
  *
  * @param    dst_buf   Destination buffer to copy to.
  * @param    dst_len   Maximum length in bytes of the destination buffer.

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -24,9 +24,12 @@
  *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
  *   2) "src_buf" and "dst_buf" overlap.
  *   3) "len" is greater than "dst_len".
- *   4) "len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
- *   5) "len" is greater than (MAX_ADDRESS - "src_buf" + 1).
- *   6) "len" is greater than (SIZE_MAX >> 1).
+ *   4) "len" or "dst_len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
+ *   5) "len" or "dst_len" is greater than (MAX_ADDRESS - "src_buf" + 1).
+ *   6) "len" or "dst_len" is greater than (SIZE_MAX >> 1).
+ *
+ * In case of error, the "dst_buf" is left unmodifed. This behavior is different
+ * than memcopy_s, which zeros the "dst_buf" if "dst_buf" is valid.
  *
  * @param    dst_buf   Destination buffer to copy to.
  * @param    dst_len   Maximum length in bytes of the destination buffer.
@@ -36,7 +39,7 @@
  * @return   0 on success. non-zero on error.
  *
 **/
-int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len);
+int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len);
 
 int copy_mem(OUT void* dst_buf, IN const void* src_buf, IN uintn len);
 

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -15,8 +15,6 @@
 #ifndef __BASE_MEMORY_LIB__
 #define __BASE_MEMORY_LIB__
 
-#include <stddef.h>
-
 /**
  * Copies bytes from a source buffer to a destination buffer.
  *
@@ -41,7 +39,7 @@
  * @return   0 on success. non-zero on error.
  *
  **/
-int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len);
+int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len);
 
 int copy_mem(OUT void* dst_buf, IN const void* src_buf, IN uintn len);
 

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -16,24 +16,29 @@
 #define __BASE_MEMORY_LIB__
 
 /**
- * Copies a source buffer to a destination buffer, and returns the destination buffer.
+ * Copies bytes from a source buffer to a destination buffer.
  *
- * This function copies length bytes from source_buffer to destination_buffer, and returns
- * destination_buffer.  The implementation must be reentrant, and it must handle the case
- * where source_buffer overlaps destination_buffer.
+ * This function copies "len" bytes from "src_buf" to "dst_buf".
  *
- * If length is greater than (MAX_ADDRESS - destination_buffer + 1), then ASSERT().
- * If length is greater than (MAX_ADDRESS - source_buffer + 1), then ASSERT().
+ * Asserts and returns a non-zero value if any of the following are true:
+ *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
+ *   2) "src_buf" and "dst_buf" overlap.
+ *   3) "len" is greater than "dst_len".
+ *   4) "len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
+ *   5) "len" is greater than (MAX_ADDRESS - "src_buf" + 1).
+ *   6) "len" is greater than (SIZE_MAX >> 1).
  *
- * @param  destination_buffer   The pointer to the destination buffer of the memory copy.
- * @param  source_buffer        The pointer to the source buffer of the memory copy.
- * @param  length              The number of bytes to copy from source_buffer to destination_buffer.
+ * @param    dst_buf   Destination buffer to copy to.
+ * @param    dst_len   Maximum length in bytes of the destination buffer.
+ * @param    src_buf   Source buffer to copy from.
+ * @param    len       The number of bytes to copy.
  *
- * @return destination_buffer.
+ * @return   0 on success. non-zero on error.
  *
- **/
-void *copy_mem(OUT void *destination_buffer, IN const void *source_buffer,
-               IN uintn length);
+**/
+int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len);
+
+int copy_mem(OUT void* dst_buf, IN const void* src_buf, IN uintn len);
 
 /**
  * Fills a target buffer with a byte value, and returns the target buffer.

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -15,6 +15,8 @@
 #ifndef __BASE_MEMORY_LIB__
 #define __BASE_MEMORY_LIB__
 
+#include <stddef.h>
+
 /**
  * Copies bytes from a source buffer to a destination buffer.
  *

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -206,7 +206,7 @@ return_status spdm_get_response_challenge_auth(IN void *context,
 
     if (spdm_context->local_context.opaque_challenge_auth_rsp != NULL) {
         copy_mem(ptr, spdm_context->local_context.opaque_challenge_auth_rsp,
-            spdm_context->local_context.opaque_challenge_auth_rsp_size);
+                 spdm_context->local_context.opaque_challenge_auth_rsp_size);
         ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -203,10 +203,12 @@ return_status spdm_get_response_challenge_auth(IN void *context,
     *(uint16_t *)ptr = (uint16_t)spdm_context->local_context
                        .opaque_challenge_auth_rsp_size;
     ptr += sizeof(uint16_t);
-    copy_mem(ptr, spdm_context->local_context.opaque_challenge_auth_rsp,
-             spdm_context->local_context.opaque_challenge_auth_rsp_size);
-    ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
 
+    if (spdm_context->local_context.opaque_challenge_auth_rsp != NULL) {
+        copy_mem(ptr, spdm_context->local_context.opaque_challenge_auth_rsp,
+            spdm_context->local_context.opaque_challenge_auth_rsp_size);
+        ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
+    }
 
     /* Calc Sign*/
 

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -50,9 +50,12 @@ boolean spdm_create_measurement_signature(IN spdm_context_t *spdm_context,
     *(uint16_t *)ptr =
         (uint16_t)spdm_context->local_context.opaque_measurement_rsp_size;
     ptr += sizeof(uint16_t);
-    copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
+
+    if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
+        copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
              spdm_context->local_context.opaque_measurement_rsp_size);
-    ptr += spdm_context->local_context.opaque_measurement_rsp_size;
+        ptr += spdm_context->local_context.opaque_measurement_rsp_size;
+    }
 
     status = libspdm_append_message_m(spdm_context, session_info, response_message,
                                       response_message_size - signature_size);
@@ -93,9 +96,12 @@ boolean spdm_create_measurement_opaque(IN spdm_context_t *spdm_context,
     *(uint16_t *)ptr =
         (uint16_t)spdm_context->local_context.opaque_measurement_rsp_size;
     ptr += sizeof(uint16_t);
-    copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
-             spdm_context->local_context.opaque_measurement_rsp_size);
-    ptr += spdm_context->local_context.opaque_measurement_rsp_size;
+
+    if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
+        copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
+                spdm_context->local_context.opaque_measurement_rsp_size);
+        ptr += spdm_context->local_context.opaque_measurement_rsp_size;
+    }
 
     return TRUE;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -53,7 +53,7 @@ boolean spdm_create_measurement_signature(IN spdm_context_t *spdm_context,
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
         copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
-            spdm_context->local_context.opaque_measurement_rsp_size);
+                 spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 
@@ -99,7 +99,7 @@ boolean spdm_create_measurement_opaque(IN spdm_context_t *spdm_context,
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
         copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
-            spdm_context->local_context.opaque_measurement_rsp_size);
+                 spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -53,7 +53,7 @@ boolean spdm_create_measurement_signature(IN spdm_context_t *spdm_context,
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
         copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
-             spdm_context->local_context.opaque_measurement_rsp_size);
+            spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 
@@ -99,7 +99,7 @@ boolean spdm_create_measurement_opaque(IN spdm_context_t *spdm_context,
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
         copy_mem(ptr, spdm_context->local_context.opaque_measurement_rsp,
-                spdm_context->local_context.opaque_measurement_rsp_size);
+            spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -17,15 +17,16 @@
  * This function copies "len" bytes from "src_buf" to "dst_buf".
  *
  * Asserts and returns a non-zero value if any of the following are true:
- *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
+ *   1) "src_buf" or "dst_buf" are NULL.
  *   2) "src_buf" and "dst_buf" overlap.
  *   3) "len" is greater than "dst_len".
  *   4) "len" or "dst_len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
  *   5) "len" or "dst_len" is greater than (MAX_ADDRESS - "src_buf" + 1).
  *   6) "len" or "dst_len" is greater than (SIZE_MAX >> 1).
  *
- * In case of error, the "dst_buf" is left unmodifed. This behavior is different
- * than memcopy_s, which zeros the "dst_buf" if "dst_buf" is valid.
+ * In case of error, the "dst_buf" is left unmodifed.
+ * This behavior is different than C11 memcopy_s, which zeros the "dst_buf"
+ * if there is a runtime violation.
  *
  * @param    dst_buf   Destination buffer to copy to.
  * @param    dst_len   Maximum length in bytes of the destination buffer.

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -35,7 +35,7 @@
  * @return   0 on success. non-zero on error.
  *
 **/
-int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len)
+int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len)
 {
     volatile uint8_t* dst;
     const volatile uint8_t* src;
@@ -48,16 +48,23 @@ int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN u
         return -1;
     }
 
-    if ((src < dst && src + len > dst)
-     || (dst < src && dst + len > src)) {
+    if ((src < dst && src + len > dst) || (dst < src && dst + len > src)) {
         ASSERT(0);
         return -1;
     }
 
-    if (len > dst_len
-     || len > MAX_ADDRESS - (uintn)dst + 1
-     || len > MAX_ADDRESS - (uintn)src + 1
-     || len > (SIZE_MAX >> 1)) {
+    if (len > dst_len ||
+        len > MAX_ADDRESS - (size_t)dst + 1 ||
+        len > MAX_ADDRESS - (size_t)src + 1 ||
+        len > (SIZE_MAX >> 1)) {
+
+        ASSERT(0);
+        return -1;
+    }
+
+    if (dst_len > MAX_ADDRESS - (size_t)dst + 1 ||
+        dst_len > MAX_ADDRESS - (size_t)src + 1 ||
+        dst_len > (SIZE_MAX >> 1)) {
 
         ASSERT(0);
         return -1;

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -9,35 +9,65 @@
  **/
 
 #include "base.h"
+#include "library/debuglib.h"
 
 /**
- * Copies a source buffer to a destination buffer, and returns the destination buffer.
+ * Copies bytes from a source buffer to a destination buffer.
  *
- * This function copies length bytes from source_buffer to destination_buffer, and returns
- * destination_buffer.  The implementation must be reentrant, and it must handle the case
- * where source_buffer overlaps destination_buffer.
+ * This function copies "len" bytes from "src_buf" to "dst_buf".
  *
- * If length is greater than (MAX_ADDRESS - destination_buffer + 1), then ASSERT().
- * If length is greater than (MAX_ADDRESS - source_buffer + 1), then ASSERT().
+ * Asserts and returns a non-zero value if any of the following are true:
+ *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
+ *   2) "src_buf" and "dst_buf" overlap.
+ *   3) "len" is greater than "dst_len".
+ *   4) "len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
+ *   5) "len" is greater than (MAX_ADDRESS - "src_buf" + 1).
+ *   6) "len" is greater than (SIZE_MAX >> 1).
  *
- * @param  destination_buffer   A pointer to the destination buffer of the memory copy.
- * @param  source_buffer        A pointer to the source buffer of the memory copy.
- * @param  length              The number of bytes to copy from source_buffer to destination_buffer.
+ * @param    dst_buf   Destination buffer to copy to.
+ * @param    dst_len   Maximum length in bytes of the destination buffer.
+ * @param    src_buf   Source buffer to copy from.
+ * @param    len       The number of bytes to copy.
  *
- * @return destination_buffer.
+ * @return   0 on success. non-zero on error.
  *
- **/
-void *copy_mem(OUT void *destination_buffer, IN const void *source_buffer,
-               IN uintn length)
+**/
+int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len)
 {
-    volatile uint8_t *pointer_dst;
-    const volatile uint8_t *pointer_src;
+    volatile uint8_t* dst;
+    const volatile uint8_t* src;
 
-    pointer_dst = (uint8_t *)destination_buffer;
-    pointer_src = (const uint8_t *)source_buffer;
-    while (length-- != 0) {
-        *(pointer_dst++) = *(pointer_src++);
+    dst = (uint8_t*) dst_buf;
+    src = (const uint8_t*) src_buf;
+
+    if ((src == NULL || dst == NULL) && len > 0) {
+        ASSERT(0);
+        return -1;
     }
 
-    return destination_buffer;
+    if ((src < dst && src + len > dst)
+     || (dst < src && dst + len > src)) {
+        ASSERT(0);
+        return -1;
+    }
+
+    if (len > dst_len
+     || len > MAX_ADDRESS - (uintn)dst + 1
+     || len > MAX_ADDRESS - (uintn)src + 1
+     || len > (SIZE_MAX >> 1)) {
+
+        ASSERT(0);
+        return -1;
+    }
+
+    while (len-- != 0) {
+        *(dst++) = *(src++);
+    }
+
+    return 0;
+}
+
+void copy_mem(OUT void* dst_buf, IN const void* src_buf, IN uintn len)
+{
+    copy_mem_s(dst_buf, len, src_buf, len);
 }

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -20,9 +20,12 @@
  *   1) ("src_buf" or "dst_buf" are NULL) and "len" is greater 0.
  *   2) "src_buf" and "dst_buf" overlap.
  *   3) "len" is greater than "dst_len".
- *   4) "len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
- *   5) "len" is greater than (MAX_ADDRESS - "src_buf" + 1).
- *   6) "len" is greater than (SIZE_MAX >> 1).
+ *   4) "len" or "dst_len" is greater than (MAX_ADDRESS - "dst_buf" + 1).
+ *   5) "len" or "dst_len" is greater than (MAX_ADDRESS - "src_buf" + 1).
+ *   6) "len" or "dst_len" is greater than (SIZE_MAX >> 1).
+ *
+ * In case of error, the "dst_buf" is left unmodifed. This behavior is different
+ * than memcopy_s, which zeros the "dst_buf" if "dst_buf" is valid.
  *
  * @param    dst_buf   Destination buffer to copy to.
  * @param    dst_len   Maximum length in bytes of the destination buffer.
@@ -40,7 +43,7 @@ int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN u
     dst = (uint8_t*) dst_buf;
     src = (const uint8_t*) src_buf;
 
-    if ((src == NULL || dst == NULL) && len > 0) {
+    if (src == NULL || dst == NULL) {
         ASSERT(0);
         return -1;
     }

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -10,7 +10,6 @@
 
 #include "base.h"
 #include "library/debuglib.h"
-#include <stddef.h>
 
 /**
  * Copies bytes from a source buffer to a destination buffer.
@@ -36,7 +35,7 @@
  * @return   0 on success. non-zero on error.
  *
  **/
-int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len)
+int copy_mem_s(OUT void* dst_buf, IN uintn dst_len, IN const void* src_buf, IN uintn len)
 {
     volatile uint8_t* dst;
     const volatile uint8_t* src;
@@ -55,16 +54,16 @@ int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN 
     }
 
     if (len > dst_len ||
-        len > MAX_ADDRESS - (size_t)dst + 1 ||
-        len > MAX_ADDRESS - (size_t)src + 1 ||
+        len > MAX_ADDRESS - (uintn)dst + 1 ||
+        len > MAX_ADDRESS - (uintn)src + 1 ||
         len > (SIZE_MAX >> 1)) {
 
         ASSERT(0);
         return -1;
     }
 
-    if (dst_len > MAX_ADDRESS - (size_t)dst + 1 ||
-        dst_len > MAX_ADDRESS - (size_t)src + 1 ||
+    if (dst_len > MAX_ADDRESS - (uintn)dst + 1 ||
+        dst_len > MAX_ADDRESS - (uintn)src + 1 ||
         dst_len > (SIZE_MAX >> 1)) {
 
         ASSERT(0);

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -10,6 +10,7 @@
 
 #include "base.h"
 #include "library/debuglib.h"
+#include <stddef.h>
 
 /**
  * Copies bytes from a source buffer to a destination buffer.

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -35,7 +35,7 @@
  *
  * @return   0 on success. non-zero on error.
  *
-**/
+ **/
 int copy_mem_s(OUT void* dst_buf, IN size_t dst_len, IN const void* src_buf, IN size_t len)
 {
     volatile uint8_t* dst;

--- a/unit_test/test_size/intrinsiclib/copy_mem.c
+++ b/unit_test/test_size/intrinsiclib/copy_mem.c
@@ -17,7 +17,8 @@
 static __attribute__((__used__)) void *__memcpy(void *dest, const void *src,
                                                 unsigned int count)
 {
-    return copy_mem(dest, src, (uintn)count);
+    copy_mem(dest, src, (uintn)count);
+    return dest;
 }
 __attribute__((__alias__("__memcpy"))) void *memcpy(void *dest, const void *src,
                                                     unsigned int count);
@@ -26,6 +27,7 @@ __attribute__((__alias__("__memcpy"))) void *memcpy(void *dest, const void *src,
 /* Copies bytes between buffers */
 void *memcpy(void *dest, const void *src, unsigned int count)
 {
-    return copy_mem(dest, src, (uintn)count);
+    copy_mem(dest, src, (uintn)count);
+    return dest;
 }
 #endif


### PR DESCRIPTION
@jyao1 @steven-bellock @taprinz 
This is a proposal for a copy_mem_s function that behaves similar to memcpy_s. This is just a review for the function change itself.  Once this new function is approved, I will add another PR to change all the calling locations to the new function and remove the older copy_mem function.