### PR TITLE
Use copy_mem_s in os_stub files part 1.

### DIFF
--- a/os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
+++ b/os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
@@ -149,10 +149,10 @@ bool hmac_md_duplicate(IN mbedtls_md_type_t md_type, IN const void *hmac_md_ctx,
     }
     /*Temporary solution to the problem of context clone.
      * There are not any standard function in mbedtls to clone a complete hmac context.*/
-    copy_mem(
-        ((mbedtls_md_context_t *)new_hmac_md_ctx)->hmac_ctx,
-        ((mbedtls_md_context_t *)hmac_md_ctx)->hmac_ctx,
-        hmac_md_get_blocksize(md_type) * 2);
+    copy_mem_s(((mbedtls_md_context_t *)new_hmac_md_ctx)->hmac_ctx,
+               hmac_md_get_blocksize(md_type) * 2,
+               ((mbedtls_md_context_t *)hmac_md_ctx)->hmac_ctx,
+               hmac_md_get_blocksize(md_type) * 2);
     return true;
 }
 

--- a/os_stub/cryptlib_mbedtls/pem/pem.c
+++ b/os_stub/cryptlib_mbedtls/pem/pem.c
@@ -69,7 +69,7 @@ bool rsa_get_private_key_from_pem(IN const uint8_t *pem_data,
         if (new_pem_data == NULL) {
             return false;
         }
-        copy_mem(new_pem_data, pem_data, pem_size);
+        copy_mem_s(new_pem_data, pem_size + 1, pem_data, pem_size);
         new_pem_data[pem_size] = 0;
         pem_data = new_pem_data;
         pem_size += 1;
@@ -154,7 +154,7 @@ bool ec_get_private_key_from_pem(IN const uint8_t *pem_data, IN uintn pem_size,
         if (new_pem_data == NULL) {
             return false;
         }
-        copy_mem(new_pem_data, pem_data, pem_size);
+        copy_mem_s(new_pem_data, pem_size + 1, pem_data, pem_size);
         new_pem_data[pem_size] = 0;
         pem_data = new_pem_data;
         pem_size += 1;

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -64,7 +64,7 @@ bool random_bytes(OUT uint8_t *output, IN uintn size)
             output += sizeof(uint64_t);
             size -= sizeof(temp_rand);
         } else {
-            copy_mem(output, &temp_rand, size);
+            copy_mem_s(output, size, &temp_rand, size);
             size = 0;
         }
     }

--- a/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
@@ -20,7 +20,7 @@ struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt,
     lt = gmtime(tt);
 
     if (lt != NULL) {
-        copy_mem(tm_buf, lt, sizeof(struct tm));
+        copy_mem_s(tm_buf, sizeof(struct tm), lt, sizeof(struct tm));
     }
 
     return ((lt == NULL) ? NULL : tm_buf);

--- a/os_stub/cryptlib_null/cipher/aead_aes_gcm.c
+++ b/os_stub/cryptlib_null/cipher/aead_aes_gcm.c
@@ -44,7 +44,7 @@ bool aead_aes_gcm_encrypt(IN const uint8_t *key, IN uintn key_size,
                           OUT uint8_t *tag_out, IN uintn tag_size,
                           OUT uint8_t *data_out, OUT uintn *data_out_size)
 {
-    copy_mem(data_out, data_in, data_in_size);
+    copy_mem_s(data_out, *data_out_size, data_in, data_in_size);
     *data_out_size = data_in_size;
     zero_mem(tag_out, tag_size);
     return true;
@@ -82,7 +82,7 @@ bool aead_aes_gcm_decrypt(IN const uint8_t *key, IN uintn key_size,
                           IN const uint8_t *tag, IN uintn tag_size,
                           OUT uint8_t *data_out, OUT uintn *data_out_size)
 {
-    copy_mem(data_out, data_in, data_in_size);
+    copy_mem_s(data_out, *data_out_size, data_in, data_in_size);
     *data_out_size = data_in_size;
     return true;
 }

--- a/os_stub/cryptlib_openssl/pem/pem.c
+++ b/os_stub/cryptlib_openssl/pem/pem.c
@@ -49,7 +49,7 @@ intn PasswordCallback(OUT char *buf, IN intn size, IN intn flag, IN void *key)
 
         key_length = (intn)ascii_str_len((char *)key);
         key_length = (key_length > size) ? size : key_length;
-        copy_mem(buf, key, (uintn)key_length);
+        copy_mem_s(buf, size, key, (uintn)key_length);
         return key_length;
     } else {
         return 0;

--- a/os_stub/cryptlib_openssl/pk/sm2.c
+++ b/os_stub/cryptlib_openssl/pk/sm2.c
@@ -610,8 +610,12 @@ static void ecc_signature_der_to_bin(IN uint8_t *der_signature,
     }
     ASSERT(r_size <= half_size && s_size <= half_size);
     zero_mem(signature, sig_size);
-    copy_mem(&signature[0 + half_size - r_size], bn_r, r_size);
-    copy_mem(&signature[half_size + half_size - s_size], bn_s, s_size);
+    copy_mem_s(&signature[0 + half_size - r_size],
+               sig_size - (0 + half_size - r_size),
+               bn_r, r_size);
+    copy_mem_s(&signature[half_size + half_size - s_size],
+               sig_size - (half_size + half_size - s_size),
+               bn_s, s_size);
 }
 
 static void ecc_signature_bin_to_der(IN uint8_t *signature, IN uintn sig_size,
@@ -667,16 +671,24 @@ static void ecc_signature_bin_to_der(IN uint8_t *signature, IN uintn sig_size,
     der_signature[2] = 0x02;
     der_signature[3] = der_r_size;
     if (bn_r[0] < 0x80) {
-        copy_mem(&der_signature[4], bn_r, r_size);
+        copy_mem_s(&der_signature[4],
+                   der_sig_size - (&der_signature[4] - der_signature),
+                   bn_r, r_size);
     } else {
-        copy_mem(&der_signature[5], bn_r, r_size);
+        copy_mem_s(&der_signature[5],
+                   der_sig_size - (&der_signature[5] - der_signature),
+                   bn_r, r_size);
     }
     der_signature[4 + der_r_size] = 0x02;
     der_signature[5 + der_r_size] = der_s_size;
     if (bn_s[0] < 0x80) {
-        copy_mem(&der_signature[6 + der_r_size], bn_s, s_size);
+        copy_mem_s(&der_signature[6 + der_r_size],
+                   der_sig_size - (&der_signature[6 + der_r_size] - der_signature),
+                   bn_s, s_size);
     } else {
-        copy_mem(&der_signature[7 + der_r_size], bn_s, s_size);
+        copy_mem_s(&der_signature[7 + der_r_size],
+                   der_sig_size - (&der_signature[7 + der_r_size] - der_signature),
+                   bn_s, s_size);
     }
 }
 

--- a/os_stub/openssllib/rand_pool.c
+++ b/os_stub/openssllib/rand_pool.c
@@ -49,7 +49,7 @@ static bool rand_get_bytes(IN uintn length, OUT uint8_t *RandBuffer)
             RandBuffer += sizeof(uint64_t);
             length -= sizeof(temp_rand);
         } else {
-            copy_mem(RandBuffer, &temp_rand, length);
+            copy_mem_s(RandBuffer, length, &temp_rand, length);
             length = 0;
         }
     }

