### PR TITLE
Fix version=0 in ERROR message.

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1997,6 +1997,7 @@ void libspdm_reset_context(IN void *context)
 
     spdm_context = context;
     /*Clear all info about last connection*/
+    zero_mem(&spdm_context->connection_info.version, sizeof(spdm_version_number_t));
     zero_mem(&spdm_context->connection_info.capability, sizeof(spdm_device_capability_t));
     zero_mem(&spdm_context->connection_info.algorithm, sizeof(spdm_device_algorithm_t));
     zero_mem(&spdm_context->last_spdm_error, sizeof(libspdm_error_struct_t));

--- a/library/spdm_responder_lib/libspdm_rsp_error.c
+++ b/library/spdm_responder_lib/libspdm_rsp_error.c
@@ -36,6 +36,10 @@ return_status libspdm_generate_error_response(IN void *context,
     spdm_response = response;
 
     spdm_response->header.spdm_version = spdm_get_connection_version (context);
+    if (spdm_response->header.spdm_version == 0) {
+        /* if version is not negotiated, then use default version 1.0 */
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+    }
     spdm_response->header.request_response_code = SPDM_ERROR;
     spdm_response->header.param1 = error_code;
     spdm_response->header.param2 = error_data;


### PR DESCRIPTION
In some cases, if the version is not negotiated, the ERROR message shall use version=0x10.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>