### PR TITLE
fix the direct memory leak with the initial corpus for test_spdm_resp…

### DIFF
--- a/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
@@ -54,6 +54,7 @@ void test_spdm_responder_certificate_case1(void **State)
                                   spdm_test_context->test_buffer_size,
                                   spdm_test_context->test_buffer,
                                   &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_certificate_case2(void **State)
@@ -90,6 +91,7 @@ void test_spdm_responder_certificate_case2(void **State)
                                   spdm_test_context->test_buffer_size,
                                   spdm_test_context->test_buffer,
                                   &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_certificate_case3(void **State)
@@ -170,6 +172,7 @@ void test_spdm_responder_certificate_case5(void **State)
                                   spdm_test_context->test_buffer_size,
                                   spdm_test_context->test_buffer,
                                   &response_size, response);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -54,6 +54,7 @@ void test_spdm_responder_challenge_case1(void **State)
 
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_challenge_case2(void **State)
@@ -89,6 +90,7 @@ void test_spdm_responder_challenge_case2(void **State)
 
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_challenge_case3(void **State)
@@ -125,6 +127,7 @@ void test_spdm_responder_challenge_case3(void **State)
 
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_challenge_case4(void **State)
@@ -163,6 +166,7 @@ void test_spdm_responder_challenge_case4(void **State)
     libspdm_reset_message_c(spdm_context);
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_challenge_case5(void **State)
@@ -200,6 +204,11 @@ void test_spdm_responder_challenge_case5(void **State)
 
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_m1m2);
+    #endif
 }
 
 void test_spdm_responder_challenge_case6(void **State)
@@ -239,6 +248,7 @@ void test_spdm_responder_challenge_case6(void **State)
     libspdm_reset_message_c(spdm_context);
     spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
@@ -103,6 +103,10 @@ void test_spdm_responder_encap_challenge_case1(void **State)
     spdm_process_encap_response_challenge_auth(spdm_context, spdm_response_size, spdm_response,
                                                NULL);
     free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_mut_m1m2);
+    #endif
 }
 
 void test_spdm_get_encap_request_challenge_case2(void **State)
@@ -137,6 +141,11 @@ void test_spdm_get_encap_request_challenge_case2(void **State)
 
     spdm_get_encap_request_challenge(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
+    free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_mut_m1m2);
+    #endif
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
@@ -63,6 +63,7 @@ void test_spdm_responder_encap_get_certificate_case1(void **State)
 
     spdm_process_encap_response_certificate(spdm_context, spdm_response_size, spdm_response,
                                             &need_continue);
+    free(data);
 }
 
 void test_spdm_get_encap_request_get_certificate_case2(void **State)
@@ -98,6 +99,11 @@ void test_spdm_get_encap_request_get_certificate_case2(void **State)
 
     spdm_get_encap_request_get_certificate(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
+    free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_mut_m1m2);
+    #endif
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
@@ -76,6 +76,11 @@ void test_spdm_get_encap_request_get_digest_case2(void **State)
 
     spdm_get_encap_request_get_digest(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
+    free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_mut_m1m2);
+    #endif
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/encap_key_update.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/encap_key_update.c
@@ -178,6 +178,7 @@ void test_spdm_get_encap_request_key_update_case1(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     spdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
+    free(data);
 }
 
 void test_spdm_get_encap_request_key_update_case2(void **State)
@@ -227,6 +228,7 @@ void test_spdm_get_encap_request_key_update_case2(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     spdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
@@ -54,6 +54,11 @@ void test_spdm_get_response_encapsulated_request_case1(void **State)
     spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
                                            spdm_test_context->test_buffer, &response_size,
                                            response);
+    free(data);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_mut_m1m2);
+    #endif
 }
 
 void test_spdm_get_response_encapsulated_request_case2(void **State)
@@ -208,6 +213,7 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case1(void **State)
     spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
                                                 spdm_test_context->test_buffer, &response_size,
                                                 response);
+    free(data);
 }
 
 void test_spdm_spdm_get_response_encapsulated_response_ack_case2(void **State)
@@ -274,6 +280,7 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case3(void **State)
     spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
                                                 spdm_test_context->test_buffer, &response_size,
                                                 response);
+    free(data);
 }
 
 void test_spdm_spdm_get_response_encapsulated_response_ack_case4(void **State)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
