### PR TITLE
fix memory leak with initial corpus for test_spdm_requester_psk_finish

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
@@ -163,6 +163,7 @@ void test_spdm_requester_psk_finish_case1(void **State)
     spdm_secured_message_set_dummy_finished_key(session_info->secured_message_context);
     spdm_send_receive_psk_finish(spdm_context, session_id);
     free(data);
+    libspdm_reset_message_k(spdm_context, session_info);
 }
 
 spdm_test_context_t m_spdm_requester_psk_finish_test_context = {


### PR DESCRIPTION
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>