### PR TITLE
Use copy_mem_s in unit_test/test_spdm_responder/*

### DIFF
--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -69,8 +69,8 @@ void test_spdm_responder_end_session_case1(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -147,8 +147,8 @@ void test_spdm_responder_end_session_case2(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -229,8 +229,8 @@ void test_spdm_responder_end_session_case3(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -312,8 +312,8 @@ void test_spdm_responder_end_session_case4(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -397,8 +397,8 @@ void test_spdm_responder_end_session_case5(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -486,8 +486,8 @@ void test_spdm_responder_end_session_case6(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -567,8 +567,8 @@ void test_spdm_responder_end_session_case7(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -44,8 +44,9 @@ void spdm_secured_message_set_request_finished_key(
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
-    copy_mem(secured_message_context->handshake_secret.request_finished_key,
-             key, secured_message_context->hash_size);
+    copy_mem_s(secured_message_context->handshake_secret.request_finished_key,
+               sizeof(secured_message_context->handshake_secret.request_finished_key),
+               key, secured_message_context->hash_size);
     secured_message_context->finished_key_ready = true;
 }
 
@@ -948,8 +949,9 @@ void test_spdm_responder_finish_case8(void **state)
     spdm_context->local_context.peer_cert_chain_provision_size =
         data_size2;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-             data2, data_size2);
+    copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
+               sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+               data2, data_size2);
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size2;
 #else
@@ -1559,7 +1561,8 @@ void test_spdm_responder_finish_case13(void **state)
     libspdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
                      get_managed_buffer_size(&th_curr), request_finished_key,
                      hash_size, ptr);
-    copy_mem(ptr, ptr + hmac_size, hmac_size); /* 2x HMAC size*/
+    copy_mem_s(ptr, sizeof(m_spdm_finish_request1.signature),
+               ptr + hmac_size, hmac_size); /* 2x HMAC size*/
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + 2*hmac_size;
     response_size = sizeof(response);
     status = spdm_get_response_finish(spdm_context,
@@ -1767,8 +1770,9 @@ void test_spdm_responder_finish_case15(void **state)
     spdm_context->local_context.peer_cert_chain_provision_size =
         data_size2;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-             data2, data_size2);
+    copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
+               sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+               data2, data_size2);
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size2;
 #endif
@@ -1920,8 +1924,9 @@ void test_spdm_responder_finish_case16(void **state)
     spdm_context->local_context.peer_cert_chain_provision_size =
         data_size2;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-             data2, data_size2);
