### PR TITLE
Rename copy_mem_s to copy_mem

### DIFF
--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -54,7 +54,8 @@
 int copy_mem_s(void *restrict dst_buf, uintn dst_len,
                const void *restrict src_buf, uintn src_len);
 
-void* copy_mem(void* dst_buf, const void* src_buf, uintn len);
+int copy_mem(void *restrict dst_buf, uintn dst_len,
+             const void *restrict src_buf, uintn src_len);
 
 /**
  * Fills a target buffer with a byte value, and returns the target buffer.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -82,20 +82,20 @@ return_status libspdm_set_data(void *context, libspdm_data_type_t data_type,
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
             /* Only have one connected version */
             ASSERT (data_size == sizeof(spdm_version_number_t));
-            copy_mem_s(&(spdm_context->connection_info.version),
-                       sizeof(spdm_context->connection_info.version),
-                       data,
-                       sizeof(spdm_version_number_t));
+            copy_mem(&(spdm_context->connection_info.version),
+                     sizeof(spdm_context->connection_info.version),
+                     data,
+                     sizeof(spdm_version_number_t));
         } else {
             spdm_context->local_context.version.spdm_version_count =
                 (uint8_t)(data_size /
                           sizeof(spdm_version_number_t));
-            copy_mem_s(spdm_context->local_context.version.spdm_version,
-                       sizeof(spdm_context->local_context.version.spdm_version),
-                       data,
-                       spdm_context->local_context.version
-                       .spdm_version_count *
-                       sizeof(spdm_version_number_t));
+            copy_mem(spdm_context->local_context.version.spdm_version,
+                     sizeof(spdm_context->local_context.version.spdm_version),
+                     data,
+                     spdm_context->local_context.version
+                     .spdm_version_count *
+                     sizeof(spdm_version_number_t));
         }
         break;
     case LIBSPDM_DATA_SECURED_MESSAGE_VERSION:
@@ -103,23 +103,23 @@ return_status libspdm_set_data(void *context, libspdm_data_type_t data_type,
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
             /* Only have one connected version */
             ASSERT (data_size == sizeof(spdm_version_number_t));
-            copy_mem_s(&(spdm_context->connection_info.secured_message_version),
-                       sizeof(spdm_context->connection_info.secured_message_version),
-                       data,
-                       sizeof(spdm_version_number_t));
+            copy_mem(&(spdm_context->connection_info.secured_message_version),
+                     sizeof(spdm_context->connection_info.secured_message_version),
+                     data,
+                     sizeof(spdm_version_number_t));
         } else {
             spdm_context->local_context.secured_message_version
             .spdm_version_count = (uint8_t)(
                 data_size / sizeof(spdm_version_number_t));
-            copy_mem_s(spdm_context->local_context
-                       .secured_message_version.spdm_version,
-                       sizeof(spdm_context->local_context
-                              .secured_message_version.spdm_version),
-                       data,
-                       spdm_context->local_context
-                       .secured_message_version
-                       .spdm_version_count *
-                       sizeof(spdm_version_number_t));
+            copy_mem(spdm_context->local_context
+                     .secured_message_version.spdm_version,
+                     sizeof(spdm_context->local_context
+                            .secured_message_version.spdm_version),
+                     data,
+                     spdm_context->local_context
+                     .secured_message_version
+                     .spdm_version_count *
+                     sizeof(spdm_version_number_t));
         }
         break;
     case LIBSPDM_DATA_CAPABILITY_FLAGS:
@@ -361,9 +361,9 @@ return_status libspdm_set_data(void *context, libspdm_data_type_t data_type,
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         spdm_context->connection_info.peer_used_cert_chain_buffer_size =
             data_size;
-        copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                   sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
-                   data, data_size);
+        copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                 sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                 data, data_size);
 #else
         status = libspdm_hash_all(
             spdm_context->connection_info.algorithm.base_hash_algo,
@@ -721,7 +721,7 @@ return_status libspdm_get_data(void *context, libspdm_data_type_t data_type,
         *data_size = target_data_size;
         return RETURN_BUFFER_TOO_SMALL;
     }
-    copy_mem_s(data, *data_size, target_data, target_data_size);
+    copy_mem(data, *data_size, target_data, target_data_size);
     *data_size = target_data_size;
 
     return RETURN_SUCCESS;
@@ -1431,10 +1431,10 @@ return_status libspdm_append_message_k(void *context, void *session_info,
                     if(spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size != 0) {
                         hash_size =
                             spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size;
-                        copy_mem_s(cert_chain_buffer_hash,
-                                   sizeof(cert_chain_buffer_hash),
-                                   spdm_context->connection_info.peer_used_cert_chain_buffer_hash,
-                                   hash_size);
+                        copy_mem(cert_chain_buffer_hash,
+                                 sizeof(cert_chain_buffer_hash),
+                                 spdm_context->connection_info.peer_used_cert_chain_buffer_hash,
+                                 hash_size);
                         result = true;
                     } else {
                         result = libspdm_get_peer_cert_chain_buffer(
@@ -1651,7 +1651,7 @@ return_status libspdm_append_message_f(void *context, void *session_info,
                     if (spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size != 0) {
                         hash_size =
                             spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size;
-                        copy_mem_s(mut_cert_chain_buffer_hash,
+                        copy_mem(mut_cert_chain_buffer_hash,
                                    sizeof(mut_cert_chain_buffer_hash),
                                    spdm_context->connection_info.peer_used_cert_chain_buffer_hash,
                                    hash_size);
@@ -1901,8 +1901,8 @@ void libspdm_get_last_spdm_error_struct(void *context,
     spdm_context_t *spdm_context;
 
     spdm_context = context;
-    copy_mem_s(last_spdm_error, sizeof(libspdm_error_struct_t),
-               &spdm_context->last_spdm_error,sizeof(libspdm_error_struct_t));
+    copy_mem(last_spdm_error, sizeof(libspdm_error_struct_t),
+             &spdm_context->last_spdm_error,sizeof(libspdm_error_struct_t));
 }
 
 /**
@@ -1917,8 +1917,8 @@ void libspdm_set_last_spdm_error_struct(void *context,
     spdm_context_t *spdm_context;
 
     spdm_context = context;
-    copy_mem_s(&spdm_context->last_spdm_error, sizeof(spdm_context->last_spdm_error),
-               last_spdm_error, sizeof(libspdm_error_struct_t));
+    copy_mem(&spdm_context->last_spdm_error, sizeof(spdm_context->last_spdm_error),
+             last_spdm_error, sizeof(libspdm_error_struct_t));
 }
 
 /**

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1652,9 +1652,9 @@ return_status libspdm_append_message_f(void *context, void *session_info,
                         hash_size =
                             spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size;
                         copy_mem(mut_cert_chain_buffer_hash,
-                                   sizeof(mut_cert_chain_buffer_hash),
-                                   spdm_context->connection_info.peer_used_cert_chain_buffer_hash,
-                                   hash_size);
+                                 sizeof(mut_cert_chain_buffer_hash),
+                                 spdm_context->connection_info.peer_used_cert_chain_buffer_hash,
+                                 hash_size);
                         result = true;
                     } else {
                         result = libspdm_get_peer_cert_chain_buffer(

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -279,8 +279,8 @@ bool spdm_calculate_m1m2(void *context, bool is_mut,
     }
     m1m2_buffer_capacity = *m1m2_buffer_size;
     *m1m2_buffer_size = get_managed_buffer_size(&m1m2);
-    copy_mem_s(m1m2_buffer, m1m2_buffer_capacity,
-               get_managed_buffer(&m1m2), *m1m2_buffer_size);
+    copy_mem(m1m2_buffer, m1m2_buffer_capacity,
+             get_managed_buffer(&m1m2), *m1m2_buffer_size);
 
     return true;
 }
@@ -430,8 +430,8 @@ bool spdm_calculate_l1l2(void *context, void *session_info,
 
     l1l2_buffer_capacity = *l1l2_buffer_size;
     *l1l2_buffer_size = get_managed_buffer_size(&l1l2);
-    copy_mem_s(l1l2_buffer, l1l2_buffer_capacity,
-               get_managed_buffer(&l1l2), *l1l2_buffer_size);
+    copy_mem(l1l2_buffer, l1l2_buffer_capacity,
+             get_managed_buffer(&l1l2), *l1l2_buffer_size);
 
     return true;
 }

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -87,8 +87,8 @@ bool libspdm_calculate_th_for_exchange(
 
     th_data_buffer_capacity = *th_data_buffer_size;
     *th_data_buffer_size = get_managed_buffer_size(&th_curr);
-    copy_mem_s(th_data_buffer, th_data_buffer_capacity,
-               get_managed_buffer(&th_curr), *th_data_buffer_size);
+    copy_mem(th_data_buffer, th_data_buffer_capacity,
+             get_managed_buffer(&th_curr), *th_data_buffer_size);
 
     return true;
 }
@@ -332,8 +332,8 @@ bool libspdm_calculate_th_for_finish(void *context,
 
     th_data_buffer_capacity = *th_data_buffer_size;
     *th_data_buffer_size = get_managed_buffer_size(&th_curr);
-    copy_mem_s(th_data_buffer, th_data_buffer_capacity,
-               get_managed_buffer(&th_curr), *th_data_buffer_size);
+    copy_mem(th_data_buffer, th_data_buffer_capacity,
+             get_managed_buffer(&th_curr), *th_data_buffer_size);
 
     return true;
 }
@@ -653,7 +653,7 @@ spdm_generate_key_exchange_rsp_hmac(spdm_context_t *spdm_context,
     DEBUG((DEBUG_INFO, "th_curr hmac - "));
     internal_dump_data(hmac_data, hash_size);
     DEBUG((DEBUG_INFO, "\n"));
-    copy_mem_s(hmac, hash_size, hmac_data, hash_size);
+    copy_mem(hmac, hash_size, hmac_data, hash_size);
 
     return true;
 }
@@ -1048,7 +1048,7 @@ bool spdm_generate_finish_req_hmac(spdm_context_t *spdm_context,
     internal_dump_data(calc_hmac_data, hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    copy_mem_s(hmac, hash_size, calc_hmac_data, hash_size);
+    copy_mem(hmac, hash_size, calc_hmac_data, hash_size);
 
     return true;
 }
@@ -1376,7 +1376,7 @@ bool spdm_generate_finish_rsp_hmac(spdm_context_t *spdm_context,
     internal_dump_data(hmac_data, hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    copy_mem_s(hmac, hash_size, hmac_data, hash_size);
+    copy_mem(hmac, hash_size, hmac_data, hash_size);
 
     return true;
 }
@@ -1517,7 +1517,7 @@ spdm_generate_psk_exchange_rsp_hmac(spdm_context_t *spdm_context,
     internal_dump_data(hmac_data, hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    copy_mem_s(hmac, hash_size, hmac_data, hash_size);
+    copy_mem(hmac, hash_size, hmac_data, hash_size);
 
     return true;
 }
@@ -1638,7 +1638,7 @@ spdm_generate_psk_exchange_req_hmac(spdm_context_t *spdm_context,
     internal_dump_data(calc_hmac_data, hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    copy_mem_s(hmac, hash_size, calc_hmac_data, hash_size);
+    copy_mem(hmac, hash_size, calc_hmac_data, hash_size);
 
     return true;
 }

--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -146,11 +146,11 @@ spdm_build_opaque_data_supported_version_data(spdm_context_t *spdm_context,
         spdm_context->local_context.secured_message_version.spdm_version_count;
 
     versions_list = (void *)(opaque_element_support_version + 1);
-    copy_mem_s(versions_list,
-               *data_out_size - ((uint8_t*)versions_list - (uint8_t*)data_out),
-               spdm_context->local_context.secured_message_version.spdm_version,
-               spdm_context->local_context.secured_message_version.spdm_version_count *
-               sizeof(spdm_version_number_t));
+    copy_mem(versions_list,
+             *data_out_size - ((uint8_t*)versions_list - (uint8_t*)data_out),
+             spdm_context->local_context.secured_message_version.spdm_version,
+             spdm_context->local_context.secured_message_version.spdm_version_count *
+             sizeof(spdm_version_number_t));
 
     /* Zero Padding. *data_out_size does not need to be changed, because data is 0 padded */
     end = versions_list + spdm_context->local_context.secured_message_version.spdm_version_count;
@@ -241,10 +241,10 @@ spdm_process_opaque_data_supported_version_data(spdm_context_t *spdm_context,
     if (result == false) {
         return RETURN_UNSUPPORTED;
     }
-    copy_mem_s(&(spdm_context->connection_info.secured_message_version),
-               sizeof(spdm_context->connection_info.secured_message_version),
-               &(common_version),
-               sizeof(spdm_version_number_t));
+    copy_mem(&(spdm_context->connection_info.secured_message_version),
+             sizeof(spdm_context->connection_info.secured_message_version),
+             &(common_version),
+             sizeof(spdm_version_number_t));
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -134,9 +134,9 @@ return_status append_managed_buffer(void *m_buffer, const void *buffer,
     ASSERT(buffer_size <=
            managed_buffer->max_buffer_size - managed_buffer->buffer_size);
 
-    copy_mem_s((uint8_t *)(managed_buffer + 1) + managed_buffer->buffer_size,
-               buffer_size,
-               buffer, buffer_size);
+    copy_mem((uint8_t *)(managed_buffer + 1) + managed_buffer->buffer_size,
+             buffer_size,
+             buffer, buffer_size);
     managed_buffer->buffer_size += buffer_size;
     return RETURN_SUCCESS;
 }

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -3150,10 +3150,10 @@ bool libspdm_req_asym_sign_hash(
 
         create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
         copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
-                   sizeof(spdm12_signing_context_with_hash)
-                   - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
-                      - spdm12_signing_context_with_hash),
-                   message_hash, hash_size);
+                 sizeof(spdm12_signing_context_with_hash)
+                 - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
+                    - spdm12_signing_context_with_hash),
+                 message_hash, hash_size);
 
         /* assign message and message_size for signing*/
 
@@ -3327,13 +3327,13 @@ void *libspdm_dhe_new(spdm_version_number_t spdm_version,
             SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE];
 
         copy_mem(spdm12_key_change_requester_context,
-                   sizeof(spdm12_key_change_requester_context),
-                   SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT,
-                   SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT_SIZE);
+                 sizeof(spdm12_key_change_requester_context),
+                 SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT,
+                 SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT_SIZE);
         copy_mem(spdm12_key_change_responder_context,
-                   sizeof(spdm12_key_change_responder_context),
-                   SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT,
-                   SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE);
+                 sizeof(spdm12_key_change_responder_context),
+                 SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT,
+                 SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE);
         /* patch the version*/
         spdm12_key_change_requester_context[25] = (char)('0' + ((spdm_version >> 12) & 0xF));
         spdm12_key_change_requester_context[27] = (char)('0' + ((spdm_version >> 8) & 0xF));

--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -1622,10 +1622,10 @@ create_spdm_signing_context (
 
     context_str = spdm_signing_context;
     for (index = 0; index < 4; index++) {
-        copy_mem_s(context_str,
-                   SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE,
-                   SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT,
-                   SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE);
+        copy_mem(context_str,
+                 SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE,
+                 SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT,
+                 SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE);
         /* patch the version*/
         context_str[11] = (char)('0' + ((spdm_version >> 12) & 0xF));
         context_str[13] = (char)('0' + ((spdm_version >> 8) & 0xF));
@@ -1638,10 +1638,10 @@ create_spdm_signing_context (
             zero_mem (
                 context_str,
                 m_spdm_signing_context_str_table[index].zero_pad_size);
-            copy_mem_s(context_str + m_spdm_signing_context_str_table[index].zero_pad_size,
-                       m_spdm_signing_context_str_table[index].context_size,
-                       m_spdm_signing_context_str_table[index].context,
-                       m_spdm_signing_context_str_table[index].context_size);
+            copy_mem(context_str + m_spdm_signing_context_str_table[index].zero_pad_size,
+                     m_spdm_signing_context_str_table[index].context_size,
+                     m_spdm_signing_context_str_table[index].context,
+                     m_spdm_signing_context_str_table[index].context_size);
             return;
         }
     }
@@ -2160,11 +2160,11 @@ bool libspdm_asym_verify_hash(
 
         create_spdm_signing_context (spdm_version, op_code, false,
                                      spdm12_signing_context_with_hash);
-        copy_mem_s(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
-                   sizeof(spdm12_signing_context_with_hash)
-                   - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
-                      - spdm12_signing_context_with_hash),
-                   message_hash, hash_size);
+        copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
+                 sizeof(spdm12_signing_context_with_hash)
+                 - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
+                    - spdm12_signing_context_with_hash),
+                 message_hash, hash_size);
 
         /* assign message and message_size for signing*/
 
@@ -2573,11 +2573,11 @@ bool libspdm_asym_sign_hash(
 
         create_spdm_signing_context (spdm_version, op_code, false,
                                      spdm12_signing_context_with_hash);
-        copy_mem_s(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
-                   sizeof(spdm12_signing_context_with_hash)
-                   - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
-                      - spdm12_signing_context_with_hash),
-                   message_hash, hash_size);
+        copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
+                 sizeof(spdm12_signing_context_with_hash)
+                 - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
+                    - spdm12_signing_context_with_hash),
+                 message_hash, hash_size);
 
         /* assign message and message_size for signing*/
 
