### PR TITLE
Delete the duplicate code for clear_handshake_secret

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -277,9 +277,6 @@ return_status try_spdm_send_receive_finish(IN spdm_context_t *spdm_context,
 error:
     if (RETURN_NO_RESPONSE != status) {
         libspdm_free_session_id(spdm_context, session_id);
-        if (session_state == LIBSPDM_SESSION_STATE_HANDSHAKING) {
-            libspdm_clear_handshake_secret(session_info->secured_message_context);
-        }
     }
     return status;
 }

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -185,9 +185,6 @@ return_status try_spdm_send_receive_psk_finish(IN spdm_context_t *spdm_context,
 error:
     if (RETURN_NO_RESPONSE != status) {
         libspdm_free_session_id(spdm_context, session_id);
-        if (session_state == LIBSPDM_SESSION_STATE_HANDSHAKING) {
-            libspdm_clear_handshake_secret(session_info->secured_message_context);
-        }
     }
     return status;
 }


### PR DESCRIPTION
Because the libspdm_free_session_id function feature contain libspdm_clear_handshake_secret, the code is duplicate.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>