+    copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
+               sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+               data2, data_size2);
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         data_size2;
 #endif

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -69,8 +69,8 @@ void test_spdm_responder_heartbeat_case1(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -147,8 +147,8 @@ void test_spdm_responder_heartbeat_case2(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -229,8 +229,8 @@ void test_spdm_responder_heartbeat_case3(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -312,8 +312,8 @@ void test_spdm_responder_heartbeat_case4(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -397,8 +397,8 @@ void test_spdm_responder_heartbeat_case5(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -486,8 +486,8 @@ void test_spdm_responder_heartbeat_case6(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -567,8 +567,8 @@ void test_spdm_responder_heartbeat_case7(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;

--- a/unit_test/test_spdm_responder/key_update.c
+++ b/unit_test/test_spdm_responder/key_update.c
@@ -121,12 +121,12 @@ static void spdm_set_standard_key_update_test_secrets(
     set_mem(m_req_secret_buffer, secured_message_context
             ->hash_size, req_secret_fill);
 
-    copy_mem(secured_message_context->application_secret
-             .response_data_secret,
-             m_rsp_secret_buffer, secured_message_context->aead_key_size);
-    copy_mem(secured_message_context->application_secret
-             .request_data_secret,
-             m_req_secret_buffer, secured_message_context->aead_key_size);
+    copy_mem_s(secured_message_context->application_secret.response_data_secret,
+               sizeof(secured_message_context->application_secret.response_data_secret),
+               m_rsp_secret_buffer, secured_message_context->aead_key_size);
+    copy_mem_s(secured_message_context->application_secret.request_data_secret,
+               sizeof(secured_message_context->application_secret.request_data_secret),
+               m_req_secret_buffer, secured_message_context->aead_key_size);
 
     set_mem(secured_message_context->application_secret
             .response_data_encryption_key,
@@ -158,11 +158,13 @@ static void spdm_compute_secret_update(uintn hash_size,
     uint16_t length;
 
     length = (uint16_t) hash_size;
-    copy_mem(m_bin_str9, &length, sizeof(uint16_t));
-    copy_mem(m_bin_str9 + sizeof(uint16_t), SPDM_BIN_CONCAT_LABEL,
-             sizeof(SPDM_BIN_CONCAT_LABEL) - 1);
-    copy_mem(m_bin_str9 + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1,
-             SPDM_BIN_STR_9_LABEL, sizeof(SPDM_BIN_STR_9_LABEL));
+    copy_mem_s(m_bin_str9, sizeof(m_bin_str9), &length, sizeof(uint16_t));
+    copy_mem_s(m_bin_str9 + sizeof(uint16_t),
+               sizeof(m_bin_str9) - sizeof(uint16_t),
+               SPDM_BIN_CONCAT_LABEL, sizeof(SPDM_BIN_CONCAT_LABEL) - 1);
+    copy_mem_s(m_bin_str9 + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1,
+               sizeof(m_bin_str9) - (sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1),
+               SPDM_BIN_STR_9_LABEL, sizeof(SPDM_BIN_STR_9_LABEL));
     m_bin_str9_size = sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1 +
                       sizeof(SPDM_BIN_STR_9_LABEL) - 1;
     /*context is NULL for key update*/
@@ -981,16 +983,16 @@ void test_spdm_responder_key_update_case12(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request1,
-             m_spdm_key_update_request1_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request1,
+               m_spdm_key_update_request1_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1069,16 +1071,16 @@ void test_spdm_responder_key_update_case13(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request1,
-             m_spdm_key_update_request1_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request1,
+               m_spdm_key_update_request1_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1156,21 +1158,20 @@ void test_spdm_responder_key_update_case14(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateallKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request3,
-             m_spdm_key_update_request3_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request3,
+               m_spdm_key_update_request3_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.response_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1259,21 +1260,20 @@ void test_spdm_responder_key_update_case15(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateAllKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request3,
-             m_spdm_key_update_request3_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request3,
+               m_spdm_key_update_request3_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.response_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1427,16 +1427,16 @@ void test_spdm_responder_key_update_case17(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request1,
-             m_spdm_key_update_request1_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request1,
+               m_spdm_key_update_request1_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1514,21 +1514,20 @@ void test_spdm_responder_key_update_case18(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateAllKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request3,
-             m_spdm_key_update_request3_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request3,
+               m_spdm_key_update_request3_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.response_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1617,9 +1616,10 @@ void test_spdm_responder_key_update_case19(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: VerifyNewKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request5,
-             m_spdm_key_update_request5_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request5,
+               m_spdm_key_update_request5_size);
 
     /*no keys updated (already activated)*/
 
@@ -1689,21 +1689,20 @@ void test_spdm_responder_key_update_case20(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateAllKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request5,
-             m_spdm_key_update_request5_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request5,
+               m_spdm_key_update_request5_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1792,16 +1791,16 @@ void test_spdm_responder_key_update_case21(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request1,
-             m_spdm_key_update_request1_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request1,
+               m_spdm_key_update_request1_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1881,21 +1880,20 @@ void test_spdm_responder_key_update_case22(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateAllKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request3,
-             m_spdm_key_update_request3_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request3,
+               m_spdm_key_update_request3_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.response_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -1981,16 +1979,16 @@ void test_spdm_responder_key_update_case23(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request1,
-             m_spdm_key_update_request1_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request1,
+               m_spdm_key_update_request1_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -2068,21 +2066,20 @@ void test_spdm_responder_key_update_case24(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: UpdateAllKeys*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request3,
-             m_spdm_key_update_request3_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request3,
+               m_spdm_key_update_request3_size);
 
     /*mocked major secret update*/
-    copy_mem(&secured_message_context->application_secret_backup
-             .request_data_secret,
-             &secured_message_context->application_secret
-             .request_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
-    copy_mem(&secured_message_context->application_secret_backup
-             .response_data_secret,
-             &secured_message_context->application_secret
-             .response_data_secret,
-             LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.request_data_secret,
+               sizeof(secured_message_context->application_secret_backup.request_data_secret),
+               &secured_message_context->application_secret.request_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
+    copy_mem_s(&secured_message_context->application_secret_backup.response_data_secret,
+               sizeof(secured_message_context->application_secret_backup.response_data_secret),
+               &secured_message_context->application_secret.response_data_secret,
+               LIBSPDM_MAX_HASH_SIZE);
     spdm_compute_secret_update(secured_message_context->hash_size,
                                secured_message_context->application_secret
                                .request_data_secret,
@@ -2168,9 +2165,10 @@ void test_spdm_responder_key_update_case25(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*last request: VerifyNewKey*/
-    copy_mem(spdm_context->last_update_request,
-             &m_spdm_key_update_request5,
-             m_spdm_key_update_request5_size);
+    copy_mem_s(spdm_context->last_update_request,
+               sizeof(spdm_context->last_update_request),
+               &m_spdm_key_update_request5,
+               m_spdm_key_update_request5_size);
 
     /*no keys updated (already activated)*/
 

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -1472,8 +1472,8 @@ void test_spdm_responder_measurements_case23(void **state)
                               m_spdm_get_measurements_request5.nonce);
 
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -86,8 +86,8 @@ void test_spdm_responder_psk_exchange_case1(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -101,8 +101,9 @@ void test_spdm_responder_psk_exchange_case1(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;
@@ -181,8 +182,8 @@ void test_spdm_responder_psk_exchange_case2(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -196,8 +197,9 @@ void test_spdm_responder_psk_exchange_case2(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request2.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request2.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request2.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request2.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request2.context_length;
@@ -268,8 +270,8 @@ void test_spdm_responder_psk_exchange_case3(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -283,8 +285,9 @@ void test_spdm_responder_psk_exchange_case3(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;
@@ -356,8 +359,8 @@ void test_spdm_responder_psk_exchange_case4(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -371,8 +374,9 @@ void test_spdm_responder_psk_exchange_case4(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;
@@ -446,8 +450,8 @@ void test_spdm_responder_psk_exchange_case5(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -461,8 +465,9 @@ void test_spdm_responder_psk_exchange_case5(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;
@@ -540,8 +545,8 @@ void test_spdm_responder_psk_exchange_case6(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -555,8 +560,9 @@ void test_spdm_responder_psk_exchange_case6(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;
@@ -626,8 +632,8 @@ void test_spdm_responder_psk_exchange_case7(void **state)
     spdm_context->local_context.slot_count = 1;
     libspdm_reset_message_a(spdm_context);
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -641,8 +647,9 @@ void test_spdm_responder_psk_exchange_case7(void **state)
         (uint16_t)opaque_psk_exchange_req_size;
     m_spdm_psk_exchange_request1.req_session_id = 0xFFFF;
     ptr = m_spdm_psk_exchange_request1.psk_hint;
-    copy_mem(ptr, spdm_context->local_context.psk_hint,
-             spdm_context->local_context.psk_hint_size);
+    copy_mem_s(ptr, sizeof(m_spdm_psk_exchange_request1.psk_hint),
+               spdm_context->local_context.psk_hint,
+               spdm_context->local_context.psk_hint_size);
     ptr += m_spdm_psk_exchange_request1.psk_hint_length;
     libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
     ptr += m_spdm_psk_exchange_request1.context_length;

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -37,8 +37,9 @@ static void spdm_secured_message_set_request_finished_key(
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
-    copy_mem(secured_message_context->handshake_secret.request_finished_key,
-             key, secured_message_context->hash_size);
+    copy_mem_s(secured_message_context->handshake_secret.request_finished_key,
+               sizeof(secured_message_context->handshake_secret.request_finished_key),
+               key, secured_message_context->hash_size);
     secured_message_context->finished_key_ready = true;
 }
 
@@ -102,8 +103,8 @@ void test_spdm_responder_psk_finish_case1(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -208,8 +209,8 @@ void test_spdm_responder_psk_finish_case2(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -317,8 +318,8 @@ void test_spdm_responder_psk_finish_case3(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -430,8 +431,8 @@ void test_spdm_responder_psk_finish_case4(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -545,8 +546,8 @@ void test_spdm_responder_psk_finish_case5(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -666,8 +667,8 @@ void test_spdm_responder_psk_finish_case6(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -771,8 +772,8 @@ void test_spdm_responder_psk_finish_case7(void **state)
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -901,8 +902,8 @@ void test_spdm_responder_psk_finish_case8(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -1013,8 +1014,8 @@ void test_spdm_responder_psk_finish_case9(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -1122,8 +1123,8 @@ void test_spdm_responder_psk_finish_case10(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -1225,8 +1226,8 @@ void test_spdm_responder_psk_finish_case11(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -1332,8 +1333,8 @@ void test_spdm_responder_psk_finish_case12(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;
@@ -1365,7 +1366,8 @@ void test_spdm_responder_psk_finish_case12(void **state)
     libspdm_hmac_all(m_use_hash_algo, get_managed_buffer(&th_curr),
                      get_managed_buffer_size(&th_curr), request_finished_key,
                      hash_size, ptr);
-    copy_mem(ptr, ptr + hmac_size, hmac_size); /* 2x HMAC size*/
+    copy_mem_s(ptr, sizeof(m_spdm_psk_finish_request1.verify_data),
+               ptr + hmac_size, hmac_size); /* 2x HMAC size*/
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + 2*hmac_size;
     response_size = sizeof(response);
@@ -1444,8 +1446,8 @@ void test_spdm_responder_psk_finish_case13(void **state)
     spdm_context->transcript.message_a.buffer_size = 0;
     spdm_context->local_context.mut_auth_requested = 0;
     zero_mem(m_local_psk_hint, 32);
-    copy_mem(&m_local_psk_hint[0], TEST_PSK_HINT_STRING,
-             sizeof(TEST_PSK_HINT_STRING));
+    copy_mem_s(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+               TEST_PSK_HINT_STRING, sizeof(TEST_PSK_HINT_STRING));
     spdm_context->local_context.psk_hint_size =
         sizeof(TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_local_psk_hint;

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -274,8 +274,9 @@ static void spdm_secured_message_set_request_finished_key(
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
-    copy_mem(secured_message_context->handshake_secret.request_finished_key,
-             key, secured_message_context->hash_size);
+    copy_mem_s(secured_message_context->handshake_secret.request_finished_key,
+               sizeof(secured_message_context->handshake_secret.request_finished_key),
+               key, secured_message_context->hash_size);
     secured_message_context->finished_key_ready = true;
 }
 


### PR DESCRIPTION
Change code under unit_test/test_spdm_responder to use copy_mem_s.

Signed-off-by: Kong, Richard <richard.kong@intel.com>