@@ -2883,11 +2883,11 @@ bool libspdm_req_asym_verify_hash(
         }
 
         create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
-        copy_mem_s(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
-                   sizeof(spdm12_signing_context_with_hash)
-                   - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
-                      - spdm12_signing_context_with_hash),
-                   message_hash, hash_size);
+        copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
+                 sizeof(spdm12_signing_context_with_hash)
+                 - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
+                    - spdm12_signing_context_with_hash),
+                 message_hash, hash_size);
 
         /* assign message and message_size for signing*/
 
@@ -3149,7 +3149,7 @@ bool libspdm_req_asym_sign_hash(
         }
 
         create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
-        copy_mem_s(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
+        copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
                    sizeof(spdm12_signing_context_with_hash)
                    - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
                       - spdm12_signing_context_with_hash),
@@ -3326,11 +3326,11 @@ void *libspdm_dhe_new(spdm_version_number_t spdm_version,
         uint8_t spdm12_key_change_responder_context[
             SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE];
 
-        copy_mem_s(spdm12_key_change_requester_context,
+        copy_mem(spdm12_key_change_requester_context,
                    sizeof(spdm12_key_change_requester_context),
                    SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT,
                    SPDM_VERSION_1_2_KEY_EXCHANGE_REQUESTER_CONTEXT_SIZE);
-        copy_mem_s(spdm12_key_change_responder_context,
+        copy_mem(spdm12_key_change_responder_context,
                    sizeof(spdm12_key_change_responder_context),
                    SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT,
                    SPDM_VERSION_1_2_KEY_EXCHANGE_RESPONDER_CONTEXT_SIZE);
@@ -4172,7 +4172,7 @@ return_status libspdm_get_dmtf_subject_alt_name_from_bytes(
         return RETURN_BUFFER_TOO_SMALL;
     }
     if (oid != NULL) {
-        copy_mem_s(oid, *oid_size, ptr, obj_len);
+        copy_mem(oid, *oid_size, ptr, obj_len);
         *oid_size = obj_len;
     }
 
@@ -4194,7 +4194,7 @@ return_status libspdm_get_dmtf_subject_alt_name_from_bytes(
     }
 
     if (name_buffer != NULL) {
-        copy_mem_s(name_buffer, *name_buffer_size, ptr, obj_len);
+        copy_mem(name_buffer, *name_buffer_size, ptr, obj_len);
         *name_buffer_size = obj_len + 1;
         name_buffer[obj_len] = 0;
     }

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -101,15 +101,15 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
             return RETURN_DEVICE_ERROR;
         }
     } else {
-        copy_mem_s(spdm_request.nonce, sizeof(spdm_request.nonce),
-                   requester_nonce_in, SPDM_NONCE_SIZE);
+        copy_mem(spdm_request.nonce, sizeof(spdm_request.nonce),
+                 requester_nonce_in, SPDM_NONCE_SIZE);
     }
     DEBUG((DEBUG_INFO, "ClientNonce - "));
     internal_dump_data(spdm_request.nonce, SPDM_NONCE_SIZE);
     DEBUG((DEBUG_INFO, "\n"));
     if (requester_nonce != NULL) {
-        copy_mem_s(requester_nonce, SPDM_NONCE_SIZE,
-                   spdm_request.nonce, SPDM_NONCE_SIZE);
+        copy_mem(requester_nonce, SPDM_NONCE_SIZE,
+                 spdm_request.nonce, SPDM_NONCE_SIZE);
     }
 
     status = spdm_send_spdm_request(spdm_context, NULL,
@@ -212,7 +212,7 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
     DEBUG((DEBUG_INFO, "\n"));
     ptr += SPDM_NONCE_SIZE;
     if (responder_nonce != NULL) {
-        copy_mem_s(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
+        copy_mem(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
     }
 
     measurement_summary_hash = ptr;
@@ -273,8 +273,8 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
     spdm_context->error_state = LIBSPDM_STATUS_SUCCESS;
 
     if (measurement_hash != NULL) {
-        copy_mem_s(measurement_hash, measurement_summary_hash_size,
-                   measurement_summary_hash, measurement_summary_hash_size);
+        copy_mem(measurement_hash, measurement_summary_hash_size,
+                 measurement_summary_hash, measurement_summary_hash_size);
     }
     if (slot_mask != NULL) {
         *slot_mask = spdm_response.header.param2;

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -119,11 +119,11 @@ return_status spdm_get_encap_response_certificate(void *context,
     spdm_response->header.param2 = 0;
     spdm_response->portion_length = length;
     spdm_response->remainder_length = (uint16_t)remainder_length;
-    copy_mem_s(spdm_response + 1,
-               response_capacity - sizeof(spdm_certificate_response_t),
-               (uint8_t *)spdm_context->local_context
-               .local_cert_chain_provision[slot_id] + offset,
-               length);
+    copy_mem(spdm_response + 1,
+             response_capacity - sizeof(spdm_certificate_response_t),
+             (uint8_t *)spdm_context->local_context
+             .local_cert_chain_provision[slot_id] + offset,
+             length);
 
     /* Cache*/
 

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -128,10 +128,10 @@ return_status spdm_get_encap_response_challenge_auth(
                        .opaque_challenge_auth_rsp_size;
     ptr += sizeof(uint16_t);
     if (spdm_context->local_context.opaque_challenge_auth_rsp != NULL) {
-        copy_mem_s(ptr,
-                   response_capacity - (ptr - (uint8_t*)response),
-                   spdm_context->local_context.opaque_challenge_auth_rsp,
-                   spdm_context->local_context.opaque_challenge_auth_rsp_size);
+        copy_mem(ptr,
+                 response_capacity - (ptr - (uint8_t*)response),
+                 spdm_context->local_context.opaque_challenge_auth_rsp,
+                 spdm_context->local_context.opaque_challenge_auth_rsp_size);
         ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
     }
 

--- a/library/spdm_requester_lib/libspdm_req_encap_error.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_error.c
@@ -76,8 +76,8 @@ return_status libspdm_generate_encap_extended_error_response(
     spdm_response->header.request_response_code = SPDM_ERROR;
     spdm_response->header.param1 = error_code;
     spdm_response->header.param2 = error_data;
-    copy_mem_s(spdm_response + 1, *response_size - (sizeof(spdm_error_response_t)),
-               extended_error_data, extended_error_data_size);
+    copy_mem(spdm_response + 1, *response_size - (sizeof(spdm_error_response_t)),
+             extended_error_data, extended_error_data_size);
     *response_size =
         sizeof(spdm_error_response_t) + extended_error_data_size;
     return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -231,10 +231,10 @@ return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         get_managed_buffer_size(&certificate_chain_buffer);
-    copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
-               sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
-               get_managed_buffer(&certificate_chain_buffer),
-               get_managed_buffer_size(&certificate_chain_buffer));
+    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+             sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+             get_managed_buffer(&certificate_chain_buffer),
+             get_managed_buffer_size(&certificate_chain_buffer));
 #else
     result = libspdm_hash_all(
         spdm_context->connection_info.algorithm.base_hash_algo,
@@ -278,11 +278,10 @@ return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
         *cert_chain_size =
             get_managed_buffer_size(&certificate_chain_buffer);
         if (cert_chain != NULL) {
-            copy_mem_s(cert_chain,
-                       cert_chain_capacity,
-                       get_managed_buffer(&certificate_chain_buffer),
-                       get_managed_buffer_size(
-                           &certificate_chain_buffer));
+            copy_mem(cert_chain,
+                     cert_chain_capacity,
+                     get_managed_buffer(&certificate_chain_buffer),
+                     get_managed_buffer_size(&certificate_chain_buffer));
         }
     }
 

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -156,8 +156,8 @@ return_status try_spdm_get_digest(void *context, uint8_t *slot_mask,
     spdm_context->error_state = LIBSPDM_STATUS_SUCCESS;
 
     if (total_digest_buffer != NULL) {
-        copy_mem_s(total_digest_buffer, digest_size * digest_count,
-                   spdm_response.digest, digest_size * digest_count);
+        copy_mem(total_digest_buffer, digest_size * digest_count,
+                 spdm_response.digest, digest_size * digest_count);
     }
 
     spdm_context->connection_info.connection_state =

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -157,8 +157,8 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
                 return RETURN_DEVICE_ERROR;
             }
         } else {
-            copy_mem_s(spdm_request.nonce, sizeof(spdm_request.nonce),
-                       requester_nonce_in, SPDM_NONCE_SIZE);
+            copy_mem(spdm_request.nonce, sizeof(spdm_request.nonce),
+                     requester_nonce_in, SPDM_NONCE_SIZE);
         }
         DEBUG((DEBUG_INFO, "ClientNonce - "));
         internal_dump_data(spdm_request.nonce, SPDM_NONCE_SIZE);
@@ -166,8 +166,8 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
         spdm_request.slot_id_param = slot_id_param;
 
         if (requester_nonce != NULL) {
-            copy_mem_s(requester_nonce, SPDM_NONCE_SIZE,
-                       spdm_request.nonce, SPDM_NONCE_SIZE);
+            copy_mem(requester_nonce, SPDM_NONCE_SIZE,
+                     spdm_request.nonce, SPDM_NONCE_SIZE);
         }
     } else {
         spdm_request_size = sizeof(spdm_request.header);
@@ -280,7 +280,7 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
         DEBUG((DEBUG_INFO, "\n"));
         ptr += SPDM_NONCE_SIZE;
         if (responder_nonce != NULL) {
-            copy_mem_s(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
+            copy_mem(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
         }
 
         opaque_length = *(uint16_t *)ptr;
@@ -349,7 +349,7 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
         DEBUG((DEBUG_INFO, "\n"));
         ptr += SPDM_NONCE_SIZE;
         if (responder_nonce != NULL) {
-            copy_mem_s(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
+            copy_mem(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
         }
 
         opaque_length = *(uint16_t *)ptr;
@@ -465,10 +465,10 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
         }
 
         *measurement_record_length = measurement_record_data_length;
-        copy_mem_s(measurement_record,
-                   measurement_record_data_length,
-                   measurement_record_data,
-                   measurement_record_data_length);
+        copy_mem(measurement_record,
+                 measurement_record_data_length,
+                 measurement_record_data,
+                 measurement_record_data_length);
     }
 
     spdm_context->error_state = LIBSPDM_STATUS_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -128,10 +128,10 @@ return_status try_spdm_get_version(spdm_context_t *spdm_context,
         libspdm_reset_message_a(spdm_context);
         return RETURN_DEVICE_ERROR;
     } else {
-        copy_mem_s(&(spdm_context->connection_info.version),
-                   sizeof(spdm_context->connection_info.version),
-                   &(common_version),
-                   sizeof(spdm_version_number_t));
+        copy_mem(&(spdm_context->connection_info.version),
+                 sizeof(spdm_context->connection_info.version),
+                 &(common_version),
+                 sizeof(spdm_version_number_t));
     }
 
     if (version_number_entry_count != NULL && version_number_entry != NULL) {
@@ -141,10 +141,10 @@ return_status try_spdm_get_version(spdm_context_t *spdm_context,
             return RETURN_BUFFER_TOO_SMALL;
         } else {
             *version_number_entry_count = spdm_response.version_number_entry_count;
-            copy_mem_s(version_number_entry,
-                       spdm_response.version_number_entry_count * sizeof(spdm_version_number_t),
-                       spdm_response.version_number_entry,
-                       spdm_response.version_number_entry_count * sizeof(spdm_version_number_t));
+            copy_mem(version_number_entry,
+                     spdm_response.version_number_entry_count * sizeof(spdm_version_number_t),
+                     spdm_response.version_number_entry,
+                     spdm_response.version_number_entry_count * sizeof(spdm_version_number_t));
             spdm_version_number_sort (version_number_entry, *version_number_entry_count);
         }
     }

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -117,16 +117,16 @@ return_status try_spdm_send_receive_key_exchange(
             return RETURN_DEVICE_ERROR;
         }
     } else {
-        copy_mem_s(spdm_request.random_data, sizeof(spdm_request.random_data),
-                   requester_random_in, SPDM_RANDOM_DATA_SIZE);
+        copy_mem(spdm_request.random_data, sizeof(spdm_request.random_data),
+                 requester_random_in, SPDM_RANDOM_DATA_SIZE);
     }
     DEBUG((DEBUG_INFO, "ClientRandomData (0x%x) - ",
            SPDM_RANDOM_DATA_SIZE));
     internal_dump_data(spdm_request.random_data, SPDM_RANDOM_DATA_SIZE);
     DEBUG((DEBUG_INFO, "\n"));
     if (requester_random != NULL) {
-        copy_mem_s(requester_random, SPDM_RANDOM_DATA_SIZE,
-                   spdm_request.random_data, SPDM_RANDOM_DATA_SIZE);
+        copy_mem(requester_random, SPDM_RANDOM_DATA_SIZE,
+                 spdm_request.random_data, SPDM_RANDOM_DATA_SIZE);
     }
 
     req_session_id = spdm_allocate_req_session_id(spdm_context);
@@ -321,8 +321,8 @@ return_status try_spdm_send_receive_key_exchange(
     internal_dump_data(spdm_response.random_data, SPDM_RANDOM_DATA_SIZE);
     DEBUG((DEBUG_INFO, "\n"));
     if (responder_random != NULL) {
-        copy_mem_s(responder_random, SPDM_RANDOM_DATA_SIZE,
-                   spdm_response.random_data, SPDM_RANDOM_DATA_SIZE);
+        copy_mem(responder_random, SPDM_RANDOM_DATA_SIZE,
+                 spdm_response.random_data, SPDM_RANDOM_DATA_SIZE);
     }
 
     DEBUG((DEBUG_INFO, "ServerKey (0x%x):\n", dhe_key_size));
@@ -481,8 +481,8 @@ return_status try_spdm_send_receive_key_exchange(
     }
 
     if (measurement_hash != NULL) {
-        copy_mem_s(measurement_hash, measurement_summary_hash_size,
-                   measurement_summary_hash, measurement_summary_hash_size);
+        copy_mem(measurement_hash, measurement_summary_hash_size,
+                 measurement_summary_hash, measurement_summary_hash_size);
     }
     session_info->mut_auth_requested = spdm_response.mut_auth_requested;
     session_info->session_policy = session_policy;

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -159,9 +159,9 @@ return_status try_spdm_send_receive_psk_exchange(
     spdm_request.req_session_id = req_session_id;
 
     ptr = spdm_request.psk_hint;
-    copy_mem_s(ptr, sizeof(spdm_request.psk_hint),
-               spdm_context->local_context.psk_hint,
-               spdm_context->local_context.psk_hint_size);
+    copy_mem(ptr, sizeof(spdm_request.psk_hint),
+             spdm_context->local_context.psk_hint,
+             spdm_context->local_context.psk_hint_size);
     DEBUG((DEBUG_INFO, "psk_hint (0x%x) - ", spdm_request.psk_hint_length));
     internal_dump_data(ptr, spdm_request.psk_hint_length);
     DEBUG((DEBUG_INFO, "\n"));
@@ -172,8 +172,8 @@ return_status try_spdm_send_receive_psk_exchange(
             return RETURN_DEVICE_ERROR;
         }
     } else {
-        copy_mem_s(ptr, sizeof(spdm_request.context),
-                   requester_context_in, spdm_request.context_length);
+        copy_mem(ptr, sizeof(spdm_request.context),
+                 requester_context_in, spdm_request.context_length);
     }
     DEBUG((DEBUG_INFO, "ClientContextData (0x%x) - ",
            spdm_request.context_length));
@@ -183,8 +183,8 @@ return_status try_spdm_send_receive_psk_exchange(
         if (*requester_context_size > spdm_request.context_length) {
             *requester_context_size = spdm_request.context_length;
         }
-        copy_mem_s(requester_context, *requester_context_size,
-                   ptr, *requester_context_size);
+        copy_mem(requester_context, *requester_context_size,
+                 ptr, *requester_context_size);
     }
     ptr += spdm_request.context_length;
 
@@ -300,8 +300,8 @@ return_status try_spdm_send_receive_psk_exchange(
         if (*responder_context_size > spdm_response.context_length) {
             *responder_context_size = spdm_response.context_length;
         }
-        copy_mem_s(responder_context, *responder_context_size,
-                   ptr, *responder_context_size);
+        copy_mem(responder_context, *responder_context_size,
+                 ptr, *responder_context_size);
     }
 
     ptr += spdm_response.context_length;
@@ -359,8 +359,8 @@ return_status try_spdm_send_receive_psk_exchange(
     }
 
     if (measurement_hash != NULL) {
-        copy_mem_s(measurement_hash, measurement_summary_hash_size,
-                   measurement_summary_hash, measurement_summary_hash_size);
+        copy_mem(measurement_hash, measurement_summary_hash_size,
+                 measurement_summary_hash, measurement_summary_hash_size);
     }
 
     session_info->session_policy = session_policy;

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -133,11 +133,11 @@ return_status spdm_get_response_certificate(void *context,
     spdm_response->header.param2 = 0;
     spdm_response->portion_length = length;
     spdm_response->remainder_length = (uint16_t)remainder_length;
-    copy_mem_s(spdm_response + 1,
-               response_capacity - sizeof(spdm_certificate_response_t),
-               (uint8_t *)spdm_context->local_context
-               .local_cert_chain_provision[slot_id] + offset,
-               length);
+    copy_mem(spdm_response + 1,
+             response_capacity - sizeof(spdm_certificate_response_t),
+             (uint8_t *)spdm_context->local_context
+             .local_cert_chain_provision[slot_id] + offset,
+             length);
 
     /* Cache*/
 

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -204,10 +204,10 @@ return_status spdm_get_response_challenge_auth(void *context,
     ptr += sizeof(uint16_t);
 
     if (spdm_context->local_context.opaque_challenge_auth_rsp != NULL) {
-        copy_mem_s(ptr,
-                   response_capacity - (ptr - (uint8_t*)response),
-                   spdm_context->local_context.opaque_challenge_auth_rsp,
-                   spdm_context->local_context.opaque_challenge_auth_rsp_size);
+        copy_mem(ptr,
+                 response_capacity - (ptr - (uint8_t*)response),
+                 spdm_context->local_context.opaque_challenge_auth_rsp,
+                 spdm_context->local_context.opaque_challenge_auth_rsp_size);
         ptr += spdm_context->local_context.opaque_challenge_auth_rsp_size;
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -65,9 +65,9 @@ return_status spdm_get_encap_request_challenge(spdm_context_t *spdm_context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    copy_mem_s(&spdm_context->encap_context.last_encap_request_header,
-               sizeof(spdm_context->encap_context.last_encap_request_header),
-               &spdm_request->header, sizeof(spdm_message_header_t));
+    copy_mem(&spdm_context->encap_context.last_encap_request_header,
+             sizeof(spdm_context->encap_context.last_encap_request_header),
+             &spdm_request->header, sizeof(spdm_message_header_t));
     spdm_context->encap_context.last_encap_request_size =
         *encap_request_size;
 

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -64,9 +64,9 @@ spdm_get_encap_request_get_certificate(spdm_context_t *spdm_context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    copy_mem_s(&spdm_context->encap_context.last_encap_request_header,
-               sizeof(spdm_context->encap_context.last_encap_request_header),
-               &spdm_request->header, sizeof(spdm_message_header_t));
+    copy_mem(&spdm_context->encap_context.last_encap_request_header,
+             sizeof(spdm_context->encap_context.last_encap_request_header),
+             &spdm_request->header, sizeof(spdm_message_header_t));
     spdm_context->encap_context.last_encap_request_size =
         *encap_request_size;
 
@@ -206,12 +206,12 @@ return_status spdm_process_encap_response_certificate(
     spdm_context->connection_info.peer_used_cert_chain_buffer_size =
         get_managed_buffer_size(
             &spdm_context->encap_context.certificate_chain_buffer);
-    copy_mem_s(spdm_context->connection_info.peer_used_cert_chain_buffer,
-               sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
-               get_managed_buffer(
-                   &spdm_context->encap_context.certificate_chain_buffer),
-               get_managed_buffer_size(
-                   &spdm_context->encap_context.certificate_chain_buffer));
+    copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+             sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+             get_managed_buffer(
+                 &spdm_context->encap_context.certificate_chain_buffer),
+             get_managed_buffer_size(
+                 &spdm_context->encap_context.certificate_chain_buffer));
 #else
     result = libspdm_hash_all(
         spdm_context->connection_info.algorithm.base_hash_algo,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
@@ -59,9 +59,9 @@ spdm_get_encap_request_get_digest(spdm_context_t *spdm_context,
         return RETURN_SECURITY_VIOLATION;
     }
 
-    copy_mem_s(&spdm_context->encap_context.last_encap_request_header,
-               sizeof(spdm_context->encap_context.last_encap_request_header),
-               &spdm_request->header, sizeof(spdm_message_header_t));
+    copy_mem(&spdm_context->encap_context.last_encap_request_header,
+             sizeof(spdm_context->encap_context.last_encap_request_header),
+             &spdm_request->header, sizeof(spdm_message_header_t));
     spdm_context->encap_context.last_encap_request_size =
         *encap_request_size;
 

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -104,9 +104,9 @@ spdm_get_encap_request_key_update(spdm_context_t *spdm_context,
         }
     }
 
-    copy_mem_s(&spdm_context->encap_context.last_encap_request_header,
-               sizeof(spdm_context->encap_context.last_encap_request_header),
-               &spdm_request->header, sizeof(spdm_message_header_t));
+    copy_mem(&spdm_context->encap_context.last_encap_request_header,
+             sizeof(spdm_context->encap_context.last_encap_request_header),
+             &spdm_request->header, sizeof(spdm_message_header_t));
     spdm_context->encap_context.last_encap_request_size =
         *encap_request_size;
 

--- a/library/spdm_responder_lib/libspdm_rsp_error.c
+++ b/library/spdm_responder_lib/libspdm_rsp_error.c
@@ -85,8 +85,8 @@ return_status libspdm_generate_extended_error_response(
     spdm_response->header.request_response_code = SPDM_ERROR;
     spdm_response->header.param1 = error_code;
     spdm_response->header.param2 = error_data;
-    copy_mem_s(spdm_response + 1, response_capacity - sizeof(spdm_error_response_t),
-               extended_error_data, extended_error_data_size);
+    copy_mem(spdm_response + 1, response_capacity - sizeof(spdm_error_response_t),
+             extended_error_data, extended_error_data_size);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -52,10 +52,10 @@ return_status spdm_responder_handle_response_state(void *context,
         if(request_code != SPDM_RESPOND_IF_READY) {
             spdm_context->cache_spdm_request_size =
                 spdm_context->last_spdm_request_size;
-            copy_mem_s(spdm_context->cache_spdm_request,
-                       sizeof(spdm_context->cache_spdm_request),
-                       spdm_context->last_spdm_request,
-                       spdm_context->last_spdm_request_size);
+            copy_mem(spdm_context->cache_spdm_request,
+                     sizeof(spdm_context->cache_spdm_request),
+                     spdm_context->last_spdm_request,
+                     spdm_context->last_spdm_request_size);
             spdm_context->error_data.rd_exponent = 1;
             spdm_context->error_data.rd_tm = 1;
             spdm_context->error_data.request_code = request_code;

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -186,7 +186,7 @@ return_status spdm_get_response_key_update(void *context,
     }
 
     copy_mem(prev_spdm_request, sizeof(spdm_key_update_request_t),
-               spdm_request, request_size);
+             spdm_request, request_size);
 
     spdm_reset_message_buffer_via_request_code(spdm_context, session_info,
                                                spdm_request->header.request_response_code);

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -185,7 +185,7 @@ return_status spdm_get_response_key_update(void *context,
         }
     }
 
-    copy_mem_s(prev_spdm_request, sizeof(spdm_key_update_request_t),
+    copy_mem(prev_spdm_request, sizeof(spdm_key_update_request_t),
                spdm_request, request_size);
 
     spdm_reset_message_buffer_via_request_code(spdm_context, session_info,

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -52,10 +52,10 @@ bool spdm_create_measurement_signature(spdm_context_t *spdm_context,
     ptr += sizeof(uint16_t);
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
-        copy_mem_s(ptr,
-                   response_message_size - (ptr - (uint8_t*)response_message),
-                   spdm_context->local_context.opaque_measurement_rsp,
-                   spdm_context->local_context.opaque_measurement_rsp_size);
+        copy_mem(ptr,
+                 response_message_size - (ptr - (uint8_t*)response_message),
+                 spdm_context->local_context.opaque_measurement_rsp,
+                 spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 
@@ -100,10 +100,10 @@ bool spdm_create_measurement_opaque(spdm_context_t *spdm_context,
     ptr += sizeof(uint16_t);
 
     if (spdm_context->local_context.opaque_measurement_rsp != NULL) {
-        copy_mem_s(ptr,
-                   response_message_size - (ptr - (uint8_t*)response_message),
-                   spdm_context->local_context.opaque_measurement_rsp,
-                   spdm_context->local_context.opaque_measurement_rsp_size);
+        copy_mem(ptr,
+                 response_message_size - (ptr - (uint8_t*)response_message),
+                 spdm_context->local_context.opaque_measurement_rsp,
+                 spdm_context->local_context.opaque_measurement_rsp_size);
         ptr += spdm_context->local_context.opaque_measurement_rsp_size;
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -105,11 +105,11 @@ return_status spdm_get_response_version(void *context, uintn request_size,
     spdm_response->header.param2 = 0;
     spdm_response->version_number_entry_count =
         spdm_context->local_context.version.spdm_version_count;
-    copy_mem_s(spdm_response->version_number_entry,
-               sizeof(spdm_response->version_number_entry),
-               spdm_context->local_context.version.spdm_version,
-               sizeof(spdm_version_number_t) *
-               spdm_context->local_context.version.spdm_version_count);
+    copy_mem(spdm_response->version_number_entry,
+             sizeof(spdm_response->version_number_entry),
+             spdm_context->local_context.version.spdm_version,
+             sizeof(spdm_version_number_t) *
+             spdm_context->local_context.version.spdm_version_count);
 
 
     /* Cache*/

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -194,9 +194,9 @@ libspdm_secured_message_import_dhe_secret(void *spdm_secured_message_context,
         return RETURN_OUT_OF_RESOURCES;
     }
     secured_message_context->dhe_key_size = dhe_secret_size;
-    copy_mem_s(secured_message_context->master_secret.dhe_secret,
-               sizeof(secured_message_context->master_secret.dhe_secret),
-               dhe_secret, dhe_secret_size);
+    copy_mem(secured_message_context->master_secret.dhe_secret,
+             sizeof(secured_message_context->master_secret.dhe_secret),
+             dhe_secret, dhe_secret_size);
     return RETURN_SUCCESS;
 }
 
@@ -220,9 +220,9 @@ return_status libspdm_secured_message_export_master_secret(
         *export_master_secret_size = secured_message_context->hash_size;
         return RETURN_BUFFER_TOO_SMALL;
     }
-    copy_mem_s(export_master_secret, *export_master_secret_size,
-               secured_message_context->handshake_secret.export_master_secret,
-               secured_message_context->hash_size);
+    copy_mem(export_master_secret, *export_master_secret_size,
+             secured_message_context->handshake_secret.export_master_secret,
+             secured_message_context->hash_size);
     *export_master_secret_size = secured_message_context->hash_size;
     return RETURN_SUCCESS;
 }
@@ -265,35 +265,35 @@ libspdm_secured_message_export_session_keys(void *spdm_secured_message_context,
         (uint32_t)secured_message_context->aead_iv_size;
 
     ptr = (void *)(session_keys_struct + 1);
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               secured_message_context->application_secret.request_data_encryption_key,
-               secured_message_context->aead_key_size);
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             secured_message_context->application_secret.request_data_encryption_key,
+             secured_message_context->aead_key_size);
     ptr += secured_message_context->aead_key_size;
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               secured_message_context->application_secret.request_data_salt,
-               secured_message_context->aead_iv_size);
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             secured_message_context->application_secret.request_data_salt,
+             secured_message_context->aead_iv_size);
     ptr += secured_message_context->aead_iv_size;
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               &secured_message_context->application_secret.request_data_sequence_number,
-               sizeof(uint64_t));
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             &secured_message_context->application_secret.request_data_sequence_number,
+             sizeof(uint64_t));
     ptr += sizeof(uint64_t);
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               secured_message_context->application_secret.response_data_encryption_key,
-               secured_message_context->aead_key_size);
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             secured_message_context->application_secret.response_data_encryption_key,
+             secured_message_context->aead_key_size);
     ptr += secured_message_context->aead_key_size;
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               secured_message_context->application_secret.response_data_salt,
-               secured_message_context->aead_iv_size);
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             secured_message_context->application_secret.response_data_salt,
+             secured_message_context->aead_iv_size);
     ptr += secured_message_context->aead_iv_size;
-    copy_mem_s(ptr,
-               *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
-               &secured_message_context->application_secret.response_data_sequence_number,
-               sizeof(uint64_t));
+    copy_mem(ptr,
+             *SessionKeysSize - (ptr - (uint8_t*)SessionKeys),
+             &secured_message_context->application_secret.response_data_sequence_number,
+             sizeof(uint64_t));
     ptr += sizeof(uint64_t);
     return RETURN_SUCCESS;
 }
@@ -338,39 +338,39 @@ spdm_secured_message_import_session_keys(void *spdm_secured_message_context,
     }
 
     ptr = (void *)(session_keys_struct + 1);
-    copy_mem_s(secured_message_context->application_secret
-               .request_data_encryption_key,
-               sizeof(secured_message_context->application_secret
-                      .request_data_encryption_key),
-               ptr, secured_message_context->aead_key_size);
+    copy_mem(secured_message_context->application_secret
+             .request_data_encryption_key,
+             sizeof(secured_message_context->application_secret
+                    .request_data_encryption_key),
+             ptr, secured_message_context->aead_key_size);
     ptr += secured_message_context->aead_key_size;
-    copy_mem_s(secured_message_context->application_secret.request_data_salt,
-               sizeof(secured_message_context->application_secret
-                      .request_data_salt),
-               ptr, secured_message_context->aead_iv_size);
+    copy_mem(secured_message_context->application_secret.request_data_salt,
+             sizeof(secured_message_context->application_secret
+                    .request_data_salt),
+             ptr, secured_message_context->aead_iv_size);
     ptr += secured_message_context->aead_iv_size;
-    copy_mem_s(&secured_message_context->application_secret
-               .request_data_sequence_number,
-               sizeof(secured_message_context->application_secret
-                      .request_data_sequence_number),
-               ptr, sizeof(uint64_t));
+    copy_mem(&secured_message_context->application_secret
+             .request_data_sequence_number,
+             sizeof(secured_message_context->application_secret
+                    .request_data_sequence_number),
+             ptr, sizeof(uint64_t));
     ptr += sizeof(uint64_t);
-    copy_mem_s(secured_message_context->application_secret
-               .response_data_encryption_key,
-               sizeof(secured_message_context->application_secret
-                      .response_data_encryption_key),
-               ptr, secured_message_context->aead_key_size);
+    copy_mem(secured_message_context->application_secret
+             .response_data_encryption_key,
+             sizeof(secured_message_context->application_secret
+                    .response_data_encryption_key),
+             ptr, secured_message_context->aead_key_size);
     ptr += secured_message_context->aead_key_size;
-    copy_mem_s(secured_message_context->application_secret.response_data_salt,
-               sizeof(secured_message_context->application_secret
-                      .response_data_salt),
-               ptr, secured_message_context->aead_iv_size);
+    copy_mem(secured_message_context->application_secret.response_data_salt,
+             sizeof(secured_message_context->application_secret
+                   .response_data_salt),
+             ptr, secured_message_context->aead_iv_size);
     ptr += secured_message_context->aead_iv_size;
-    copy_mem_s(&secured_message_context->application_secret
-               .response_data_sequence_number,
-               sizeof(secured_message_context->application_secret
-                      .response_data_sequence_number),
-               ptr, sizeof(uint64_t));
+    copy_mem(&secured_message_context->application_secret
+             .response_data_sequence_number,
+             sizeof(secured_message_context->application_secret
+                    .response_data_sequence_number),
+             ptr, sizeof(uint64_t));
     ptr += sizeof(uint64_t);
     return RETURN_SUCCESS;
 }
@@ -388,9 +388,9 @@ void libspdm_secured_message_get_last_spdm_error_struct(
     spdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
-    copy_mem_s(last_spdm_error, sizeof(libspdm_error_struct_t),
-               &secured_message_context->last_spdm_error,
-               sizeof(libspdm_error_struct_t));
+    copy_mem(last_spdm_error, sizeof(libspdm_error_struct_t),
+             &secured_message_context->last_spdm_error,
+             sizeof(libspdm_error_struct_t));
 }
 
 /**
@@ -406,8 +406,8 @@ void libspdm_secured_message_set_last_spdm_error_struct(
     spdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
-    copy_mem_s(&secured_message_context->last_spdm_error,
-               sizeof(secured_message_context->last_spdm_error),
-               last_spdm_error,
-               sizeof(libspdm_error_struct_t));
+    copy_mem(&secured_message_context->last_spdm_error,
+             sizeof(secured_message_context->last_spdm_error),
+             last_spdm_error,
+             sizeof(libspdm_error_struct_t));
 }

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -363,7 +363,7 @@ spdm_secured_message_import_session_keys(void *spdm_secured_message_context,
     ptr += secured_message_context->aead_key_size;
     copy_mem(secured_message_context->application_secret.response_data_salt,
              sizeof(secured_message_context->application_secret
-                   .response_data_salt),
+                    .response_data_salt),
              ptr, secured_message_context->aead_iv_size);
     ptr += secured_message_context->aead_iv_size;
     copy_mem(&secured_message_context->application_secret

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -71,26 +71,26 @@ return_status libspdm_encode_secured_message(
     switch (session_state) {
     case LIBSPDM_SESSION_STATE_HANDSHAKING:
         if (is_requester) {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->handshake_secret
-                       .request_handshake_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->handshake_secret
-                       .request_handshake_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->handshake_secret
+                     .request_handshake_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->handshake_secret
+                     .request_handshake_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->handshake_secret
                 .request_handshake_sequence_number;
         } else {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->handshake_secret
-                       .response_handshake_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->handshake_secret
-                       .response_handshake_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->handshake_secret
+                     .response_handshake_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->handshake_secret
+                     .response_handshake_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->handshake_secret
                 .response_handshake_sequence_number;
@@ -98,26 +98,26 @@ return_status libspdm_encode_secured_message(
         break;
     case LIBSPDM_SESSION_STATE_ESTABLISHED:
         if (is_requester) {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->application_secret
-                       .request_data_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->application_secret
-                       .request_data_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->application_secret
+                     .request_data_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->application_secret
+                     .request_data_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->application_secret
                 .request_data_sequence_number;
         } else {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->application_secret
-                       .response_data_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->application_secret
-                       .response_data_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->application_secret
+                     .response_data_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->application_secret
+                     .response_data_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->application_secret
                 .response_data_sequence_number;
@@ -208,20 +208,20 @@ return_status libspdm_encode_secured_message(
                      sizeof(spdm_secured_message_a_data_header1_t) +
                      sequence_num_in_header_size);
         record_header1->session_id = session_id;
-        copy_mem_s(record_header1 + 1,
-                   *secured_message_size
-                   - ((uint8_t*)(record_header1 + 1) - (uint8_t*)secured_message),
-                   &sequence_num_in_header,
-                   sequence_num_in_header_size);
+        copy_mem(record_header1 + 1,
+                 *secured_message_size
+                 - ((uint8_t*)(record_header1 + 1) - (uint8_t*)secured_message),
+                 &sequence_num_in_header,
+                 sequence_num_in_header_size);
         record_header2->length =
             (uint16_t)(cipher_text_size + aead_tag_size);
         enc_msg_header = (void *)(record_header2 + 1);
         enc_msg_header->application_data_length =
             (uint16_t)app_message_size;
-        copy_mem_s(enc_msg_header + 1,
-                   *secured_message_size
-                   - ((uint8_t*)(enc_msg_header + 1) - (uint8_t*)secured_message),
-                   app_message, app_message_size);
+        copy_mem(enc_msg_header + 1,
+                 *secured_message_size
+                 - ((uint8_t*)(enc_msg_header + 1) - (uint8_t*)secured_message),
+                 app_message, app_message_size);
         result = libspdm_get_random_number(rand_count,
                                            (uint8_t *)enc_msg_header +
                                            sizeof(spdm_secured_message_cipher_header_t) +
@@ -262,17 +262,17 @@ return_status libspdm_encode_secured_message(
                      sizeof(spdm_secured_message_a_data_header1_t) +
                      sequence_num_in_header_size);
         record_header1->session_id = session_id;
-        copy_mem_s(record_header1 + 1,
-                   *secured_message_size
-                   - ((uint8_t*)(record_header1 + 1) - (uint8_t*)secured_message),
-                   &sequence_num_in_header,
-                   sequence_num_in_header_size);
+        copy_mem(record_header1 + 1,
+                 *secured_message_size
+                 - ((uint8_t*)(record_header1 + 1) - (uint8_t*)secured_message),
+                 &sequence_num_in_header,
+                 sequence_num_in_header_size);
         record_header2->length =
             (uint16_t)(app_message_size + aead_tag_size);
-        copy_mem_s(record_header2 + 1,
-                   *secured_message_size
-                   - ((uint8_t*)(record_header2 + 1) - (uint8_t*)secured_message),
-                   app_message, app_message_size);
+        copy_mem(record_header2 + 1,
+                 *secured_message_size
+                 - ((uint8_t*)(record_header2 + 1) - (uint8_t*)secured_message),
+                 app_message, app_message_size);
         a_data = (uint8_t *)record_header1;
         tag = (uint8_t *)record_header1 + record_header_size +
               app_message_size;
@@ -368,26 +368,26 @@ return_status libspdm_decode_secured_message(
     switch (session_state) {
     case LIBSPDM_SESSION_STATE_HANDSHAKING:
         if (is_requester) {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->handshake_secret
-                       .request_handshake_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->handshake_secret
-                       .request_handshake_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->handshake_secret
+                     .request_handshake_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->handshake_secret
+                     .request_handshake_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->handshake_secret
                 .request_handshake_sequence_number;
         } else {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->handshake_secret
-                       .response_handshake_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->handshake_secret
-                       .response_handshake_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->handshake_secret
+                     .response_handshake_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->handshake_secret
+                     .response_handshake_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->handshake_secret
                 .response_handshake_sequence_number;
@@ -395,26 +395,26 @@ return_status libspdm_decode_secured_message(
         break;
     case LIBSPDM_SESSION_STATE_ESTABLISHED:
         if (is_requester) {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->application_secret
-                       .request_data_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->application_secret
-                       .request_data_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->application_secret
+                     .request_data_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->application_secret
+                     .request_data_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->application_secret
                 .request_data_sequence_number;
         } else {
-            copy_mem_s(key, sizeof(key),
-                       secured_message_context->application_secret
-                       .response_data_encryption_key,
-                       secured_message_context->aead_key_size);
-            copy_mem_s(salt, sizeof(salt),
-                       secured_message_context->application_secret
-                       .response_data_salt,
-                       secured_message_context->aead_iv_size);
+            copy_mem(key, sizeof(key),
+                     secured_message_context->application_secret
+                     .response_data_encryption_key,
+                     secured_message_context->aead_key_size);
+            copy_mem(salt, sizeof(salt),
+                     secured_message_context->application_secret
+                     .response_data_salt,
+                     secured_message_context->aead_iv_size);
             sequence_number =
                 secured_message_context->application_secret
                 .response_data_sequence_number;
@@ -571,7 +571,7 @@ return_status libspdm_decode_secured_message(
             *app_message_size = plain_text_size;
             return RETURN_BUFFER_TOO_SMALL;
         }
-        copy_mem_s(app_message, *app_message_size, enc_msg_header + 1, plain_text_size);
+        copy_mem(app_message, *app_message_size, enc_msg_header + 1, plain_text_size);
         *app_message_size = plain_text_size;
         break;
 
@@ -661,7 +661,7 @@ return_status libspdm_decode_secured_message(
             *app_message_size = plain_text_size;
             return RETURN_BUFFER_TOO_SMALL;
         }
-        copy_mem_s(app_message, *app_message_size, record_header2 + 1, plain_text_size);
+        copy_mem(app_message, *app_message_size, record_header2 + 1, plain_text_size);
         *app_message_size = plain_text_size;
         break;
 

--- a/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
@@ -101,9 +101,9 @@ bool libspdm_secured_message_dhe_compute_key(
     if (!ret) {
         return ret;
     }
-    copy_mem_s(secured_message_context->master_secret.dhe_secret,
-               sizeof(secured_message_context->master_secret.dhe_secret),
-               final_key, final_key_size);
+    copy_mem(secured_message_context->master_secret.dhe_secret,
+             sizeof(secured_message_context->master_secret.dhe_secret),
+             final_key, final_key_size);
     zero_mem(final_key, final_key_size);
     secured_message_context->dhe_key_size = final_key_size;
     return true;

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -64,21 +64,21 @@ return_status libspdm_bin_concat(const char *label, uintn label_size,
 
     *out_bin_size = final_size;
 
-    copy_mem_s(out_bin, *out_bin_size, &length, sizeof(uint16_t));
-    copy_mem_s(out_bin + sizeof(uint16_t),
-               *out_bin_size - sizeof(uint16_t),
-               SPDM_BIN_CONCAT_LABEL,
-               sizeof(SPDM_BIN_CONCAT_LABEL) - 1);
-    copy_mem_s(out_bin + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1,
-               *out_bin_size - (sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1),
-               label,
-               label_size);
+    copy_mem(out_bin, *out_bin_size, &length, sizeof(uint16_t));
+    copy_mem(out_bin + sizeof(uint16_t),
+             *out_bin_size - sizeof(uint16_t),
+             SPDM_BIN_CONCAT_LABEL,
+             sizeof(SPDM_BIN_CONCAT_LABEL) - 1);
+    copy_mem(out_bin + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1,
+             *out_bin_size - (sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) - 1),
+             label,
+             label_size);
     if (context != NULL) {
-        copy_mem_s(out_bin + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) -
-                   1 + label_size,
-                   *out_bin_size - (sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) -
-                                    1 + label_size),
-                   context, hash_size);
+        copy_mem(out_bin + sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) -
+                 1 + label_size,
+                 *out_bin_size - (sizeof(uint16_t) + sizeof(SPDM_BIN_CONCAT_LABEL) -
+                                  1 + label_size),
+                 context, hash_size);
     }
 
     return RETURN_SUCCESS;
@@ -593,27 +593,27 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
     internal_dump_hex(bin_str9, bin_str9_size);
 
     if (action == LIBSPDM_KEY_UPDATE_ACTION_REQUESTER) {
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .request_data_secret,
-                   sizeof(secured_message_context->application_secret_backup
-                          .request_data_secret),
-                   &secured_message_context->application_secret
-                   .request_data_secret,
-                   LIBSPDM_MAX_HASH_SIZE);
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .request_data_encryption_key,
-                   sizeof(secured_message_context->application_secret_backup
-                          .request_data_encryption_key),
-                   &secured_message_context->application_secret
-                   .request_data_encryption_key,
-                   LIBSPDM_MAX_AEAD_KEY_SIZE);
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .request_data_salt,
-                   sizeof(secured_message_context->application_secret_backup
-                          .request_data_salt),
-                   &secured_message_context->application_secret
-                   .request_data_salt,
-                   LIBSPDM_MAX_AEAD_IV_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .request_data_secret,
+                 sizeof(secured_message_context->application_secret_backup
+                        .request_data_secret),
+                 &secured_message_context->application_secret
+                 .request_data_secret,
+                 LIBSPDM_MAX_HASH_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .request_data_encryption_key,
+                 sizeof(secured_message_context->application_secret_backup
+                        .request_data_encryption_key),
+                 &secured_message_context->application_secret
+                 .request_data_encryption_key,
+                 LIBSPDM_MAX_AEAD_KEY_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .request_data_salt,
+                 sizeof(secured_message_context->application_secret_backup
+                        .request_data_salt),
+                 &secured_message_context->application_secret
+                 .request_data_salt,
+                 LIBSPDM_MAX_AEAD_IV_SIZE);
         secured_message_context->application_secret_backup
         .request_data_sequence_number =
             secured_message_context->application_secret
@@ -654,27 +654,27 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
 
         secured_message_context->requester_backup_valid = true;
     } else if (action == LIBSPDM_KEY_UPDATE_ACTION_RESPONDER) {
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .response_data_secret,
-                   sizeof(secured_message_context->application_secret_backup
-                          .response_data_secret),
-                   &secured_message_context->application_secret
-                   .response_data_secret,
-                   LIBSPDM_MAX_HASH_SIZE);
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .response_data_encryption_key,
-                   sizeof(secured_message_context->application_secret_backup
-                          .response_data_encryption_key),
-                   &secured_message_context->application_secret
-                   .response_data_encryption_key,
-                   LIBSPDM_MAX_AEAD_KEY_SIZE);
-        copy_mem_s(&secured_message_context->application_secret_backup
-                   .response_data_salt,
-                   sizeof(secured_message_context->application_secret_backup
-                          .response_data_salt),
-                   &secured_message_context->application_secret
-                   .response_data_salt,
-                   LIBSPDM_MAX_AEAD_IV_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .response_data_secret,
+                 sizeof(secured_message_context->application_secret_backup
+                        .response_data_secret),
+                 &secured_message_context->application_secret
+                 .response_data_secret,
+                 LIBSPDM_MAX_HASH_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .response_data_encryption_key,
+                 sizeof(secured_message_context->application_secret_backup
+                        .response_data_encryption_key),
+                 &secured_message_context->application_secret
+                 .response_data_encryption_key,
+                 LIBSPDM_MAX_AEAD_KEY_SIZE);
+        copy_mem(&secured_message_context->application_secret_backup
+                 .response_data_salt,
+                 sizeof(secured_message_context->application_secret_backup
+                        .response_data_salt),
+                 &secured_message_context->application_secret
+                 .response_data_salt,
+                 LIBSPDM_MAX_AEAD_IV_SIZE);
         secured_message_context->application_secret_backup
         .response_data_sequence_number =
             secured_message_context->application_secret
@@ -762,30 +762,30 @@ libspdm_activate_update_session_data_key(void *spdm_secured_message_context,
     if (!use_new_key) {
         if ((action == LIBSPDM_KEY_UPDATE_ACTION_REQUESTER) &&
             secured_message_context->requester_backup_valid) {
-            copy_mem_s(&secured_message_context->application_secret
-                       .request_data_secret,
-                       sizeof(secured_message_context->application_secret
-                              .request_data_secret),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .request_data_secret,
-                       LIBSPDM_MAX_HASH_SIZE);
-            copy_mem_s(&secured_message_context->application_secret
-                       .request_data_encryption_key,
-                       sizeof(secured_message_context->application_secret
-                              .request_data_encryption_key),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .request_data_encryption_key,
-                       LIBSPDM_MAX_AEAD_KEY_SIZE);
-            copy_mem_s(&secured_message_context->application_secret
-                       .request_data_salt,
-                       sizeof(secured_message_context->application_secret
-                              .request_data_salt),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .request_data_salt,
-                       LIBSPDM_MAX_AEAD_IV_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .request_data_secret,
+                     sizeof(secured_message_context->application_secret
+                            .request_data_secret),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .request_data_secret,
+                     LIBSPDM_MAX_HASH_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .request_data_encryption_key,
+                     sizeof(secured_message_context->application_secret
+                            .request_data_encryption_key),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .request_data_encryption_key,
+                     LIBSPDM_MAX_AEAD_KEY_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .request_data_salt,
+                     sizeof(secured_message_context->application_secret
+                            .request_data_salt),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .request_data_salt,
+                     LIBSPDM_MAX_AEAD_IV_SIZE);
             secured_message_context->application_secret
             .request_data_sequence_number =
                 secured_message_context
@@ -793,30 +793,30 @@ libspdm_activate_update_session_data_key(void *spdm_secured_message_context,
                 .request_data_sequence_number;
         } else if ((action == LIBSPDM_KEY_UPDATE_ACTION_RESPONDER) &&
                    secured_message_context->responder_backup_valid) {
-            copy_mem_s(&secured_message_context->application_secret
-                       .response_data_secret,
-                       sizeof(secured_message_context->application_secret
-                              .response_data_secret),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .response_data_secret,
-                       LIBSPDM_MAX_HASH_SIZE);
-            copy_mem_s(&secured_message_context->application_secret
-                       .response_data_encryption_key,
-                       sizeof(secured_message_context->application_secret
-                              .response_data_encryption_key),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .response_data_encryption_key,
-                       LIBSPDM_MAX_AEAD_KEY_SIZE);
-            copy_mem_s(&secured_message_context->application_secret
-                       .response_data_salt,
-                       sizeof(secured_message_context->application_secret
-                              .response_data_salt),
-                       &secured_message_context
-                       ->application_secret_backup
-                       .response_data_salt,
-                       LIBSPDM_MAX_AEAD_IV_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .response_data_secret,
+                     sizeof(secured_message_context->application_secret
+                            .response_data_secret),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .response_data_secret,
+                     LIBSPDM_MAX_HASH_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .response_data_encryption_key,
+                     sizeof(secured_message_context->application_secret
+                            .response_data_encryption_key),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .response_data_encryption_key,
+                     LIBSPDM_MAX_AEAD_KEY_SIZE);
+            copy_mem(&secured_message_context->application_secret
+                     .response_data_salt,
+                     sizeof(secured_message_context->application_secret
+                            .response_data_salt),
+                     &secured_message_context
+                     ->application_secret_backup
+                     .response_data_salt,
+                     LIBSPDM_MAX_AEAD_IV_SIZE);
             secured_message_context->application_secret
             .response_data_sequence_number =
                 secured_message_context

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -309,7 +309,7 @@ return_status libspdm_transport_mctp_decode_message(
                 return RETURN_BUFFER_TOO_SMALL;
             }
             *message_size = app_message_size;
-            copy_mem_s(message, *message_size, app_message, *message_size);
+            copy_mem(message, *message_size, app_message, *message_size);
             return RETURN_SUCCESS;
         } else {
             *is_app_message = false;

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -27,8 +27,8 @@
 uint8_t libspdm_mctp_get_sequence_number(uint64_t sequence_number,
                                          uint8_t *sequence_number_buffer)
 {
-    copy_mem_s(sequence_number_buffer, MCTP_SEQUENCE_NUMBER_COUNT,
-               &sequence_number, MCTP_SEQUENCE_NUMBER_COUNT);
+    copy_mem(sequence_number_buffer, MCTP_SEQUENCE_NUMBER_COUNT,
+             &sequence_number, MCTP_SEQUENCE_NUMBER_COUNT);
     return MCTP_SEQUENCE_NUMBER_COUNT;
 }
 
@@ -93,9 +93,9 @@ return_status mctp_encode_message(const uint32_t *session_id, uintn message_size
     } else {
         mctp_message_header->message_type = MCTP_MESSAGE_TYPE_SPDM;
     }
-    copy_mem_s((uint8_t *)transport_message + sizeof(mctp_message_header_t),
-               *transport_message_size - sizeof(mctp_message_header_t),
-               message, message_size);
+    copy_mem((uint8_t *)transport_message + sizeof(mctp_message_header_t),
+             *transport_message_size - sizeof(mctp_message_header_t),
+             message, message_size);
     zero_mem((uint8_t *)transport_message + sizeof(mctp_message_header_t) +
              message_size,
              *transport_message_size - sizeof(mctp_message_header_t) -
@@ -167,10 +167,10 @@ return_status mctp_decode_message(uint32_t **session_id,
 
         if (*message_size + alignment - 1 >=
             transport_message_size - sizeof(mctp_message_header_t)) {
-            copy_mem_s(message, *message_size,
-                       (uint8_t *)transport_message +
-                       sizeof(mctp_message_header_t),
-                       *message_size);
+            copy_mem(message, *message_size,
+                     (uint8_t *)transport_message +
+                     sizeof(mctp_message_header_t),
+                     *message_size);
             return RETURN_SUCCESS;
         }
         ASSERT(*message_size >=
@@ -180,8 +180,8 @@ return_status mctp_decode_message(uint32_t **session_id,
         return RETURN_BUFFER_TOO_SMALL;
     }
     *message_size = transport_message_size - sizeof(mctp_message_header_t);
-    copy_mem_s(message, *message_size,
-               (uint8_t *)transport_message + sizeof(mctp_message_header_t),
-               *message_size);
+    copy_mem(message, *message_size,
+             (uint8_t *)transport_message + sizeof(mctp_message_header_t),
+             *message_size);
     return RETURN_SUCCESS;
 }

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -27,8 +27,8 @@
 uint8_t libspdm_pci_doe_get_sequence_number(uint64_t sequence_number,
                                             uint8_t *sequence_number_buffer)
 {
-    copy_mem_s(sequence_number_buffer, PCI_DOE_SEQUENCE_NUMBER_COUNT,
-               &sequence_number, PCI_DOE_SEQUENCE_NUMBER_COUNT);
+    copy_mem(sequence_number_buffer, PCI_DOE_SEQUENCE_NUMBER_COUNT,
+             &sequence_number, PCI_DOE_SEQUENCE_NUMBER_COUNT);
     return PCI_DOE_SEQUENCE_NUMBER_COUNT;
 }
 
@@ -105,9 +105,9 @@ return_status pci_doe_encode_message(const uint32_t *session_id,
             (uint32_t)*transport_message_size / sizeof(uint32_t);
     }
 
-    copy_mem_s((uint8_t *)transport_message + sizeof(pci_doe_data_object_header_t),
-               *transport_message_size - sizeof(pci_doe_data_object_header_t),
-               message, message_size);
+    copy_mem((uint8_t *)transport_message + sizeof(pci_doe_data_object_header_t),
+             *transport_message_size - sizeof(pci_doe_data_object_header_t),
+             message, message_size);
     zero_mem((uint8_t *)transport_message +
              sizeof(pci_doe_data_object_header_t) + message_size,
              *transport_message_size -
@@ -199,10 +199,10 @@ return_status pci_doe_decode_message(uint32_t **session_id,
         if (*message_size + alignment - 1 >=
             transport_message_size -
             sizeof(pci_doe_data_object_header_t)) {
-            copy_mem_s(message, *message_size,
-                       (uint8_t *)transport_message +
-                       sizeof(pci_doe_data_object_header_t),
-                       *message_size);
+            copy_mem(message, *message_size,
+                     (uint8_t *)transport_message +
+                     sizeof(pci_doe_data_object_header_t),
+                     *message_size);
             return RETURN_SUCCESS;
         }
         ASSERT(*message_size >=
@@ -214,9 +214,9 @@ return_status pci_doe_decode_message(uint32_t **session_id,
     }
     *message_size =
         transport_message_size - sizeof(pci_doe_data_object_header_t);
-    copy_mem_s(message, *message_size,
-               (uint8_t *)transport_message +
-               sizeof(pci_doe_data_object_header_t),
-               *message_size);
+    copy_mem(message, *message_size,
+             (uint8_t *)transport_message +
+             sizeof(pci_doe_data_object_header_t),
+             *message_size);
     return RETURN_SUCCESS;
 }

--- a/os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
+++ b/os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
@@ -149,10 +149,10 @@ bool hmac_md_duplicate(const mbedtls_md_type_t md_type, const void *hmac_md_ctx,
     }
     /*Temporary solution to the problem of context clone.
      * There are not any standard function in mbedtls to clone a complete hmac context.*/
-    copy_mem_s(((mbedtls_md_context_t *)new_hmac_md_ctx)->hmac_ctx,
-               hmac_md_get_blocksize(md_type) * 2,
-               ((mbedtls_md_context_t *)hmac_md_ctx)->hmac_ctx,
-               hmac_md_get_blocksize(md_type) * 2);
+    copy_mem(((mbedtls_md_context_t *)new_hmac_md_ctx)->hmac_ctx,
+             hmac_md_get_blocksize(md_type) * 2,
+             ((mbedtls_md_context_t *)hmac_md_ctx)->hmac_ctx,
+             hmac_md_get_blocksize(md_type) * 2);
     return true;
 }
 

--- a/os_stub/cryptlib_mbedtls/pem/pem.c
+++ b/os_stub/cryptlib_mbedtls/pem/pem.c
@@ -69,7 +69,7 @@ bool rsa_get_private_key_from_pem(const uint8_t *pem_data,
         if (new_pem_data == NULL) {
             return false;
         }
-        copy_mem_s(new_pem_data, pem_size + 1, pem_data, pem_size);
+        copy_mem(new_pem_data, pem_size + 1, pem_data, pem_size);
         new_pem_data[pem_size] = 0;
         pem_data = new_pem_data;
         pem_size += 1;
@@ -154,7 +154,7 @@ bool ec_get_private_key_from_pem(const uint8_t *pem_data, uintn pem_size,
         if (new_pem_data == NULL) {
             return false;
         }
-        copy_mem_s(new_pem_data, pem_size + 1, pem_data, pem_size);
+        copy_mem(new_pem_data, pem_size + 1, pem_data, pem_size);
         new_pem_data[pem_size] = 0;
         pem_data = new_pem_data;
         pem_size += 1;

--- a/os_stub/cryptlib_mbedtls/pk/dh.c
+++ b/os_stub/cryptlib_mbedtls/pk/dh.c
@@ -325,9 +325,9 @@ bool dh_compute_key(void *dh_context, const uint8_t *peer_public_key,
         return false;
     }
     if (return_size < dh_key_size) {
-        copy_mem_s(key + dh_key_size - return_size,
-                   key_capacity - (dh_key_size - return_size),
-                   key, return_size);
+        copy_mem(key + dh_key_size - return_size,
+                 key_capacity - (dh_key_size - return_size),
+                 key, return_size);
         zero_mem(key, dh_key_size - return_size);
     }
 

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -229,8 +229,8 @@ bool x509_get_subject_name(const uint8_t *cert, uintn cert_size,
             goto cleanup;
         }
         if (cert_subject != NULL) {
-            copy_mem_s(cert_subject, *subject_size,
-                       crt.subject_raw.p, crt.subject_raw.len);
+            copy_mem(cert_subject, *subject_size,
+                     crt.subject_raw.p, crt.subject_raw.len);
         }
         *subject_size = crt.subject_raw.len;
         status = true;
@@ -256,7 +256,7 @@ internal_x509_get_nid_name(mbedtls_x509_name *name, const uint8_t *oid,
             return RETURN_BUFFER_TOO_SMALL;
         }
         if (common_name != NULL) {
-            copy_mem_s(common_name, *common_name_size, data->val.p, data->val.len);
+            copy_mem(common_name, *common_name_size, data->val.p, data->val.len);
             common_name[data->val.len] = '\0';
         }
         *common_name_size = data->val.len + 1;
@@ -579,9 +579,9 @@ bool x509_verify_cert(const uint8_t *cert, uintn cert_size,
         return false;
     }
 
-    copy_mem_s(&profile, sizeof(profile),
-               &mbedtls_x509_crt_profile_default,
-               sizeof(mbedtls_x509_crt_profile));
+    copy_mem(&profile, sizeof(profile),
+             &mbedtls_x509_crt_profile_default,
+             sizeof(mbedtls_x509_crt_profile));
 
     mbedtls_x509_crt_init(&ca);
     mbedtls_x509_crt_init(&end);
@@ -873,7 +873,7 @@ return_status x509_get_serial_number(const uint8_t *cert, uintn cert_size,
             goto cleanup;
         }
         if (serial_number != NULL) {
-            copy_mem_s(serial_number, *serial_number_size, crt.serial.p, crt.serial.len);
+            copy_mem(serial_number, *serial_number_size, crt.serial.p, crt.serial.len);
             serial_number[crt.serial.len] = '\0';
         }
         *serial_number_size = crt.serial.len + 1;
@@ -929,7 +929,7 @@ bool x509_get_issuer_name(const uint8_t *cert, uintn cert_size,
             goto cleanup;
         }
         if (cert_issuer != NULL) {
-            copy_mem_s(cert_issuer, *issuer_size, crt.issuer_raw.p, crt.issuer_raw.len);
+            copy_mem(cert_issuer, *issuer_size, crt.issuer_raw.p, crt.issuer_raw.len);
         }
         *issuer_size = crt.issuer_raw.len;
         status = true;
@@ -1057,7 +1057,7 @@ return_status x509_get_signature_algorithm(const uint8_t *cert,
             goto cleanup;
         }
         if (oid != NULL) {
-            copy_mem_s(oid, *oid_size, crt.sig_oid.p, crt.sig_oid.len);
+            copy_mem(oid, *oid_size, crt.sig_oid.p, crt.sig_oid.len);
         }
         *oid_size = crt.sig_oid.len;
         status = RETURN_SUCCESS;
@@ -1212,7 +1212,7 @@ return_status x509_get_extension_data(const uint8_t *cert, uintn cert_size,
             goto cleanup;
         }
         if (oid != NULL) {
-            copy_mem_s(extension_data, *extension_data_size, ptr, obj_len);
+            copy_mem(extension_data, *extension_data_size, ptr, obj_len);
         }
         *extension_data_size = obj_len;
         status = RETURN_SUCCESS;
@@ -1272,7 +1272,7 @@ bool x509_get_validity(const uint8_t *cert, uintn cert_size,
             goto done;
         }
         if (from != NULL) {
-            copy_mem_s(from, *from_size, &(crt.valid_from), f_size);
+            copy_mem(from, *from_size, &(crt.valid_from), f_size);
         }
         *from_size = f_size;
 
@@ -1282,8 +1282,8 @@ bool x509_get_validity(const uint8_t *cert, uintn cert_size,
             goto done;
         }
         if (to != NULL) {
-            copy_mem_s(to, *to_size, &(crt.valid_to),
-                       sizeof(mbedtls_x509_time));
+            copy_mem(to, *to_size, &(crt.valid_to),
+                     sizeof(mbedtls_x509_time));
         }
         *to_size = t_size;
         status = true;
@@ -1478,7 +1478,7 @@ return_status x509_set_date_time(char *date_time_str, void *date_time,
         goto cleanup;
     }
     if (date_time != NULL) {
-        copy_mem_s(date_time, *date_time_size, &dt, sizeof(mbedtls_x509_time));
+        copy_mem(date_time, *date_time_size, &dt, sizeof(mbedtls_x509_time));
     }
     *date_time_size = sizeof(mbedtls_x509_time);
     status = RETURN_SUCCESS;

--- a/os_stub/cryptlib_mbedtls/rand/rand.c
+++ b/os_stub/cryptlib_mbedtls/rand/rand.c
@@ -64,7 +64,7 @@ bool random_bytes(uint8_t *output, uintn size)
             output += sizeof(uint64_t);
             size -= sizeof(temp_rand);
         } else {
-            copy_mem_s(output, size, &temp_rand, size);
+            copy_mem(output, size, &temp_rand, size);
             size = 0;
         }
     }

--- a/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/timer_wrapper_host.c
@@ -20,7 +20,7 @@ struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt,
     lt = gmtime(tt);
 
     if (lt != NULL) {
-        copy_mem_s(tm_buf, sizeof(struct tm), lt, sizeof(struct tm));
+        copy_mem(tm_buf, sizeof(struct tm), lt, sizeof(struct tm));
     }
 
     return ((lt == NULL) ? NULL : tm_buf);

--- a/os_stub/cryptlib_null/cipher/aead_aes_gcm.c
+++ b/os_stub/cryptlib_null/cipher/aead_aes_gcm.c
@@ -44,7 +44,7 @@ bool aead_aes_gcm_encrypt(const uint8_t *key, uintn key_size,
                           uint8_t *tag_out, uintn tag_size,
                           uint8_t *data_out, uintn *data_out_size)
 {
-    copy_mem_s(data_out, *data_out_size, data_in, data_in_size);
+    copy_mem(data_out, *data_out_size, data_in, data_in_size);
     *data_out_size = data_in_size;
     zero_mem(tag_out, tag_size);
     return true;
@@ -82,7 +82,7 @@ bool aead_aes_gcm_decrypt(const uint8_t *key, uintn key_size,
                           const uint8_t *tag, uintn tag_size,
                           uint8_t *data_out, uintn *data_out_size)
 {
-    copy_mem_s(data_out, *data_out_size, data_in, data_in_size);
+    copy_mem(data_out, *data_out_size, data_in, data_in_size);
     *data_out_size = data_in_size;
     return true;
 }

--- a/os_stub/cryptlib_openssl/pem/pem.c
+++ b/os_stub/cryptlib_openssl/pem/pem.c
@@ -49,7 +49,7 @@ intn PasswordCallback(char *buf, const intn size, const intn flag, const void *k
 
         key_length = (intn)ascii_str_len((char *)key);
         key_length = (key_length > size) ? size : key_length;
-        copy_mem_s(buf, size, key, (uintn)key_length);
+        copy_mem(buf, size, key, (uintn)key_length);
         return key_length;
     } else {
         return 0;

--- a/os_stub/cryptlib_openssl/pk/sm2.c
+++ b/os_stub/cryptlib_openssl/pk/sm2.c
@@ -610,12 +610,12 @@ static void ecc_signature_der_to_bin(uint8_t *der_signature,
     }
     ASSERT(r_size <= half_size && s_size <= half_size);
     zero_mem(signature, sig_size);
-    copy_mem_s(&signature[0 + half_size - r_size],
-               sig_size - (0 + half_size - r_size),
-               bn_r, r_size);
-    copy_mem_s(&signature[half_size + half_size - s_size],
-               sig_size - (half_size + half_size - s_size),
-               bn_s, s_size);
+    copy_mem(&signature[0 + half_size - r_size],
+             sig_size - (0 + half_size - r_size),
+             bn_r, r_size);
+    copy_mem(&signature[half_size + half_size - s_size],
+             sig_size - (half_size + half_size - s_size),
+             bn_s, s_size);
 }
 
 static void ecc_signature_bin_to_der(uint8_t *signature, uintn sig_size,
@@ -671,24 +671,24 @@ static void ecc_signature_bin_to_der(uint8_t *signature, uintn sig_size,
     der_signature[2] = 0x02;
     der_signature[3] = der_r_size;
     if (bn_r[0] < 0x80) {
-        copy_mem_s(&der_signature[4],
-                   der_sig_size - (&der_signature[4] - der_signature),
-                   bn_r, r_size);
+        copy_mem(&der_signature[4],
+                 der_sig_size - (&der_signature[4] - der_signature),
+                 bn_r, r_size);
     } else {
-        copy_mem_s(&der_signature[5],
-                   der_sig_size - (&der_signature[5] - der_signature),
-                   bn_r, r_size);
+        copy_mem(&der_signature[5],
+                 der_sig_size - (&der_signature[5] - der_signature),
+                 bn_r, r_size);
     }
     der_signature[4 + der_r_size] = 0x02;
     der_signature[5 + der_r_size] = der_s_size;
     if (bn_s[0] < 0x80) {
-        copy_mem_s(&der_signature[6 + der_r_size],
-                   der_sig_size - (&der_signature[6 + der_r_size] - der_signature),
-                   bn_s, s_size);
+        copy_mem(&der_signature[6 + der_r_size],
+                 der_sig_size - (&der_signature[6 + der_r_size] - der_signature),
+                 bn_s, s_size);
     } else {
-        copy_mem_s(&der_signature[7 + der_r_size],
-                   der_sig_size - (&der_signature[7 + der_r_size] - der_signature),
-                   bn_s, s_size);
+        copy_mem(&der_signature[7 + der_r_size],
+                 der_sig_size - (&der_signature[7 + der_r_size] - der_signature),
+                 bn_s, s_size);
     }
 }
 

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -433,8 +433,8 @@ internal_x509_get_nid_name(X509_NAME *x509_name, const int32_t request_nid,
         common_name_capacity = *common_name_size;
         *common_name_size =
             MIN((uintn)length, *common_name_size - 1) + 1;
-        copy_mem_s(common_name, common_name_capacity,
-                   utf8_name, *common_name_size - 1);
+        copy_mem(common_name, common_name_capacity,
+                 utf8_name, *common_name_size - 1);
         common_name[*common_name_size - 1] = '\0';
         status = RETURN_SUCCESS;
     }
@@ -791,8 +791,8 @@ return_status x509_get_serial_number(const uint8_t *cert, uintn cert_size,
     }
 
     if (serial_number != NULL) {
-        copy_mem_s(serial_number, *serial_number_size,
-                   asn1_integer->data, (uintn)asn1_integer->length);
+        copy_mem(serial_number, *serial_number_size,
+                 asn1_integer->data, (uintn)asn1_integer->length);
         status = RETURN_SUCCESS;
     }
     *serial_number_size = (uintn)asn1_integer->length;
@@ -1026,7 +1026,7 @@ return_status x509_get_signature_algorithm(const uint8_t *cert,
         goto done;
     }
     if (oid != NULL) {
-        copy_mem_s(oid, *oid_size, OBJ_get0_data(asn1_obj), obj_length);
+        copy_mem(oid, *oid_size, OBJ_get0_data(asn1_obj), obj_length);
     }
     *oid_size = obj_length;
     status = RETURN_SUCCESS;
@@ -1109,11 +1109,11 @@ bool x509_get_validity(const uint8_t *cert, uintn cert_size,
         goto done;
     }
     if (from != NULL) {
-        copy_mem_s(from, *from_size, f_time, sizeof(ASN1_TIME));
+        copy_mem(from, *from_size, f_time, sizeof(ASN1_TIME));
         ((ASN1_TIME *)from)->data = from + sizeof(ASN1_TIME);
-        copy_mem_s(from + sizeof(ASN1_TIME),
-                   *from_size - sizeof(ASN1_TIME),
-                   f_time->data, f_time->length);
+        copy_mem(from + sizeof(ASN1_TIME),
+                 *from_size - sizeof(ASN1_TIME),
+                 f_time->data, f_time->length);
     }
     *from_size = f_size;
 
@@ -1123,11 +1123,11 @@ bool x509_get_validity(const uint8_t *cert, uintn cert_size,
         goto done;
     }
     if (to != NULL) {
-        copy_mem_s(to, *to_size, t_time, sizeof(ASN1_TIME));
+        copy_mem(to, *to_size, t_time, sizeof(ASN1_TIME));
         ((ASN1_TIME *)to)->data = to + sizeof(ASN1_TIME);
-        copy_mem_s(to + sizeof(ASN1_TIME),
-                   *to_size - sizeof(ASN1_TIME),
-                   t_time->data, t_time->length);
+        copy_mem(to + sizeof(ASN1_TIME),
+                 *to_size - sizeof(ASN1_TIME),
+                 t_time->data, t_time->length);
     }
     *to_size = t_size;
 
@@ -1197,12 +1197,12 @@ return_status x509_set_date_time(char *date_time_str, void *date_time,
         goto cleanup;
     }
     if (date_time != NULL) {
-        copy_mem_s(date_time, *date_time_size, dt, sizeof(ASN1_TIME));
+        copy_mem(date_time, *date_time_size, dt, sizeof(ASN1_TIME));
         ((ASN1_TIME *)date_time)->data =
             (uint8_t *)date_time + sizeof(ASN1_TIME);
-        copy_mem_s((uint8_t *)date_time + sizeof(ASN1_TIME),
-                   *date_time_size - sizeof(ASN1_TIME),
-                   dt->data, dt->length);
+        copy_mem((uint8_t *)date_time + sizeof(ASN1_TIME),
+                 *date_time_size - sizeof(ASN1_TIME),
+                 dt->data, dt->length);
     }
     *date_time_size = d_size;
     status = RETURN_SUCCESS;
@@ -1392,8 +1392,8 @@ return_status x509_get_extension_data(const uint8_t *cert, uintn cert_size,
             goto cleanup;
         }
         if (oid != NULL) {
-            copy_mem_s(extension_data, *extension_data_size,
-                       ASN1_STRING_get0_data(asn1_oct), asn1_oct->length);
+            copy_mem(extension_data, *extension_data_size,
+                     ASN1_STRING_get0_data(asn1_oct), asn1_oct->length);
         }
         *extension_data_size = oct_length;
         status = RETURN_SUCCESS;

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -94,8 +94,8 @@ int copy_mem_s(void *restrict dst_buf, uintn dst_len,
     return 0;
 }
 
-void* copy_mem(void* dst_buf, const void* src_buf, uintn len)
+int copy_mem(void *restrict dst_buf, uintn dst_len,
+             const void *restrict src_buf, uintn src_len)
 {
-    copy_mem_s(dst_buf, len, src_buf, len);
-    return dst_buf;
+    return copy_mem_s(dst_buf, dst_len, src_buf, src_len);
 }

--- a/os_stub/openssllib/rand_pool.c
+++ b/os_stub/openssllib/rand_pool.c
@@ -49,7 +49,7 @@ static bool rand_get_bytes(uintn length, uint8_t *RandBuffer)
             RandBuffer += sizeof(uint64_t);
             length -= sizeof(temp_rand);
         } else {
-            copy_mem_s(RandBuffer, length, &temp_rand, length);
+            copy_mem(RandBuffer, length, &temp_rand, length);
             length = 0;
         }
     }

--- a/os_stub/spdm_device_secret_lib_sample/cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/cert.c
@@ -108,9 +108,9 @@ bool read_responder_root_public_certificate(uint32_t base_hash_algo,
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -210,9 +210,9 @@ bool read_requester_root_public_certificate(uint32_t base_hash_algo,
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -330,9 +330,9 @@ bool read_responder_public_certificate_chain(
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -450,9 +450,9 @@ bool read_requester_public_certificate_chain(
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -528,9 +528,9 @@ bool read_responder_root_public_certificate_by_size(
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;
@@ -626,9 +626,9 @@ bool read_responder_public_certificate_chain_by_size(
         free(cert_chain);
         return res;
     }
-    copy_mem_s((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
-               cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
-               file_data, file_size);
+    copy_mem((uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + digest_size,
+             cert_chain_size - (sizeof(spdm_cert_chain_t) + digest_size),
+             file_data, file_size);
 
     *data = cert_chain;
     *size = cert_chain_size;

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -176,7 +176,7 @@ uintn fill_measurement_image_hash_block (
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                        (uint16_t)sizeof(data));
 
-        copy_mem_s((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
+        copy_mem((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
 
         return sizeof(spdm_measurement_block_dmtf_t) + sizeof(data);
     }
@@ -214,7 +214,7 @@ uintn fill_measurement_svn_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(svn));
 
-    copy_mem_s((void *)(measurement_block + 1), sizeof(svn), (void *)&svn, sizeof(svn));
+    copy_mem((void *)(measurement_block + 1), sizeof(svn), (void *)&svn, sizeof(svn));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(svn);
 }
@@ -252,7 +252,7 @@ uintn fill_measurement_manifest_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(data));
 
-    copy_mem_s((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
+    copy_mem((void *)(measurement_block + 1), sizeof(data), data, sizeof(data));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(data);
 }
@@ -306,8 +306,8 @@ uintn fill_measurement_device_mode_block (
         (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
                    (uint16_t)sizeof(device_mode));
 
-    copy_mem_s((void *)(measurement_block + 1), sizeof(device_mode),
-               (void *)&device_mode, sizeof(device_mode));
+    copy_mem((void *)(measurement_block + 1), sizeof(device_mode),
+             (void *)&device_mode, sizeof(device_mode));
 
     return sizeof(spdm_measurement_block_dmtf_t) + sizeof(device_mode);
 }
@@ -660,12 +660,12 @@ bool libspdm_generate_measurement_summary_hash(
                   .dmtf_spec_measurement_value_type &
                   SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MASK) ==
                  SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_IMMUTABLE_ROM)) {
-                copy_mem_s(&measurement_data[measurment_data_size],
-                           sizeof(measurement_data)
-                           - (&measurement_data[measurment_data_size] - measurement_data),
-                           &cached_measurment_block->measurement_block_dmtf_header,
-                           cached_measurment_block->measurement_block_common_header
-                           .measurement_size);
+                copy_mem(&measurement_data[measurment_data_size],
+                         sizeof(measurement_data)
+                         - (&measurement_data[measurment_data_size] - measurement_data),
+                         &cached_measurment_block->measurement_block_dmtf_header,
+                         cached_measurment_block->measurement_block_common_header
+                         .measurement_size);
 
                 measurment_data_size +=
                     cached_measurment_block


### PR DESCRIPTION
This change removes the 3 parameter copy_mem function and renames the 4 parameter copy_mem_s function to 4 parameter copy_mem. This change is for library and os_stub. Unit_test will be in later PRs.