--- a/os_stub/spdm_device_secret_lib_sample/cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/cert.c
@@ -108,8 +108,9 @@ bool read_responder_root_public_certificate(IN uint32_t base_hash_algo,
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -209,8 +210,9 @@ bool read_requester_root_public_certificate(IN uint32_t base_hash_algo,
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -328,8 +330,9 @@ bool read_responder_public_certificate_chain(
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -447,8 +450,9 @@ bool read_requester_public_certificate_chain(
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -524,8 +528,9 @@ bool read_responder_root_public_certificate_by_size(
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -621,8 +626,9 @@ bool read_responder_public_certificate_chain_by_size(
         free(cert_chain);
         return res;
     }
-    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-             file_data, file_size);
+    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+               file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -176,7 +176,7 @@ uintn fill_measurement_image_hash_block (
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                        (uint16_t)sizeof(data));
 
-        copy_mem((void *)(measurement_block + 1), data, sizeof(data));
+        copy_mem_s((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
 
         return sizeof(spdm_measurement_block_dmtf_t) + sizeof(data);
     }
@@ -214,7 +214,7 @@ uintn fill_measurement_svn_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(svn));
 
-    copy_mem((void *)(measurement_block + 1), (void *)&svn, sizeof(svn));
+    copy_mem_s((void *)(measurement_block + 1), sizeof(svn), (void *)&svn, sizeof(svn));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(svn);
 }
@@ -252,7 +252,7 @@ uintn fill_measurement_manifest_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(data));
 
-    copy_mem((void *)(measurement_block + 1), data, sizeof(data));
+    copy_mem_s((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(data);
 }
@@ -306,7 +306,8 @@ uintn fill_measurement_device_mode_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(device_mode));
 
-    copy_mem((void *)(measurement_block + 1), (void *)&device_mode, sizeof(device_mode));
+    copy_mem_s((void *)(measurement_block + 1), sizeof(device_mode),
+               (void *)&device_mode, sizeof(device_mode));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(device_mode);
 }
@@ -659,13 +660,12 @@ bool libspdm_generate_measurement_summary_hash(
                   .dmtf_spec_measurement_value_type &
                   SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MASK) ==
                  SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_IMMUTABLE_ROM)) {
-                copy_mem(
-                    &measurement_data[measurment_data_size],
-                    &cached_measurment_block
-                    ->measurement_block_dmtf_header,
-                    cached_measurment_block
-                    ->measurement_block_common_header
-                    .measurement_size);
+                copy_mem_s(&measurement_data[measurment_data_size],
+                           sizeof(measurement_data)
+                               - (&measurement_data[measurment_data_size] - measurement_data),
+                           &cached_measurment_block->measurement_block_dmtf_header,
+                           cached_measurment_block->measurement_block_common_header
+                               .measurement_size);
 
                 measurment_data_size +=
                     cached_measurment_block

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -662,10 +662,10 @@ bool libspdm_generate_measurement_summary_hash(
                  SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_IMMUTABLE_ROM)) {
                 copy_mem_s(&measurement_data[measurment_data_size],
                            sizeof(measurement_data)
-                               - (&measurement_data[measurment_data_size] - measurement_data),
+                           - (&measurement_data[measurment_data_size] - measurement_data),
                            &cached_measurment_block->measurement_block_dmtf_header,
                            cached_measurment_block->measurement_block_common_header
-                               .measurement_size);
+                           .measurement_size);
 
                 measurment_data_size +=
                     cached_measurment_block


### PR DESCRIPTION
Use copy_mem_s in these files:

os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
os_stub/cryptlib_mbedtls/pem/pem.c
os_stub/cryptlib_mbedtls/rand/rand.c
os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
os_stub/cryptlib_null/cipher/aead_aes_gcm.c
os_stub/cryptlib_openssl/pem/pem.c
os_stub/cryptlib_openssl/pk/sm2.c
os_stub/openssllib/rand_pool.c
os_stub/spdm_device_secret_lib_sample/cert.c
os_stub/spdm_device_secret_lib_sample/lib.c

Signed-off-by: Kong, Richard <richard.kong@intel.com>