### PR TITLE
Add full response version info in get_version API.

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -60,7 +60,9 @@ return_status spdm_handle_error_response_main(
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_version(IN spdm_context_t *spdm_context);
+return_status spdm_get_version(IN spdm_context_t *spdm_context,
+                               IN OUT uint8_t *version_number_entry_count,
+                               OUT spdm_version_number_t *version_number_entry);
 
 /**
  * This function sends GET_CAPABILITIES and receives CAPABILITIES.

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -26,7 +26,7 @@ return_status libspdm_init_connection(IN void *context,
 
     spdm_context = context;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     if (RETURN_ERROR(status)) {
         return status;
     }

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -24,7 +24,9 @@ typedef struct {
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
+return_status try_spdm_get_version(IN spdm_context_t *spdm_context,
+                                   IN OUT uint8_t *version_number_entry_count,
+                                   OUT spdm_version_number_t *version_number_entry)
 {
     return_status status;
     bool result;
@@ -131,6 +133,19 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
                  sizeof(spdm_version_number_t));
     }
 
+    if (version_number_entry_count != NULL && version_number_entry != NULL) {
+        if (*version_number_entry_count < spdm_response.version_number_entry_count) {
+            *version_number_entry_count = spdm_response.version_number_entry_count;
+            libspdm_reset_message_a(spdm_context);
+            return RETURN_BUFFER_TOO_SMALL;
+        } else {
+            *version_number_entry_count = spdm_response.version_number_entry_count;
+            copy_mem (version_number_entry, spdm_response.version_number_entry,
+                      spdm_response.version_number_entry_count * sizeof(spdm_version_number_t));
+            spdm_version_number_sort (version_number_entry, *version_number_entry_count);
+        }
+    }
+
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
     return RETURN_SUCCESS;
@@ -146,14 +161,17 @@ return_status try_spdm_get_version(IN spdm_context_t *spdm_context)
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_version(IN spdm_context_t *spdm_context)
+return_status spdm_get_version(IN spdm_context_t *spdm_context,
+                               IN OUT uint8_t *version_number_entry_count,
+                               OUT spdm_version_number_t *version_number_entry)
 {
     uintn retry;
     return_status status;
 
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_version(spdm_context);
+        status = try_spdm_get_version(spdm_context,
+                                      version_number_entry_count, version_number_entry);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
@@ -43,7 +43,7 @@ void test_spdm_requester_get_version(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
 
-    spdm_get_version(spdm_context);
+    spdm_get_version(spdm_context, NULL, NULL);
 }
 
 spdm_test_context_t m_spdm_requester_get_version_test_context = {

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -407,7 +407,7 @@ void test_spdm_requester_get_version_case1(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -425,7 +425,7 @@ void test_spdm_requester_get_version_case2(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -443,7 +443,7 @@ void test_spdm_requester_get_version_case3(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -461,7 +461,7 @@ void test_spdm_requester_get_version_case4(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -479,7 +479,7 @@ void test_spdm_requester_get_version_case5(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_NO_RESPONSE);
 }
 
@@ -498,7 +498,7 @@ void test_spdm_requester_get_version_case6(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -519,7 +519,7 @@ void test_spdm_requester_get_version_case7(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -541,7 +541,7 @@ void test_spdm_requester_get_version_case8(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -562,7 +562,7 @@ void test_spdm_requester_get_version_case9(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -583,7 +583,7 @@ void test_spdm_requester_get_version_case10(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -602,7 +602,7 @@ void test_spdm_requester_get_version_case11(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -621,7 +621,7 @@ void test_spdm_requester_get_version_case12(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -641,7 +641,7 @@ void test_spdm_requester_get_version_case13(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
 
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -666,7 +666,7 @@ void test_spdm_requester_get_version_case14(void **state) {
     error_code = SPDM_ERROR_CODE_RESERVED_00;
     while(error_code <= 0xff) {
         /* no additional state control is necessary as a new GET_VERSION resets the state*/
-        status = spdm_get_version (spdm_context);
+        status = spdm_get_version (spdm_context, NULL, NULL);
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
         error_code++;
@@ -703,7 +703,7 @@ void test_spdm_requester_get_version_case15(void **state)
     spdm_context->local_context.version.spdm_version[2] = 0x09 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.version.spdm_version[3] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.version.spdm_version[4] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
-    status = spdm_get_version(spdm_context);
+    status = spdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT, 0x11);


### PR DESCRIPTION
It will be used in conformance test.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>