### PR TITLE
Add uncrustify style problem output on failure

### DIFF
--- a/.github/workflows/compliance-checks.yml
+++ b/.github/workflows/compliance-checks.yml
@@ -34,5 +34,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Check
         # uncrustify is unable to parse the assembly directives in the ia32 intrinsiclib
+        # run an uncrustify check, if the check indicates problems, then apply the fixes and show the diff
         run: |
-          find -not -path "./unit_test/test_size/intrinsiclib/ia32/*" \( -name "*.c" -o -name "*.h" \) -exec uncrustify -c ./.uncrustify.cfg --check {} +
+          set +e
+          find -not -path "./unit_test/test_size/intrinsiclib/ia32/*" \( -name "*.c" -o -name "*.h" \) -exec uncrustify -q -c ./.uncrustify.cfg --check {} +
+          if [ $? -ne 0 ]; then
+            set -e
+            find -not -path "./unit_test/test_size/intrinsiclib/ia32/*" \( -name "*.c" -o -name "*.h" \) -exec uncrustify -q -c ./.uncrustify.cfg --replace --no-backup {} +
+            git diff
+            exit 1
+          fi


### PR DESCRIPTION
The current implementation of uncrustify style application silently
fails if the style is not compliant. This change shows the diff between
the current implementation and style corrections done by uncrustify.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>