@@ -87,6 +87,7 @@ void test_spdm_responder_end_session(void **State)
                                   spdm_test_context->test_buffer_size,
                                   spdm_test_context->test_buffer,
                                   &response_size, response);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -120,6 +120,7 @@ void test_spdm_responder_finish_case1(void **State)
     response_size = sizeof(response);
     spdm_get_response_finish(&spdm_context, m_spdm_finish_request1_size, &m_spdm_finish_request1,
                              &response_size, response);
+    free(data1);
 }
 
 void test_spdm_responder_finish_case2(void **State)
@@ -274,6 +275,7 @@ void test_spdm_responder_finish_case7(void **State)
     response_size = sizeof(response);
     spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
                              spdm_test_context->test_buffer, &response_size, response);
+    free(data1);
 }
 
 void test_spdm_responder_finish_case8(void **State)
@@ -381,6 +383,8 @@ void test_spdm_responder_finish_case8(void **State)
     response_size = sizeof(response);
     spdm_get_response_finish(&spdm_context, m_spdm_finish_request_size, &m_spdm_finish_request,
                              &response_size, response);
+    free(data1);
+    free(data2);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -85,6 +85,7 @@ void test_spdm_responder_heartbeat(void **State)
                                 spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer,
                                 &response_size, response);
+    free(data1);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -75,6 +75,10 @@ void test_spdm_responder_respond_if_ready(void **State)
                                        spdm_test_context->test_buffer_size,
                                        spdm_test_context->test_buffer,
                                        &response_size, response);
+    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    #else
+    free(spdm_context->transcript.digest_context_m1m2);
+    #endif
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
@@ -87,6 +87,7 @@ void test_spdm_responder_key_exchange_case1(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_key_exchange_case2(void **State)
@@ -144,6 +145,7 @@ void test_spdm_responder_key_exchange_case2(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_key_exchange_case3(void **State)
@@ -186,6 +188,7 @@ void test_spdm_responder_key_exchange_case3(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_key_exchange_case4(void **State)
@@ -250,6 +253,7 @@ void test_spdm_responder_key_exchange_case4(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_key_exchange_case5(void **State)
@@ -312,6 +316,7 @@ void test_spdm_responder_key_exchange_case5(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_key_exchange_case6(void **State)
@@ -368,6 +373,7 @@ void test_spdm_responder_key_exchange_case6(void **State)
 
     spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
                                    &m_spdm_key_exchange_request, &response_size, response);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
@@ -124,6 +124,7 @@ void test_spdm_responder_measurements_case3(void **State)
 
     spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                    spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_measurements_case4(void **State)
@@ -180,6 +181,7 @@ void test_spdm_responder_measurements_case4(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                    spdm_test_context->test_buffer, &response_size, response);
+    free(data);
 }
 
 spdm_test_context_t m_spdm_responder_measurements_test_context = {

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -89,6 +89,7 @@ void test_spdm_responder_psk_exchange_case1(void **State)
 
     spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
                                    &m_spdm_psk_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_psk_exchange_case2(void **State)
@@ -146,6 +147,7 @@ void test_spdm_responder_psk_exchange_case2(void **State)
 
     spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
                                    &m_spdm_psk_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_psk_exchange_case3(void **State)
@@ -204,6 +206,7 @@ void test_spdm_responder_psk_exchange_case3(void **State)
 
     spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
                                    &m_spdm_psk_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_psk_exchange_case4(void **State)
@@ -267,6 +270,7 @@ void test_spdm_responder_psk_exchange_case4(void **State)
 
     spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
                                    &m_spdm_psk_exchange_request, &response_size, response);
+    free(data);
 }
 
 void test_spdm_responder_psk_exchange_case5(void **State)
@@ -331,6 +335,7 @@ void test_spdm_responder_psk_exchange_case5(void **State)
 
     spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
                                    &m_spdm_psk_exchange_request, &response_size, response);
+    free(data);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -92,6 +92,7 @@ void test_spdm_responder_psk_finish_rsp_case1(void **State)
     response_size = sizeof(response);
     spdm_get_response_psk_finish(spdm_context, spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer, &response_size, response);
+    free(data1);
 }
 
 void test_spdm_responder_psk_finish_rsp_case2(void **State)
@@ -169,6 +170,7 @@ void test_spdm_responder_psk_finish_rsp_case2(void **State)
     response_size = sizeof(response);
     spdm_get_response_psk_finish(spdm_context, m_spdm_psk_finish_request_size,
                                  &m_spdm_psk_finish_request, &response_size, response);
+    free(data1);
 }
 
 void run_test_harness(IN void *test_buffer, IN uintn test_buffer_size)


### PR DESCRIPTION
…onder_encap_key_update and so on

fix: #625
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>