### PR TITLE
Check opaque data ptr before copy_mem.

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -125,10 +125,11 @@ return_status spdm_get_encap_response_challenge_auth(
     *(uint16_t *)ptr = (uint16_t)spdm_context->local_context
                        .opaque_challenge_auth_rsp_size;
     ptr += sizeof(uint16_t);
-    copy_mem(ptr, spdm_context->local_context.opaque_challenge_auth_rsp,
-             spdm_context->local_context.opaque_challenge_auth_rsp_size);
-    ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
-
+    if (spdm_context->local_context.opaque_challenge_auth_rsp != NULL) {
+        copy_mem(ptr, spdm_context->local_context.opaque_challenge_auth_rsp,
+                 spdm_context->local_context.opaque_challenge_auth_rsp_size);
+        ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
+    }
 
     /* Calc Sign*/
 


### PR DESCRIPTION
This is to avoid assert in copy_mem.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>