### PR TITLE
change libspdm_start_watchdog uint64_t seconds to uint16_t.

### DIFF
--- a/include/hal/library/platform_lib.h
+++ b/include/hal/library/platform_lib.h
@@ -22,7 +22,7 @@ void libspdm_sleep(uint64_t milliseconds);
  * @param  seconds        heartbeat period, in seconds.
  *
  **/
-bool libspdm_start_watchdog(uint32_t session_id, uint64_t seconds);
+bool libspdm_start_watchdog(uint32_t session_id, uint16_t seconds);
 
 /**
  * stop watchdog.

--- a/os_stub/platform_lib/watchdog.c
+++ b/os_stub/platform_lib/watchdog.c
@@ -15,7 +15,7 @@
  * @param  seconds        heartbeat period, in seconds.
  *
  **/
-bool libspdm_start_watchdog(uint32_t session_id, uint64_t seconds)
+bool libspdm_start_watchdog(uint32_t session_id, uint16_t seconds)
 {
     return true;
 }


### PR DESCRIPTION
Fix: #637 

Signed-off-by: Qi Zhang <qi1.zhang@intel.com>