### PR TITLE
add libspdm_ for any external symbol or MACRO.

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -20,8 +20,8 @@
  * @retval RETURN_NO_RESPONSE           If the error code is BUSY.
  * @retval RETURN_DEVICE_ERROR          If the error code is REQUEST_RESYNCH or others.
  **/
-return_status spdm_handle_simple_error_response(void *context,
-                                                uint8_t error_code);
+return_status libspdm_handle_simple_error_response(void *context,
+                                                   uint8_t error_code);
 
 /**
  * This function handles the error response.
@@ -51,7 +51,7 @@ return_status spdm_handle_simple_error_response(void *context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    The error code is DECRYPT_ERROR and session_id is NOT NULL.
  **/
-return_status spdm_handle_error_response_main(
+return_status libspdm_handle_error_response_main(
     libspdm_context_t *spdm_context, const uint32_t *session_id,
     uintn *response_size, void *response,
     uint8_t original_request_code, uint8_t expected_response_code,
@@ -65,9 +65,9 @@ return_status spdm_handle_error_response_main(
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_version(libspdm_context_t *spdm_context,
-                               uint8_t *version_number_entry_count,
-                               spdm_version_number_t *version_number_entry);
+return_status libspdm_get_version(libspdm_context_t *spdm_context,
+                                  uint8_t *version_number_entry_count,
+                                  spdm_version_number_t *version_number_entry);
 
 /**
  * This function sends GET_CAPABILITIES and receives CAPABILITIES.
@@ -81,7 +81,7 @@ return_status spdm_get_version(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The GET_CAPABILITIES is sent and the CAPABILITIES is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_capabilities(libspdm_context_t *spdm_context);
+return_status libspdm_get_capabilities(libspdm_context_t *spdm_context);
 
 /**
  * This function sends NEGOTIATE_ALGORITHMS and receives ALGORITHMS.
@@ -91,7 +91,7 @@ return_status spdm_get_capabilities(libspdm_context_t *spdm_context);
  * @retval RETURN_SUCCESS               The NEGOTIATE_ALGORITHMS is sent and the ALGORITHMS is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_negotiate_algorithms(libspdm_context_t *spdm_context);
+return_status libspdm_negotiate_algorithms(libspdm_context_t *spdm_context);
 
 /**
  * This function sends KEY_EXCHANGE and receives KEY_EXCHANGE_RSP for SPDM key exchange.
@@ -110,7 +110,7 @@ return_status spdm_negotiate_algorithms(libspdm_context_t *spdm_context);
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-return_status spdm_send_receive_key_exchange(
+return_status libspdm_send_receive_key_exchange(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t slot_id, uint8_t session_policy, uint32_t *session_id,
     uint8_t *heartbeat_period,
@@ -138,7 +138,7 @@ return_status spdm_send_receive_key_exchange(
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-return_status spdm_send_receive_key_exchange_ex(
+return_status libspdm_send_receive_key_exchange_ex(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t slot_id, uint8_t session_policy, uint32_t *session_id,
     uint8_t *heartbeat_period,
@@ -159,9 +159,9 @@ return_status spdm_send_receive_key_exchange_ex(
  * @retval RETURN_SUCCESS               The FINISH is sent and the FINISH_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_finish(libspdm_context_t *spdm_context,
-                                       uint32_t session_id,
-                                       uint8_t req_slot_id_param);
+return_status libspdm_send_receive_finish(libspdm_context_t *spdm_context,
+                                          uint32_t session_id,
+                                          uint8_t req_slot_id_param);
 
 /**
  * This function sends PSK_EXCHANGE and receives PSK_EXCHANGE_RSP for SPDM PSK exchange.
@@ -178,12 +178,12 @@ return_status spdm_send_receive_finish(libspdm_context_t *spdm_context,
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
-return_status spdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
-                                             uint8_t measurement_hash_type,
-                                             uint8_t session_policy,
-                                             uint32_t *session_id,
-                                             uint8_t *heartbeat_period,
-                                             void *measurement_hash);
+return_status libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
+                                                uint8_t measurement_hash_type,
+                                                uint8_t session_policy,
+                                                uint32_t *session_id,
+                                                uint8_t *heartbeat_period,
+                                                void *measurement_hash);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
@@ -213,18 +213,18 @@ return_status spdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
-return_status spdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
-                                                uint8_t measurement_hash_type,
-                                                uint8_t session_policy,
-                                                uint32_t *session_id,
-                                                uint8_t *heartbeat_period,
-                                                void *measurement_hash,
-                                                const void *requester_context_in,
-                                                uintn requester_context_in_size,
-                                                void *requester_context,
-                                                uintn *requester_context_size,
-                                                void *responder_context,
-                                                uintn *responder_context_size);
+return_status libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
+                                                   uint8_t measurement_hash_type,
+                                                   uint8_t session_policy,
+                                                   uint32_t *session_id,
+                                                   uint8_t *heartbeat_period,
+                                                   void *measurement_hash,
+                                                   const void *requester_context_in,
+                                                   uintn requester_context_in_size,
+                                                   void *requester_context,
+                                                   uintn *requester_context_size,
+                                                   void *responder_context,
+                                                   uintn *responder_context_size);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
@@ -239,8 +239,8 @@ return_status spdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
-return_status spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
-                                           uint32_t session_id);
+return_status libspdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
+                                              uint32_t session_id);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
@@ -254,9 +254,9 @@ return_status spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The END_SESSION is sent and the END_SESSION_ACK is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_end_session(libspdm_context_t *spdm_context,
-                                            uint32_t session_id,
-                                            uint8_t end_session_attributes);
+return_status libspdm_send_receive_end_session(libspdm_context_t *spdm_context,
+                                               uint32_t session_id,
+                                               uint8_t end_session_attributes);
 
 /**
  * This function executes a series of SPDM encapsulated requests and receives SPDM encapsulated responses.
@@ -274,10 +274,10 @@ return_status spdm_send_receive_end_session(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The SPDM Encapsulated requests are sent and the responses are received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
-                                        const uint32_t *session_id,
-                                        uint8_t mut_auth_requested,
-                                        uint8_t *req_slot_id_param);
+return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
+                                           const uint32_t *session_id,
+                                           uint8_t mut_auth_requested,
+                                           uint8_t *req_slot_id_param);
 
 /**
  * Process the SPDM encapsulated GET_DIGESTS request and return the response.
@@ -296,11 +296,11 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_digest(void *context,
-                                             uintn request_size,
-                                             void *request,
-                                             uintn *response_size,
-                                             void *response);
+return_status libspdm_get_encap_response_digest(void *context,
+                                                uintn request_size,
+                                                void *request,
+                                                uintn *response_size,
+                                                void *response);
 
 /**
  * Process the SPDM encapsulated GET_CERTIFICATE request and return the response.
@@ -321,11 +321,11 @@ return_status spdm_get_encap_response_digest(void *context,
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-return_status spdm_get_encap_response_certificate(void *context,
-                                                  uintn request_size,
-                                                  void *request,
-                                                  uintn *response_size,
-                                                  void *response);
+return_status libspdm_get_encap_response_certificate(void *context,
+                                                     uintn request_size,
+                                                     void *request,
+                                                     uintn *response_size,
+                                                     void *response);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
@@ -346,7 +346,7 @@ return_status spdm_get_encap_response_certificate(void *context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_challenge_auth(
+return_status libspdm_get_encap_response_challenge_auth(
     void *context, uintn request_size, void *request,
     uintn *response_size, void *response);
 
@@ -367,11 +367,11 @@ return_status spdm_get_encap_response_challenge_auth(
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_key_update(void *context,
-                                                 uintn request_size,
-                                                 void *request,
-                                                 uintn *response_size,
-                                                 void *response);
+return_status libspdm_get_encap_response_key_update(void *context,
+                                                    uintn request_size,
+                                                    void *request,
+                                                    uintn *response_size,
+                                                    void *response);
 
 /**
  * Send an SPDM request to a device.
@@ -388,9 +388,9 @@ return_status spdm_get_encap_response_key_update(void *context,
  * @retval RETURN_SUCCESS               The SPDM request is sent successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM request is sent to the device.
  **/
-return_status spdm_send_spdm_request(libspdm_context_t *spdm_context,
-                                     const uint32_t *session_id,
-                                     uintn request_size, const void *request);
+return_status libspdm_send_spdm_request(libspdm_context_t *spdm_context,
+                                        const uint32_t *session_id,
+                                        uintn request_size, const void *request);
 
 /**
  * Receive an SPDM response from a device.
@@ -407,9 +407,9 @@ return_status spdm_send_spdm_request(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The SPDM response is received successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is received from the device.
  **/
-return_status spdm_receive_spdm_response(libspdm_context_t *spdm_context,
-                                         const uint32_t *session_id,
-                                         uintn *response_size,
-                                         void *response);
+return_status libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
+                                            const uint32_t *session_id,
+                                            uintn *response_size,
+                                            void *response);
 
 #endif

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -28,7 +28,7 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-typedef return_status (*spdm_get_spdm_response_func)(
+typedef return_status (*libspdm_get_spdm_response_func)(
     void *spdm_context, uintn request_size, const void *request,
     uintn *response_size, void *response);
 
@@ -48,10 +48,10 @@ typedef return_status (*spdm_get_spdm_response_func)(
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_responder_handle_response_state(void *spdm_context,
-                                                   uint8_t request_code,
-                                                   uintn *response_size,
-                                                   void *response);
+return_status libspdm_responder_handle_response_state(void *spdm_context,
+                                                      uint8_t request_code,
+                                                      uintn *response_size,
+                                                      void *response);
 
 /**
  * Process the SPDM RESPONSE_IF_READY request and return the response.
@@ -70,11 +70,11 @@ return_status spdm_responder_handle_response_state(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_respond_if_ready(void *spdm_context,
-                                                 uintn request_size,
-                                                 const void *request,
-                                                 uintn *response_size,
-                                                 void *response);
+return_status libspdm_get_response_respond_if_ready(void *spdm_context,
+                                                    uintn request_size,
+                                                    const void *request,
+                                                    uintn *response_size,
+                                                    void *response);
 
 /**
  * Process the SPDM GET_VERSION request and return the response.
@@ -93,10 +93,10 @@ return_status spdm_get_response_respond_if_ready(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_version(void *spdm_context,
-                                        uintn request_size, const void *request,
-                                        uintn *response_size,
-                                        void *response);
+return_status libspdm_get_response_version(void *spdm_context,
+                                           uintn request_size, const void *request,
+                                           uintn *response_size,
+                                           void *response);
 
 /**
  * Process the SPDM GET_CAPABILITIES request and return the response.
@@ -115,11 +115,11 @@ return_status spdm_get_response_version(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_capabilities(void *spdm_context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response);
+return_status libspdm_get_response_capabilities(void *spdm_context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response);
 
 /**
  * Process the SPDM NEGOTIATE_ALGORITHMS request and return the response.
@@ -138,11 +138,11 @@ return_status spdm_get_response_capabilities(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_algorithms(void *spdm_context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response);
+return_status libspdm_get_response_algorithms(void *spdm_context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response);
 
 /**
  * Process the SPDM GET_DIGESTS request and return the response.
@@ -164,10 +164,10 @@ return_status spdm_get_response_algorithms(void *spdm_context,
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-return_status spdm_get_response_digests(void *spdm_context,
-                                        uintn request_size, const void *request,
-                                        uintn *response_size,
-                                        void *response);
+return_status libspdm_get_response_digests(void *spdm_context,
+                                           uintn request_size, const void *request,
+                                           uintn *response_size,
+                                           void *response);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
@@ -191,11 +191,11 @@ return_status spdm_get_response_digests(void *spdm_context,
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-return_status spdm_get_response_certificate(void *spdm_context,
-                                            uintn request_size,
-                                            const void *request,
-                                            uintn *response_size,
-                                            void *response);
+return_status libspdm_get_response_certificate(void *spdm_context,
+                                               uintn request_size,
+                                               const void *request,
+                                               uintn *response_size,
+                                               void *response);
 
 #endif /* ENABLE_SPDM_GET_CERTIFICATE*/
 
@@ -219,11 +219,11 @@ return_status spdm_get_response_certificate(void *spdm_context,
 
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
 
-return_status spdm_get_response_challenge_auth(void *spdm_context,
-                                               uintn request_size,
-                                               const void *request,
-                                               uintn *response_size,
-                                               void *response);
+return_status libspdm_get_response_challenge_auth(void *spdm_context,
+                                                  uintn request_size,
+                                                  const void *request,
+                                                  uintn *response_size,
+                                                  void *response);
 
 #endif /* #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
@@ -247,11 +247,11 @@ return_status spdm_get_response_challenge_auth(void *spdm_context,
 
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
 
-return_status spdm_get_response_measurements(void *spdm_context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response);
+return_status libspdm_get_response_measurements(void *spdm_context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/
 
@@ -272,11 +272,11 @@ return_status spdm_get_response_measurements(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_key_exchange(void *spdm_context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response);
+return_status libspdm_get_response_key_exchange(void *spdm_context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response);
 
 /**
  * Process the SPDM FINISH request and return the response.
@@ -295,10 +295,10 @@ return_status spdm_get_response_key_exchange(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_finish(void *spdm_context,
-                                       uintn request_size, const void *request,
-                                       uintn *response_size,
-                                       void *response);
+return_status libspdm_get_response_finish(void *spdm_context,
+                                          uintn request_size, const void *request,
+                                          uintn *response_size,
+                                          void *response);
 
 /**
  * Process the SPDM PSK_EXCHANGE request and return the response.
@@ -317,11 +317,11 @@ return_status spdm_get_response_finish(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_psk_exchange(void *spdm_context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response);
+return_status libspdm_get_response_psk_exchange(void *spdm_context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response);
 
 /**
  * Process the SPDM PSK_FINISH request and return the response.
@@ -340,11 +340,11 @@ return_status spdm_get_response_psk_exchange(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_psk_finish(void *spdm_context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response);
+return_status libspdm_get_response_psk_finish(void *spdm_context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response);
 
 /**
  * Process the SPDM END_SESSION request and return the response.
@@ -363,11 +363,11 @@ return_status spdm_get_response_psk_finish(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_end_session(void *spdm_context,
-                                            uintn request_size,
-                                            const void *request,
-                                            uintn *response_size,
-                                            void *response);
+return_status libspdm_get_response_end_session(void *spdm_context,
+                                               uintn request_size,
+                                               const void *request,
+                                               uintn *response_size,
+                                               void *response);
 
 /**
  * Process the SPDM HEARTBEAT request and return the response.
@@ -386,11 +386,11 @@ return_status spdm_get_response_end_session(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_heartbeat(void *spdm_context,
-                                          uintn request_size,
-                                          const void *request,
-                                          uintn *response_size,
-                                          void *response);
+return_status libspdm_get_response_heartbeat(void *spdm_context,
+                                             uintn request_size,
+                                             const void *request,
+                                             uintn *response_size,
+                                             void *response);
 
 /**
  * Process the SPDM KEY_UPDATE request and return the response.
@@ -409,11 +409,11 @@ return_status spdm_get_response_heartbeat(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_key_update(void *spdm_context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response);
+return_status libspdm_get_response_key_update(void *spdm_context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response);
 
 /**
  * Process the SPDM ENCAPSULATED_REQUEST request and return the response.
@@ -432,7 +432,7 @@ return_status spdm_get_response_key_update(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_encapsulated_request(
+return_status libspdm_get_response_encapsulated_request(
     void *spdm_context, uintn request_size, const void *request,
     uintn *response_size, void *response);
 
@@ -453,7 +453,7 @@ return_status spdm_get_response_encapsulated_request(
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_encapsulated_response_ack(
+return_status libspdm_get_response_encapsulated_response_ack(
     void *spdm_context, uintn request_size, const void *request,
     uintn *response_size, void *response);
 
@@ -471,9 +471,9 @@ return_status spdm_get_response_encapsulated_response_ack(
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
-                                  uintn *encap_request_size,
-                                  void *encap_request);
+libspdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
+                                     uintn *encap_request_size,
+                                     void *encap_request);
 
 /**
  * Process the SPDM encapsulated DIGESTS response.
@@ -489,7 +489,7 @@ spdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-return_status spdm_process_encap_response_digest(
+return_status libspdm_process_encap_response_digest(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue);
 
@@ -509,9 +509,9 @@ return_status spdm_process_encap_response_digest(
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
-                                       uintn *encap_request_size,
-                                       void *encap_request);
+libspdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
+                                          uintn *encap_request_size,
+                                          void *encap_request);
 
 /**
  * Process the SPDM encapsulated CERTIFICATE response.
@@ -525,7 +525,7 @@ spdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_certificate(
+return_status libspdm_process_encap_response_certificate(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue);
 
@@ -542,9 +542,9 @@ return_status spdm_process_encap_response_certificate(
  * @retval RETURN_SUCCESS               The encapsulated request is returned.
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
-return_status spdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
-                                               uintn *encap_request_size,
-                                               void *encap_request);
+return_status libspdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
+                                                  uintn *encap_request_size,
+                                                  void *encap_request);
 
 /**
  * Process the SPDM encapsulated CHALLENGE_AUTH response.
@@ -558,7 +558,7 @@ return_status spdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_challenge_auth(
+return_status libspdm_process_encap_response_challenge_auth(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue);
 
@@ -576,9 +576,9 @@ return_status spdm_process_encap_response_challenge_auth(
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
-                                  uintn *encap_request_size,
-                                  void *encap_request);
+libspdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
+                                     uintn *encap_request_size,
+                                     void *encap_request);
 
 /**
  * Process the SPDM encapsulated KEY_UPDATE response.
@@ -592,7 +592,7 @@ spdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_key_update(
+return_status libspdm_process_encap_response_key_update(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue);
 
@@ -603,8 +603,8 @@ return_status spdm_process_encap_response_key_update(
  *
  * @return GET_SPDM_RESPONSE function according to the request code.
  **/
-spdm_get_spdm_response_func
-spdm_get_response_func_via_request_code(uint8_t request_code);
+libspdm_get_spdm_response_func
+libspdm_get_response_func_via_request_code(uint8_t request_code);
 
 /**
  * This function initializes the mut_auth encapsulated state.
@@ -612,15 +612,15 @@ spdm_get_response_func_via_request_code(uint8_t request_code);
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  mut_auth_requested             Indicate of the mut_auth_requested through KEY_EXCHANGE response.
  **/
-void spdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context,
-                                    uint8_t mut_auth_requested);
+void libspdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context,
+                                       uint8_t mut_auth_requested);
 
 /**
  * This function initializes the basic_mut_auth encapsulated state.
  *
  * @param  spdm_context                  A pointer to the SPDM context.
  **/
-void spdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context);
+void libspdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context);
 
 /**
  * This function handles the encap error response.
@@ -630,7 +630,7 @@ void spdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context);
  *
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_handle_encap_error_response_main(
+return_status libspdm_handle_encap_error_response_main(
     libspdm_context_t *spdm_context, uint8_t error_code);
 
 /**
@@ -640,9 +640,9 @@ return_status spdm_handle_encap_error_response_main(
  * @param  session_id                    Indicate the SPDM session ID.
  * @param  session_state                 Indicate the SPDM session state.
  */
-void spdm_set_session_state(libspdm_context_t *spdm_context,
-                            uint32_t session_id,
-                            libspdm_session_state_t session_state);
+void libspdm_set_session_state(libspdm_context_t *spdm_context,
+                               uint32_t session_id,
+                               libspdm_session_state_t session_state);
 
 /**
  * Set connection_state to an SPDM context and trigger callback.
@@ -650,7 +650,7 @@ void spdm_set_session_state(libspdm_context_t *spdm_context,
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  connection_state              Indicate the SPDM connection state.
  */
-void spdm_set_connection_state(libspdm_context_t *spdm_context,
-                               libspdm_connection_state_t connection_state);
+void libspdm_set_connection_state(libspdm_context_t *spdm_context,
+                                  libspdm_connection_state_t connection_state);
 
 #endif

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -13,7 +13,7 @@ typedef struct {
     uint8_t dhe_secret[LIBSPDM_MAX_DHE_KEY_SIZE];
     uint8_t handshake_secret[LIBSPDM_MAX_HASH_SIZE];
     uint8_t master_secret[LIBSPDM_MAX_HASH_SIZE];
-} spdm_session_info_struct_master_secret_t;
+} libspdm_session_info_struct_master_secret_t;
 
 typedef struct {
     uint8_t request_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
@@ -27,7 +27,7 @@ typedef struct {
     uint8_t response_handshake_encryption_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
     uint8_t response_handshake_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
     uint64_t response_handshake_sequence_number;
-} spdm_session_info_struct_handshake_secret_t;
+} libspdm_session_info_struct_handshake_secret_t;
 
 typedef struct {
     uint8_t request_data_secret[LIBSPDM_MAX_HASH_SIZE];
@@ -38,7 +38,7 @@ typedef struct {
     uint8_t response_data_encryption_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
     uint8_t response_data_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
     uint64_t response_data_sequence_number;
-} spdm_session_info_struct_application_secret_t;
+} libspdm_session_info_struct_application_secret_t;
 
 typedef struct {
     libspdm_session_type_t session_type;
@@ -56,10 +56,10 @@ typedef struct {
     bool use_psk;
     bool finished_key_ready;
     libspdm_session_state_t session_state;
-    spdm_session_info_struct_master_secret_t master_secret;
-    spdm_session_info_struct_handshake_secret_t handshake_secret;
-    spdm_session_info_struct_application_secret_t application_secret;
-    spdm_session_info_struct_application_secret_t application_secret_backup;
+    libspdm_session_info_struct_master_secret_t master_secret;
+    libspdm_session_info_struct_handshake_secret_t handshake_secret;
+    libspdm_session_info_struct_application_secret_t application_secret;
+    libspdm_session_info_struct_application_secret_t application_secret_backup;
     bool requester_backup_valid;
     bool responder_backup_valid;
     uintn psk_hint_size;
@@ -68,6 +68,6 @@ typedef struct {
     /* Cache the error in libspdm_decode_secured_message. It is handled in libspdm_build_response.*/
 
     libspdm_error_struct_t last_spdm_error;
-} spdm_secured_message_context_t;
+} libspdm_secured_message_context_t;
 
 #endif

--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -403,11 +403,13 @@ libspdm_process_opaque_data_version_selection_data(libspdm_context_t *spdm_conte
          spdm_context->local_context.secured_message_version.spdm_version_count;
          secured_message_version_index++) {
 
-        if (libspdm_get_version_from_version_number(opaque_element_version_section->selected_version)
+        if (libspdm_get_version_from_version_number(opaque_element_version_section->
+                                                    selected_version)
             ==
             libspdm_get_version_from_version_number(spdm_context->local_context.
                                                     secured_message_version
-                                                    .spdm_version[secured_message_version_index])) {
+                                                    .spdm_version[secured_message_version_index]))
+        {
             return RETURN_SUCCESS;
         }
     }

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -112,15 +112,15 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
                  spdm_request.nonce, SPDM_NONCE_SIZE);
     }
 
-    status = spdm_send_spdm_request(spdm_context, NULL,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -132,7 +132,7 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, NULL,
             &spdm_response_size,
             &spdm_response, SPDM_CHALLENGE, SPDM_CHALLENGE_AUTH,
@@ -282,9 +282,9 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
 
     if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ) != 0) {
         DEBUG((DEBUG_INFO, "BasicMutAuth :\n"));
-        status = spdm_encapsulated_request(spdm_context, NULL, 0, NULL);
+        status = libspdm_encapsulated_request(spdm_context, NULL, 0, NULL);
         DEBUG((DEBUG_INFO,
-               "libspdm_challenge - spdm_encapsulated_request - %p\n",
+               "libspdm_challenge - libspdm_encapsulated_request - %p\n",
                status));
         if (RETURN_ERROR(status)) {
             libspdm_reset_message_c(spdm_context);

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -26,17 +26,17 @@ return_status libspdm_init_connection(void *context,
 
     spdm_context = context;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     if (!get_version_only) {
-        status = spdm_get_capabilities(spdm_context);
+        status = libspdm_get_capabilities(spdm_context);
         if (RETURN_ERROR(status)) {
             return status;
         }
-        status = spdm_negotiate_algorithms(spdm_context);
+        status = libspdm_negotiate_algorithms(spdm_context);
         if (RETURN_ERROR(status)) {
             return status;
         }
@@ -86,13 +86,13 @@ return_status libspdm_start_session(void *context, bool use_psk,
 
     if (!use_psk) {
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-        status = spdm_send_receive_key_exchange(
+        status = libspdm_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, &req_slot_id_param,
             measurement_hash);
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_key_exchange - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_key_exchange - %p\n",
                    status));
             return status;
         }
@@ -111,12 +111,12 @@ return_status libspdm_start_session(void *context, bool use_psk,
             break;
         case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST:
         case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_GET_DIGESTS:
-            status = spdm_encapsulated_request(
+            status = libspdm_encapsulated_request(
                 spdm_context, session_id,
                 session_info->mut_auth_requested,
                 &req_slot_id_param);
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_encapsulated_request - %p\n",
+                   "libspdm_start_session - libspdm_encapsulated_request - %p\n",
                    status));
             if (RETURN_ERROR(status)) {
                 return status;
@@ -132,10 +132,10 @@ return_status libspdm_start_session(void *context, bool use_psk,
         if (req_slot_id_param == 0xF) {
             req_slot_id_param = 0xFF;
         }
-        status = spdm_send_receive_finish(spdm_context, *session_id,
-                                          req_slot_id_param);
+        status = libspdm_send_receive_finish(spdm_context, *session_id,
+                                             req_slot_id_param);
         DEBUG((DEBUG_INFO,
-               "libspdm_start_session - spdm_send_receive_finish - %p\n",
+               "libspdm_start_session - libspdm_send_receive_finish - %p\n",
                status));
     #else /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
         ASSERT(false);
@@ -143,12 +143,12 @@ return_status libspdm_start_session(void *context, bool use_psk,
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
     } else {
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-        status = spdm_send_receive_psk_exchange(
+        status = libspdm_send_receive_psk_exchange(
             spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash);
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_psk_exchange - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_psk_exchange - %p\n",
                    status));
             return status;
         }
@@ -157,10 +157,10 @@ return_status libspdm_start_session(void *context, bool use_psk,
         if (libspdm_is_capabilities_flag_supported(
                 spdm_context, true, 0,
                 SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
-            status = spdm_send_receive_psk_finish(spdm_context,
-                                                  *session_id);
+            status = libspdm_send_receive_psk_finish(spdm_context,
+                                                     *session_id);
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_psk_finish - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_psk_finish - %p\n",
                    status));
         }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
@@ -234,14 +234,14 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
         ASSERT (requester_random_in_size == 0 || requester_random_in_size == SPDM_RANDOM_DATA_SIZE);
         ASSERT (requester_random_size == NULL || *requester_random_size == SPDM_RANDOM_DATA_SIZE);
         ASSERT (responder_random_size == NULL || *responder_random_size == SPDM_RANDOM_DATA_SIZE);
-        status = spdm_send_receive_key_exchange_ex(
+        status = libspdm_send_receive_key_exchange_ex(
             spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, &req_slot_id_param,
             measurement_hash, requester_random_in,
             requester_random, responder_random);
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_key_exchange - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_key_exchange - %p\n",
                    status));
             return status;
         }
@@ -260,12 +260,12 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
             break;
         case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST:
         case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_GET_DIGESTS:
-            status = spdm_encapsulated_request(
+            status = libspdm_encapsulated_request(
                 spdm_context, session_id,
                 session_info->mut_auth_requested,
                 &req_slot_id_param);
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_encapsulated_request - %p\n",
+                   "libspdm_start_session - libspdm_encapsulated_request - %p\n",
                    status));
             if (RETURN_ERROR(status)) {
                 return status;
@@ -281,10 +281,10 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
         if (req_slot_id_param == 0xF) {
             req_slot_id_param = 0xFF;
         }
-        status = spdm_send_receive_finish(spdm_context, *session_id,
-                                          req_slot_id_param);
+        status = libspdm_send_receive_finish(spdm_context, *session_id,
+                                             req_slot_id_param);
         DEBUG((DEBUG_INFO,
-               "libspdm_start_session - spdm_send_receive_finish - %p\n",
+               "libspdm_start_session - libspdm_send_receive_finish - %p\n",
                status));
     #else /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
         ASSERT(false);
@@ -292,7 +292,7 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
     } else {
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-        status = spdm_send_receive_psk_exchange_ex(
+        status = libspdm_send_receive_psk_exchange_ex(
             spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             requester_random_in, requester_random_in_size,
@@ -300,7 +300,7 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
             responder_random, responder_random_size);
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_psk_exchange - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_psk_exchange - %p\n",
                    status));
             return status;
         }
@@ -309,10 +309,10 @@ return_status libspdm_start_session_ex(void *context, bool use_psk,
         if (libspdm_is_capabilities_flag_supported(
                 spdm_context, true, 0,
                 SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT)) {
-            status = spdm_send_receive_psk_finish(spdm_context,
-                                                  *session_id);
+            status = libspdm_send_receive_psk_finish(spdm_context,
+                                                     *session_id);
             DEBUG((DEBUG_INFO,
-                   "libspdm_start_session - spdm_send_receive_psk_finish - %p\n",
+                   "libspdm_start_session - libspdm_send_receive_psk_finish - %p\n",
                    status));
         }
     #else /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
@@ -345,8 +345,8 @@ return_status libspdm_stop_session(void *context, uint32_t session_id,
 
     spdm_context = context;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id,
-                                           end_session_attributes);
+    status = libspdm_send_receive_end_session(spdm_context, session_id,
+                                              end_session_attributes);
     DEBUG((DEBUG_INFO, "libspdm_stop_session - %p\n", status));
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -25,11 +25,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_certificate(void *context,
-                                                  uintn request_size,
-                                                  void *request,
-                                                  uintn *response_size,
-                                                  void *response)
+return_status libspdm_get_encap_response_certificate(void *context,
+                                                     uintn request_size,
+                                                     void *request,
+                                                     uintn *response_size,
+                                                     void *response)
 {
     spdm_get_certificate_request_t *spdm_request;
     spdm_certificate_response_t *spdm_response;

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -25,7 +25,7 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_challenge_auth(
+return_status libspdm_get_encap_response_challenge_auth(
     void *context, uintn request_size, void *request,
     uintn *response_size, void *response)
 {

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -25,11 +25,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_digest(void *context,
-                                             uintn request_size,
-                                             void *request,
-                                             uintn *response_size,
-                                             void *response)
+return_status libspdm_get_encap_response_digest(void *context,
+                                                uintn request_size,
+                                                void *request,
+                                                uintn *response_size,
+                                                void *response)
 {
     spdm_get_digest_request_t *spdm_request;
     spdm_digest_response_t *spdm_response;

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -23,11 +23,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_encap_response_key_update(void *context,
-                                                 uintn request_size,
-                                                 void *request,
-                                                 uintn *response_size,
-                                                 void *response)
+return_status libspdm_get_encap_response_key_update(void *context,
+                                                    uintn request_size,
+                                                    void *request,
+                                                    uintn *response_size,
+                                                    void *response)
 {
     uint32_t session_id;
     spdm_key_update_response_t *spdm_response;

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -14,15 +14,15 @@ typedef struct {
 spdm_get_encap_response_struct_t m_spdm_get_encap_response_struct[] = {
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-    { SPDM_GET_DIGESTS, spdm_get_encap_response_digest },
-    { SPDM_GET_CERTIFICATE, spdm_get_encap_response_certificate },
+    { SPDM_GET_DIGESTS, libspdm_get_encap_response_digest },
+    { SPDM_GET_CERTIFICATE, libspdm_get_encap_response_certificate },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-    { SPDM_CHALLENGE, spdm_get_encap_response_challenge_auth },
+    { SPDM_CHALLENGE, libspdm_get_encap_response_challenge_auth },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
-    { SPDM_KEY_UPDATE, spdm_get_encap_response_key_update },
+    { SPDM_KEY_UPDATE, libspdm_get_encap_response_key_update },
 };
 
 /**
@@ -142,10 +142,10 @@ return_status SpdmProcessEncapsulatedRequest(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The SPDM Encapsulated requests are sent and the responses are received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
-                                        const uint32_t *session_id,
-                                        uint8_t mut_auth_requested,
-                                        uint8_t *req_slot_id_param)
+return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
+                                           const uint32_t *session_id,
+                                           uint8_t mut_auth_requested,
+                                           uint8_t *req_slot_id_param)
 {
     return_status status;
     uint8_t request[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -156,7 +156,7 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
     *spdm_deliver_encapsulated_response_request;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uintn spdm_response_size;
-    spdm_encapsulated_request_response_t *spdm_encapsulated_request_response;
+    spdm_encapsulated_request_response_t *libspdm_encapsulated_request_response;
     spdm_encapsulated_response_ack_response_t
     *spdm_encapsulated_response_ack_response;
     libspdm_session_info_t *session_info;
@@ -237,23 +237,23 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
             sizeof(spdm_get_encapsulated_request_request_t);
         libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
                                                       spdm_get_encapsulated_request_request->header.request_response_code);
-        status = spdm_send_spdm_request(
+        status = libspdm_send_spdm_request(
             spdm_context, session_id, spdm_request_size,
             spdm_get_encapsulated_request_request);
         if (RETURN_ERROR(status)) {
             return status;
         }
 
-        spdm_encapsulated_request_response = (void *)response;
+        libspdm_encapsulated_request_response = (void *)response;
         spdm_response_size = sizeof(response);
         zero_mem(&response, sizeof(response));
-        status = spdm_receive_spdm_response(
+        status = libspdm_receive_spdm_response(
             spdm_context, session_id, &spdm_response_size,
-            spdm_encapsulated_request_response);
+            libspdm_encapsulated_request_response);
         if (RETURN_ERROR(status)) {
             return status;
         }
-        if (spdm_encapsulated_request_response->header
+        if (libspdm_encapsulated_request_response->header
             .request_response_code !=
             SPDM_ENCAPSULATED_REQUEST) {
             return RETURN_DEVICE_ERROR;
@@ -269,10 +269,10 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
 
             return RETURN_SUCCESS;
         }
-        request_id = spdm_encapsulated_request_response->header.param1;
+        request_id = libspdm_encapsulated_request_response->header.param1;
 
         encapsulated_request =
-            (void *)(spdm_encapsulated_request_response + 1);
+            (void *)(libspdm_encapsulated_request_response + 1);
         encapsulated_request_size =
             spdm_response_size -
             sizeof(spdm_encapsulated_request_response_t);
@@ -309,7 +309,7 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
         spdm_request_size =
             sizeof(spdm_deliver_encapsulated_response_request_t) +
             encapsulated_response_size;
-        status = spdm_send_spdm_request(
+        status = libspdm_send_spdm_request(
             spdm_context, session_id, spdm_request_size,
             spdm_deliver_encapsulated_response_request);
         if (RETURN_ERROR(status)) {
@@ -319,7 +319,7 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
         spdm_encapsulated_response_ack_response = (void *)response;
         spdm_response_size = sizeof(response);
         zero_mem(&response, sizeof(response));
-        status = spdm_receive_spdm_response(
+        status = libspdm_receive_spdm_response(
             spdm_context, session_id, &spdm_response_size,
             spdm_encapsulated_response_ack_response);
         if (RETURN_ERROR(status)) {
@@ -410,5 +410,5 @@ return_status spdm_encapsulated_request(libspdm_context_t *spdm_context,
 return_status libspdm_send_receive_encap_request(void *spdm_context,
                                                  const uint32_t *session_id)
 {
-    return spdm_encapsulated_request(spdm_context, session_id, 0, NULL);
+    return libspdm_encapsulated_request(spdm_context, session_id, 0, NULL);
 }

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -25,9 +25,9 @@ typedef struct {
  * @retval RETURN_SUCCESS               The END_SESSION is sent and the END_SESSION_ACK is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_send_receive_end_session(libspdm_context_t *spdm_context,
-                                                uint32_t session_id,
-                                                uint8_t end_session_attributes)
+return_status libspdm_try_send_receive_end_session(libspdm_context_t *spdm_context,
+                                                   uint32_t session_id,
+                                                   uint8_t end_session_attributes)
 {
     return_status status;
     spdm_end_session_request_t spdm_request;
@@ -67,8 +67,8 @@ return_status try_spdm_send_receive_end_session(libspdm_context_t *spdm_context,
     spdm_request.header.param2 = 0;
 
     spdm_request_size = sizeof(spdm_end_session_request_t);
-    status = spdm_send_spdm_request(spdm_context, &session_id,
-                                    spdm_request_size, &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                       spdm_request_size, &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
@@ -78,7 +78,7 @@ return_status try_spdm_send_receive_end_session(libspdm_context_t *spdm_context,
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -90,7 +90,7 @@ return_status try_spdm_send_receive_end_session(libspdm_context_t *spdm_context,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_END_SESSION, SPDM_END_SESSION_ACK,
             sizeof(spdm_end_session_response_mine_t));
@@ -117,9 +117,9 @@ return_status try_spdm_send_receive_end_session(libspdm_context_t *spdm_context,
     return RETURN_SUCCESS;
 }
 
-return_status spdm_send_receive_end_session(libspdm_context_t *spdm_context,
-                                            uint32_t session_id,
-                                            uint8_t end_session_attributes)
+return_status libspdm_send_receive_end_session(libspdm_context_t *spdm_context,
+                                               uint32_t session_id,
+                                               uint8_t end_session_attributes)
 {
     uintn retry;
     return_status status;
@@ -127,7 +127,7 @@ return_status spdm_send_receive_end_session(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_end_session(
+        status = libspdm_try_send_receive_end_session(
             spdm_context, session_id, end_session_attributes);
         if (RETURN_NO_RESPONSE != status) {
             return status;

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -33,9 +33,9 @@ typedef struct {
  * @retval RETURN_SUCCESS               The FINISH is sent and the FINISH_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_send_receive_finish(libspdm_context_t *spdm_context,
-                                           uint32_t session_id,
-                                           uint8_t req_slot_id_param)
+return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
+                                              uint32_t session_id,
+                                              uint8_t req_slot_id_param)
 {
     return_status status;
     spdm_finish_request_mine_t spdm_request;
@@ -164,8 +164,8 @@ return_status try_spdm_send_receive_finish(libspdm_context_t *spdm_context,
         goto error;
     }
 
-    status = spdm_send_spdm_request(spdm_context, &session_id,
-                                    spdm_request_size, &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                       spdm_request_size, &spdm_request);
     if (RETURN_ERROR(status)) {
         goto error;
     }
@@ -175,7 +175,7 @@ return_status try_spdm_send_receive_finish(libspdm_context_t *spdm_context,
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         goto error;
@@ -196,7 +196,7 @@ return_status try_spdm_send_receive_finish(libspdm_context_t *spdm_context,
         if (spdm_response.header.param1 != SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
             libspdm_reset_message_f (spdm_context, session_info);
         }
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_FINISH, SPDM_FINISH_RSP,
@@ -281,9 +281,9 @@ error:
     return status;
 }
 
-return_status spdm_send_receive_finish(libspdm_context_t *spdm_context,
-                                       uint32_t session_id,
-                                       uint8_t req_slot_id_param)
+return_status libspdm_send_receive_finish(libspdm_context_t *spdm_context,
+                                          uint32_t session_id,
+                                          uint8_t req_slot_id_param)
 {
     uintn retry;
     return_status status;
@@ -291,8 +291,8 @@ return_status spdm_send_receive_finish(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_finish(spdm_context, session_id,
-                                              req_slot_id_param);
+        status = libspdm_try_send_receive_finish(spdm_context, session_id,
+                                                 req_slot_id_param);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -97,7 +97,7 @@ bool spdm_check_response_flag_compability(uint32_t capabilities_flag,
  * @retval RETURN_SUCCESS               The GET_CAPABILITIES is sent and the CAPABILITIES is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_get_capabilities(libspdm_context_t *spdm_context)
+return_status libspdm_try_get_capabilities(libspdm_context_t *spdm_context)
 {
     return_status status;
     spdm_get_capabilities_request_t spdm_request;
@@ -131,15 +131,15 @@ return_status try_spdm_get_capabilities(libspdm_context_t *spdm_context)
     spdm_request.flags = spdm_context->local_context.capability.flags;
     spdm_request.data_transfer_size = spdm_context->local_context.capability.data_transfer_size;
     spdm_request.max_spdm_msg_size = spdm_context->local_context.capability.max_spdm_msg_size;
-    status = spdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
-                                    &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
+                                       &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -151,7 +151,7 @@ return_status try_spdm_get_capabilities(libspdm_context_t *spdm_context)
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_simple_error_response(
+        status = libspdm_handle_simple_error_response(
             spdm_context, spdm_response.header.param1);
         if (RETURN_ERROR(status)) {
             return status;
@@ -230,7 +230,7 @@ return_status try_spdm_get_capabilities(libspdm_context_t *spdm_context)
  * @retval RETURN_SUCCESS               The GET_CAPABILITIES is sent and the CAPABILITIES is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_capabilities(libspdm_context_t *spdm_context)
+return_status libspdm_get_capabilities(libspdm_context_t *spdm_context)
 {
     uintn retry;
     return_status status;
@@ -238,7 +238,7 @@ return_status spdm_get_capabilities(libspdm_context_t *spdm_context)
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_capabilities(spdm_context);
+        status = libspdm_try_get_capabilities(spdm_context);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -101,18 +101,18 @@ return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
         DEBUG((DEBUG_INFO, "request (offset 0x%x, size 0x%x):\n",
                spdm_request.offset, spdm_request.length));
 
-        status = spdm_send_spdm_request(spdm_context, NULL,
-                                        sizeof(spdm_request),
-                                        &spdm_request);
+        status = libspdm_send_spdm_request(spdm_context, NULL,
+                                           sizeof(spdm_request),
+                                           &spdm_request);
         if (RETURN_ERROR(status)) {
             goto done;
         }
 
         spdm_response_size = sizeof(spdm_response);
         zero_mem(&spdm_response, sizeof(spdm_response));
-        status = spdm_receive_spdm_response(spdm_context, NULL,
-                                            &spdm_response_size,
-                                            &spdm_response);
+        status = libspdm_receive_spdm_response(spdm_context, NULL,
+                                               &spdm_response_size,
+                                               &spdm_response);
         if (RETURN_ERROR(status)) {
             goto done;
         }
@@ -124,7 +124,7 @@ return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response.header.request_response_code == SPDM_ERROR) {
-            status = spdm_handle_error_response_main(
+            status = libspdm_handle_error_response_main(
                 spdm_context, NULL,
                 &spdm_response_size,
                 &spdm_response, SPDM_GET_CERTIFICATE,

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -66,14 +66,14 @@ return_status try_spdm_get_digest(void *context, uint8_t *slot_mask,
     spdm_request.header.request_response_code = SPDM_GET_DIGESTS;
     spdm_request.header.param1 = 0;
     spdm_request.header.param2 = 0;
-    status = spdm_send_spdm_request(spdm_context, NULL,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -85,7 +85,7 @@ return_status try_spdm_get_digest(void *context, uint8_t *slot_mask,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, NULL,
             &spdm_response_size,
             &spdm_response, SPDM_GET_DIGESTS, SPDM_DIGESTS,

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -176,15 +176,15 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
             zero_mem (requester_nonce, SPDM_NONCE_SIZE);
         }
     }
-    status = spdm_send_spdm_request(spdm_context, session_id,
-                                    spdm_request_size, &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, session_id,
+                                       spdm_request_size, &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -196,7 +196,7 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, session_id,
             &spdm_response_size, &spdm_response,
             SPDM_GET_MEASUREMENTS, SPDM_MEASUREMENTS,

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -24,9 +24,9 @@ typedef struct {
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_get_version(libspdm_context_t *spdm_context,
-                                   uint8_t *version_number_entry_count,
-                                   spdm_version_number_t *version_number_entry)
+return_status libspdm_try_get_version(libspdm_context_t *spdm_context,
+                                      uint8_t *version_number_entry_count,
+                                      spdm_version_number_t *version_number_entry)
 {
     return_status status;
     bool result;
@@ -52,15 +52,15 @@ return_status try_spdm_get_version(libspdm_context_t *spdm_context,
     libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
                                                   spdm_request.header.request_response_code);
 
-    status = spdm_send_spdm_request(spdm_context, NULL,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -72,7 +72,7 @@ return_status try_spdm_get_version(libspdm_context_t *spdm_context,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_simple_error_response(
+        status = libspdm_handle_simple_error_response(
             spdm_context, spdm_response.header.param1);
         if (RETURN_ERROR(status)) {
             return status;
@@ -164,9 +164,9 @@ return_status try_spdm_get_version(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_get_version(libspdm_context_t *spdm_context,
-                               uint8_t *version_number_entry_count,
-                               spdm_version_number_t *version_number_entry)
+return_status libspdm_get_version(libspdm_context_t *spdm_context,
+                                  uint8_t *version_number_entry_count,
+                                  spdm_version_number_t *version_number_entry)
 {
     uintn retry;
     return_status status;
@@ -174,8 +174,8 @@ return_status spdm_get_version(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_version(spdm_context,
-                                      version_number_entry_count, version_number_entry);
+        status = libspdm_try_get_version(spdm_context,
+                                         version_number_entry_count, version_number_entry);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -39,16 +39,16 @@ return_status spdm_requester_respond_if_ready(libspdm_context_t *spdm_context,
     spdm_request.header.request_response_code = SPDM_RESPOND_IF_READY;
     spdm_request.header.param1 = spdm_context->error_data.request_code;
     spdm_request.header.param2 = spdm_context->error_data.token;
-    status = spdm_send_spdm_request(spdm_context, session_id,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, session_id,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     *response_size = expected_response_size;
     zero_mem(response, expected_response_size);
-    status = spdm_receive_spdm_response(spdm_context, session_id,
-                                        response_size, response);
+    status = libspdm_receive_spdm_response(spdm_context, session_id,
+                                           response_size, response);
     if (RETURN_ERROR(status)) {
         return status;
     }
@@ -77,8 +77,8 @@ return_status spdm_requester_respond_if_ready(libspdm_context_t *spdm_context,
  * @retval RETURN_NO_RESPONSE           If the error code is BUSY.
  * @retval RETURN_DEVICE_ERROR          If the error code is REQUEST_RESYNCH or others.
  **/
-return_status spdm_handle_simple_error_response(void *context,
-                                                uint8_t error_code)
+return_status libspdm_handle_simple_error_response(void *context,
+                                                   uint8_t error_code)
 {
     libspdm_context_t *spdm_context;
 
@@ -86,7 +86,7 @@ return_status spdm_handle_simple_error_response(void *context,
 
 
     /* NOT_READY is treated as error here.
-     * Use spdm_handle_error_response_main to handle NOT_READY message in long latency command.*/
+     * Use libspdm_handle_error_response_main to handle NOT_READY message in long latency command.*/
 
     if (error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
         return RETURN_DEVICE_ERROR;
@@ -185,7 +185,7 @@ return_status spdm_handle_response_not_ready(libspdm_context_t *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    The error code is DECRYPT_ERROR and session_id is NOT NULL.
  **/
-return_status spdm_handle_error_response_main(
+return_status libspdm_handle_error_response_main(
     libspdm_context_t *spdm_context, const uint32_t *session_id,
     uintn *response_size, void *response,
     uint8_t original_request_code, uint8_t expected_response_code,
@@ -207,7 +207,7 @@ return_status spdm_handle_error_response_main(
                                               expected_response_code,
                                               expected_response_size);
     } else {
-        return spdm_handle_simple_error_response(spdm_context,
-                                                 spdm_response->param1);
+        return libspdm_handle_simple_error_response(spdm_context,
+                                                    spdm_response->param1);
     }
 }

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -64,8 +64,8 @@ return_status try_spdm_heartbeat(void *context, uint32_t session_id)
     spdm_request.header.request_response_code = SPDM_HEARTBEAT;
     spdm_request.header.param1 = 0;
     spdm_request.header.param2 = 0;
-    status = spdm_send_spdm_request(spdm_context, &session_id,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
@@ -75,7 +75,7 @@ return_status try_spdm_heartbeat(void *context, uint32_t session_id)
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -87,7 +87,7 @@ return_status try_spdm_heartbeat(void *context, uint32_t session_id)
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_HEARTBEAT, SPDM_HEARTBEAT_ACK,
             sizeof(spdm_heartbeat_response_mine_t));

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -55,7 +55,7 @@ typedef struct {
  * @retval RETURN_SUCCESS               The KEY_EXCHANGE is sent and the KEY_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_send_receive_key_exchange(
+return_status libspdm_try_send_receive_key_exchange(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t slot_id, uint8_t session_policy, uint32_t *session_id,
     uint8_t *heartbeat_period,
@@ -171,8 +171,8 @@ return_status try_spdm_send_receive_key_exchange(
     ptr += opaque_key_exchange_req_size;
 
     spdm_request_size = (uintn)ptr - (uintn)&spdm_request;
-    status = spdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
-                                    &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
+                                       &spdm_request);
     if (RETURN_ERROR(status)) {
         libspdm_secured_message_dhe_free(
             spdm_context->connection_info.algorithm.dhe_named_group,
@@ -182,7 +182,7 @@ return_status try_spdm_send_receive_key_exchange(
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         libspdm_secured_message_dhe_free(
@@ -203,7 +203,7 @@ return_status try_spdm_send_receive_key_exchange(
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, NULL, &spdm_response_size,
             &spdm_response, SPDM_KEY_EXCHANGE,
             SPDM_KEY_EXCHANGE_RSP,
@@ -510,7 +510,7 @@ return_status try_spdm_send_receive_key_exchange(
  * @retval RETURN_SUCCESS               The KEY_EXCHANGE is sent and the KEY_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_key_exchange(
+return_status libspdm_send_receive_key_exchange(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t slot_id, uint8_t session_policy, uint32_t *session_id,
     uint8_t *heartbeat_period,
@@ -522,7 +522,7 @@ return_status spdm_send_receive_key_exchange(
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_key_exchange(
+        status = libspdm_try_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, NULL, NULL, NULL);
@@ -552,7 +552,7 @@ return_status spdm_send_receive_key_exchange(
  * @retval RETURN_SUCCESS               The KEY_EXCHANGE is sent and the KEY_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_key_exchange_ex(
+return_status libspdm_send_receive_key_exchange_ex(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t slot_id, uint8_t session_policy, uint32_t *session_id,
     uint8_t *heartbeat_period,
@@ -567,7 +567,7 @@ return_status spdm_send_receive_key_exchange_ex(
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_key_exchange(
+        status = libspdm_try_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, requester_random_in,

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -103,15 +103,15 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
             }
         }
 
-        status = spdm_send_spdm_request(spdm_context, &session_id,
-                                        sizeof(spdm_request), &spdm_request);
+        status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                           sizeof(spdm_request), &spdm_request);
         if (RETURN_ERROR(status)) {
             return status;
         }
 
         spdm_response_size = sizeof(spdm_response);
         zero_mem(&spdm_response, sizeof(spdm_response));
-        status = spdm_receive_spdm_response(
+        status = libspdm_receive_spdm_response(
             spdm_context, &session_id, &spdm_response_size, &spdm_response);
 
         if (RETURN_ERROR(status) ||
@@ -134,7 +134,7 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response.header.request_response_code == SPDM_ERROR) {
-            status = spdm_handle_error_response_main(
+            status = libspdm_handle_error_response_main(
                 spdm_context, &session_id,
                 &spdm_response_size, &spdm_response,
                 SPDM_KEY_UPDATE, SPDM_KEY_UPDATE_ACK,
@@ -221,15 +221,15 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
         return RETURN_DEVICE_ERROR;
     }
 
-    status = spdm_send_spdm_request(spdm_context, &session_id,
-                                    sizeof(spdm_request), &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                       sizeof(spdm_request), &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -242,7 +242,7 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_KEY_UPDATE, SPDM_KEY_UPDATE_ACK,

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -25,7 +25,7 @@ typedef struct {
     uint8_t ext_hash_count;
     uint16_t reserved3;
     spdm_negotiate_algorithms_common_struct_table_t struct_table[4];
-} spdm_negotiate_algorithms_request_mine_t;
+} libspdm_negotiate_algorithms_request_mine_t;
 
 typedef struct {
     spdm_message_header_t header;
@@ -53,10 +53,10 @@ typedef struct {
  * @retval RETURN_SUCCESS               The NEGOTIATE_ALGORITHMS is sent and the ALGORITHMS is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
+return_status libspdm_try_negotiate_algorithms(libspdm_context_t *spdm_context)
 {
     return_status status;
-    spdm_negotiate_algorithms_request_mine_t spdm_request;
+    libspdm_negotiate_algorithms_request_mine_t spdm_request;
     spdm_algorithms_response_max_t spdm_response;
     uintn spdm_response_size;
     uint32_t algo_size;
@@ -119,15 +119,15 @@ return_status try_spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
     spdm_request.struct_table[3].alg_supported =
         spdm_context->local_context.algorithm.key_schedule;
 
-    status = spdm_send_spdm_request(spdm_context, NULL, spdm_request.length,
-                                    &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request.length,
+                                       &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -139,7 +139,7 @@ return_status try_spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_simple_error_response(
+        status = libspdm_handle_simple_error_response(
             spdm_context, spdm_response.header.param1);
         if (RETURN_ERROR(status)) {
             return status;
@@ -406,7 +406,7 @@ return_status try_spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
  * @retval RETURN_SUCCESS               The NEGOTIATE_ALGORITHMS is sent and the ALGORITHMS is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
+return_status libspdm_negotiate_algorithms(libspdm_context_t *spdm_context)
 {
     uintn retry;
     return_status status;
@@ -414,7 +414,7 @@ return_status spdm_negotiate_algorithms(libspdm_context_t *spdm_context)
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_negotiate_algorithms(spdm_context);
+        status = libspdm_try_negotiate_algorithms(spdm_context);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -59,7 +59,7 @@ typedef struct {
  * @retval RETURN_SUCCESS               The PSK_EXCHANGE is sent and the PSK_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_send_receive_psk_exchange(
+return_status libspdm_try_send_receive_psk_exchange(
     libspdm_context_t *spdm_context, uint8_t measurement_hash_type,
     uint8_t session_policy,
     uint32_t *session_id, uint8_t *heartbeat_period,
@@ -194,15 +194,15 @@ return_status try_spdm_send_receive_psk_exchange(
     ptr += opaque_psk_exchange_req_size;
 
     spdm_request_size = (uintn)ptr - (uintn)&spdm_request;
-    status = spdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
-                                    &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
+                                       &spdm_request);
     if (RETURN_ERROR(status)) {
         return status;
     }
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, NULL, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         return status;
@@ -214,7 +214,7 @@ return_status try_spdm_send_receive_psk_exchange(
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, NULL, &spdm_response_size,
             &spdm_response, SPDM_PSK_EXCHANGE,
             SPDM_PSK_EXCHANGE_RSP,
@@ -411,12 +411,12 @@ return_status try_spdm_send_receive_psk_exchange(
  * @retval RETURN_SUCCESS               The PSK_EXCHANGE is sent and the PSK_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
-                                             uint8_t measurement_hash_type,
-                                             uint8_t session_policy,
-                                             uint32_t *session_id,
-                                             uint8_t *heartbeat_period,
-                                             void *measurement_hash)
+return_status libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
+                                                uint8_t measurement_hash_type,
+                                                uint8_t session_policy,
+                                                uint32_t *session_id,
+                                                uint8_t *heartbeat_period,
+                                                void *measurement_hash)
 {
     uintn retry;
     return_status status;
@@ -424,7 +424,7 @@ return_status spdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_psk_exchange(
+        status = libspdm_try_send_receive_psk_exchange(
             spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             NULL, 0, NULL, NULL, NULL, NULL);
@@ -460,18 +460,18 @@ return_status spdm_send_receive_psk_exchange(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The PSK_EXCHANGE is sent and the PSK_EXCHANGE_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
-                                                uint8_t measurement_hash_type,
-                                                uint8_t session_policy,
-                                                uint32_t *session_id,
-                                                uint8_t *heartbeat_period,
-                                                void *measurement_hash,
-                                                const void *requester_context_in,
-                                                uintn requester_context_in_size,
-                                                void *requester_context,
-                                                uintn *requester_context_size,
-                                                void *responder_context,
-                                                uintn *responder_context_size)
+return_status libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
+                                                   uint8_t measurement_hash_type,
+                                                   uint8_t session_policy,
+                                                   uint32_t *session_id,
+                                                   uint8_t *heartbeat_period,
+                                                   void *measurement_hash,
+                                                   const void *requester_context_in,
+                                                   uintn requester_context_in_size,
+                                                   void *requester_context,
+                                                   uintn *requester_context_size,
+                                                   void *responder_context,
+                                                   uintn *responder_context_size)
 {
     uintn retry;
     return_status status;
@@ -479,7 +479,7 @@ return_status spdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_psk_exchange(
+        status = libspdm_try_send_receive_psk_exchange(
             spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             requester_context_in, requester_context_in_size,

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -31,8 +31,8 @@ typedef struct {
  * @retval RETURN_SUCCESS               The PSK_FINISH is sent and the PSK_FINISH_RSP is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status try_spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
-                                               uint32_t session_id)
+return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_context,
+                                                  uint32_t session_id)
 {
     return_status status;
     spdm_psk_finish_request_mine_t spdm_request;
@@ -107,8 +107,8 @@ return_status try_spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
         goto error;
     }
 
-    status = spdm_send_spdm_request(spdm_context, &session_id,
-                                    spdm_request_size, &spdm_request);
+    status = libspdm_send_spdm_request(spdm_context, &session_id,
+                                       spdm_request_size, &spdm_request);
     if (RETURN_ERROR(status)) {
         goto error;
     }
@@ -118,7 +118,7 @@ return_status try_spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
 
     spdm_response_size = sizeof(spdm_response);
     zero_mem(&spdm_response, sizeof(spdm_response));
-    status = spdm_receive_spdm_response(
+    status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, &spdm_response);
     if (RETURN_ERROR(status)) {
         goto error;
@@ -136,7 +136,7 @@ return_status try_spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
             status = RETURN_SECURITY_VIOLATION;
             goto error;
         }
-        status = spdm_handle_error_response_main(
+        status = libspdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_PSK_FINISH, SPDM_PSK_FINISH_RSP,
@@ -189,8 +189,8 @@ error:
     return status;
 }
 
-return_status spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
-                                           uint32_t session_id)
+return_status libspdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
+                                              uint32_t session_id)
 {
     uintn retry;
     return_status status;
@@ -198,8 +198,8 @@ return_status spdm_send_receive_psk_finish(libspdm_context_t *spdm_context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_send_receive_psk_finish(spdm_context,
-                                                  session_id);
+        status = libspdm_try_send_receive_psk_finish(spdm_context,
+                                                     session_id);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -34,7 +34,7 @@ return_status libspdm_send_request(void *context, const uint32_t *session_id,
 
     spdm_context = context;
 
-    DEBUG((DEBUG_INFO, "spdm_send_spdm_request[%x] (0x%x): \n",
+    DEBUG((DEBUG_INFO, "libspdm_send_spdm_request[%x] (0x%x): \n",
            (session_id != NULL) ? *session_id : 0x0, request_size));
     libspdm_internal_dump_hex(request, request_size);
 
@@ -53,7 +53,7 @@ return_status libspdm_send_request(void *context, const uint32_t *session_id,
     status = spdm_context->send_message(spdm_context, message_size, message,
                                         timeout);
     if (RETURN_ERROR(status)) {
-        DEBUG((DEBUG_INFO, "spdm_send_spdm_request[%x] status - %p\n",
+        DEBUG((DEBUG_INFO, "libspdm_send_spdm_request[%x] status - %p\n",
                (session_id != NULL) ? *session_id : 0x0, status));
     }
 
@@ -106,7 +106,7 @@ return_status libspdm_receive_response(void *context, const uint32_t *session_id
                                            message, timeout);
     if (RETURN_ERROR(status)) {
         DEBUG((DEBUG_INFO,
-               "spdm_receive_spdm_response[%x] status - %p\n",
+               "libspdm_receive_spdm_response[%x] status - %p\n",
                (session_id != NULL) ? *session_id : 0x0, status));
         return status;
     }
@@ -120,13 +120,13 @@ return_status libspdm_receive_response(void *context, const uint32_t *session_id
     if (session_id != NULL) {
         if (message_session_id == NULL) {
             DEBUG((DEBUG_INFO,
-                   "spdm_receive_spdm_response[%x] GetSessionId - NULL\n",
+                   "libspdm_receive_spdm_response[%x] GetSessionId - NULL\n",
                    (session_id != NULL) ? *session_id : 0x0));
             goto error;
         }
         if (*message_session_id != *session_id) {
             DEBUG((DEBUG_INFO,
-                   "spdm_receive_spdm_response[%x] GetSessionId - %x\n",
+                   "libspdm_receive_spdm_response[%x] GetSessionId - %x\n",
                    (session_id != NULL) ? *session_id : 0x0,
                    *message_session_id));
             goto error;
@@ -134,7 +134,7 @@ return_status libspdm_receive_response(void *context, const uint32_t *session_id
     } else {
         if (message_session_id != NULL) {
             DEBUG((DEBUG_INFO,
-                   "spdm_receive_spdm_response[%x] GetSessionId - %x\n",
+                   "libspdm_receive_spdm_response[%x] GetSessionId - %x\n",
                    (session_id != NULL) ? *session_id : 0x0,
                    *message_session_id));
             goto error;
@@ -144,16 +144,16 @@ return_status libspdm_receive_response(void *context, const uint32_t *session_id
     if ((is_app_message && !is_message_app_message) ||
         (!is_app_message && is_message_app_message)) {
         DEBUG((DEBUG_INFO,
-               "spdm_receive_spdm_response[%x] app_message mismatch\n",
+               "libspdm_receive_spdm_response[%x] app_message mismatch\n",
                (session_id != NULL) ? *session_id : 0x0));
         goto error;
     }
 
-    DEBUG((DEBUG_INFO, "spdm_receive_spdm_response[%x] (0x%x): \n",
+    DEBUG((DEBUG_INFO, "libspdm_receive_spdm_response[%x] (0x%x): \n",
            (session_id != NULL) ? *session_id : 0x0, *response_size));
     if (RETURN_ERROR(status)) {
         DEBUG((DEBUG_INFO,
-               "spdm_receive_spdm_response[%x] status - %p\n",
+               "libspdm_receive_spdm_response[%x] status - %p\n",
                (session_id != NULL) ? *session_id : 0x0, status));
     } else {
         libspdm_internal_dump_hex(response, *response_size);
@@ -183,9 +183,9 @@ error:
  * @retval RETURN_SUCCESS               The SPDM request is sent successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM request is sent to the device.
  **/
-return_status spdm_send_spdm_request(libspdm_context_t *spdm_context,
-                                     const uint32_t *session_id,
-                                     uintn request_size, const void *request)
+return_status libspdm_send_spdm_request(libspdm_context_t *spdm_context,
+                                        const uint32_t *session_id,
+                                        uintn request_size, const void *request)
 {
     libspdm_session_info_t *session_info;
     libspdm_session_state_t session_state;
@@ -233,10 +233,10 @@ return_status spdm_send_spdm_request(libspdm_context_t *spdm_context,
  * @retval RETURN_SUCCESS               The SPDM response is received successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is received from the device.
  **/
-return_status spdm_receive_spdm_response(libspdm_context_t *spdm_context,
-                                         const uint32_t *session_id,
-                                         uintn *response_size,
-                                         void *response)
+return_status libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
+                                            const uint32_t *session_id,
+                                            uintn *response_size,
+                                            void *response)
 {
     libspdm_session_info_t *session_info;
     libspdm_session_state_t session_state;

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -217,11 +217,11 @@ uint32_t spdm_prioritize_algorithm(const uint32_t *priority_table,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_algorithms(void *context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response)
+return_status libspdm_get_response_algorithms(void *context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response)
 {
     const spdm_negotiate_algorithms_request_t *spdm_request;
     uintn spdm_request_size;
@@ -254,7 +254,7 @@ return_status spdm_get_response_algorithms(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -639,8 +639,8 @@ return_status spdm_get_response_algorithms(void *context,
                                                response_size, response);
     }
 
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_NEGOTIATED);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_NEGOTIATED);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -142,11 +142,11 @@ bool spdm_check_request_flag_compability(uint32_t capabilities_flag,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_capabilities(void *context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response)
+return_status libspdm_get_response_capabilities(void *context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response)
 {
     const spdm_get_capabilities_request_t *spdm_request;
     spdm_capabilities_response_t *spdm_response;
@@ -157,7 +157,7 @@ return_status spdm_get_response_capabilities(void *context,
     spdm_request = request;
 
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -267,8 +267,8 @@ return_status spdm_get_response_capabilities(void *context,
         spdm_context->connection_info.capability.data_transfer_size = 0;
         spdm_context->connection_info.capability.max_spdm_msg_size = 0;
     }
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -24,11 +24,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_certificate(void *context,
-                                            uintn request_size,
-                                            const void *request,
-                                            uintn *response_size,
-                                            void *response)
+return_status libspdm_get_response_certificate(void *context,
+                                               uintn request_size,
+                                               const void *request,
+                                               uintn *response_size,
+                                               void *response)
 {
     const spdm_get_certificate_request_t *spdm_request;
     spdm_certificate_response_t *spdm_response;
@@ -49,7 +49,7 @@ return_status spdm_get_response_certificate(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -157,8 +157,8 @@ return_status spdm_get_response_certificate(void *context,
                                                response_size, response);
     }
 
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_AFTER_CERTIFICATE);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_AFTER_CERTIFICATE);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -26,11 +26,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_challenge_auth(void *context,
-                                               uintn request_size,
-                                               const void *request,
-                                               uintn *response_size,
-                                               void *response)
+return_status libspdm_get_response_challenge_auth(void *context,
+                                                  uintn request_size,
+                                                  const void *request,
+                                                  uintn *response_size,
+                                                  void *response)
 {
     const spdm_challenge_request_t *spdm_request;
     spdm_challenge_auth_response_t *spdm_response;
@@ -55,7 +55,7 @@ return_status spdm_get_response_challenge_auth(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -147,7 +147,7 @@ return_status spdm_get_response_challenge_auth(void *context,
             }
         }
         if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ) != 0) {
-            spdm_init_basic_mut_auth_encap_state(context);
+            libspdm_init_basic_mut_auth_encap_state(context);
         }
     }
 
@@ -240,8 +240,8 @@ return_status spdm_get_response_challenge_auth(void *context,
     ptr += signature_size;
 
     if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ) == 0) {
-        spdm_set_connection_state(spdm_context,
-                                  LIBSPDM_CONNECTION_STATE_AUTHENTICATED);
+        libspdm_set_connection_state(spdm_context,
+                                     LIBSPDM_CONNECTION_STATE_AUTHENTICATED);
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -25,10 +25,10 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_digests(void *context, uintn request_size,
-                                        const void *request,
-                                        uintn *response_size,
-                                        void *response)
+return_status libspdm_get_response_digests(void *context, uintn request_size,
+                                           const void *request,
+                                           uintn *response_size,
+                                           void *response)
 {
     const spdm_get_digest_request_t *spdm_request;
     spdm_digest_response_t *spdm_response;
@@ -49,7 +49,7 @@ return_status spdm_get_response_digests(void *context, uintn request_size,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -143,8 +143,8 @@ return_status spdm_get_response_digests(void *context, uintn request_size,
                                                response_size, response);
     }
 
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -21,9 +21,9 @@
  * @retval RETURN_SUCCESS               The encapsulated request is returned.
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
-return_status spdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
-                                               uintn *encap_request_size,
-                                               void *encap_request)
+return_status libspdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
+                                                  uintn *encap_request_size,
+                                                  void *encap_request)
 {
     spdm_challenge_request_t *spdm_request;
     return_status status;
@@ -86,7 +86,7 @@ return_status spdm_get_encap_request_challenge(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_challenge_auth(
+return_status libspdm_process_encap_response_challenge_auth(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue)
 {
@@ -119,7 +119,7 @@ return_status spdm_process_encap_response_challenge_auth(
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_encap_error_response_main(
+        status = libspdm_handle_encap_error_response_main(
             spdm_context,
             spdm_response->header.param1);
         if (RETURN_ERROR(status)) {
@@ -232,8 +232,8 @@ return_status spdm_process_encap_response_challenge_auth(
     }
 
     spdm_context->encap_context.error_state = LIBSPDM_STATUS_SUCCESS;
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_AUTHENTICATED);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_AUTHENTICATED);
 
     *need_continue = false;
 

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -22,9 +22,9 @@
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
-                                       uintn *encap_request_size,
-                                       void *encap_request)
+libspdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
+                                          uintn *encap_request_size,
+                                          void *encap_request)
 {
     spdm_get_certificate_request_t *spdm_request;
     return_status status;
@@ -85,7 +85,7 @@ spdm_get_encap_request_get_certificate(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_certificate(
+return_status libspdm_process_encap_response_certificate(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue)
 {
@@ -108,7 +108,7 @@ return_status spdm_process_encap_response_certificate(
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_encap_error_response_main(
+        status = libspdm_handle_encap_error_response_main(
             spdm_context,
             spdm_response->header.param1);
         if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_digests.c
@@ -22,9 +22,9 @@
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
-                                  uintn *encap_request_size,
-                                  void *encap_request)
+libspdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
+                                     uintn *encap_request_size,
+                                     void *encap_request)
 {
     spdm_get_digest_request_t *spdm_request;
     return_status status;
@@ -80,7 +80,7 @@ spdm_get_encap_request_get_digest(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_digest(
+return_status libspdm_process_encap_response_digest(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue)
 {
@@ -103,7 +103,7 @@ return_status spdm_process_encap_response_digest(
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
-        status = spdm_handle_encap_error_response_main(
+        status = libspdm_handle_encap_error_response_main(
             spdm_context,
             spdm_response->header.param1);
         if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -20,9 +20,9 @@
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 return_status
-spdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
-                                  uintn *encap_request_size,
-                                  void *encap_request)
+libspdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
+                                     uintn *encap_request_size,
+                                     void *encap_request)
 {
     spdm_key_update_request_t *spdm_request;
     uint32_t session_id;
@@ -125,7 +125,7 @@ spdm_get_encap_request_key_update(libspdm_context_t *spdm_context,
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_process_encap_response_key_update(
+return_status libspdm_process_encap_response_key_update(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue)
 {

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -47,20 +47,20 @@ typedef struct {
 
 spdm_encap_response_struct_t m_encap_response_struct[] = {
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-    { SPDM_GET_DIGESTS, spdm_get_encap_request_get_digest,
-      spdm_process_encap_response_digest },
+    { SPDM_GET_DIGESTS, libspdm_get_encap_request_get_digest,
+      libspdm_process_encap_response_digest },
 
-    { SPDM_GET_CERTIFICATE, spdm_get_encap_request_get_certificate,
-      spdm_process_encap_response_certificate },
+    { SPDM_GET_CERTIFICATE, libspdm_get_encap_request_get_certificate,
+      libspdm_process_encap_response_certificate },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-    { SPDM_CHALLENGE, spdm_get_encap_request_challenge,
-      spdm_process_encap_response_challenge_auth },
+    { SPDM_CHALLENGE, libspdm_get_encap_request_challenge,
+      libspdm_process_encap_response_challenge_auth },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
-    { SPDM_KEY_UPDATE, spdm_get_encap_request_key_update,
-      spdm_process_encap_response_key_update },
+    { SPDM_KEY_UPDATE, libspdm_get_encap_request_key_update,
+      libspdm_process_encap_response_key_update },
 };
 
 spdm_encap_response_struct_t *
@@ -182,8 +182,8 @@ return_status spdm_process_encapsulated_response(
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  mut_auth_requested             Indicate of the mut_auth_requested through KEY_EXCHANGE or CHALLENG response.
  **/
-void spdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context,
-                                    uint8_t mut_auth_requested)
+void libspdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context,
+                                       uint8_t mut_auth_requested)
 {
     spdm_context->encap_context.error_state = 0;
     spdm_context->encap_context.current_request_op_code = 0x00;
@@ -240,7 +240,7 @@ void spdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context,
  *
  * @param  spdm_context                  A pointer to the SPDM context.
  **/
-void spdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context)
+void libspdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context)
 {
     spdm_context->encap_context.error_state = 0;
     spdm_context->encap_context.current_request_op_code = 0x00;
@@ -337,7 +337,7 @@ void libspdm_init_key_update_encap_state(void *context)
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_encapsulated_request(
+return_status libspdm_get_response_encapsulated_request(
     void *context, uintn request_size, const void *request,
     uintn *response_size, void *response)
 {
@@ -368,7 +368,7 @@ return_status spdm_get_response_encapsulated_request(
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
         }
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -432,7 +432,7 @@ return_status spdm_get_response_encapsulated_request(
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_encapsulated_response_ack(
+return_status libspdm_get_response_encapsulated_response_ack(
     void *context, uintn request_size, const void *request,
     uintn *response_size, void *response)
 {
@@ -468,7 +468,7 @@ return_status spdm_get_response_encapsulated_response_ack(
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
         }
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -564,7 +564,7 @@ return_status spdm_get_response_encapsulated_response_ack(
  *
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_handle_encap_error_response_main(
+return_status libspdm_handle_encap_error_response_main(
     libspdm_context_t *spdm_context, uint8_t error_code)
 {
 

--- a/library/spdm_responder_lib/libspdm_rsp_end_session.c
+++ b/library/spdm_responder_lib/libspdm_rsp_end_session.c
@@ -23,11 +23,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_end_session(void *context,
-                                            uintn request_size,
-                                            const void *request,
-                                            uintn *response_size,
-                                            void *response)
+return_status libspdm_get_response_end_session(void *context,
+                                               uintn request_size,
+                                               const void *request,
+                                               uintn *response_size,
+                                               void *response)
 {
     spdm_end_session_response_t *spdm_response;
     const spdm_end_session_request_t *spdm_request;
@@ -44,7 +44,7 @@ return_status spdm_get_response_end_session(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -26,10 +26,10 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_finish(void *context, uintn request_size,
-                                       const void *request,
-                                       uintn *response_size,
-                                       void *response)
+return_status libspdm_get_response_finish(void *context, uintn request_size,
+                                          const void *request,
+                                          uintn *response_size,
+                                          void *response)
 {
     uint32_t session_id;
     bool result;
@@ -53,7 +53,7 @@ return_status spdm_get_response_finish(void *context, uintn request_size,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -22,10 +22,10 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_responder_handle_response_state(void *context,
-                                                   uint8_t request_code,
-                                                   uintn *response_size,
-                                                   void *response)
+return_status libspdm_responder_handle_response_state(void *context,
+                                                      uint8_t request_code,
+                                                      uintn *response_size,
+                                                      void *response)
 {
     libspdm_context_t *spdm_context;
     return_status status;
@@ -44,8 +44,8 @@ return_status spdm_responder_handle_response_state(void *context,
             return status;
         }
         /* NOTE: Need to let SPDM_VERSION reset the State*/
-        spdm_set_connection_state(spdm_context,
-                                  LIBSPDM_CONNECTION_STATE_NOT_STARTED);
+        libspdm_set_connection_state(spdm_context,
+                                     LIBSPDM_CONNECTION_STATE_NOT_STARTED);
         return RETURN_SUCCESS;
     case LIBSPDM_RESPONSE_STATE_NOT_READY:
         /*do not update ErrorData if a previous request has not been completed*/

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -23,11 +23,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_heartbeat(void *context,
-                                          uintn request_size,
-                                          const void *request,
-                                          uintn *response_size,
-                                          void *response)
+return_status libspdm_get_response_heartbeat(void *context,
+                                             uintn request_size,
+                                             const void *request,
+                                             uintn *response_size,
+                                             void *response)
 {
     spdm_heartbeat_response_t *spdm_response;
     const spdm_heartbeat_request_t *spdm_request;
@@ -44,7 +44,7 @@ return_status spdm_get_response_heartbeat(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -25,11 +25,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_key_exchange(void *context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response)
+return_status libspdm_get_response_key_exchange(void *context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response)
 {
     const spdm_key_exchange_request_t *spdm_request;
     spdm_key_exchange_response_t *spdm_response;
@@ -61,7 +61,7 @@ return_status spdm_get_response_key_exchange(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -88,7 +88,7 @@ return_status spdm_get_response_key_exchange(void *context,
         if (spdm_context->encap_context.error_state !=
             LIBSPDM_STATUS_SUCCESS) {
             DEBUG((DEBUG_INFO,
-                   "spdm_get_response_key_exchange fail due to Mutual Auth fail\n"));
+                   "libspdm_get_response_key_exchange fail due to Mutual Auth fail\n"));
             return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
@@ -216,7 +216,7 @@ return_status spdm_get_response_key_exchange(void *context,
             spdm_context->local_context.mut_auth_requested;
     }
     if (spdm_response->mut_auth_requested != 0) {
-        spdm_init_mut_auth_encap_state(
+        libspdm_init_mut_auth_encap_state(
             context, spdm_response->mut_auth_requested);
         spdm_response->req_slot_id_param =
             (spdm_context->encap_context.req_slot_id & 0xF);
@@ -389,8 +389,8 @@ return_status spdm_get_response_key_exchange(void *context,
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
         session_info->session_policy = spdm_request->session_policy;
     }
-    spdm_set_session_state(spdm_context, session_id,
-                           LIBSPDM_SESSION_STATE_HANDSHAKING);
+    libspdm_set_session_state(spdm_context, session_id,
+                              LIBSPDM_SESSION_STATE_HANDSHAKING);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -23,11 +23,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_key_update(void *context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response)
+return_status libspdm_get_response_key_update(void *context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response)
 {
     uint32_t session_id;
     spdm_key_update_response_t *spdm_response;
@@ -47,7 +47,7 @@ return_status spdm_get_response_key_update(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -127,11 +127,11 @@ bool spdm_create_measurement_opaque(libspdm_context_t *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_measurements(void *context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response)
+return_status libspdm_get_response_measurements(void *context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response)
 {
     uint8_t index;
     const spdm_get_measurements_request_t *spdm_request;
@@ -162,7 +162,7 @@ return_status spdm_get_response_measurements(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -25,11 +25,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_psk_exchange(void *context,
-                                             uintn request_size,
-                                             const void *request,
-                                             uintn *response_size,
-                                             void *response)
+return_status libspdm_get_response_psk_exchange(void *context,
+                                                uintn request_size,
+                                                const void *request,
+                                                uintn *response_size,
+                                                void *response)
 {
     const spdm_psk_exchange_request_t *spdm_request;
     spdm_psk_exchange_response_t *spdm_response;
@@ -60,7 +60,7 @@ return_status spdm_get_response_psk_exchange(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -131,7 +131,7 @@ return_status spdm_get_response_psk_exchange(void *context,
         if (spdm_context->encap_context.error_state !=
             LIBSPDM_STATUS_SUCCESS) {
             DEBUG((DEBUG_INFO,
-                   "spdm_get_response_psk_exchange fail due to Mutual Auth fail\n"));
+                   "libspdm_get_response_psk_exchange fail due to Mutual Auth fail\n"));
             return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);
@@ -332,8 +332,8 @@ return_status spdm_get_response_psk_exchange(void *context,
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
         session_info->session_policy = spdm_request->header.param2;
     }
-    spdm_set_session_state(spdm_context, session_id,
-                           LIBSPDM_SESSION_STATE_HANDSHAKING);
+    libspdm_set_session_state(spdm_context, session_id,
+                              LIBSPDM_SESSION_STATE_HANDSHAKING);
 
     if (!libspdm_is_capabilities_flag_supported(
             spdm_context, false, 0,
@@ -357,8 +357,8 @@ return_status spdm_get_response_psk_exchange(void *context,
                 0, response_size, response);
         }
 
-        spdm_set_session_state(spdm_context, session_id,
-                               LIBSPDM_SESSION_STATE_ESTABLISHED);
+        libspdm_set_session_state(spdm_context, session_id,
+                                  LIBSPDM_SESSION_STATE_ESTABLISHED);
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -24,11 +24,11 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_psk_finish(void *context,
-                                           uintn request_size,
-                                           const void *request,
-                                           uintn *response_size,
-                                           void *response)
+return_status libspdm_get_response_psk_finish(void *context,
+                                              uintn request_size,
+                                              const void *request,
+                                              uintn *response_size,
+                                              void *response)
 {
     uint32_t session_id;
     bool result;
@@ -50,7 +50,7 @@ return_status spdm_get_response_psk_finish(void *context,
                                                response_size, response);
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -9,56 +9,56 @@
 
 typedef struct {
     uint8_t request_response_code;
-    spdm_get_spdm_response_func get_response_func;
+    libspdm_get_spdm_response_func get_response_func;
 } spdm_get_response_struct_t;
 
 spdm_get_response_struct_t mSpdmGetResponseStruct[] = {
-    { SPDM_GET_VERSION, spdm_get_response_version },
-    { SPDM_GET_CAPABILITIES, spdm_get_response_capabilities },
-    { SPDM_NEGOTIATE_ALGORITHMS, spdm_get_response_algorithms },
+    { SPDM_GET_VERSION, libspdm_get_response_version },
+    { SPDM_GET_CAPABILITIES, libspdm_get_response_capabilities },
+    { SPDM_NEGOTIATE_ALGORITHMS, libspdm_get_response_algorithms },
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-    { SPDM_GET_DIGESTS, spdm_get_response_digests },
-    { SPDM_GET_CERTIFICATE, spdm_get_response_certificate },
+    { SPDM_GET_DIGESTS, libspdm_get_response_digests },
+    { SPDM_GET_CERTIFICATE, libspdm_get_response_certificate },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-    { SPDM_CHALLENGE, spdm_get_response_challenge_auth },
+    { SPDM_CHALLENGE, libspdm_get_response_challenge_auth },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
-    { SPDM_GET_MEASUREMENTS, spdm_get_response_measurements },
+    { SPDM_GET_MEASUREMENTS, libspdm_get_response_measurements },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-    { SPDM_KEY_EXCHANGE, spdm_get_response_key_exchange },
+    { SPDM_KEY_EXCHANGE, libspdm_get_response_key_exchange },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-    { SPDM_PSK_EXCHANGE, spdm_get_response_psk_exchange },
+    { SPDM_PSK_EXCHANGE, libspdm_get_response_psk_exchange },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
     { SPDM_GET_ENCAPSULATED_REQUEST,
-      spdm_get_response_encapsulated_request },
+      libspdm_get_response_encapsulated_request },
     { SPDM_DELIVER_ENCAPSULATED_RESPONSE,
-      spdm_get_response_encapsulated_response_ack },
+      libspdm_get_response_encapsulated_response_ack },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
-    { SPDM_RESPOND_IF_READY, spdm_get_response_respond_if_ready },
+    { SPDM_RESPOND_IF_READY, libspdm_get_response_respond_if_ready },
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-    { SPDM_FINISH, spdm_get_response_finish },
+    { SPDM_FINISH, libspdm_get_response_finish },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-    { SPDM_PSK_FINISH, spdm_get_response_psk_finish },
+    { SPDM_PSK_FINISH, libspdm_get_response_psk_finish },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-    { SPDM_END_SESSION, spdm_get_response_end_session },
-    { SPDM_HEARTBEAT, spdm_get_response_heartbeat },
-    { SPDM_KEY_UPDATE, spdm_get_response_key_update },
+    { SPDM_END_SESSION, libspdm_get_response_end_session },
+    { SPDM_HEARTBEAT, libspdm_get_response_heartbeat },
+    { SPDM_KEY_UPDATE, libspdm_get_response_key_update },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 };
 
@@ -69,8 +69,8 @@ spdm_get_response_struct_t mSpdmGetResponseStruct[] = {
  *
  * @return GET_SPDM_RESPONSE function according to the request code.
  **/
-spdm_get_spdm_response_func
-spdm_get_response_func_via_request_code(uint8_t request_code)
+libspdm_get_spdm_response_func
+libspdm_get_response_func_via_request_code(uint8_t request_code)
 {
     uintn index;
 
@@ -93,13 +93,13 @@ spdm_get_response_func_via_request_code(uint8_t request_code)
  *
  * @return GET_SPDM_RESPONSE function according to the last request.
  **/
-spdm_get_spdm_response_func
+libspdm_get_spdm_response_func
 spdm_get_response_func_via_last_request(libspdm_context_t *spdm_context)
 {
     spdm_message_header_t *spdm_request;
 
     spdm_request = (void *)spdm_context->last_spdm_request;
-    return spdm_get_response_func_via_request_code(
+    return libspdm_get_response_func_via_request_code(
         spdm_request->request_response_code);
 }
 
@@ -222,9 +222,9 @@ void spdm_trigger_session_state_callback(libspdm_context_t *spdm_context,
  * @param  session_id                    Indicate the SPDM session ID.
  * @param  session_state                 Indicate the SPDM session state.
  */
-void spdm_set_session_state(libspdm_context_t *spdm_context,
-                            uint32_t session_id,
-                            libspdm_session_state_t session_state)
+void libspdm_set_session_state(libspdm_context_t *spdm_context,
+                               uint32_t session_id,
+                               libspdm_session_state_t session_state)
 {
     libspdm_session_info_t *session_info;
     libspdm_session_state_t old_session_state;
@@ -274,8 +274,8 @@ void spdm_trigger_connection_state_callback(libspdm_context_t *spdm_context,
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  connection_state              Indicate the SPDM connection state.
  */
-void spdm_set_connection_state(libspdm_context_t *spdm_context,
-                               libspdm_connection_state_t connection_state)
+void libspdm_set_connection_state(libspdm_context_t *spdm_context,
+                                  libspdm_connection_state_t connection_state)
 {
     if (spdm_context->connection_info.connection_state !=
         connection_state) {
@@ -313,7 +313,7 @@ return_status libspdm_build_response(void *context, const uint32_t *session_id,
     uint8_t my_response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uintn my_response_size;
     return_status status;
-    spdm_get_spdm_response_func get_response_func;
+    libspdm_get_spdm_response_func get_response_func;
     libspdm_session_info_t *session_info;
     spdm_message_header_t *spdm_request;
     spdm_message_header_t *spdm_response;
@@ -484,18 +484,18 @@ return_status libspdm_build_response(void *context, const uint32_t *session_id,
                     spdm_context, false,
                     SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
                     SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)) {
-                spdm_set_session_state(
+                libspdm_set_session_state(
                     spdm_context, *session_id,
                     LIBSPDM_SESSION_STATE_ESTABLISHED);
             }
             break;
         case SPDM_PSK_FINISH_RSP:
-            spdm_set_session_state(spdm_context, *session_id,
-                                   LIBSPDM_SESSION_STATE_ESTABLISHED);
+            libspdm_set_session_state(spdm_context, *session_id,
+                                      LIBSPDM_SESSION_STATE_ESTABLISHED);
             break;
         case SPDM_END_SESSION_ACK:
-            spdm_set_session_state(spdm_context, *session_id,
-                                   LIBSPDM_SESSION_STATE_NOT_STARTED);
+            libspdm_set_session_state(spdm_context, *session_id,
+                                      LIBSPDM_SESSION_STATE_NOT_STARTED);
             result = libspdm_stop_watchdog(*session_id);
             if (!result) {
                 return RETURN_DEVICE_ERROR;
@@ -517,7 +517,7 @@ return_status libspdm_build_response(void *context, const uint32_t *session_id,
                     spdm_context, false,
                     SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
                     SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)) {
-                spdm_set_session_state(
+                libspdm_set_session_state(
                     spdm_context,
                     spdm_context->latest_session_id,
                     LIBSPDM_SESSION_STATE_ESTABLISHED);

--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -23,15 +23,15 @@
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_respond_if_ready(void *context,
-                                                 uintn request_size,
-                                                 const void *request,
-                                                 uintn *response_size,
-                                                 void *response)
+return_status libspdm_get_response_respond_if_ready(void *context,
+                                                    uintn request_size,
+                                                    const void *request,
+                                                    uintn *response_size,
+                                                    void *response)
 {
     const spdm_message_header_t *spdm_request;
     libspdm_context_t *spdm_context;
-    spdm_get_spdm_response_func get_response_func;
+    libspdm_get_spdm_response_func get_response_func;
     return_status status;
 
     spdm_context = context;
@@ -44,7 +44,7 @@ return_status spdm_get_response_respond_if_ready(void *context,
     }
     if (spdm_context->response_state == LIBSPDM_RESPONSE_STATE_NEED_RESYNC ||
         spdm_context->response_state == LIBSPDM_RESPONSE_STATE_NOT_READY) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context, spdm_request->request_response_code,
             response_size, response);
     }
@@ -73,7 +73,7 @@ return_status spdm_get_response_respond_if_ready(void *context,
 
     get_response_func = NULL;
     get_response_func =
-        spdm_get_response_func_via_request_code(spdm_request->param1);
+        libspdm_get_response_func_via_request_code(spdm_request->param1);
     if (get_response_func == NULL) {
         return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -32,10 +32,10 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status spdm_get_response_version(void *context, uintn request_size,
-                                        const void *request,
-                                        uintn *response_size,
-                                        void *response)
+return_status libspdm_get_response_version(void *context, uintn request_size,
+                                           const void *request,
+                                           uintn *response_size,
+                                           void *response)
 {
     const spdm_get_version_request_t *spdm_request;
     spdm_version_response_mine_t *spdm_response;
@@ -57,8 +57,8 @@ return_status spdm_get_response_version(void *context, uintn request_size,
                                                response_size, response);
     }
 
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_NOT_STARTED);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_NOT_STARTED);
 
     if ((spdm_context->response_state == LIBSPDM_RESPONSE_STATE_NEED_RESYNC) ||
         (spdm_context->response_state ==
@@ -67,7 +67,7 @@ return_status spdm_get_response_version(void *context, uintn request_size,
         spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     }
     if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
-        return spdm_responder_handle_response_state(
+        return libspdm_responder_handle_response_state(
             spdm_context,
             spdm_request->header.request_response_code,
             response_size, response);
@@ -123,8 +123,8 @@ return_status spdm_get_response_version(void *context, uintn request_size,
                                                response_size, response);
     }
 
-    spdm_set_connection_state(spdm_context,
-                              LIBSPDM_CONNECTION_STATE_AFTER_VERSION);
+    libspdm_set_connection_state(spdm_context,
+                                 LIBSPDM_CONNECTION_STATE_AFTER_VERSION);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -13,7 +13,7 @@
  **/
 uintn libspdm_secured_message_get_context_size(void)
 {
-    return sizeof(spdm_secured_message_context_t);
+    return sizeof(libspdm_secured_message_context_t);
 }
 
 /**
@@ -25,11 +25,11 @@ uintn libspdm_secured_message_get_context_size(void)
  */
 void libspdm_secured_message_init_context(void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     zero_mem(secured_message_context,
-             sizeof(spdm_secured_message_context_t));
+             sizeof(libspdm_secured_message_context_t));
 }
 
 /**
@@ -41,7 +41,7 @@ void libspdm_secured_message_init_context(void *spdm_secured_message_context)
 void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context,
                                          bool use_psk)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->use_psk = use_psk;
@@ -58,7 +58,7 @@ void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context,
 bool
 libspdm_secured_message_is_finished_key_ready(void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return secured_message_context->finished_key_ready;
@@ -74,7 +74,7 @@ void libspdm_secured_message_set_session_state(
     void *spdm_secured_message_context,
     libspdm_session_state_t session_state)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->session_state = session_state;
@@ -95,7 +95,7 @@ void libspdm_secured_message_set_session_state(
 libspdm_session_state_t
 libspdm_secured_message_get_session_state(void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return secured_message_context->session_state;
@@ -110,7 +110,7 @@ libspdm_secured_message_get_session_state(void *spdm_secured_message_context)
 void libspdm_secured_message_set_session_type(void *spdm_secured_message_context,
                                               libspdm_session_type_t session_type)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->session_type = session_type;
@@ -133,7 +133,7 @@ void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
                                             uint16_t aead_cipher_suite,
                                             uint16_t key_schedule)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->version = version;
@@ -166,7 +166,7 @@ void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
                                           const void *psk_hint,
                                           uintn psk_hint_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->psk_hint = psk_hint;
@@ -187,7 +187,7 @@ libspdm_secured_message_import_dhe_secret(void *spdm_secured_message_context,
                                           const void *dhe_secret,
                                           uintn dhe_secret_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     if (dhe_secret_size > secured_message_context->dhe_key_size) {
@@ -213,7 +213,7 @@ return_status libspdm_secured_message_export_master_secret(
     void *spdm_secured_message_context, void *export_master_secret,
     uintn *export_master_secret_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     if (*export_master_secret_size < secured_message_context->hash_size) {
@@ -241,7 +241,7 @@ libspdm_secured_message_export_session_keys(void *spdm_secured_message_context,
                                             void *SessionKeys,
                                             uintn *SessionKeysSize)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn struct_size;
     libspdm_secure_session_keys_struct_t *session_keys_struct;
     uint8_t *ptr;
@@ -312,7 +312,7 @@ spdm_secured_message_import_session_keys(void *spdm_secured_message_context,
                                          const void *SessionKeys,
                                          uintn SessionKeysSize)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn struct_size;
     const libspdm_secure_session_keys_struct_t *session_keys_struct;
     uint8_t *ptr;
@@ -385,7 +385,7 @@ void libspdm_secured_message_get_last_spdm_error_struct(
     void *spdm_secured_message_context,
     libspdm_error_struct_t *last_spdm_error)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     copy_mem(last_spdm_error, sizeof(libspdm_error_struct_t),
@@ -403,7 +403,7 @@ void libspdm_secured_message_set_last_spdm_error_struct(
     void *spdm_secured_message_context,
     const libspdm_error_struct_t *last_spdm_error)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     copy_mem(&secured_message_context->last_spdm_error,

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -28,7 +28,7 @@ return_status libspdm_encode_secured_message(
     void *secured_message,
     const libspdm_secured_message_callbacks_t *spdm_secured_message_callbacks)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn total_secured_message_size;
     uintn plain_text_size;
     uintn cipher_text_size;
@@ -318,7 +318,7 @@ return_status libspdm_decode_secured_message(
     void *app_message,
     const libspdm_secured_message_callbacks_t *spdm_secured_message_callbacks)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn plain_text_size;
     uintn cipher_text_size;
     uintn aead_tag_size;

--- a/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
@@ -87,7 +87,7 @@ bool libspdm_secured_message_dhe_compute_key(
     const uint8_t *peer_public, uintn peer_public_size,
     void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uint8_t final_key[LIBSPDM_MAX_DHE_KEY_SIZE];
     uintn final_key_size;
     bool ret;

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -95,7 +95,7 @@ return_status libspdm_bin_concat(const char *label, uintn label_size,
  * @retval RETURN_SUCCESS  SPDM AEAD key and IV for a session is generated.
  **/
 return_status spdm_generate_aead_key_and_iv(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     const uint8_t *major_secret, uint8_t *key, uint8_t *iv)
 {
     return_status status;
@@ -155,7 +155,7 @@ return_status spdm_generate_aead_key_and_iv(
  * @retval RETURN_SUCCESS  SPDM finished_key for a session is generated.
  **/
 return_status spdm_generate_finished_key(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     const uint8_t *handshake_secret, uint8_t *finished_key)
 {
     return_status status;
@@ -205,7 +205,7 @@ libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
     uintn bin_str1_size;
     uint8_t bin_str2[128];
     uintn bin_str2_size;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
 
@@ -388,7 +388,7 @@ libspdm_generate_session_data_key(void *spdm_secured_message_context,
     uintn bin_str4_size;
     uint8_t bin_str8[128];
     uintn bin_str8_size;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
 
@@ -575,7 +575,7 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
     uintn hash_size;
     uint8_t bin_str9[128];
     uintn bin_str9_size;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
 
@@ -728,14 +728,14 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
  **/
 void libspdm_clear_handshake_secret(void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
 
     zero_mem(secured_message_context->master_secret.handshake_secret,
              LIBSPDM_MAX_HASH_SIZE);
     zero_mem(&(secured_message_context->handshake_secret),
-             sizeof(spdm_session_info_struct_handshake_secret_t));
+             sizeof(libspdm_session_info_struct_handshake_secret_t));
 
     secured_message_context->requester_backup_valid = false;
     secured_message_context->responder_backup_valid = false;
@@ -755,7 +755,7 @@ libspdm_activate_update_session_data_key(void *spdm_secured_message_context,
                                          libspdm_key_update_action_t action,
                                          bool use_new_key)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
 
@@ -867,7 +867,7 @@ void *
 libspdm_hmac_new_with_request_finished_key(
     void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_new(secured_message_context->base_hash_algo);
@@ -882,7 +882,7 @@ libspdm_hmac_new_with_request_finished_key(
 void libspdm_hmac_free_with_request_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     libspdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
@@ -901,7 +901,7 @@ void libspdm_hmac_free_with_request_finished_key(
 bool libspdm_hmac_init_with_request_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_init(
@@ -924,7 +924,7 @@ bool libspdm_hmac_duplicate_with_request_finished_key(
     void *spdm_secured_message_context,
     const void *hmac_ctx, void *new_hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_duplicate(
@@ -948,7 +948,7 @@ bool libspdm_hmac_update_with_request_finished_key(
     void *hmac_ctx, const void *data,
     uintn data_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_update(
@@ -970,7 +970,7 @@ bool libspdm_hmac_final_with_request_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx,  uint8_t *hmac_value)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_final(
@@ -994,7 +994,7 @@ libspdm_hmac_all_with_request_finished_key(void *spdm_secured_message_context,
                                            const void *data, uintn data_size,
                                            uint8_t *hmac_value)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_all(
@@ -1014,7 +1014,7 @@ void *
 libspdm_hmac_new_with_response_finished_key(
     void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_new(secured_message_context->base_hash_algo);
@@ -1029,7 +1029,7 @@ libspdm_hmac_new_with_response_finished_key(
 void libspdm_hmac_free_with_response_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     libspdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
@@ -1048,7 +1048,7 @@ void libspdm_hmac_free_with_response_finished_key(
 bool libspdm_hmac_init_with_response_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_init(
@@ -1071,7 +1071,7 @@ bool libspdm_hmac_duplicate_with_response_finished_key(
     void *spdm_secured_message_context,
     const void *hmac_ctx, void *new_hmac_ctx)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_duplicate(
@@ -1095,7 +1095,7 @@ bool libspdm_hmac_update_with_response_finished_key(
     void *hmac_ctx, const void *data,
     uintn data_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_update(
@@ -1117,7 +1117,7 @@ bool libspdm_hmac_final_with_response_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx,  uint8_t *hmac_value)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_final(
@@ -1140,7 +1140,7 @@ bool libspdm_hmac_all_with_response_finished_key(
     void *spdm_secured_message_context, const void *data,
     uintn data_size, uint8_t *hmac_value)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     return libspdm_hmac_all(

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -94,7 +94,7 @@ return_status spdm_device_send_message(void *spdm_context, uintn request_size,
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_challenge_case1(void **State)
+void libspdm_test_requester_challenge_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -133,7 +133,7 @@ void test_spdm_requester_challenge_case1(void **State)
     free(data);
 }
 
-void test_spdm_requester_challenge_ex_case1(void **State)
+void libspdm_test_requester_challenge_ex_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -193,11 +193,11 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_challenge_case1(&State);
+    libspdm_test_requester_challenge_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_challenge_ex_case1(&State);
+    libspdm_test_requester_challenge_ex_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
@@ -16,7 +16,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_requester_encap_certificate(void **State)
+void libspdm_test_requester_encap_certificate(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -49,10 +49,10 @@ void test_spdm_requester_encap_certificate(void **State)
     }
 
     response_size = sizeof(response);
-    spdm_get_encap_response_certificate(spdm_context, request_size,
-                                        (uint8_t *)spdm_test_context->test_buffer +
-                                        test_message_header_size,
-                                        &response_size, response);
+    libspdm_get_encap_response_certificate(spdm_context, request_size,
+                                           (uint8_t *)spdm_test_context->test_buffer +
+                                           test_message_header_size,
+                                           &response_size, response);
     free(data);
 }
 
@@ -72,7 +72,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_encap_certificate(&State);
+    libspdm_test_requester_encap_certificate(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_challenge_auth/encap_challenge_auth.c
@@ -16,7 +16,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_requester_encap_challenge(void **State)
+void libspdm_test_requester_encap_challenge(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -59,10 +59,10 @@ void test_spdm_requester_encap_challenge(void **State)
     }
 
     response_size = sizeof(response);
-    spdm_get_encap_response_challenge_auth(spdm_context, request_size,
-                                           (uint8_t *)spdm_test_context->test_buffer +
-                                           test_message_header_size,
-                                           &response_size, response);
+    libspdm_get_encap_response_challenge_auth(spdm_context, request_size,
+                                              (uint8_t *)spdm_test_context->test_buffer +
+                                              test_message_header_size,
+                                              &response_size, response);
     free(data);
     libspdm_reset_message_mut_c(spdm_context);
 }
@@ -83,7 +83,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_encap_challenge(&State);
+    libspdm_test_requester_encap_challenge(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/encap_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/encap_digests.c
@@ -16,7 +16,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_requester_encap_digests(void **State)
+void libspdm_test_requester_encap_digests(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -44,10 +44,10 @@ void test_spdm_requester_encap_digests(void **State)
     }
 
     response_size = sizeof(response);
-    spdm_get_encap_response_digest(spdm_context, request_size,
-                                   (uint8_t *)spdm_test_context->test_buffer +
-                                   test_message_header_size,
-                                   &response_size, response);
+    libspdm_get_encap_response_digest(spdm_context, request_size,
+                                      (uint8_t *)spdm_test_context->test_buffer +
+                                      test_message_header_size,
+                                      &response_size, response);
 }
 
 spdm_test_context_t m_spdm_requester_encap_digests_test_context = {
@@ -66,7 +66,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_encap_digests(&State);
+    libspdm_test_requester_encap_digests(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_key_update/encap_key_update.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_key_update/encap_key_update.c
@@ -44,7 +44,7 @@ static void spdm_set_standard_key_update_test_state(libspdm_context_t *spdm_cont
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill, uint8_t *m_req_secret_buffer,
     uint8_t req_secret_fill)
 {
@@ -100,13 +100,13 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_requester_encap_key_update(void **State)
+void libspdm_test_requester_encap_key_update(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn request_size;
     uintn response_size;
     uint8_t test_message_header_size;
@@ -136,10 +136,10 @@ void test_spdm_requester_encap_key_update(void **State)
     }
 
     response_size = sizeof(response);
-    spdm_get_encap_response_key_update(spdm_context, request_size,
-                                       (uint8_t *)spdm_test_context->test_buffer +
-                                       test_message_header_size,
-                                       &response_size, response);
+    libspdm_get_encap_response_key_update(spdm_context, request_size,
+                                          (uint8_t *)spdm_test_context->test_buffer +
+                                          test_message_header_size,
+                                          &response_size, response);
 }
 
 spdm_test_context_t m_spdm_requester_encap_key_update_test_context = {
@@ -158,6 +158,6 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_encap_key_update(&State);
+    libspdm_test_requester_encap_key_update(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_request/encap_request.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_request/encap_request.c
@@ -83,7 +83,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
         return RETURN_DEVICE_ERROR;
     }
     /* WALKAROUND: If just use single context to encode message and then decode message */
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
 
     sub_index++;
@@ -97,7 +97,7 @@ spdm_test_context_t m_spdm_requester_encap_request_test_context = {
     spdm_device_receive_message,
 };
 
-void test_spdm_requester_encap_request(void **State)
+void libspdm_test_requester_encap_request(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -143,7 +143,7 @@ void test_spdm_requester_encap_request(void **State)
     libspdm_session_info_init(spdm_context, session_info, session_id, true);
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
-    libspdm_register_get_encap_response_func(spdm_context,spdm_get_encap_response_digest);
+    libspdm_register_get_encap_response_func(spdm_context,libspdm_get_encap_response_digest);
     libspdm_send_receive_encap_request(spdm_context, &session_id);
 }
 
@@ -158,7 +158,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_encap_request(&State);
+    libspdm_test_requester_encap_request(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/end_session.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/end_session.c
@@ -17,7 +17,7 @@ static void
 spdm_secured_message_set_response_data_encryption_key(void *spdm_secured_message_context,
                                                       const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     copy_mem_s(secured_message_context->application_secret.response_data_encryption_key,
@@ -28,7 +28,7 @@ spdm_secured_message_set_response_data_encryption_key(void *spdm_secured_message
 static void spdm_secured_message_set_response_data_salt(void *spdm_secured_message_context,
                                                         const void *salt, uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     copy_mem_s(secured_message_context->application_secret.response_data_salt,
@@ -72,13 +72,13 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
         return RETURN_DEVICE_ERROR;
     }
     /* WALKAROUND: If just use single context to encode message and then decode message */
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
 
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_end_session(void **State)
+void libspdm_test_requester_end_session(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -134,22 +134,22 @@ void test_spdm_requester_end_session(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(
         m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
     set_mem(
         m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    spdm_send_receive_end_session(spdm_context, session_id, 0);
+    libspdm_send_receive_end_session(spdm_context, session_id, 0);
     free(data);
 }
 
@@ -171,6 +171,6 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_end_session(&State);
+    libspdm_test_requester_end_session(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
@@ -14,7 +14,7 @@
 void spdm_secured_message_set_response_finished_key(void *spdm_secured_message_context,
                                                     const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -59,7 +59,7 @@ spdm_finish_request_mine_t m_spdm_finish_request1 = {
 };
 uintn m_spdm_finish_request1_size = sizeof(m_spdm_finish_request1);
 
-void test_spdm_send_receive_finish_case1(void **State)
+void test_libspdm_send_receive_finish_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -116,7 +116,7 @@ void test_spdm_send_receive_finish_case1(void **State)
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
 
     req_slot_id_param = 0;
-    spdm_send_receive_finish(spdm_context, session_id, req_slot_id_param);
+    libspdm_send_receive_finish(spdm_context, session_id, req_slot_id_param);
 
     free(data);
 }
@@ -139,7 +139,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_send_receive_finish_case1(&State);
+    test_libspdm_send_receive_finish_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
@@ -34,7 +34,7 @@ return_status spdm_device_receive_message(void *spdm_context,
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_get_capabilities(void **State)
+void libspdm_test_requester_get_capabilities(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -42,10 +42,10 @@ void test_spdm_requester_get_capabilities(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
 
-    spdm_get_capabilities(spdm_context);
+    libspdm_get_capabilities(spdm_context);
 }
 
-spdm_test_context_t test_spdm_requester_context = {
+spdm_test_context_t libspdm_test_requester_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     true,
     spdm_device_send_message,
@@ -56,15 +56,15 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 {
     void *State;
 
-    setup_spdm_test_context(&test_spdm_requester_context);
+    setup_spdm_test_context(&libspdm_test_requester_context);
 
-    test_spdm_requester_context.test_buffer = (void *)test_buffer;
-    test_spdm_requester_context.test_buffer_size = test_buffer_size;
+    libspdm_test_requester_context.test_buffer = (void *)test_buffer;
+    libspdm_test_requester_context.test_buffer_size = test_buffer_size;
 
     spdm_unit_test_group_setup(&State);
 
     /* Successful response*/
-    test_spdm_requester_get_capabilities(&State);
+    libspdm_test_requester_get_capabilities(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
@@ -54,7 +54,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_get_certificate_case1(void **State)
+void libspdm_test_requester_get_certificate_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -95,7 +95,7 @@ void test_spdm_requester_get_certificate_case1(void **State)
     libspdm_reset_message_b(spdm_context);
 }
 
-void test_spdm_requester_get_certificate_case2(void **State)
+void libspdm_test_requester_get_certificate_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -137,7 +137,7 @@ void test_spdm_requester_get_certificate_case2(void **State)
     libspdm_reset_message_b(spdm_context);
 }
 
-void test_spdm_requester_get_certificate_ex_case1(void **State)
+void libspdm_test_requester_get_certificate_ex_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -196,16 +196,16 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_certificate_case1(&State);
+    libspdm_test_requester_get_certificate_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*Support local_context.verify_peer_spdm_cert_chain  */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_certificate_case2(&State);
+    libspdm_test_requester_get_certificate_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_certificate_ex_case1(&State);
+    libspdm_test_requester_get_certificate_ex_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
@@ -36,7 +36,7 @@ return_status spdm_device_receive_message(void *spdm_context,
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_get_diges(void **State)
+void libspdm_test_requester_get_diges(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -83,7 +83,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Successful response*/
-    test_spdm_requester_get_diges(&State);
+    libspdm_test_requester_get_diges(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
@@ -96,7 +96,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_get_measurement_case1(void **State)
+void libspdm_test_requester_get_measurement_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -160,7 +160,7 @@ void test_spdm_requester_get_measurement_case1(void **State)
 #endif
 }
 
-void test_spdm_requester_get_measurement_case2(void **State)
+void libspdm_test_requester_get_measurement_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -219,7 +219,7 @@ void test_spdm_requester_get_measurement_case2(void **State)
 #endif
 }
 
-void test_spdm_requester_get_measurement_case3(void **State)
+void libspdm_test_requester_get_measurement_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -298,7 +298,7 @@ void test_spdm_requester_get_measurement_case3(void **State)
 #endif
 }
 
-void test_spdm_requester_get_measurement_case4(void **State)
+void libspdm_test_requester_get_measurement_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -376,22 +376,22 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response to get measurement with signature*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_measurement_case1(&State);
+    libspdm_test_requester_get_measurement_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Successful response to get measurement with signature*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_measurement_case2(&State);
+    libspdm_test_requester_get_measurement_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Successful response to get a session based measurement with signature*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_measurement_case3(&State);
+    libspdm_test_requester_get_measurement_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Successful response to get all measurements without signature*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_get_measurement_case4(&State);
+    libspdm_test_requester_get_measurement_case4(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
@@ -34,7 +34,7 @@ return_status spdm_device_receive_message(void *spdm_context,
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_get_version(void **State)
+void libspdm_test_requester_get_version(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -42,7 +42,7 @@ void test_spdm_requester_get_version(void **State)
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
 
-    spdm_get_version(spdm_context, NULL, NULL);
+    libspdm_get_version(spdm_context, NULL, NULL);
 }
 
 spdm_test_context_t m_spdm_requester_get_version_test_context = {
@@ -65,7 +65,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Successful response*/
-    test_spdm_requester_get_version(&State);
+    libspdm_test_requester_get_version(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
@@ -17,7 +17,7 @@ uint8_t test_message_header;
 void spdm_secured_message_set_response_data_encryption_key(void *spdm_secured_message_context,
                                                            const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->aead_key_size);
@@ -29,7 +29,7 @@ void spdm_secured_message_set_response_data_encryption_key(void *spdm_secured_me
 void spdm_secured_message_set_response_data_salt(void *spdm_secured_message_context,
                                                  const void *salt, uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(salt_size == secured_message_context->aead_iv_size);
@@ -74,12 +74,12 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
         return RETURN_DEVICE_ERROR;
     }
     /* WALKAROUND: If just use single context to encode message and then decode message */
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_heartbeat_case1(void **State)
+void libspdm_test_requester_heartbeat_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -135,19 +135,19 @@ void test_spdm_requester_heartbeat_case1(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(
         m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
     set_mem(
         m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     libspdm_heartbeat(spdm_context, session_id);
@@ -172,6 +172,6 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_heartbeat_case1(&State);
+    libspdm_test_requester_heartbeat_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -229,7 +229,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_key_exchange_case1(void **State)
+void libspdm_test_requester_key_exchange_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -269,13 +269,14 @@ void test_spdm_requester_key_exchange_case1(void **State)
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
 
-    spdm_send_receive_key_exchange(spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-                                   0, 0, &session_id, &heartbeat_period, &slot_id_param,
-                                   measurement_hash);
+    libspdm_send_receive_key_exchange(spdm_context,
+                                      SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                      0, 0, &session_id, &heartbeat_period, &slot_id_param,
+                                      measurement_hash);
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case2(void **State)
+void libspdm_test_requester_key_exchange_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -318,13 +319,14 @@ void test_spdm_requester_key_exchange_case2(void **State)
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
 
-    spdm_send_receive_key_exchange(spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-                                   0, 0, &session_id, &heartbeat_period, &slot_id_param,
-                                   measurement_hash);
+    libspdm_send_receive_key_exchange(spdm_context,
+                                      SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                      0, 0, &session_id, &heartbeat_period, &slot_id_param,
+                                      measurement_hash);
     free(data);
 }
 
-void test_spdm_requester_key_exchange_ex_case1(void **State)
+void libspdm_test_requester_key_exchange_ex_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -366,11 +368,11 @@ void test_spdm_requester_key_exchange_ex_case1(void **State)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    spdm_send_receive_key_exchange_ex(spdm_context,
-                                      SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
-                                      &session_id, &heartbeat_period, &slot_id_param,
-                                      measurement_hash, requester_random_in, requester_random,
-                                      responder_random);
+    libspdm_send_receive_key_exchange_ex(spdm_context,
+                                         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
+                                         &session_id, &heartbeat_period, &slot_id_param,
+                                         measurement_hash, requester_random_in, requester_random,
+                                         responder_random);
     free(data);
 }
 
@@ -392,15 +394,15 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_key_exchange_case1(&State);
+    libspdm_test_requester_key_exchange_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_key_exchange_case2(&State);
+    libspdm_test_requester_key_exchange_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_key_exchange_ex_case1(&State);
+    libspdm_test_requester_key_exchange_ex_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
@@ -76,7 +76,7 @@ static void spdm_compute_secret_update(uintn hash_size, const uint8_t *in_secret
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill, uint8_t *m_req_secret_buffer,
     uint8_t req_secret_fill)
 {
@@ -147,14 +147,14 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
                                        response);
     /* WALKAROUND: If just use single context to encode
      *     message and then decode message */
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
 
     sub_index++;
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_key_update_case1(void **State)
+void libspdm_test_requester_key_update_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -179,14 +179,14 @@ void test_spdm_requester_key_update_case1(void **State)
 
     /*request side updated*/
     spdm_compute_secret_update(
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
         m_req_secret_buffer, m_req_secret_buffer, sizeof(m_req_secret_buffer));
     /*response side *not* updated*/
 
     libspdm_key_update(spdm_context, session_id, true);
 }
 
-void test_spdm_requester_key_update_case2(void **state)
+void libspdm_test_requester_key_update_case2(void **state)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -210,11 +210,11 @@ void test_spdm_requester_key_update_case2(void **state)
 
     /*request side updated*/
     spdm_compute_secret_update(
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
         m_req_secret_buffer, m_req_secret_buffer, sizeof(m_req_secret_buffer));
     /*response side updated*/
     spdm_compute_secret_update(
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->hash_size,
         m_rsp_secret_buffer, m_rsp_secret_buffer, sizeof(m_rsp_secret_buffer));
 
     libspdm_key_update(spdm_context, session_id, false);
@@ -238,11 +238,11 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response. update single key */
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_key_update_case1(&State);
+    libspdm_test_requester_key_update_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Sucessful response  update all keys*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_key_update_case2(&State);
+    libspdm_test_requester_key_update_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
@@ -31,7 +31,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_negotiate_algorithms_case1(void **State)
+void libspdm_test_requester_negotiate_algorithms_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -45,10 +45,10 @@ void test_spdm_requester_negotiate_algorithms_case1(void **State)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    spdm_negotiate_algorithms(spdm_context);
+    libspdm_negotiate_algorithms(spdm_context);
 }
 
-void test_spdm_requester_negotiate_algorithms_case2(void **State)
+void libspdm_test_requester_negotiate_algorithms_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -62,10 +62,10 @@ void test_spdm_requester_negotiate_algorithms_case2(void **State)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    spdm_negotiate_algorithms(spdm_context);
+    libspdm_negotiate_algorithms(spdm_context);
 }
 
-void test_spdm_requester_negotiate_algorithms_case3(void **State)
+void libspdm_test_requester_negotiate_algorithms_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -99,10 +99,10 @@ void test_spdm_requester_negotiate_algorithms_case3(void **State)
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    spdm_negotiate_algorithms(spdm_context);
+    libspdm_negotiate_algorithms(spdm_context);
 }
 
-spdm_test_context_t test_spdm_requester_context = {
+spdm_test_context_t libspdm_test_requester_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     true,
     spdm_device_send_message,
@@ -113,22 +113,22 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 {
     void *State;
 
-    setup_spdm_test_context(&test_spdm_requester_context);
+    setup_spdm_test_context(&libspdm_test_requester_context);
 
-    test_spdm_requester_context.test_buffer = (void *)test_buffer;
-    test_spdm_requester_context.test_buffer_size = test_buffer_size;
+    libspdm_test_requester_context.test_buffer = (void *)test_buffer;
+    libspdm_test_requester_context.test_buffer_size = test_buffer_size;
 
     /* Successful V1.0 response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_negotiate_algorithms_case1(&State);
+    libspdm_test_requester_negotiate_algorithms_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Successful V1.1 response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_negotiate_algorithms_case2(&State);
+    libspdm_test_requester_negotiate_algorithms_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_negotiate_algorithms_case3(&State);
+    libspdm_test_requester_negotiate_algorithms_case3(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -162,7 +162,7 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_psk_exchange_case1(void **State)
+void libspdm_test_requester_psk_exchange_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -207,12 +207,13 @@ void test_spdm_requester_psk_exchange_case1(void **State)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    spdm_send_receive_psk_exchange(spdm_context, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-                                   0, &session_id, &heartbeat_period, measurement_hash);
+    libspdm_send_receive_psk_exchange(spdm_context,
+                                      SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                      0, &session_id, &heartbeat_period, measurement_hash);
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_ex_case1(void **State)
+void libspdm_test_requester_psk_exchange_ex_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -254,10 +255,10 @@ void test_spdm_requester_psk_exchange_ex_case1(void **State)
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
 
-    spdm_send_receive_psk_exchange_ex(spdm_context,
-                                      SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
-                                      &session_id, &heartbeat_period, measurement_hash, NULL, 0,
-                                      NULL, NULL, NULL, NULL);
+    libspdm_send_receive_psk_exchange_ex(spdm_context,
+                                         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0,
+                                         &session_id, &heartbeat_period, measurement_hash, NULL, 0,
+                                         NULL, NULL, NULL, NULL);
     free(data);
 }
 
@@ -280,11 +281,11 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_psk_exchange_case1(&State);
+    libspdm_test_requester_psk_exchange_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_psk_exchange_ex_case1(&State);
+    libspdm_test_requester_psk_exchange_ex_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
@@ -18,7 +18,7 @@ static uint8_t m_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 
 static void spdm_secured_message_set_dummy_finished_key(void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->finished_key_ready = true;
@@ -27,7 +27,7 @@ static void spdm_secured_message_set_dummy_finished_key(void *spdm_secured_messa
 void spdm_secured_message_set_response_handshake_encryption_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->aead_key_size);
@@ -39,7 +39,7 @@ void spdm_secured_message_set_response_handshake_encryption_key(
 void spdm_secured_message_set_response_handshake_salt(void *spdm_secured_message_context,
                                                       const void *salt, uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(salt_size == secured_message_context->aead_iv_size);
@@ -85,13 +85,13 @@ return_status spdm_device_receive_message(void *spdm_context, uintn *response_si
         return RETURN_DEVICE_ERROR;
     }
     /* WALKAROUND: If just use single context to encode message and then decode message */
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number--;
 
     return RETURN_SUCCESS;
 }
 
-void test_spdm_requester_psk_finish_case1(void **State)
+void libspdm_test_requester_psk_finish_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -147,22 +147,22 @@ void test_spdm_requester_psk_finish_case1(void **State)
 
     set_mem(
         m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
     set_mem(
         m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
         (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info->secured_message_context))
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key(session_info->secured_message_context);
-    spdm_send_receive_psk_finish(spdm_context, session_id);
+    libspdm_send_receive_psk_finish(spdm_context, session_id);
     free(data);
     libspdm_reset_message_k(spdm_context, session_info);
 }
@@ -185,7 +185,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Successful response*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_requester_psk_finish_case1(&State);
+    libspdm_test_requester_psk_finish_case1(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
@@ -13,7 +13,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_responder_algorithms_case1(void **State)
+void libspdm_test_responder_algorithms_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -27,11 +27,11 @@ void test_spdm_responder_algorithms_case1(void **State)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case2(void **State)
+void libspdm_test_responder_algorithms_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -50,11 +50,11 @@ void test_spdm_responder_algorithms_case2(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case3(void **State)
+void libspdm_test_responder_algorithms_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -80,11 +80,11 @@ void test_spdm_responder_algorithms_case3(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case4(void **State)
+void libspdm_test_responder_algorithms_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -123,10 +123,10 @@ void test_spdm_responder_algorithms_case4(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
-void test_spdm_responder_algorithms_case5(void **State)
+void libspdm_test_responder_algorithms_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -154,11 +154,11 @@ void test_spdm_responder_algorithms_case5(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case6(void **State)
+void libspdm_test_responder_algorithms_case6(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -186,11 +186,11 @@ void test_spdm_responder_algorithms_case6(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case7(void **State)
+void libspdm_test_responder_algorithms_case7(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -217,11 +217,11 @@ void test_spdm_responder_algorithms_case7(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case8(void **State)
+void libspdm_test_responder_algorithms_case8(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -247,11 +247,11 @@ void test_spdm_responder_algorithms_case8(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case9(void **State)
+void libspdm_test_responder_algorithms_case9(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -269,11 +269,11 @@ void test_spdm_responder_algorithms_case9(void **State)
 
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_algorithms_case10(void **State)
+void libspdm_test_responder_algorithms_case10(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -303,11 +303,11 @@ void test_spdm_responder_algorithms_case10(void **State)
         SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_TPM_ALG_SHA_512;
     libspdm_reset_message_a(spdm_context);
 
-    spdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
 }
 
-spdm_test_context_t test_spdm_responder_context = {
+spdm_test_context_t libspdm_test_responder_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     false,
 };
@@ -315,59 +315,59 @@ spdm_test_context_t test_spdm_responder_context = {
 void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 {
     void *State;
-    setup_spdm_test_context(&test_spdm_responder_context);
+    setup_spdm_test_context(&libspdm_test_responder_context);
 
-    test_spdm_responder_context.test_buffer = (void *)test_buffer;
-    test_spdm_responder_context.test_buffer_size = test_buffer_size;
+    libspdm_test_responder_context.test_buffer = (void *)test_buffer;
+    libspdm_test_responder_context.test_buffer_size = test_buffer_size;
 
     /* Success Case*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case1(&State);
+    libspdm_test_responder_algorithms_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* connection_state Check */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case2(&State);
+    libspdm_test_responder_algorithms_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case3(&State);
+    libspdm_test_responder_algorithms_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case4(&State);
+    libspdm_test_responder_algorithms_case4(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case5(&State);
+    libspdm_test_responder_algorithms_case5(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case6(&State);
+    libspdm_test_responder_algorithms_case6(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case7(&State);
+    libspdm_test_responder_algorithms_case7(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case8(&State);
+    libspdm_test_responder_algorithms_case8(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* response_state: LIBSPDM_RESPONSE_STATE_BUSY */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case9(&State);
+    libspdm_test_responder_algorithms_case9(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* capablities: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_algorithms_case10(&State);
+    libspdm_test_responder_algorithms_case10(&State);
     spdm_unit_test_group_teardown(&State);
 
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_capabilities/capabilities.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_capabilities/capabilities.c
@@ -13,7 +13,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_responder_capabilities_case1(void **State)
+void libspdm_test_responder_capabilities_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -27,13 +27,13 @@ void test_spdm_responder_capabilities_case1(void **State)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    spdm_get_response_capabilities(spdm_context,
-                                   spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer,
-                                   &response_size, response);
+    libspdm_get_response_capabilities(spdm_context,
+                                      spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer,
+                                      &response_size, response);
 }
 
-void test_spdm_responder_capabilities_case2(void **State)
+void libspdm_test_responder_capabilities_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -48,13 +48,13 @@ void test_spdm_responder_capabilities_case2(void **State)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    spdm_get_response_capabilities(spdm_context,
-                                   spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer,
-                                   &response_size, response);
+    libspdm_get_response_capabilities(spdm_context,
+                                      spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer,
+                                      &response_size, response);
 }
 
-void test_spdm_responder_capabilities_case3(void **State)
+void libspdm_test_responder_capabilities_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -69,13 +69,13 @@ void test_spdm_responder_capabilities_case3(void **State)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    spdm_get_response_capabilities(spdm_context,
-                                   spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer,
-                                   &response_size, response);
+    libspdm_get_response_capabilities(spdm_context,
+                                      spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer,
+                                      &response_size, response);
 }
 
-spdm_test_context_t test_spdm_responder_context = {
+spdm_test_context_t libspdm_test_responder_context = {
     SPDM_TEST_CONTEXT_SIGNATURE,
     false,
 };
@@ -83,19 +83,19 @@ spdm_test_context_t test_spdm_responder_context = {
 void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 {
     void *State;
-    setup_spdm_test_context(&test_spdm_responder_context);
+    setup_spdm_test_context(&libspdm_test_responder_context);
 
-    test_spdm_responder_context.test_buffer = (void *)test_buffer;
-    test_spdm_responder_context.test_buffer_size = test_buffer_size;
+    libspdm_test_responder_context.test_buffer = (void *)test_buffer;
+    libspdm_test_responder_context.test_buffer_size = test_buffer_size;
 
     spdm_unit_test_group_setup(&State);
 
     /* Success Case */
-    test_spdm_responder_capabilities_case1(&State);
+    libspdm_test_responder_capabilities_case1(&State);
     /* connection_state Check*/
-    test_spdm_responder_capabilities_case2(&State);
+    libspdm_test_responder_capabilities_case2(&State);
     /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY */
-    test_spdm_responder_capabilities_case3(&State);
+    libspdm_test_responder_capabilities_case3(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
@@ -21,7 +21,7 @@ spdm_test_context_t m_spdm_responder_certificate_test_context = {
     false,
 };
 
-void test_spdm_responder_certificate_case1(void **State)
+void libspdm_test_responder_certificate_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -50,14 +50,14 @@ void test_spdm_responder_certificate_case1(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_certificate(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_certificate(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_certificate_case2(void **State)
+void libspdm_test_responder_certificate_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -87,14 +87,14 @@ void test_spdm_responder_certificate_case2(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_certificate(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_certificate(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_certificate_case3(void **State)
+void libspdm_test_responder_certificate_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -111,13 +111,13 @@ void test_spdm_responder_certificate_case3(void **State)
         m_use_hash_algo;
 
     response_size = sizeof(response);
-    spdm_get_response_certificate(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_certificate(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
 }
 
-void test_spdm_responder_certificate_case4(void **State)
+void libspdm_test_responder_certificate_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -132,13 +132,13 @@ void test_spdm_responder_certificate_case4(void **State)
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
 
     response_size = sizeof(response);
-    spdm_get_response_certificate(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_certificate(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
 }
 
-void test_spdm_responder_certificate_case5(void **State)
+void libspdm_test_responder_certificate_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -168,10 +168,10 @@ void test_spdm_responder_certificate_case5(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_certificate(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_certificate(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
     free(data);
 }
 
@@ -188,15 +188,15 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case */
-    test_spdm_responder_certificate_case1(&State);
+    libspdm_test_responder_certificate_case1(&State);
     /* connection_state Check */
-    test_spdm_responder_certificate_case2(&State);
+    libspdm_test_responder_certificate_case2(&State);
     /* response_state: LIBSPDM_RESPONSE_STATE_BUSY */
-    test_spdm_responder_certificate_case3(&State);
+    libspdm_test_responder_certificate_case3(&State);
     /* response_state: LIBSPDM_RESPONSE_STATE_NORMAL */
-    test_spdm_responder_certificate_case4(&State);
+    libspdm_test_responder_certificate_case4(&State);
     /* capability.flags: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP */
-    test_spdm_responder_certificate_case5(&State);
+    libspdm_test_responder_certificate_case5(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -21,7 +21,7 @@ spdm_test_context_t m_spdm_responder_challenge_test_context = {
     false,
 };
 
-void test_spdm_responder_challenge_case1(void **State)
+void libspdm_test_responder_challenge_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -52,12 +52,12 @@ void test_spdm_responder_challenge_case1(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_challenge_case2(void **State)
+void libspdm_test_responder_challenge_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -88,12 +88,12 @@ void test_spdm_responder_challenge_case2(void **State)
     libspdm_reset_message_c(spdm_context);
     response_size = sizeof(response);
 
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_challenge_case3(void **State)
+void libspdm_test_responder_challenge_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -125,12 +125,12 @@ void test_spdm_responder_challenge_case3(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_challenge_case4(void **State)
+void libspdm_test_responder_challenge_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -164,12 +164,12 @@ void test_spdm_responder_challenge_case4(void **State)
     spdm_context->local_context.basic_mut_auth_requested = 1;
     response_size = sizeof(response);
     libspdm_reset_message_c(spdm_context);
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_challenge_case5(void **State)
+void libspdm_test_responder_challenge_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -202,8 +202,8 @@ void test_spdm_responder_challenge_case5(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     #else
@@ -211,7 +211,7 @@ void test_spdm_responder_challenge_case5(void **State)
     #endif
 }
 
-void test_spdm_responder_challenge_case6(void **State)
+void libspdm_test_responder_challenge_case6(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -246,8 +246,8 @@ void test_spdm_responder_challenge_case6(void **State)
     spdm_context->local_context.basic_mut_auth_requested = 1;
     response_size = sizeof(response);
     libspdm_reset_message_c(spdm_context);
-    spdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
-                                     spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
@@ -262,32 +262,32 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case1(&State);
+    libspdm_test_responder_challenge_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case2(&State);
+    libspdm_test_responder_challenge_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* connection_state Check*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case3(&State);
+    libspdm_test_responder_challenge_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Support Capabilities flag */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case4(&State);
+    libspdm_test_responder_challenge_case4(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*  Capabilities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case5(&State);
+    libspdm_test_responder_challenge_case5(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* basic_mut_auth_requested : 1 */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_challenge_case6(&State);
+    libspdm_test_responder_challenge_case6(&State);
     spdm_unit_test_group_teardown(&State);
 
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
@@ -15,7 +15,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_responder_digests_case1(void **State)
+void libspdm_test_responder_digests_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -40,13 +40,13 @@ void test_spdm_responder_digests_case1(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_digests(spdm_context,
-                              spdm_test_context->test_buffer_size,
-                              spdm_test_context->test_buffer,
-                              &response_size, response);
+    libspdm_get_response_digests(spdm_context,
+                                 spdm_test_context->test_buffer_size,
+                                 spdm_test_context->test_buffer,
+                                 &response_size, response);
 }
 
-void test_spdm_responder_digests_case2(void **State)
+void libspdm_test_responder_digests_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -63,13 +63,13 @@ void test_spdm_responder_digests_case2(void **State)
         m_use_hash_algo;
 
     response_size = sizeof(response);
-    spdm_get_response_digests(spdm_context,
-                              spdm_test_context->test_buffer_size,
-                              spdm_test_context->test_buffer,
-                              &response_size, response);
+    libspdm_get_response_digests(spdm_context,
+                                 spdm_test_context->test_buffer_size,
+                                 spdm_test_context->test_buffer,
+                                 &response_size, response);
 }
 
-void test_spdm_responder_digests_case3(void **State)
+void libspdm_test_responder_digests_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -85,13 +85,13 @@ void test_spdm_responder_digests_case3(void **State)
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
 
     response_size = sizeof(response);
-    spdm_get_response_digests(spdm_context,
-                              spdm_test_context->test_buffer_size,
-                              spdm_test_context->test_buffer,
-                              &response_size, response);
+    libspdm_get_response_digests(spdm_context,
+                                 spdm_test_context->test_buffer_size,
+                                 spdm_test_context->test_buffer,
+                                 &response_size, response);
 }
 
-void test_spdm_responder_digests_case4(void **State)
+void libspdm_test_responder_digests_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -108,10 +108,10 @@ void test_spdm_responder_digests_case4(void **State)
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
 
     response_size = sizeof(response);
-    spdm_get_response_digests(spdm_context,
-                              spdm_test_context->test_buffer_size,
-                              spdm_test_context->test_buffer,
-                              &response_size, response);
+    libspdm_get_response_digests(spdm_context,
+                                 spdm_test_context->test_buffer_size,
+                                 spdm_test_context->test_buffer,
+                                 &response_size, response);
 }
 
 spdm_test_context_t m_spdm_responder_digests_test_context = {
@@ -132,13 +132,13 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_digests_case1(&State);
+    libspdm_test_responder_digests_case1(&State);
     /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-    test_spdm_responder_digests_case2(&State);
+    libspdm_test_responder_digests_case2(&State);
     /* response_state: LIBSPDM_RESPONSE_STATE_NORMAL*/
-    test_spdm_responder_digests_case3(&State);
+    libspdm_test_responder_digests_case3(&State);
     /* capabilities.flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP */
-    test_spdm_responder_digests_case4(&State);
+    libspdm_test_responder_digests_case4(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_challenge/encap_challenge.c
@@ -24,7 +24,7 @@ spdm_test_context_t m_spdm_responder_encap_challenge_test_context = {
 static uintn m_local_buffer_size;
 static uint8_t m_local_buffer[LIBSPDM_MAX_MESSAGE_SMALL_BUFFER_SIZE];
 
-void test_spdm_responder_encap_challenge_case1(void **State)
+void libspdm_test_responder_encap_challenge_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -103,8 +103,8 @@ void test_spdm_responder_encap_challenge_case1(void **State)
 
     ptr += sig_size;
 
-    spdm_process_encap_response_challenge_auth(spdm_context, spdm_response_size, spdm_response,
-                                               NULL);
+    libspdm_process_encap_response_challenge_auth(spdm_context, spdm_response_size, spdm_response,
+                                                  NULL);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     #else
@@ -112,7 +112,7 @@ void test_spdm_responder_encap_challenge_case1(void **State)
     #endif
 }
 
-void test_spdm_get_encap_request_challenge_case2(void **State)
+void test_libspdm_get_encap_request_challenge_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -142,7 +142,7 @@ void test_spdm_get_encap_request_challenge_case2(void **State)
     spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_c(spdm_context);
 
-    spdm_get_encap_request_challenge(spdm_context, &encap_request_size, spdm_request);
+    libspdm_get_encap_request_challenge(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -162,12 +162,12 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_encap_challenge_case1(&State);
+    libspdm_test_responder_encap_challenge_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_encap_request_challenge_case2(&State);
+    test_libspdm_get_encap_request_challenge_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
@@ -21,7 +21,7 @@ spdm_test_context_t m_spdm_responder_encap_get_certificate_test_context = {
     false,
 };
 
-void test_spdm_responder_encap_get_certificate_case1(void **State)
+void libspdm_test_responder_encap_get_certificate_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_certificate_response_t *spdm_response;
@@ -61,12 +61,12 @@ void test_spdm_responder_encap_get_certificate_case1(void **State)
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
     spdm_context->local_context.slot_count = 1;
 
-    spdm_process_encap_response_certificate(spdm_context, spdm_response_size, spdm_response,
-                                            &need_continue);
+    libspdm_process_encap_response_certificate(spdm_context, spdm_response_size, spdm_response,
+                                               &need_continue);
     free(data);
 }
 
-void test_spdm_get_encap_request_get_certificate_case2(void **State)
+void test_libspdm_get_encap_request_get_certificate_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -97,7 +97,7 @@ void test_spdm_get_encap_request_get_certificate_case2(void **State)
     spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_b(spdm_context);
 
-    spdm_get_encap_request_get_certificate(spdm_context, &encap_request_size, spdm_request);
+    libspdm_get_encap_request_get_certificate(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -117,12 +117,12 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_encap_get_certificate_case1(&State);
+    libspdm_test_responder_encap_get_certificate_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_encap_request_get_certificate_case2(&State);
+    test_libspdm_get_encap_request_get_certificate_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
@@ -21,7 +21,7 @@ spdm_test_context_t m_spdm_responder_encap_get_digests_test_context = {
     false,
 };
 
-void test_spdm_responder_encap_get_digests_case1(void **State)
+void libspdm_test_responder_encap_get_digests_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -39,11 +39,11 @@ void test_spdm_responder_encap_get_digests_case1(void **State)
     set_mem(m_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, (uint8_t)(0xFF));
     spdm_context->local_context.slot_count = 1;
 
-    spdm_process_encap_response_digest(spdm_context, spdm_test_context->test_buffer_size,
-                                       spdm_test_context->test_buffer, &need_continue);
+    libspdm_process_encap_response_digest(spdm_context, spdm_test_context->test_buffer_size,
+                                          spdm_test_context->test_buffer, &need_continue);
 }
 
-void test_spdm_get_encap_request_get_digest_case2(void **State)
+void test_libspdm_get_encap_request_get_digest_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_get_digest_request_t *spdm_request;
@@ -74,7 +74,7 @@ void test_spdm_get_encap_request_get_digest_case2(void **State)
     spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_b(spdm_context);
 
-    spdm_get_encap_request_get_digest(spdm_context, &encap_request_size, spdm_request);
+    libspdm_get_encap_request_get_digest(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -94,12 +94,12 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_encap_get_digests_case1(&State);
+    libspdm_test_responder_encap_get_digests_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_encap_request_get_digest_case2(&State);
+    test_libspdm_get_encap_request_get_digest_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/encap_key_update.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_key_update/encap_key_update.c
@@ -44,7 +44,7 @@ static void spdm_set_standard_key_update_test_state(libspdm_context_t *spdm_cont
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill, uint8_t *m_req_secret_buffer,
     uint8_t req_secret_fill)
 {
@@ -105,14 +105,14 @@ spdm_test_context_t m_spdm_responder_encap_get_digests_test_context = {
     false,
 };
 
-void test_spdm_process_encap_response_key_update_case1(void **State)
+void test_libspdm_process_encap_response_key_update_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint32_t session_id;
     bool need_continue;
     libspdm_session_info_t *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
@@ -133,11 +133,11 @@ void test_spdm_process_encap_response_key_update_case1(void **State)
 
     libspdm_init_key_update_encap_state(spdm_context);
 
-    spdm_process_encap_response_key_update(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &need_continue);
+    libspdm_process_encap_response_key_update(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &need_continue);
 }
 
-void test_spdm_get_encap_request_key_update_case1(void **State)
+void test_libspdm_get_encap_request_key_update_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_key_update_request_t *spdm_request;
@@ -180,12 +180,12 @@ void test_spdm_get_encap_request_key_update_case1(void **State)
     libspdm_session_info_init(spdm_context, session_info, session_id, true);
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
-    spdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
+    libspdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
     free(data);
 }
 
-void test_spdm_get_encap_request_key_update_case2(void **State)
+void test_libspdm_get_encap_request_key_update_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_key_update_request_t *spdm_request;
@@ -230,7 +230,7 @@ void test_spdm_get_encap_request_key_update_case2(void **State)
     libspdm_session_info_init(spdm_context, session_info, session_id, true);
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
-    spdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
+    libspdm_get_encap_request_key_update(spdm_context, &encap_request_size, spdm_request);
     free(spdm_request);
     free(data);
 }
@@ -246,16 +246,16 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_process_encap_response_key_update_case1(&State);
+    test_libspdm_process_encap_response_key_update_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_encap_request_key_update_case1(&State);
+    test_libspdm_get_encap_request_key_update_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* request_response_code: SPDM_KEY_UPDATE */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_encap_request_key_update_case2(&State);
+    test_libspdm_get_encap_request_key_update_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
@@ -21,7 +21,7 @@ spdm_test_context_t m_spdm_response_encapsulated_request_test_context = {
     false,
 };
 
-void test_spdm_get_response_encapsulated_request_case1(void **State)
+void libspdm_test_get_response_encapsulated_request_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -52,9 +52,9 @@ void test_spdm_get_response_encapsulated_request_case1(void **State)
     spdm_context->connection_info.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_b(spdm_context);
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &response_size,
-                                           response);
+    libspdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &response_size,
+                                              response);
     free(data);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     #else
@@ -62,7 +62,7 @@ void test_spdm_get_response_encapsulated_request_case1(void **State)
     #endif
 }
 
-void test_spdm_get_response_encapsulated_request_case2(void **State)
+void libspdm_test_get_response_encapsulated_request_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -89,12 +89,12 @@ void test_spdm_get_response_encapsulated_request_case2(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &response_size,
-                                           response);
+    libspdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &response_size,
+                                              response);
 }
 
-void test_spdm_get_response_encapsulated_request_case3(void **State)
+void libspdm_test_get_response_encapsulated_request_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -121,12 +121,12 @@ void test_spdm_get_response_encapsulated_request_case3(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &response_size,
-                                           response);
+    libspdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &response_size,
+                                              response);
 }
 
-void test_spdm_get_response_encapsulated_request_case4(void **State)
+void libspdm_test_get_response_encapsulated_request_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -153,12 +153,12 @@ void test_spdm_get_response_encapsulated_request_case4(void **State)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &response_size,
-                                           response);
+    libspdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &response_size,
+                                              response);
 }
 
-void test_spdm_get_response_encapsulated_request_case5(void **State)
+void libspdm_test_get_response_encapsulated_request_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -175,12 +175,12 @@ void test_spdm_get_response_encapsulated_request_case5(void **State)
     spdm_context->encap_context.current_request_op_code = 0;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
-                                           spdm_test_context->test_buffer, &response_size,
-                                           response);
+    libspdm_get_response_encapsulated_request(spdm_context, spdm_test_context->test_buffer_size,
+                                              spdm_test_context->test_buffer, &response_size,
+                                              response);
 }
 
-void test_spdm_spdm_get_response_encapsulated_response_ack_case1(void **State)
+void libspdm_test_get_response_encapsulated_response_ack_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -213,13 +213,14 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case1(void **State)
     libspdm_reset_message_b(spdm_context);
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
-                                                spdm_test_context->test_buffer, &response_size,
-                                                response);
+    libspdm_get_response_encapsulated_response_ack(spdm_context,
+                                                   spdm_test_context->test_buffer_size,
+                                                   spdm_test_context->test_buffer, &response_size,
+                                                   response);
     free(data);
 }
 
-void test_spdm_spdm_get_response_encapsulated_response_ack_case2(void **State)
+void libspdm_test_get_response_encapsulated_response_ack_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -237,12 +238,13 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case2(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
-                                                spdm_test_context->test_buffer, &response_size,
-                                                response);
+    libspdm_get_response_encapsulated_response_ack(spdm_context,
+                                                   spdm_test_context->test_buffer_size,
+                                                   spdm_test_context->test_buffer, &response_size,
+                                                   response);
 }
 
-void test_spdm_spdm_get_response_encapsulated_response_ack_case3(void **State)
+void libspdm_test_get_response_encapsulated_response_ack_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -282,13 +284,14 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case3(void **State)
     libspdm_reset_message_b(spdm_context);
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
-                                                spdm_test_context->test_buffer, &response_size,
-                                                response);
+    libspdm_get_response_encapsulated_response_ack(spdm_context,
+                                                   spdm_test_context->test_buffer_size,
+                                                   spdm_test_context->test_buffer, &response_size,
+                                                   response);
     free(data);
 }
 
-void test_spdm_spdm_get_response_encapsulated_response_ack_case4(void **State)
+void libspdm_test_get_response_encapsulated_response_ack_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -304,12 +307,13 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case4(void **State)
         LIBSPDM_MAX_ENCAP_REQUEST_OP_CODE_SEQUENCE_COUNT;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
-                                                spdm_test_context->test_buffer, &response_size,
-                                                response);
+    libspdm_get_response_encapsulated_response_ack(spdm_context,
+                                                   spdm_test_context->test_buffer_size,
+                                                   spdm_test_context->test_buffer, &response_size,
+                                                   response);
 }
 
-void test_spdm_spdm_get_response_encapsulated_response_ack_case5(void **State)
+void libspdm_test_get_response_encapsulated_response_ack_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -325,9 +329,10 @@ void test_spdm_spdm_get_response_encapsulated_response_ack_case5(void **State)
         LIBSPDM_MAX_ENCAP_REQUEST_OP_CODE_SEQUENCE_COUNT;
 
     response_size = sizeof(response);
-    spdm_get_response_encapsulated_response_ack(spdm_context, spdm_test_context->test_buffer_size,
-                                                spdm_test_context->test_buffer, &response_size,
-                                                response);
+    libspdm_get_response_encapsulated_response_ack(spdm_context,
+                                                   spdm_test_context->test_buffer_size,
+                                                   spdm_test_context->test_buffer, &response_size,
+                                                   response);
 }
 
 void run_test_harness(const void *test_buffer, uintn test_buffer_size)
@@ -341,52 +346,52 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_response_encapsulated_request_case1(&State);
+    libspdm_test_get_response_encapsulated_request_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*current_request_op_code: SPDM_CHALLENGE */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_response_encapsulated_request_case2(&State);
+    libspdm_test_get_response_encapsulated_request_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*response_state : LIBSPDM_RESPONSE_STATE_NORMAL */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_response_encapsulated_request_case3(&State);
+    libspdm_test_get_response_encapsulated_request_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*response_state : LIBSPDM_RESPONSE_STATE_NOT_READY */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_response_encapsulated_request_case4(&State);
+    libspdm_test_get_response_encapsulated_request_case4(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* current_request_op_code: NULL */
     spdm_unit_test_group_setup(&State);
-    test_spdm_get_response_encapsulated_request_case5(&State);
+    libspdm_test_get_response_encapsulated_request_case5(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Success Case */
     spdm_unit_test_group_setup(&State);
-    test_spdm_spdm_get_response_encapsulated_response_ack_case1(&State);
+    libspdm_test_get_response_encapsulated_response_ack_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* current_request_op_code: NULL */
     spdm_unit_test_group_setup(&State);
-    test_spdm_spdm_get_response_encapsulated_response_ack_case2(&State);
+    libspdm_test_get_response_encapsulated_response_ack_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*current_request_op_code: SPDM_GET_DIGESTS */
     spdm_unit_test_group_setup(&State);
-    test_spdm_spdm_get_response_encapsulated_response_ack_case3(&State);
+    libspdm_test_get_response_encapsulated_response_ack_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*response_state : LIBSPDM_RESPONSE_STATE_NORMAL */
     spdm_unit_test_group_setup(&State);
-    test_spdm_spdm_get_response_encapsulated_response_ack_case4(&State);
+    libspdm_test_get_response_encapsulated_response_ack_case4(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*response_state : LIBSPDM_RESPONSE_STATE_NOT_READY */
     spdm_unit_test_group_setup(&State);
-    test_spdm_spdm_get_response_encapsulated_response_ack_case5(&State);
+    libspdm_test_get_response_encapsulated_response_ack_case5(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
@@ -22,7 +22,7 @@ spdm_test_context_t m_spdm_responder_end_session_test_context = {
     false,
 };
 
-void test_spdm_responder_end_session(void **State)
+void libspdm_test_responder_end_session(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -83,10 +83,10 @@ void test_spdm_responder_end_session(void **State)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    spdm_get_response_end_session(spdm_context,
-                                  spdm_test_context->test_buffer_size,
-                                  spdm_test_context->test_buffer,
-                                  &response_size, response);
+    libspdm_get_response_end_session(spdm_context,
+                                     spdm_test_context->test_buffer_size,
+                                     spdm_test_context->test_buffer,
+                                     &response_size, response);
     free(data);
 }
 
@@ -103,7 +103,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_end_session(&State);
+    libspdm_test_responder_end_session(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -24,7 +24,7 @@ spdm_test_context_t m_spdm_responder_finish_test_context = {
 void spdm_secured_message_set_request_finished_key(void *spdm_secured_message_context,
                                                    const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -40,7 +40,7 @@ typedef struct {
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
 } spdm_finish_request_mine_t;
 
-void test_spdm_responder_finish_case1(void **State)
+void libspdm_test_responder_finish_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -120,12 +120,12 @@ void test_spdm_responder_finish_case1(void **State)
                      ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, m_spdm_finish_request1_size, &m_spdm_finish_request1,
-                             &response_size, response);
+    libspdm_get_response_finish(&spdm_context, m_spdm_finish_request1_size, &m_spdm_finish_request1,
+                                &response_size, response);
     free(data1);
 }
 
-void test_spdm_responder_finish_case2(void **State)
+void libspdm_test_responder_finish_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -137,11 +137,11 @@ void test_spdm_responder_finish_case2(void **State)
     spdm_context.response_state = LIBSPDM_RESPONSE_STATE_NOT_READY;
 
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_finish_case3(void **State)
+void libspdm_test_responder_finish_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -155,11 +155,11 @@ void test_spdm_responder_finish_case3(void **State)
     spdm_context.local_context.capability.flags = 0;
 
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_finish_case4(void **State)
+void libspdm_test_responder_finish_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -173,11 +173,11 @@ void test_spdm_responder_finish_case4(void **State)
     spdm_context.connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
     spdm_context.local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_finish_case5(void **State)
+void libspdm_test_responder_finish_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -193,11 +193,11 @@ void test_spdm_responder_finish_case5(void **State)
     spdm_context.local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
 
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_finish_case6(void **State)
+void libspdm_test_responder_finish_case6(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -218,11 +218,11 @@ void test_spdm_responder_finish_case6(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
     spdm_context.last_spdm_request_session_id_valid = !false;
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_finish_case7(void **State)
+void libspdm_test_responder_finish_case7(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -275,12 +275,12 @@ void test_spdm_responder_finish_case7(void **State)
                                                   m_dummy_buffer, hash_size);
 
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
-                             spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_finish(&spdm_context, spdm_test_context->test_buffer_size,
+                                spdm_test_context->test_buffer, &response_size, response);
     free(data1);
 }
 
-void test_spdm_responder_finish_case8(void **State)
+void libspdm_test_responder_finish_case8(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -386,8 +386,8 @@ void test_spdm_responder_finish_case8(void **State)
     m_spdm_finish_request_size =
         sizeof(spdm_finish_request_t) + req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
-    spdm_get_response_finish(&spdm_context, m_spdm_finish_request_size, &m_spdm_finish_request,
-                             &response_size, response);
+    libspdm_get_response_finish(&spdm_context, m_spdm_finish_request_size, &m_spdm_finish_request,
+                                &response_size, response);
     free(data1);
     free(data2);
 }
@@ -404,21 +404,21 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_finish_case1(&State);
+    libspdm_test_responder_finish_case1(&State);
     /*response_state: LIBSPDM_RESPONSE_STATE_NOT_READY */
-    test_spdm_responder_finish_case2(&State);
+    libspdm_test_responder_finish_case2(&State);
     /*not supported capabilities_flag */
-    test_spdm_responder_finish_case3(&State);
+    libspdm_test_responder_finish_case3(&State);
     /* connection_state Check */
-    test_spdm_responder_finish_case4(&State);
+    libspdm_test_responder_finish_case4(&State);
     /* No handshake in clear, then it must be in a session.*/
-    test_spdm_responder_finish_case5(&State);
+    libspdm_test_responder_finish_case5(&State);
     /* handshake in clear, then it must not be in a session.*/
-    test_spdm_responder_finish_case6(&State);
+    libspdm_test_responder_finish_case6(&State);
     /* secured_message_context:= LIBSPDM_SESSION_STATE_NOT_STARTED */
-    test_spdm_responder_finish_case7(&State);
+    libspdm_test_responder_finish_case7(&State);
     /* Success Case */
-    test_spdm_responder_finish_case8(&State);
+    libspdm_test_responder_finish_case8(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -19,7 +19,7 @@ spdm_test_context_t m_spdm_responder_heartbeat_test_context = {
     false,
 };
 
-void test_spdm_responder_heartbeat(void **State)
+void libspdm_test_responder_heartbeat(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -81,10 +81,10 @@ void test_spdm_responder_heartbeat(void **State)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    spdm_get_response_heartbeat(spdm_context,
-                                spdm_test_context->test_buffer_size,
-                                spdm_test_context->test_buffer,
-                                &response_size, response);
+    libspdm_get_response_heartbeat(spdm_context,
+                                   spdm_test_context->test_buffer_size,
+                                   spdm_test_context->test_buffer,
+                                   &response_size, response);
     free(data1);
 }
 
@@ -101,7 +101,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_heartbeat(&State);
+    libspdm_test_responder_heartbeat(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -22,7 +22,7 @@ spdm_test_context_t m_spdm_responder_if_ready_test_context = {
     false,
 };
 
-void test_spdm_responder_respond_if_ready(void **State)
+void libspdm_test_responder_respond_if_ready(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -70,10 +70,10 @@ void test_spdm_responder_respond_if_ready(void **State)
     spdm_context->error_data.token = MY_TEST_TOKEN;
 
     response_size = sizeof(response);
-    spdm_get_response_respond_if_ready(spdm_context,
-                                       spdm_test_context->test_buffer_size,
-                                       spdm_test_context->test_buffer,
-                                       &response_size, response);
+    libspdm_get_response_respond_if_ready(spdm_context,
+                                          spdm_test_context->test_buffer_size,
+                                          spdm_test_context->test_buffer,
+                                          &response_size, response);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     #else
     free(spdm_context->transcript.digest_context_m1m2);
@@ -93,7 +93,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_respond_if_ready(&State);
+    libspdm_test_responder_respond_if_ready(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
@@ -31,7 +31,7 @@ typedef struct {
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
 } spdm_key_exchange_request_mine_t;
 
-void test_spdm_responder_key_exchange_case1(void **State)
+void libspdm_test_responder_key_exchange_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -86,12 +86,12 @@ void test_spdm_responder_key_exchange_case1(void **State)
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_key_exchange_case2(void **State)
+void libspdm_test_responder_key_exchange_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_key_exchange_request_mine_t m_spdm_key_exchange_request;
@@ -145,12 +145,12 @@ void test_spdm_responder_key_exchange_case2(void **State)
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_key_exchange_case3(void **State)
+void libspdm_test_responder_key_exchange_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_key_exchange_request_mine_t m_spdm_key_exchange_request;
@@ -188,12 +188,12 @@ void test_spdm_responder_key_exchange_case3(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_key_exchange_case4(void **State)
+void libspdm_test_responder_key_exchange_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -254,12 +254,12 @@ void test_spdm_responder_key_exchange_case4(void **State)
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_key_exchange_case5(void **State)
+void libspdm_test_responder_key_exchange_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -318,12 +318,12 @@ void test_spdm_responder_key_exchange_case5(void **State)
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_key_exchange_case6(void **State)
+void libspdm_test_responder_key_exchange_case6(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_key_exchange_request_mine_t m_spdm_key_exchange_request;
@@ -376,8 +376,8 @@ void test_spdm_responder_key_exchange_case6(void **State)
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
-                                   &m_spdm_key_exchange_request, &response_size, response);
+    libspdm_get_response_key_exchange(spdm_context, m_spdm_key_exchange_request_size,
+                                      &m_spdm_key_exchange_request, &response_size, response);
     free(data);
 }
 
@@ -392,32 +392,32 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case1(&State);
+    libspdm_test_responder_key_exchange_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* capability.flags: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case2(&State);
+    libspdm_test_responder_key_exchange_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* response_state: SPDM_RESPONSE_STATE_BUSY*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case3(&State);
+    libspdm_test_responder_key_exchange_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* return response mut_auth_requested  */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case4(&State);
+    libspdm_test_responder_key_exchange_case4(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*capability.flags: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case5(&State);
+    libspdm_test_responder_key_exchange_case5(&State);
     spdm_unit_test_group_teardown(&State);
 
     /* Buffer reset */
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_key_exchange_case6(&State);
+    libspdm_test_responder_key_exchange_case6(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/key_update.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/key_update.c
@@ -56,7 +56,7 @@ spdm_set_standard_key_update_test_state(libspdm_context_t *spdm_context,
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill,
     uint8_t *m_req_secret_buffer, uint8_t req_secret_fill)
 {
@@ -124,13 +124,13 @@ spdm_test_context_t m_spdm_responder_key_update_test_context = {
     false,
 };
 
-void test_spdm_responder_key_update(void **State)
+void libspdm_test_responder_key_update(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
@@ -153,10 +153,10 @@ void test_spdm_responder_key_update(void **State)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    spdm_get_response_key_update(spdm_context,
-                                 spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer,
-                                 &response_size, response);
+    libspdm_get_response_key_update(spdm_context,
+                                    spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer,
+                                    &response_size, response);
 }
 
 void run_test_harness(const void *test_buffer, uintn test_buffer_size)
@@ -172,7 +172,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_key_update(&State);
+    libspdm_test_responder_key_update(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
@@ -18,7 +18,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_responder_measurements_case1(void **State)
+void libspdm_test_responder_measurements_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -40,11 +40,11 @@ void test_spdm_responder_measurements_case1(void **State)
     spdm_context->local_context.opaque_measurement_rsp = NULL;
 
     response_size = sizeof(response);
-    spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_measurements_case2(void **State)
+void libspdm_test_responder_measurements_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_session_info_t *session_info;
@@ -85,11 +85,11 @@ void test_spdm_responder_measurements_case2(void **State)
 
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
-    spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer, &response_size, response);
 }
 
-void test_spdm_responder_measurements_case3(void **State)
+void libspdm_test_responder_measurements_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -123,12 +123,12 @@ void test_spdm_responder_measurements_case3(void **State)
 
     response_size = sizeof(response);
 
-    spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_measurements_case4(void **State)
+void libspdm_test_responder_measurements_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_session_info_t *session_info;
@@ -181,8 +181,8 @@ void test_spdm_responder_measurements_case4(void **State)
 
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
-    spdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
-                                   spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
+                                      spdm_test_context->test_buffer, &response_size, response);
     free(data);
 }
 
@@ -202,23 +202,23 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_measurements_case1(&State);
+    libspdm_test_responder_measurements_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*last_spdm_request_session_id_valid: true*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_measurements_case2(&State);
+    libspdm_test_responder_measurements_case2(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*Select version based on GET_VERSION/VERSION support*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_measurements_case3(&State);
+    libspdm_test_responder_measurements_case3(&State);
     spdm_unit_test_group_teardown(&State);
 
     /*Select version based on GET_VERSION/VERSION support
      * last_spdm_request_session_id_valid: true*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_measurements_case4(&State);
+    libspdm_test_responder_measurements_case4(&State);
     spdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -32,7 +32,7 @@ typedef struct {
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
 } spdm_psk_exchange_request_mine_t;
 
-void test_spdm_responder_psk_exchange_case1(void **State)
+void libspdm_test_responder_psk_exchange_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -90,12 +90,12 @@ void test_spdm_responder_psk_exchange_case1(void **State)
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
-                                   &m_spdm_psk_exchange_request, &response_size, response);
+    libspdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
+                                      &m_spdm_psk_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_psk_exchange_case2(void **State)
+void libspdm_test_responder_psk_exchange_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -151,12 +151,12 @@ void test_spdm_responder_psk_exchange_case2(void **State)
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
-                                   &m_spdm_psk_exchange_request, &response_size, response);
+    libspdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
+                                      &m_spdm_psk_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_psk_exchange_case3(void **State)
+void libspdm_test_responder_psk_exchange_case3(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -213,12 +213,12 @@ void test_spdm_responder_psk_exchange_case3(void **State)
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
-                                   &m_spdm_psk_exchange_request, &response_size, response);
+    libspdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
+                                      &m_spdm_psk_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_psk_exchange_case4(void **State)
+void libspdm_test_responder_psk_exchange_case4(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -280,12 +280,12 @@ void test_spdm_responder_psk_exchange_case4(void **State)
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
-                                   &m_spdm_psk_exchange_request, &response_size, response);
+    libspdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
+                                      &m_spdm_psk_exchange_request, &response_size, response);
     free(data);
 }
 
-void test_spdm_responder_psk_exchange_case5(void **State)
+void libspdm_test_responder_psk_exchange_case5(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t spdm_context;
@@ -348,8 +348,8 @@ void test_spdm_responder_psk_exchange_case5(void **State)
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
 
-    spdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
-                                   &m_spdm_psk_exchange_request, &response_size, response);
+    libspdm_get_response_psk_exchange(&spdm_context, m_spdm_psk_exchange_request_size,
+                                      &m_spdm_psk_exchange_request, &response_size, response);
     free(data);
 }
 
@@ -365,14 +365,14 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_psk_exchange_case1(&State);
-    test_spdm_responder_psk_exchange_case2(&State);
+    libspdm_test_responder_psk_exchange_case1(&State);
+    libspdm_test_responder_psk_exchange_case2(&State);
     /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-    test_spdm_responder_psk_exchange_case3(&State);
+    libspdm_test_responder_psk_exchange_case3(&State);
     /* capability.flags: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT */
-    test_spdm_responder_psk_exchange_case4(&State);
+    libspdm_test_responder_psk_exchange_case4(&State);
     /* capability.flags: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP */
-    test_spdm_responder_psk_exchange_case5(&State);
+    libspdm_test_responder_psk_exchange_case5(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -27,7 +27,7 @@ typedef struct {
 static void spdm_secured_message_set_request_finished_key(void *spdm_secured_message_context,
                                                           const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -37,7 +37,7 @@ static void spdm_secured_message_set_request_finished_key(void *spdm_secured_mes
     secured_message_context->finished_key_ready = true;
 }
 
-void test_spdm_responder_psk_finish_rsp_case1(void **State)
+void libspdm_test_responder_psk_finish_rsp_case1(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -92,12 +92,12 @@ void test_spdm_responder_psk_finish_rsp_case1(void **State)
                                               LIBSPDM_SESSION_STATE_HANDSHAKING);
 
     response_size = sizeof(response);
-    spdm_get_response_psk_finish(spdm_context, spdm_test_context->test_buffer_size,
-                                 spdm_test_context->test_buffer, &response_size, response);
+    libspdm_get_response_psk_finish(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
     free(data1);
 }
 
-void test_spdm_responder_psk_finish_rsp_case2(void **State)
+void libspdm_test_responder_psk_finish_rsp_case2(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     spdm_psk_finish_request_mine_t m_spdm_psk_finish_request;
@@ -172,8 +172,8 @@ void test_spdm_responder_psk_finish_rsp_case2(void **State)
     m_spdm_psk_finish_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
 
     response_size = sizeof(response);
-    spdm_get_response_psk_finish(spdm_context, m_spdm_psk_finish_request_size,
-                                 &m_spdm_psk_finish_request, &response_size, response);
+    libspdm_get_response_psk_finish(spdm_context, m_spdm_psk_finish_request_size,
+                                    &m_spdm_psk_finish_request, &response_size, response);
     free(data1);
 }
 
@@ -188,10 +188,10 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
 
     /* Success Case*/
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_psk_finish_rsp_case1(&State);
+    libspdm_test_responder_psk_finish_rsp_case1(&State);
     spdm_unit_test_group_teardown(&State);
 
     spdm_unit_test_group_setup(&State);
-    test_spdm_responder_psk_finish_rsp_case2(&State);
+    libspdm_test_responder_psk_finish_rsp_case2(&State);
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_version/version.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_version/version.c
@@ -13,7 +13,7 @@ uintn get_max_buffer_size(void)
     return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 }
 
-void test_spdm_responder_version(void **State)
+void libspdm_test_responder_version(void **State)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -24,10 +24,10 @@ void test_spdm_responder_version(void **State)
     spdm_context = spdm_test_context->spdm_context;
 
     response_size = sizeof(response);
-    spdm_get_response_version(spdm_context,
-                              spdm_test_context->test_buffer_size,
-                              spdm_test_context->test_buffer,
-                              &response_size, response);
+    libspdm_get_response_version(spdm_context,
+                                 spdm_test_context->test_buffer_size,
+                                 spdm_test_context->test_buffer,
+                                 &response_size, response);
 }
 
 spdm_test_context_t m_spdm_responder_version_test_context = {
@@ -48,7 +48,7 @@ void run_test_harness(const void *test_buffer, uintn test_buffer_size)
     spdm_unit_test_group_setup(&State);
 
     /* Success Case*/
-    test_spdm_responder_version(&State);
+    libspdm_test_responder_version(&State);
 
     spdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_secured_message/test_spdm_decode_secured_message/spdm_decode_secured_message.c
+++ b/unit_test/fuzzing/test_secured_message/test_spdm_decode_secured_message/spdm_decode_secured_message.c
@@ -25,7 +25,7 @@ void test_libspdm_decode_secured_message(void **State)
     libspdm_session_info_t *session_info;
     bool is_requester;
     uint32_t session_id;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;

--- a/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/spdm_encode_secured_message.c
+++ b/unit_test/fuzzing/test_secured_message/test_spdm_encode_secured_message/spdm_encode_secured_message.c
@@ -25,7 +25,7 @@ void test_libspdm_encode_secured_message(void **State)
     libspdm_session_info_t *session_info;
     bool is_requester;
     uint32_t session_id;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1181,7 +1181,7 @@ return_status spdm_requester_challenge_test_receive_message(
  * device error.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_challenge_case1(void **state)
+void libspdm_test_requester_challenge_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1259,7 +1259,7 @@ void test_spdm_requester_challenge_case1(void **state)
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case2(void **state)
+void libspdm_test_requester_challenge_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1335,7 +1335,7 @@ void test_spdm_requester_challenge_case2(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is not set.
  **/
-void test_spdm_requester_challenge_case3(void **state)
+void libspdm_test_requester_challenge_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1406,7 +1406,7 @@ void test_spdm_requester_challenge_case3(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is reset.
  **/
-void test_spdm_requester_challenge_case4(void **state)
+void libspdm_test_requester_challenge_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1477,7 +1477,7 @@ void test_spdm_requester_challenge_case4(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is reset.
  **/
-void test_spdm_requester_challenge_case5(void **state)
+void libspdm_test_requester_challenge_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1548,7 +1548,7 @@ void test_spdm_requester_challenge_case5(void **state)
  * message to the challenge, with no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case6(void **state)
+void libspdm_test_requester_challenge_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1617,7 +1617,7 @@ void test_spdm_requester_challenge_case6(void **state)
  * transcript buffer is reset, and the communication is reset to expect a new
  * GET_VERSION message.
  **/
-void test_spdm_requester_challenge_case7(void **state)
+void libspdm_test_requester_challenge_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1690,7 +1690,7 @@ void test_spdm_requester_challenge_case7(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * buffer stores nothing.
  **/
-void test_spdm_requester_challenge_case8(void **state)
+void libspdm_test_requester_challenge_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1762,7 +1762,7 @@ void test_spdm_requester_challenge_case8(void **state)
  * on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case9(void **state)
+void libspdm_test_requester_challenge_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1832,7 +1832,7 @@ void test_spdm_requester_challenge_case9(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is not set.
  **/
-void test_spdm_requester_challenge_case10(void **state) {
+void libspdm_test_requester_challenge_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1893,7 +1893,7 @@ void test_spdm_requester_challenge_case10(void **state) {
  * response message, smaller then a standard SPDM message header.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR,.
  **/
-void test_spdm_requester_challenge_case11(void **state) {
+void libspdm_test_requester_challenge_case11(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1952,7 +1952,7 @@ void test_spdm_requester_challenge_case11(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_challenge_case12(void **state) {
+void libspdm_test_requester_challenge_case12(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2012,7 +2012,7 @@ void test_spdm_requester_challenge_case12(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_challenge_case13(void **state) {
+void libspdm_test_requester_challenge_case13(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2071,7 +2071,7 @@ void test_spdm_requester_challenge_case13(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_challenge_case14(void **state) {
+void libspdm_test_requester_challenge_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2127,7 +2127,7 @@ void test_spdm_requester_challenge_case14(void **state) {
 /**
  * Test 15: free to be populated by test.
  **/
-void test_spdm_requester_challenge_case15(void **state) {
+void libspdm_test_requester_challenge_case15(void **state) {
 }
 
 /**
@@ -2143,7 +2143,7 @@ void test_spdm_requester_challenge_case15(void **state) {
  * data with bytes from the string "openspdm", and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case16(void **state) {
+void libspdm_test_requester_challenge_case16(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2209,7 +2209,7 @@ void test_spdm_requester_challenge_case16(void **state) {
  * but with an invalid signature.
  * Expected behavior: client returns a status of RETURN_SECURITY_VIOLATION.
  **/
-void test_spdm_requester_challenge_case17(void **state) {
+void libspdm_test_requester_challenge_case17(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2275,7 +2275,7 @@ void test_spdm_requester_challenge_case17(void **state) {
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case18(void **state) {
+void libspdm_test_requester_challenge_case18(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2342,7 +2342,7 @@ void test_spdm_requester_challenge_case18(void **state) {
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_challenge_case19(void **state) {
+void libspdm_test_requester_challenge_case19(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2403,7 +2403,7 @@ void test_spdm_requester_challenge_case19(void **state) {
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_challenge_case20(void **state) {
+void libspdm_test_requester_challenge_case20(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2483,7 +2483,7 @@ void test_spdm_requester_challenge_case20(void **state) {
  * Test 21: test correct CHALLENGE_AUTH message with multiple slot numbers
  * Expected behavior: success and slot_id is included in slot_mask.
  **/
-void test_spdm_requester_challenge_case21(void **state) {
+void libspdm_test_requester_challenge_case21(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2550,41 +2550,41 @@ int spdm_requester_challenge_test_main(void)
 {
     const struct CMUnitTest spdm_requester_challenge_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_challenge_case1),
+        cmocka_unit_test(libspdm_test_requester_challenge_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_challenge_case2),
+        cmocka_unit_test(libspdm_test_requester_challenge_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_challenge_case3),
+        cmocka_unit_test(libspdm_test_requester_challenge_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_challenge_case4),
+        cmocka_unit_test(libspdm_test_requester_challenge_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_challenge_case5),
+        cmocka_unit_test(libspdm_test_requester_challenge_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_challenge_case6),
+        cmocka_unit_test(libspdm_test_requester_challenge_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_challenge_case7),
+        cmocka_unit_test(libspdm_test_requester_challenge_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_challenge_case8),
+        cmocka_unit_test(libspdm_test_requester_challenge_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_challenge_case9),
+        cmocka_unit_test(libspdm_test_requester_challenge_case9),
         /* SpdmCmdReceiveState check failed*/
-        cmocka_unit_test(test_spdm_requester_challenge_case10),
+        cmocka_unit_test(libspdm_test_requester_challenge_case10),
         /* Successful response + device error*/
-        cmocka_unit_test(test_spdm_requester_challenge_case11),
-        cmocka_unit_test(test_spdm_requester_challenge_case12),
-        cmocka_unit_test(test_spdm_requester_challenge_case13),
-        cmocka_unit_test(test_spdm_requester_challenge_case14),
+        cmocka_unit_test(libspdm_test_requester_challenge_case11),
+        cmocka_unit_test(libspdm_test_requester_challenge_case12),
+        cmocka_unit_test(libspdm_test_requester_challenge_case13),
+        cmocka_unit_test(libspdm_test_requester_challenge_case14),
         /* Invalid parameter*/
-        cmocka_unit_test(test_spdm_requester_challenge_case15),
+        cmocka_unit_test(libspdm_test_requester_challenge_case15),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_challenge_case16),
+        cmocka_unit_test(libspdm_test_requester_challenge_case16),
         /* Signature check failed*/
-        cmocka_unit_test(test_spdm_requester_challenge_case17),
+        cmocka_unit_test(libspdm_test_requester_challenge_case17),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_challenge_case18),
-        cmocka_unit_test(test_spdm_requester_challenge_case19),
+        cmocka_unit_test(libspdm_test_requester_challenge_case18),
+        cmocka_unit_test(libspdm_test_requester_challenge_case19),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_challenge_case20),
+        cmocka_unit_test(libspdm_test_requester_challenge_case20),
     };
 
     setup_spdm_test_context(&m_spdm_requester_challenge_test_context);

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -15,7 +15,7 @@ static uint8_t m_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 static void spdm_secured_message_set_response_data_encryption_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->aead_key_size);
@@ -28,7 +28,7 @@ static void spdm_secured_message_set_response_data_salt(
     void *spdm_secured_message_context, const void *salt,
     uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(salt_size == secured_message_context->aead_iv_size);
@@ -112,7 +112,7 @@ return_status spdm_requester_end_session_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -144,7 +144,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -171,7 +171,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -198,7 +198,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -228,7 +228,7 @@ return_status spdm_requester_end_session_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -259,7 +259,7 @@ return_status spdm_requester_end_session_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -288,7 +288,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -320,7 +320,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -357,7 +357,7 @@ return_status spdm_requester_end_session_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -388,7 +388,7 @@ return_status spdm_requester_end_session_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -417,7 +417,7 @@ return_status spdm_requester_end_session_test_receive_message(
                                                 sizeof(spdm_response), &spdm_response,
                                                 response_size, response);
             session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
             application_secret.response_data_sequence_number--;
         }
 
@@ -460,7 +460,7 @@ return_status spdm_requester_end_session_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -486,7 +486,7 @@ return_status spdm_requester_end_session_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -497,7 +497,7 @@ return_status spdm_requester_end_session_test_receive_message(
     }
 }
 
-void test_spdm_requester_end_session_case1(void **state)
+void libspdm_test_requester_end_session_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -561,12 +561,12 @@ void test_spdm_requester_end_session_case1(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
 
-void test_spdm_requester_end_session_case2(void **state)
+void libspdm_test_requester_end_session_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -630,30 +630,30 @@ void test_spdm_requester_end_session_case2(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -662,7 +662,7 @@ void test_spdm_requester_end_session_case2(void **state)
     free(data);
 }
 
-void test_spdm_requester_end_session_case3(void **state)
+void libspdm_test_requester_end_session_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -726,35 +726,35 @@ void test_spdm_requester_end_session_case3(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
 
-void test_spdm_requester_end_session_case4(void **state)
+void libspdm_test_requester_end_session_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -818,35 +818,35 @@ void test_spdm_requester_end_session_case4(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
 
-void test_spdm_requester_end_session_case5(void **state)
+void libspdm_test_requester_end_session_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -910,35 +910,35 @@ void test_spdm_requester_end_session_case5(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_NO_RESPONSE);
     free(data);
 }
 
-void test_spdm_requester_end_session_case6(void **state)
+void libspdm_test_requester_end_session_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1002,30 +1002,30 @@ void test_spdm_requester_end_session_case6(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1034,7 +1034,7 @@ void test_spdm_requester_end_session_case6(void **state)
     free(data);
 }
 
-void test_spdm_requester_end_session_case7(void **state)
+void libspdm_test_requester_end_session_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1098,37 +1098,37 @@ void test_spdm_requester_end_session_case7(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
     free(data);
 }
 
-void test_spdm_requester_end_session_case8(void **state)
+void libspdm_test_requester_end_session_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1192,35 +1192,35 @@ void test_spdm_requester_end_session_case8(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
 
-void test_spdm_requester_end_session_case9(void **state)
+void libspdm_test_requester_end_session_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1284,30 +1284,30 @@ void test_spdm_requester_end_session_case9(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1316,7 +1316,7 @@ void test_spdm_requester_end_session_case9(void **state)
     free(data);
 }
 
-void test_spdm_requester_end_session_case10(void **state) {
+void libspdm_test_requester_end_session_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1369,23 +1369,24 @@ void test_spdm_requester_end_session_case10(void **state) {
         libspdm_secured_message_set_session_state (session_info->secured_message_context,
                                                    LIBSPDM_SESSION_STATE_ESTABLISHED);
         set_mem (m_dummy_key_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_data_encryption_key (
             session_info->secured_message_context, m_dummy_key_buffer,
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
         set_mem (m_dummy_salt_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_data_salt (session_info->secured_message_context,
                                                      m_dummy_salt_buffer,
-                                                     ((spdm_secured_message_context_t*)(session_info
-                                                                                        ->
-                                                                                        secured_message_context))->aead_iv_size);
-        ((spdm_secured_message_context_t*)(session_info->secured_message_context))->
+                                                     ((libspdm_secured_message_context_t*)(
+                                                          session_info
+                                                          ->
+                                                          secured_message_context))->aead_iv_size);
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
         application_secret.response_data_sequence_number = 0;
 
-        status = spdm_send_receive_end_session (spdm_context, session_id, 0);
+        status = libspdm_send_receive_end_session (spdm_context, session_id, 0);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         if(error_code != SPDM_ERROR_CODE_DECRYPT_ERROR) {
             ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
@@ -1408,7 +1409,7 @@ void test_spdm_requester_end_session_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_end_session_case11(void **state)
+void libspdm_test_requester_end_session_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1472,27 +1473,27 @@ void test_spdm_requester_end_session_case11(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     session_info->session_transcript.message_m.buffer_size =
@@ -1507,7 +1508,7 @@ void test_spdm_requester_end_session_case11(void **state)
         spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1527,7 +1528,7 @@ void test_spdm_requester_end_session_case11(void **state)
  * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void test_spdm_requester_end_session_case12(void **state)
+void libspdm_test_requester_end_session_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1591,30 +1592,30 @@ void test_spdm_requester_end_session_case12(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
-    status = spdm_send_receive_end_session(spdm_context, session_id, 0);
+    status = libspdm_send_receive_end_session(spdm_context, session_id, 0);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
 
@@ -1632,29 +1633,29 @@ int spdm_requester_end_session_test_main(void)
 {
     const struct CMUnitTest spdm_requester_end_session_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_end_session_case1),
+        cmocka_unit_test(libspdm_test_requester_end_session_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_end_session_case2),
+        cmocka_unit_test(libspdm_test_requester_end_session_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_end_session_case3),
+        cmocka_unit_test(libspdm_test_requester_end_session_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_end_session_case4),
+        cmocka_unit_test(libspdm_test_requester_end_session_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_end_session_case5),
+        cmocka_unit_test(libspdm_test_requester_end_session_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_end_session_case6),
+        cmocka_unit_test(libspdm_test_requester_end_session_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_end_session_case7),
+        cmocka_unit_test(libspdm_test_requester_end_session_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_end_session_case8),
+        cmocka_unit_test(libspdm_test_requester_end_session_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_end_session_case9),
+        cmocka_unit_test(libspdm_test_requester_end_session_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_end_session_case10),
+        cmocka_unit_test(libspdm_test_requester_end_session_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_end_session_case11),
+        cmocka_unit_test(libspdm_test_requester_end_session_case11),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(test_spdm_requester_end_session_case12),
+        cmocka_unit_test(libspdm_test_requester_end_session_case12),
     };
 
     setup_spdm_test_context(&m_spdm_requester_end_session_test_context);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -18,7 +18,7 @@ uint8_t m_dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
 void spdm_secured_message_set_response_finished_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -1300,7 +1300,7 @@ return_status spdm_requester_finish_test_receive_message(
  * device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case1(void **state)
+void libspdm_test_requester_finish_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1382,8 +1382,8 @@ void test_spdm_requester_finish_case1(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -1394,7 +1394,7 @@ void test_spdm_requester_finish_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void test_spdm_requester_finish_case2(void **state)
+void libspdm_test_requester_finish_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1476,8 +1476,8 @@ void test_spdm_requester_finish_case2(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1491,7 +1491,7 @@ void test_spdm_requester_finish_case2(void **state)
  * NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_finish_case3(void **state)
+void libspdm_test_requester_finish_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1573,8 +1573,8 @@ void test_spdm_requester_finish_case3(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -1584,7 +1584,7 @@ void test_spdm_requester_finish_case3(void **state)
  * message indicating InvalidParameters.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case4(void **state)
+void libspdm_test_requester_finish_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1666,8 +1666,8 @@ void test_spdm_requester_finish_case4(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
     free(data);
@@ -1678,7 +1678,7 @@ void test_spdm_requester_finish_case4(void **state)
  * message indicating the Busy status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case5(void **state)
+void libspdm_test_requester_finish_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1760,8 +1760,8 @@ void test_spdm_requester_finish_case5(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_NO_RESPONSE);
     free(data);
 }
@@ -1772,7 +1772,7 @@ void test_spdm_requester_finish_case5(void **state)
  * message with only MAC (no mutual authentication).
  * Expected behavior: client returns a Status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_finish_case6(void **state)
+void libspdm_test_requester_finish_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1854,8 +1854,8 @@ void test_spdm_requester_finish_case6(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1870,7 +1870,7 @@ void test_spdm_requester_finish_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void test_spdm_requester_finish_case7(void **state)
+void libspdm_test_requester_finish_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1952,8 +1952,8 @@ void test_spdm_requester_finish_case7(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -1965,7 +1965,7 @@ void test_spdm_requester_finish_case7(void **state)
  * message indicating the ResponseNotReady status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR,.
  **/
-void test_spdm_requester_finish_case8(void **state)
+void libspdm_test_requester_finish_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2047,8 +2047,8 @@ void test_spdm_requester_finish_case8(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -2059,7 +2059,7 @@ void test_spdm_requester_finish_case8(void **state)
  * FINISH_RSP message with only MAC (no mutual authentication).
  * Expected behavior: client returns a Status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_finish_case9(void **state)
+void libspdm_test_requester_finish_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2141,8 +2141,8 @@ void test_spdm_requester_finish_case9(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -2159,7 +2159,7 @@ void test_spdm_requester_finish_case9(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case10(void **state) {
+void libspdm_test_requester_finish_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2232,7 +2232,7 @@ void test_spdm_requester_finish_case10(void **state) {
         libspdm_secured_message_set_session_state (session_info->secured_message_context,
                                                    LIBSPDM_SESSION_STATE_HANDSHAKING);
 
-        status = spdm_send_receive_finish (spdm_context, session_id, req_slot_id_param);
+        status = libspdm_send_receive_finish (spdm_context, session_id, req_slot_id_param);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         if(error_code != SPDM_ERROR_CODE_DECRYPT_ERROR) {
             ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
@@ -2255,7 +2255,7 @@ void test_spdm_requester_finish_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_finish_case11(void **state)
+void libspdm_test_requester_finish_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2350,8 +2350,8 @@ void test_spdm_requester_finish_case11(void **state)
         spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
 
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -2374,7 +2374,7 @@ void test_spdm_requester_finish_case11(void **state)
  * FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_finish_case12(void **state)
+void libspdm_test_requester_finish_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2457,8 +2457,8 @@ void test_spdm_requester_finish_case12(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -2470,7 +2470,7 @@ void test_spdm_requester_finish_case12(void **state)
  * responder would attempt to return a correct FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_finish_case13(void **state)
+void libspdm_test_requester_finish_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2552,8 +2552,8 @@ void test_spdm_requester_finish_case13(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -2563,7 +2563,7 @@ void test_spdm_requester_finish_case13(void **state)
  * code, but all other field correct.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case14(void **state)
+void libspdm_test_requester_finish_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2645,8 +2645,8 @@ void test_spdm_requester_finish_case14(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -2657,7 +2657,7 @@ void test_spdm_requester_finish_case14(void **state)
  * return a correct FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_finish_case15(void **state)
+void libspdm_test_requester_finish_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2739,8 +2739,8 @@ void test_spdm_requester_finish_case15(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -2751,7 +2751,7 @@ void test_spdm_requester_finish_case15(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void test_spdm_requester_finish_case16(void **state)
+void libspdm_test_requester_finish_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2845,8 +2845,8 @@ void test_spdm_requester_finish_case16(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.slot_count = 1;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -2860,7 +2860,7 @@ void test_spdm_requester_finish_case16(void **state)
  * (all-zero), mutual authentication, and 'handshake in the clear'.
  * Expected behavior: client returns a Status of RETURN_SECURITY_VIOLATION.
  **/
-void test_spdm_requester_finish_case17(void **state)
+void libspdm_test_requester_finish_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2954,8 +2954,8 @@ void test_spdm_requester_finish_case17(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.slot_count = 1;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     free(data);
 }
@@ -2965,7 +2965,7 @@ void test_spdm_requester_finish_case17(void **state)
  * (arbitrary), mutual authentication, and 'handshake in the clear'.
  * Expected behavior: client returns a Status of RETURN_SECURITY_VIOLATION.
  **/
-void test_spdm_requester_finish_case18(void **state)
+void libspdm_test_requester_finish_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3059,8 +3059,8 @@ void test_spdm_requester_finish_case18(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.slot_count = 1;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     free(data);
 }
@@ -3071,7 +3071,7 @@ void test_spdm_requester_finish_case18(void **state)
  * the clear'.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case19(void **state)
+void libspdm_test_requester_finish_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3165,8 +3165,8 @@ void test_spdm_requester_finish_case19(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.slot_count = 1;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -3177,7 +3177,7 @@ void test_spdm_requester_finish_case19(void **state)
  * in the clear'.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_finish_case20(void **state)
+void libspdm_test_requester_finish_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3271,8 +3271,8 @@ void test_spdm_requester_finish_case20(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.slot_count = 1;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -3281,7 +3281,7 @@ void test_spdm_requester_finish_case20(void **state)
  * Test 21: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void test_spdm_requester_finish_case21(void **state)
+void libspdm_test_requester_finish_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3363,8 +3363,8 @@ void test_spdm_requester_finish_case21(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     req_slot_id_param = 0;
-    status = spdm_send_receive_finish(spdm_context, session_id,
-                                      req_slot_id_param);
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
     free(data);
@@ -3381,42 +3381,42 @@ int spdm_requester_finish_test_main(void)
 {
     const struct CMUnitTest spdm_requester_finish_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_finish_case1),
+        cmocka_unit_test(libspdm_test_requester_finish_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_finish_case2),
+        cmocka_unit_test(libspdm_test_requester_finish_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_finish_case3),
+        cmocka_unit_test(libspdm_test_requester_finish_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_finish_case4),
+        cmocka_unit_test(libspdm_test_requester_finish_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_finish_case5),
+        cmocka_unit_test(libspdm_test_requester_finish_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_finish_case6),
+        cmocka_unit_test(libspdm_test_requester_finish_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_finish_case7),
+        cmocka_unit_test(libspdm_test_requester_finish_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_finish_case8),
+        cmocka_unit_test(libspdm_test_requester_finish_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_finish_case9),
+        cmocka_unit_test(libspdm_test_requester_finish_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_finish_case10),
+        cmocka_unit_test(libspdm_test_requester_finish_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_finish_case11),
+        cmocka_unit_test(libspdm_test_requester_finish_case11),
         /* No correct setup*/
-        cmocka_unit_test(test_spdm_requester_finish_case12),
-        cmocka_unit_test(test_spdm_requester_finish_case13),
-        cmocka_unit_test(test_spdm_requester_finish_case14),
-        cmocka_unit_test(test_spdm_requester_finish_case15),
+        cmocka_unit_test(libspdm_test_requester_finish_case12),
+        cmocka_unit_test(libspdm_test_requester_finish_case13),
+        cmocka_unit_test(libspdm_test_requester_finish_case14),
+        cmocka_unit_test(libspdm_test_requester_finish_case15),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_finish_case16),
+        cmocka_unit_test(libspdm_test_requester_finish_case16),
         /* Response with invalid MAC*/
-        cmocka_unit_test(test_spdm_requester_finish_case17),
-        cmocka_unit_test(test_spdm_requester_finish_case18),
+        cmocka_unit_test(libspdm_test_requester_finish_case17),
+        cmocka_unit_test(libspdm_test_requester_finish_case18),
         /* Response with invalid MAC size*/
-        cmocka_unit_test(test_spdm_requester_finish_case19),
-        cmocka_unit_test(test_spdm_requester_finish_case20),
+        cmocka_unit_test(libspdm_test_requester_finish_case19),
+        cmocka_unit_test(libspdm_test_requester_finish_case20),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(test_spdm_requester_finish_case21),
+        cmocka_unit_test(libspdm_test_requester_finish_case21),
     };
 
     setup_spdm_test_context(&m_spdm_requester_finish_test_context);

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -752,7 +752,7 @@ return_status spdm_requester_get_capabilities_test_receive_message(
     }
 }
 
-void test_spdm_requester_get_capabilities_case1(void **state)
+void libspdm_test_requester_get_capabilities_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -768,11 +768,11 @@ void test_spdm_requester_get_capabilities_case1(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case2(void **state)
+void libspdm_test_requester_get_capabilities_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -792,7 +792,7 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -803,7 +803,7 @@ void test_spdm_requester_get_capabilities_case2(void **state)
 #endif
 }
 
-void test_spdm_requester_get_capabilities_case3(void **state)
+void libspdm_test_requester_get_capabilities_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -819,11 +819,11 @@ void test_spdm_requester_get_capabilities_case3(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_UNSUPPORTED);
 }
 
-void test_spdm_requester_get_capabilities_case4(void **state)
+void libspdm_test_requester_get_capabilities_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -839,11 +839,11 @@ void test_spdm_requester_get_capabilities_case4(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case5(void **state)
+void libspdm_test_requester_get_capabilities_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -859,11 +859,11 @@ void test_spdm_requester_get_capabilities_case5(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_NO_RESPONSE);
 }
 
-void test_spdm_requester_get_capabilities_case6(void **state)
+void libspdm_test_requester_get_capabilities_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -879,7 +879,7 @@ void test_spdm_requester_get_capabilities_case6(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -887,7 +887,7 @@ void test_spdm_requester_get_capabilities_case6(void **state)
                      DEFAULT_CAPABILITY_FLAG);
 }
 
-void test_spdm_requester_get_capabilities_case7(void **state)
+void libspdm_test_requester_get_capabilities_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -903,13 +903,13 @@ void test_spdm_requester_get_capabilities_case7(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
 }
 
-void test_spdm_requester_get_capabilities_case8(void **state)
+void libspdm_test_requester_get_capabilities_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -925,11 +925,11 @@ void test_spdm_requester_get_capabilities_case8(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case9(void **state)
+void libspdm_test_requester_get_capabilities_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -945,13 +945,13 @@ void test_spdm_requester_get_capabilities_case9(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*  assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      *  assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_FLAG);*/
 }
 
-void test_spdm_requester_get_capabilities_case10(void **state)
+void libspdm_test_requester_get_capabilities_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -967,7 +967,7 @@ void test_spdm_requester_get_capabilities_case10(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -979,7 +979,7 @@ void test_spdm_requester_get_capabilities_case10(void **state)
                       SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
 }
 
-void test_spdm_requester_get_capabilities_case11(void **state)
+void libspdm_test_requester_get_capabilities_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -995,7 +995,7 @@ void test_spdm_requester_get_capabilities_case11(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -1008,7 +1008,7 @@ void test_spdm_requester_get_capabilities_case11(void **state)
           SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
 }
 
-void test_spdm_requester_get_capabilities_case12(void **state)
+void libspdm_test_requester_get_capabilities_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1024,7 +1024,7 @@ void test_spdm_requester_get_capabilities_case12(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -1032,7 +1032,7 @@ void test_spdm_requester_get_capabilities_case12(void **state)
                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP);
 }
 
-void test_spdm_requester_get_capabilities_case13(void **state)
+void libspdm_test_requester_get_capabilities_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1048,11 +1048,11 @@ void test_spdm_requester_get_capabilities_case13(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case14(void **state)
+void libspdm_test_requester_get_capabilities_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1068,11 +1068,11 @@ void test_spdm_requester_get_capabilities_case14(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case15(void **state)
+void libspdm_test_requester_get_capabilities_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1088,11 +1088,11 @@ void test_spdm_requester_get_capabilities_case15(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case16(void **state)
+void libspdm_test_requester_get_capabilities_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1109,7 +1109,7 @@ void test_spdm_requester_get_capabilities_case16(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(spdm_context->connection_info.capability.ct_exponent,
                      0);
@@ -1117,7 +1117,7 @@ void test_spdm_requester_get_capabilities_case16(void **state)
                      DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11);
 }
 
-void test_spdm_requester_get_capabilities_case17(void **state)
+void libspdm_test_requester_get_capabilities_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1134,13 +1134,13 @@ void test_spdm_requester_get_capabilities_case17(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case18(void **state)
+void libspdm_test_requester_get_capabilities_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1157,13 +1157,13 @@ void test_spdm_requester_get_capabilities_case18(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case19(void **state)
+void libspdm_test_requester_get_capabilities_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1181,13 +1181,13 @@ void test_spdm_requester_get_capabilities_case19(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case20(void **state)
+void libspdm_test_requester_get_capabilities_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1205,13 +1205,13 @@ void test_spdm_requester_get_capabilities_case20(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case21(void **state)
+void libspdm_test_requester_get_capabilities_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1229,13 +1229,13 @@ void test_spdm_requester_get_capabilities_case21(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case22(void **state)
+void libspdm_test_requester_get_capabilities_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1253,13 +1253,13 @@ void test_spdm_requester_get_capabilities_case22(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case23(void **state)
+void libspdm_test_requester_get_capabilities_case23(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1277,13 +1277,13 @@ void test_spdm_requester_get_capabilities_case23(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case24(void **state)
+void libspdm_test_requester_get_capabilities_case24(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1301,13 +1301,13 @@ void test_spdm_requester_get_capabilities_case24(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case25(void **state)
+void libspdm_test_requester_get_capabilities_case25(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1325,13 +1325,13 @@ void test_spdm_requester_get_capabilities_case25(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)));*/
 }
 
-void test_spdm_requester_get_capabilities_case26(void **state)
+void libspdm_test_requester_get_capabilities_case26(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1349,13 +1349,13 @@ void test_spdm_requester_get_capabilities_case26(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
      * assert_int_equal (spdm_context->connection_info.capability.flags, DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP);*/
 }
 
-void test_spdm_requester_get_capabilities_case27(void **state)
+void libspdm_test_requester_get_capabilities_case27(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1373,11 +1373,11 @@ void test_spdm_requester_get_capabilities_case27(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case28(void **state)
+void libspdm_test_requester_get_capabilities_case28(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1395,11 +1395,11 @@ void test_spdm_requester_get_capabilities_case28(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags =
         DEFAULT_CAPABILITY_FLAG_VERSION_11;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_get_capabilities_case29(void **state) {
+void libspdm_test_requester_get_capabilities_case29(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1418,7 +1418,7 @@ void test_spdm_requester_get_capabilities_case29(void **state) {
         spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
         libspdm_reset_message_a(spdm_context);
 
-        status = spdm_get_capabilities (spdm_context);
+        status = libspdm_get_capabilities (spdm_context);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
@@ -1435,7 +1435,7 @@ void test_spdm_requester_get_capabilities_case29(void **state) {
     }
 }
 
-void test_spdm_requester_get_capabilities_case30(void **state)
+void libspdm_test_requester_get_capabilities_case30(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1451,11 +1451,11 @@ void test_spdm_requester_get_capabilities_case30(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_TIMEOUT);
 }
 
-void test_spdm_requester_get_capabilities_case31(void **state)
+void libspdm_test_requester_get_capabilities_case31(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1471,7 +1471,7 @@ void test_spdm_requester_get_capabilities_case31(void **state)
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = DEFAULT_CAPABILITY_FLAG;
-    status = spdm_get_capabilities(spdm_context);
+    status = libspdm_get_capabilities(spdm_context);
     assert_int_equal(status, RETURN_TIMEOUT);
 }
 
@@ -1486,70 +1486,70 @@ int spdm_requester_get_capabilities_test_main(void)
 {
     const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case1),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case2),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case3),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case4),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case5),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case6),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case7),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY
          * CORRECTION for both case 8 and 9: A RESPONSE_NOT_READY is an invalid response for GET_CAPABILITIES
          * file spdm_requester_libHandleErrorResponse.c was corrected to reflect the documentation and now returns a RETURN_DEVICE_ERROR.*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case8),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case9),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case9),
         /* All flags set in response*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case10),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case10),
         /* All flags cleared in response*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case11),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case11),
         /* meas_fresh_cap set, others cleared in response. This behaviour is undefined in the protocol*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case12),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case12),
         /* Receives just header*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case13),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case13),
         /* Receives a message 1 byte bigger than the capabilites response message*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case14),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case14),
         /* Receives a message 1 byte smaller than the capabilites response message*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case15),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case15),
         /* from this point forward, tests are performed with version 1.1
          * Requester sends all flags set and receives successful response with all flags set*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case16),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case16),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap and mac_cap set, and key_ex_cap and psk_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case17),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case17),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap set and mac_cap cleared, and key_ex_cap and psk_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case18),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case18),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap cleared and mac_cap set, and key_ex_cap and psk_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case19),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case19),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap cleared and mac_cap cleared, and key_ex_cap and psk_cap set*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case20),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case20),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap and mac_cap cleared, and key_ex_cap set and psk_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case21),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case21),
         /* Requester sends all flags set and receives successful response with flags encrypt_cap and mac_cap cleared, and key_ex_cap cleared and psk_cap set*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case22),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case22),
         /* Requester sends all flags set and receives successful response with flags mut_auth_cap set, and encap_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case23),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case23),
         /* Requester sends all flags set and receives successful response with flags handshake_in_the_clear_cap set, and key_ex_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case24),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case24),
         /* Requester sends all flags set and receives successful response with flags handshake_in_the_clear_cap set, and encrypt_cap and mac_cap cleared*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case25),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case25),
         /* Requester sends all flags set and receives successful response with flags pub_key_id_cap set, and cert_cap set*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case26),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case26),
         /* Requester sends all flags set and receives response with get_capabilities request code (wrong response code)*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case27),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case27),
         /* Requester sends all flags set and receives response with 0xFF as version code (wrong version code)*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case28),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case28),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case29),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case29),
         /* SendRequest timeout */
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case30),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case30),
         /* ReceiveResponse timeout */
-        cmocka_unit_test(test_spdm_requester_get_capabilities_case31),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_case31),
 
     };
 

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1469,7 +1469,7 @@ return_status spdm_requester_get_certificate_test_receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a RETURN_DEVICE_ERROR, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_requester_get_certificate_case1(void **state)
+void libspdm_test_requester_get_certificate_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1526,7 +1526,7 @@ void test_spdm_requester_get_certificate_case1(void **state)
  * Test 2: Normal case, request a certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case2(void **state)
+void libspdm_test_requester_get_certificate_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1600,7 +1600,7 @@ void test_spdm_requester_get_certificate_case2(void **state)
  * Test 3: simulate wrong connection_state when sending GET_CERTIFICATE (missing SPDM_GET_DIGESTS_RECEIVE_FLAG and SPDM_GET_CAPABILITIES_RECEIVE_FLAG)
  * Expected Behavior: get a RETURN_UNSUPPORTED, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_requester_get_certificate_case3(void **state)
+void libspdm_test_requester_get_certificate_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1657,7 +1657,7 @@ void test_spdm_requester_get_certificate_case3(void **state)
  * Test 4: force responder to send an ERROR message with code SPDM_ERROR_CODE_INVALID_REQUEST
  * Expected Behavior: get a RETURN_DEVICE_ERROR, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_requester_get_certificate_case4(void **state)
+void libspdm_test_requester_get_certificate_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1714,7 +1714,7 @@ void test_spdm_requester_get_certificate_case4(void **state)
  * Test 5: force responder to send an ERROR message with code SPDM_ERROR_CODE_BUSY
  * Expected Behavior: get a RETURN_NO_RESPONSE, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_requester_get_certificate_case5(void **state)
+void libspdm_test_requester_get_certificate_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1771,7 +1771,7 @@ void test_spdm_requester_get_certificate_case5(void **state)
  * Test 6: force responder to first send an ERROR message with code SPDM_ERROR_CODE_BUSY, but functions normally afterwards
  * Expected Behavior: receives the correct number of CERTIFICATE messages
  **/
-void test_spdm_requester_get_certificate_case6(void **state)
+void libspdm_test_requester_get_certificate_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1835,7 +1835,7 @@ void test_spdm_requester_get_certificate_case6(void **state)
  * Test 7: force responder to send an ERROR message with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  * Expected Behavior: get a RETURN_DEVICE_ERROR, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_requester_get_certificate_case7(void **state)
+void libspdm_test_requester_get_certificate_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1894,7 +1894,7 @@ void test_spdm_requester_get_certificate_case7(void **state)
  * Test 8: force responder to send an ERROR message with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  * Expected Behavior: get a RETURN_NO_RESPONSE
  **/
-void test_spdm_requester_get_certificate_case8(void **state)
+void libspdm_test_requester_get_certificate_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1948,7 +1948,7 @@ void test_spdm_requester_get_certificate_case8(void **state)
  * Test 9: force responder to first send an ERROR message with code SPDM_ERROR_CODE_RESPONSE_NOT_READY, but functions normally afterwards
  * Expected Behavior: receives the correct number of CERTIFICATE messages
  **/
-void test_spdm_requester_get_certificate_case9(void **state)
+void libspdm_test_requester_get_certificate_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2013,7 +2013,7 @@ void test_spdm_requester_get_certificate_case9(void **state)
  * Test 10: Normal case, request a certificate chain. Validates certificate by using a prelaoded chain instead of root hash
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case10(void **state)
+void libspdm_test_requester_get_certificate_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2078,7 +2078,7 @@ void test_spdm_requester_get_certificate_case10(void **state)
  * Test 11: Normal procedure, but the retrieved certificate chain has an invalid signature
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION, and receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case11(void **state)
+void libspdm_test_requester_get_certificate_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2147,7 +2147,7 @@ void test_spdm_requester_get_certificate_case11(void **state)
  * Test 12: Normal procedure, but the retrieved root certificate does not match
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION, and receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case12(void **state)
+void libspdm_test_requester_get_certificate_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2220,7 +2220,7 @@ void test_spdm_requester_get_certificate_case12(void **state)
  * Test 13: Gets a short certificate chain (fits in 1 message)
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case13(void **state)
+void libspdm_test_requester_get_certificate_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2289,7 +2289,7 @@ void test_spdm_requester_get_certificate_case13(void **state)
  * Test 14: request a whole certificate chain byte by byte
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case14(void **state)
+void libspdm_test_requester_get_certificate_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2364,7 +2364,7 @@ void test_spdm_requester_get_certificate_case14(void **state)
  * Test 15: request a long certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case15(void **state)
+void libspdm_test_requester_get_certificate_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2441,7 +2441,7 @@ void test_spdm_requester_get_certificate_case15(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_certificate_case16(void **state) {
+void libspdm_test_requester_get_certificate_case16(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2508,7 +2508,7 @@ void test_spdm_requester_get_certificate_case16(void **state) {
  * Test 17: Normal case, get a certificate chain start not with root cert. Validates certificate by using a prelaoded chain.
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case17(void **state)
+void libspdm_test_requester_get_certificate_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2562,7 +2562,7 @@ void test_spdm_requester_get_certificate_case17(void **state)
  * Test 18: Fail case, get a certificate chain start not with root cert and with wrong signature. Validates certificate by using a prelaoded chain.
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case18(void **state)
+void libspdm_test_requester_get_certificate_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2616,7 +2616,7 @@ void test_spdm_requester_get_certificate_case18(void **state)
  * Test 19: Normal procedure, but one certificate in the retrieved certificate chain past its expiration date.
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION, and receives the correct number of Certificate messages
  **/
-void test_spdm_requester_get_certificate_case19(void **state)
+void libspdm_test_requester_get_certificate_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2686,7 +2686,7 @@ void test_spdm_requester_get_certificate_case19(void **state)
  * Test 20: Fail case, request a certificate chain, responder return portion_length is 0.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_certificate_case20(void **state)
+void libspdm_test_requester_get_certificate_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2744,7 +2744,7 @@ void test_spdm_requester_get_certificate_case20(void **state)
  * Test 21: Fail case, request a certificate chain, responder return portion_length > spdm_request.length.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_certificate_case21(void **state)
+void libspdm_test_requester_get_certificate_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2804,7 +2804,7 @@ void test_spdm_requester_get_certificate_case21(void **state)
  * total_responder_cert_chain_buffer_length.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_certificate_case22(void **state)
+void libspdm_test_requester_get_certificate_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2869,50 +2869,50 @@ int spdm_requester_get_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_certificate_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case1),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case1),
         /* Successful response: check root certificate hash*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case2),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case3),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case4),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case5),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case6),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case7),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case8),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case9),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case9),
         /* Successful response: check certificate chain*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case10),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case10),
         /* Invalid certificate signature*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case11),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case11),
         /* Fail certificate chain check*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case12),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case12),
         /* Sucessful response: get a certificate chain that fits in one single message*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case13),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case13),
         /* Sucessful response: get certificate chain byte by byte*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case14),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case14),
         /* Sucessful response: get a long certificate chain*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case15),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case15),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case16),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case16),
         /* Sucessful response: get a certificate chain not start with root cert.*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case17),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case17),
         /* Fail response: get a certificate chain not start with root cert but with wrong signature.*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case18),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case18),
         /* Fail response: one certificate in the retrieved certificate chain past its expiration date.*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case19),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case19),
         /* Fail response: responder return portion_length is 0.*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case20),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case20),
         /* Fail response: responder return portion_length > spdm_request.length*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case21),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case21),
         /* Fail response: spdm_request.offset + spdm_response.portion_length + spdm_response.remainder_length !=
          * total_responder_cert_chain_buffer_length.*/
-        cmocka_unit_test(test_spdm_requester_get_certificate_case22),
+        cmocka_unit_test(libspdm_test_requester_get_certificate_case22),
     };
 
     setup_spdm_test_context(&m_spdm_requester_get_certificate_test_context);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -643,7 +643,7 @@ return_status spdm_requester_get_digests_test_receive_message(
  * Test 1: a failure occurs during the sending of the request message
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case1(void **state)
+void libspdm_test_requester_get_digests_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -683,7 +683,7 @@ void test_spdm_requester_get_digests_case1(void **state)
  * Test 2: a request message is successfully sent and a response message is successfully received
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is received
  **/
-void test_spdm_requester_get_digests_case2(void **state)
+void libspdm_test_requester_get_digests_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -734,7 +734,7 @@ void test_spdm_requester_get_digests_case2(void **state)
  * GET_CAPABILITIES-CAPABILITIES and NEGOTIATE_ALGORITHMS-ALGORITHMS of the protocol were not previously completed
  * Expected Behavior: requester returns the status RETURN_UNSUPPORTED, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case3(void **state)
+void libspdm_test_requester_get_digests_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -774,7 +774,7 @@ void test_spdm_requester_get_digests_case3(void **state)
  * Test 4: a request message is successfully sent and an ERROR response message with error code = InvalidRequest is received
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case4(void **state)
+void libspdm_test_requester_get_digests_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -814,7 +814,7 @@ void test_spdm_requester_get_digests_case4(void **state)
  * Test 5: request messages are successfully sent and ERROR response messages with error code = Busy are received in all attempts
  * Expected Behavior: requester returns the status RETURN_NO_RESPONSE, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case5(void **state)
+void libspdm_test_requester_get_digests_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -855,7 +855,7 @@ void test_spdm_requester_get_digests_case5(void **state)
  * first attempt followed by a successful response
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is received
  **/
-void test_spdm_requester_get_digests_case6(void **state)
+void libspdm_test_requester_get_digests_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -901,7 +901,7 @@ void test_spdm_requester_get_digests_case6(void **state)
  * (Meaning Responder is requesting Requester to reissue GET_VERSION to resynchronize) is received
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case7(void **state)
+void libspdm_test_requester_get_digests_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -944,7 +944,7 @@ void test_spdm_requester_get_digests_case7(void **state)
  * are received in all attempts
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR
  **/
-void test_spdm_requester_get_digests_case8(void **state)
+void libspdm_test_requester_get_digests_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -982,7 +982,7 @@ void test_spdm_requester_get_digests_case8(void **state)
  * is received in the first attempt followed by a successful response to RESPOND_IF_READY
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is received
  **/
-void test_spdm_requester_get_digests_case9(void **state)
+void libspdm_test_requester_get_digests_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1028,7 +1028,7 @@ void test_spdm_requester_get_digests_case9(void **state)
  * CERTIFICATE response messages
  * Expected Behavior: requester returns the status RETURN_UNSUPPORTED, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case10(void **state)
+void libspdm_test_requester_get_digests_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1067,7 +1067,7 @@ void test_spdm_requester_get_digests_case10(void **state)
  * Test 11: a request message is successfully sent but a failure occurs during the receiving of the response message
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case11(void **state)
+void libspdm_test_requester_get_digests_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1109,7 +1109,7 @@ void test_spdm_requester_get_digests_case11(void **state)
  * meaning it is an invalid response message
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
  **/
-void test_spdm_requester_get_digests_case12(void **state)
+void libspdm_test_requester_get_digests_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1150,7 +1150,7 @@ void test_spdm_requester_get_digests_case12(void **state)
  * Test 13: a request message is successfully sent but the request_response_code from the response message is different than the code of SPDM_DIGESTS
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case13(void **state)
+void libspdm_test_requester_get_digests_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1191,7 +1191,7 @@ void test_spdm_requester_get_digests_case13(void **state)
  * Test 14: a request message is successfully sent but the number of digests in the response message is equal to zero
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received
  **/
-void test_spdm_requester_get_digests_case14(void **state)
+void libspdm_test_requester_get_digests_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1232,7 +1232,7 @@ void test_spdm_requester_get_digests_case14(void **state)
  * Test 15: a request message is successfully sent but it cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR
  **/
-void test_spdm_requester_get_digests_case15(void **state)
+void libspdm_test_requester_get_digests_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1273,7 +1273,7 @@ void test_spdm_requester_get_digests_case15(void **state)
  * Test 16: a request message is successfully sent but the response message cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION
  **/
-void test_spdm_requester_get_digests_case16(void **state)
+void libspdm_test_requester_get_digests_case16(void **state)
 {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     return_status status;
@@ -1318,7 +1318,7 @@ void test_spdm_requester_get_digests_case16(void **state)
  * Test 17: a request message is successfully sent but the single digest received in the response message is invalid
  * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION, with error state LIBSPDM_STATUS_ERROR_CERTIFICATE_FAILURE
  **/
-void test_spdm_requester_get_digests_case17(void **state)
+void libspdm_test_requester_get_digests_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1358,7 +1358,7 @@ void test_spdm_requester_get_digests_case17(void **state)
  * the number of bits set in param2 - Slot mask
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
  **/
-void test_spdm_requester_get_digests_case18(void **state)
+void libspdm_test_requester_get_digests_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1399,7 +1399,7 @@ void test_spdm_requester_get_digests_case18(void **state)
  * Test 19: a request message is successfully sent but several digests (except the first) received in the response message are invalid
  * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION, with error state LIBSPDM_STATUS_ERROR_CERTIFICATE_FAILURE
  **/
-void test_spdm_requester_get_digests_case19(void **state)
+void libspdm_test_requester_get_digests_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1439,7 +1439,7 @@ void test_spdm_requester_get_digests_case19(void **state)
  * meaning it is an invalid response message.
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
  **/
-void test_spdm_requester_get_digests_case20(void **state)
+void libspdm_test_requester_get_digests_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1481,7 +1481,7 @@ void test_spdm_requester_get_digests_case20(void **state)
  * meaning it is an invalid response message.
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
  **/
-void test_spdm_requester_get_digests_case21(void **state)
+void libspdm_test_requester_get_digests_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1526,7 +1526,7 @@ void test_spdm_requester_get_digests_case21(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_digests_case22(void **state) {
+void libspdm_test_requester_get_digests_case22(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1583,51 +1583,51 @@ int spdm_requester_get_digests_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_digests_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case1),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case2),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case3),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case4),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case5),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case6),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case7),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case8),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case9),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case9),
         /* capability flags check failed*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case10),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case10),
         /* ReceiveResponse failed*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case11),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case11),
         /* size of response < spdm_message_header_t
-        * cmocka_unit_test(test_spdm_requester_get_digests_case12),
+        * cmocka_unit_test(libspdm_test_requester_get_digests_case12),
         * request_response_code wrong in response*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case13),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case13),
         /* Zero digests received*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case14),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case14),
         /* Internal cache full (request message)
          * If request text is appending when reponse successfully instead of request,
          * case15 will useless and will cause a bug
-         * cmocka_unit_test(test_spdm_requester_get_digests_case15),
+         * cmocka_unit_test(libspdm_test_requester_get_digests_case15),
          * Internal cache full (response message)*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case16),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case16),
         /* Invalid digest*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case17),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case17),
         /* Slot mask != number of digests*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case18),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case18),
         /* Several invalid digests
-         * cmocka_unit_test(test_spdm_requester_get_digests_case19),
+         * cmocka_unit_test(libspdm_test_requester_get_digests_case19),
          * size of response < spdm_digest_response_t
-         * cmocka_unit_test(test_spdm_requester_get_digests_case20),
+         * cmocka_unit_test(libspdm_test_requester_get_digests_case20),
          * size of response > Max size of SPDM DIGESTS response
-         * cmocka_unit_test(test_spdm_requester_get_digests_case21),
+         * cmocka_unit_test(libspdm_test_requester_get_digests_case21),
          * Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_get_digests_case22),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case22),
     };
 
     setup_spdm_test_context(&m_spdm_requester_get_digests_test_context);

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -390,7 +390,7 @@ return_status spdm_requester_get_measurements_test_send_message(
             spdm_context, &session_id, &is_app_message,
             false, request_size, (uint8_t *)request,
             &app_message_size, app_message);
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
         copy_mem_s(m_local_buffer, sizeof(m_local_buffer),
@@ -2563,7 +2563,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -2577,7 +2577,7 @@ return_status spdm_requester_get_measurements_test_receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case1(void **state)
+void libspdm_test_requester_get_measurements_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2651,7 +2651,7 @@ void test_spdm_requester_get_measurements_case1(void **state)
  * Test 2: Successful response to get a measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case2(void **state)
+void libspdm_test_requester_get_measurements_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2725,7 +2725,7 @@ void test_spdm_requester_get_measurements_case2(void **state)
  * Test 3: Error case, attempt to get measurements before GET_DIGESTS, GET_CAPABILITIES, and NEGOTIATE_ALGORITHMS
  * Expected Behavior: get a RETURN_UNSUPPORTED return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case3(void **state)
+void libspdm_test_requester_get_measurements_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2798,7 +2798,7 @@ void test_spdm_requester_get_measurements_case3(void **state)
  * Test 4: Error case, always get an error response with code SPDM_ERROR_CODE_INVALID_REQUEST
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case4(void **state)
+void libspdm_test_requester_get_measurements_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2871,7 +2871,7 @@ void test_spdm_requester_get_measurements_case4(void **state)
  * Test 5: Error case, always get an error response with code SPDM_ERROR_CODE_BUSY
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case5(void **state)
+void libspdm_test_requester_get_measurements_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2944,7 +2944,7 @@ void test_spdm_requester_get_measurements_case5(void **state)
  * Test 6: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_BUSY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case6(void **state)
+void libspdm_test_requester_get_measurements_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3017,7 +3017,7 @@ void test_spdm_requester_get_measurements_case6(void **state)
  * Test 7: Error case, get an error response with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case7(void **state)
+void libspdm_test_requester_get_measurements_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3092,7 +3092,7 @@ void test_spdm_requester_get_measurements_case7(void **state)
  * Test 8: Error case, always get an error response with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case8(void **state)
+void libspdm_test_requester_get_measurements_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3162,7 +3162,7 @@ void test_spdm_requester_get_measurements_case8(void **state)
  * Test 9: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_RESPONSE_NOT_READY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case9(void **state)
+void libspdm_test_requester_get_measurements_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3235,7 +3235,7 @@ void test_spdm_requester_get_measurements_case9(void **state)
  * Test 10: Successful response to get total number of measurements, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct number_of_blocks, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case10(void **state)
+void libspdm_test_requester_get_measurements_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3308,7 +3308,7 @@ void test_spdm_requester_get_measurements_case10(void **state)
  * Test 11: Successful response to get a measurement block, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case11(void **state)
+void libspdm_test_requester_get_measurements_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3386,7 +3386,7 @@ void test_spdm_requester_get_measurements_case11(void **state)
  * Test 12: Error case, signature is invalid (all bytes are 0)
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION return code
  **/
-void test_spdm_requester_get_measurements_case12(void **state)
+void libspdm_test_requester_get_measurements_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3460,7 +3460,7 @@ void test_spdm_requester_get_measurements_case12(void **state)
  * Test 13: Error case, signature is invalid (random)
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION return code
  **/
-void test_spdm_requester_get_measurements_case13(void **state)
+void libspdm_test_requester_get_measurements_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3534,7 +3534,7 @@ void test_spdm_requester_get_measurements_case13(void **state)
  * Test 14: Error case, request a signed response, but response is malformed (signature absent)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-void test_spdm_requester_get_measurements_case14(void **state)
+void libspdm_test_requester_get_measurements_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3608,7 +3608,7 @@ void test_spdm_requester_get_measurements_case14(void **state)
  * Test 15: Error case, response with wrong response code
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-void test_spdm_requester_get_measurements_case15(void **state)
+void libspdm_test_requester_get_measurements_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3682,7 +3682,7 @@ void test_spdm_requester_get_measurements_case15(void **state)
  * Test 16: SlotID verificaton, the response's SlotID should match the request
  * Expected Behavior: get a RETURN_SUCCESS return code if the fields match, RETURN_DEVICE_ERROR otherwise. Either way, transcript.message_m should be empty
  **/
-void test_spdm_requester_get_measurements_case16(void **state)
+void libspdm_test_requester_get_measurements_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3773,7 +3773,7 @@ void test_spdm_requester_get_measurements_case16(void **state)
  * Test 17: Error case, response to get total number of measurements, but response number_of_blocks and/or measurement_record_length are non 0
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-void test_spdm_requester_get_measurements_case17(void **state)
+void libspdm_test_requester_get_measurements_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3849,7 +3849,7 @@ void test_spdm_requester_get_measurements_case17(void **state)
  * Test 18: Successful response to get a measurement block, without signature. Measurement block is the largest possible.
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case18(void **state)
+void libspdm_test_requester_get_measurements_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3925,7 +3925,7 @@ void test_spdm_requester_get_measurements_case18(void **state)
  * Test 19: Error case, measurement_specification field in response has 2 bits set (bit 0 is one of them)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-void test_spdm_requester_get_measurements_case19(void **state)
+void libspdm_test_requester_get_measurements_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -3998,7 +3998,7 @@ void test_spdm_requester_get_measurements_case19(void **state)
  * Test 20: Error case, measurement_specification field in response has 2 bits set (bit 0 is not one of them)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-void test_spdm_requester_get_measurements_case20(void **state)
+void libspdm_test_requester_get_measurements_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4071,7 +4071,7 @@ void test_spdm_requester_get_measurements_case20(void **state)
  * Test 21: Error case, measurement_specification field in response does not "match the selected measurement specification in the ALGORITHMS message"
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-void test_spdm_requester_get_measurements_case21(void **state)
+void libspdm_test_requester_get_measurements_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4144,7 +4144,7 @@ void test_spdm_requester_get_measurements_case21(void **state)
  * Test 22: request a large number of unsigned measurements before requesting a signature
  * Expected Behavior: RETURN_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
  **/
-void test_spdm_requester_get_measurements_case22(void **state)
+void libspdm_test_requester_get_measurements_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4241,7 +4241,7 @@ void test_spdm_requester_get_measurements_case22(void **state)
  * Test 23: Successful response to get a measurement block, without signature. response contains opaque data
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case23(void **state)
+void libspdm_test_requester_get_measurements_case23(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4321,7 +4321,7 @@ void test_spdm_requester_get_measurements_case23(void **state)
  * Test 24: Error case, reponse contains opaque data larger than the maximum allowed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case24(void **state)
+void libspdm_test_requester_get_measurements_case24(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4395,7 +4395,7 @@ void test_spdm_requester_get_measurements_case24(void **state)
  * Test 25: Successful response to get a measurement block, with signature. response contains opaque data
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case25(void **state)
+void libspdm_test_requester_get_measurements_case25(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4469,7 +4469,7 @@ void test_spdm_requester_get_measurements_case25(void **state)
  * Test 26: Error case, request with signature, but response opaque data is S bytes shorter than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case26(void **state)
+void libspdm_test_requester_get_measurements_case26(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4544,7 +4544,7 @@ void test_spdm_requester_get_measurements_case26(void **state)
  * Test 27: Error case, request with signature, but response opaque data is (S+1) bytes shorter than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case27(void **state)
+void libspdm_test_requester_get_measurements_case27(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4619,7 +4619,7 @@ void test_spdm_requester_get_measurements_case27(void **state)
  * Test 28: Error case, request with signature, but response opaque data is 1 byte longer than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case28(void **state)
+void libspdm_test_requester_get_measurements_case28(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4697,7 +4697,7 @@ void test_spdm_requester_get_measurements_case28(void **state)
  * Test 29: request measurement without signature, but response opaque data is 1 byte longer than informed
  * Expected Behavior: extra byte should just be ignored. Get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case29(void **state)
+void libspdm_test_requester_get_measurements_case29(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4778,7 +4778,7 @@ void test_spdm_requester_get_measurements_case29(void **state)
  * Test 30: request measurement without signature, response opaque data contains MAXUINT16 bytes, but informed opaque data size is valid
  * Expected Behavior: extra bytes should just be ignored. Get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case30(void **state)
+void libspdm_test_requester_get_measurements_case30(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4857,7 +4857,7 @@ void test_spdm_requester_get_measurements_case30(void **state)
  * Test 31: Error case, reponse contains opaque data larger than the maximum allowed. MAXUINT16 is used
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case31(void **state)
+void libspdm_test_requester_get_measurements_case31(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4936,7 +4936,7 @@ void test_spdm_requester_get_measurements_case31(void **state)
  * Test 32: Successful response to get all measurement blocks, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-void test_spdm_requester_get_measurements_case32(void **state)
+void libspdm_test_requester_get_measurements_case32(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5019,7 +5019,7 @@ void test_spdm_requester_get_measurements_case32(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_measurements_case33(void **state) {
+void libspdm_test_requester_get_measurements_case33(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -5099,7 +5099,7 @@ void test_spdm_requester_get_measurements_case33(void **state) {
  * Test 34: Successful response to get a session based measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
  **/
-void test_spdm_requester_get_measurements_case34(void **state)
+void libspdm_test_requester_get_measurements_case34(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5207,73 +5207,73 @@ int spdm_requester_get_measurements_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_measurements_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case1),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case1),
         /* Successful response to get measurement with signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case2),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case3),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case4),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case5),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case6),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case7),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case8),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case9),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case9),
         /* Successful response to get total measurement number without signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case10),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case10),
         /* Successful response to get one measurement without signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case11),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case11),
         /* error: request signature, but response contains null signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case12),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case12),
         /* error: request signature, but response contains wrong non-null signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case13),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case13),
         /* error: request signature, but response does not contain signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case14),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case14),
         /* error: wrong response code*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case15),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case15),
         /* error: SlotID mismatch*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case16),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case16),
         /* error: get total measurement number (no signature), but there is a measurement block*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case17),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case17),
         /* Large measurement block
-         * cmocka_unit_test(test_spdm_requester_get_measurements_case18),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
+         * cmocka_unit_test(libspdm_test_requester_get_measurements_case18),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
          * error: measurement_specification has 2 bits set (bit 0 is one of them)*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case19),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case19),
         /* error: measurement_specification has 2 bits set (bit 0 is not one of them)*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case20),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case20),
         /* error: measurement_specification does not "match the selected measurement specification in the ALGORITHMS message"*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case21),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case21),
         /* request a large number of measurement blocks before requesting a signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case22),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case22),
         /* Successful response to get one measurement with opaque data without signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case23),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case23),
         /* error: get one measurement with opaque data larger than 1024, without signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case24),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case24),
         /* Successful response to get one measurement with opaque data with signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case25),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case25),
         /* error: response to get one measurement with opaque data with signature, opaque data is S bytes shorter than announced*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case26),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case26),
         /* error: response to get one measurement with opaque data with signature, opaque data is S+1 bytes shorter than announced*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case27),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case27),
         /* error: response to get one measurement with opaque data with signature, opaque data is 1 byte longer than announced*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case28),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case28),
         /* response to get one measurement with opaque data without signature, opaque data is 1 byte longer than announced*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case29),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case29),
         /* response to get one measurement with opaque data without signature, opaque data has MAX_UINT16, but opaque data size is valid
-         * cmocka_unit_test(test_spdm_requester_get_measurements_case30),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
+         * cmocka_unit_test(libspdm_test_requester_get_measurements_case30),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
          * error: get one measurement with opaque data too large, without signature
-         * cmocka_unit_test(test_spdm_requester_get_measurements_case31),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
+         * cmocka_unit_test(libspdm_test_requester_get_measurements_case31),    test triggers runtime assert because the transmitted packet is larger than the 4096-byte buffer
          * Successful response to get all measurements without signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case32),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case32),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case33),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case33),
         /* Successful response to get a session based measurement with signature*/
-        cmocka_unit_test(test_spdm_requester_get_measurements_case34),
+        cmocka_unit_test(libspdm_test_requester_get_measurements_case34),
     };
 
     setup_spdm_test_context(

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -397,7 +397,7 @@ return_status spdm_requester_get_version_test_receive_message(
  * Test 1: when no VERSION message is received, and the client returns a device error.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case1(void **state)
+void libspdm_test_requester_get_version_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -407,7 +407,7 @@ void test_spdm_requester_get_version_case1(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -415,7 +415,7 @@ void test_spdm_requester_get_version_case1(void **state)
  * Test 2: receiving a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_get_version_case2(void **state)
+void libspdm_test_requester_get_version_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -425,7 +425,7 @@ void test_spdm_requester_get_version_case2(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x2;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -433,7 +433,7 @@ void test_spdm_requester_get_version_case2(void **state)
  * Test 3: receiving a correct VERSION message header, but with 0 versions available.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case3(void **state)
+void libspdm_test_requester_get_version_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -443,7 +443,7 @@ void test_spdm_requester_get_version_case3(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x3;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -451,7 +451,7 @@ void test_spdm_requester_get_version_case3(void **state)
  * Test 4: receiving an InvalidRequest ERROR message from the responder.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case4(void **state)
+void libspdm_test_requester_get_version_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -461,7 +461,7 @@ void test_spdm_requester_get_version_case4(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x4;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -469,7 +469,7 @@ void test_spdm_requester_get_version_case4(void **state)
  * Test 5: receiving an Busy ERROR message correct VERSION message from the responder.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case5(void **state)
+void libspdm_test_requester_get_version_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -479,7 +479,7 @@ void test_spdm_requester_get_version_case5(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x5;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_NO_RESPONSE);
 }
 
@@ -488,7 +488,7 @@ void test_spdm_requester_get_version_case5(void **state)
  * a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void test_spdm_requester_get_version_case6(void **state)
+void libspdm_test_requester_get_version_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -498,7 +498,7 @@ void test_spdm_requester_get_version_case6(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -509,7 +509,7 @@ void test_spdm_requester_get_version_case6(void **state)
  * Note: As from 1.1.c, this is an unexpected behavior, as the responder should not
  * respond a GET_VERSION message with a RequestResynch. It should expect a GET_VERSION.
  **/
-void test_spdm_requester_get_version_case7(void **state)
+void libspdm_test_requester_get_version_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -519,7 +519,7 @@ void test_spdm_requester_get_version_case7(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x7;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -531,7 +531,7 @@ void test_spdm_requester_get_version_case7(void **state)
  * Note: As from 1.0.0, this is an unexpected behavior, as the responder should not
  * respond a GET_VERSION message with a ResponseNotReady.
  **/
-void test_spdm_requester_get_version_case8(void **state)
+void libspdm_test_requester_get_version_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -541,7 +541,7 @@ void test_spdm_requester_get_version_case8(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x8;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -552,7 +552,7 @@ void test_spdm_requester_get_version_case8(void **state)
  * Note: The responder should not
  * respond a GET_VERSION message with a ResponseNotReady.
  **/
-void test_spdm_requester_get_version_case9(void **state)
+void libspdm_test_requester_get_version_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -562,7 +562,7 @@ void test_spdm_requester_get_version_case9(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -573,7 +573,7 @@ void test_spdm_requester_get_version_case9(void **state)
  * Expected behavior: client returns a status of RETURN_SUCCESS, but truncate the message
  * to consider only the two first versions, as indicated in the message.
  **/
-void test_spdm_requester_get_version_case10(void **state)
+void libspdm_test_requester_get_version_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -583,7 +583,7 @@ void test_spdm_requester_get_version_case10(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
 }
 
@@ -592,7 +592,7 @@ void test_spdm_requester_get_version_case10(void **state)
  * the requester do not have compatible versions with the responder.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case11(void **state)
+void libspdm_test_requester_get_version_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -602,7 +602,7 @@ void test_spdm_requester_get_version_case11(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -611,7 +611,7 @@ void test_spdm_requester_get_version_case11(void **state)
  * 1.0-version format, with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case12(void **state)
+void libspdm_test_requester_get_version_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -621,7 +621,7 @@ void test_spdm_requester_get_version_case12(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -631,7 +631,7 @@ void test_spdm_requester_get_version_case12(void **state)
  * VERSION message, with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case13(void **state)
+void libspdm_test_requester_get_version_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -641,7 +641,7 @@ void test_spdm_requester_get_version_case13(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
 
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
@@ -653,7 +653,7 @@ void test_spdm_requester_get_version_case13(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_get_version_case14(void **state) {
+void libspdm_test_requester_get_version_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -666,7 +666,7 @@ void test_spdm_requester_get_version_case14(void **state) {
     error_code = SPDM_ERROR_CODE_RESERVED_00;
     while(error_code <= 0xff) {
         /* no additional state control is necessary as a new GET_VERSION resets the state*/
-        status = spdm_get_version (spdm_context, NULL, NULL);
+        status = libspdm_get_version (spdm_context, NULL, NULL);
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
         error_code++;
@@ -688,7 +688,7 @@ void test_spdm_requester_get_version_case14(void **state) {
  * Responder list:4.2, 5.2, 1.2, 1.1, 1.0
  * Expected behavior: client returns a status of RETURN_SUCCESS and right negotiated version 1.1.
  **/
-void test_spdm_requester_get_version_case15(void **state)
+void libspdm_test_requester_get_version_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -703,7 +703,7 @@ void test_spdm_requester_get_version_case15(void **state)
     spdm_context->local_context.version.spdm_version[2] = 0x09 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.version.spdm_version[3] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.version.spdm_version[4] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
-    status = spdm_get_version(spdm_context, NULL, NULL);
+    status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT, 0x11);
@@ -719,31 +719,31 @@ spdm_test_context_t mSpdmRequesterGetVersionTestContext = {
 int spdm_requester_get_version_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_version_tests[] = {
-        cmocka_unit_test(test_spdm_requester_get_version_case1),
-        cmocka_unit_test(test_spdm_requester_get_version_case2),
-        cmocka_unit_test(test_spdm_requester_get_version_case3),
+        cmocka_unit_test(libspdm_test_requester_get_version_case1),
+        cmocka_unit_test(libspdm_test_requester_get_version_case2),
+        cmocka_unit_test(libspdm_test_requester_get_version_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_get_version_case4),
+        cmocka_unit_test(libspdm_test_requester_get_version_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_get_version_case5),
+        cmocka_unit_test(libspdm_test_requester_get_version_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_version_case6),
+        cmocka_unit_test(libspdm_test_requester_get_version_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_get_version_case7),
+        cmocka_unit_test(libspdm_test_requester_get_version_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_get_version_case8),
+        cmocka_unit_test(libspdm_test_requester_get_version_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_version_case9),
+        cmocka_unit_test(libspdm_test_requester_get_version_case9),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_get_version_case10),
+        cmocka_unit_test(libspdm_test_requester_get_version_case10),
         /* Successful response + device error*/
-        cmocka_unit_test(test_spdm_requester_get_version_case11),
-        cmocka_unit_test(test_spdm_requester_get_version_case12),
-        cmocka_unit_test(test_spdm_requester_get_version_case13),
+        cmocka_unit_test(libspdm_test_requester_get_version_case11),
+        cmocka_unit_test(libspdm_test_requester_get_version_case12),
+        cmocka_unit_test(libspdm_test_requester_get_version_case13),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_get_version_case14),
+        cmocka_unit_test(libspdm_test_requester_get_version_case14),
         /* Successful response for unordered version set*/
-        cmocka_unit_test(test_spdm_requester_get_version_case15),
+        cmocka_unit_test(libspdm_test_requester_get_version_case15),
     };
 
     setup_spdm_test_context(&mSpdmRequesterGetVersionTestContext);

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -15,7 +15,7 @@ static uint8_t m_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 void spdm_secured_message_set_response_data_encryption_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->aead_key_size);
@@ -28,7 +28,7 @@ void spdm_secured_message_set_response_data_salt(
     void *spdm_secured_message_context, const void *salt,
     uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(salt_size == secured_message_context->aead_iv_size);
@@ -113,7 +113,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -145,7 +145,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -172,7 +172,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -199,7 +199,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -229,7 +229,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -260,7 +260,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -289,7 +289,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -321,7 +321,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -358,7 +358,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -389,7 +389,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
@@ -418,7 +418,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
                                                 sizeof(spdm_response), &spdm_response,
                                                 response_size, response);
             session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
             application_secret.response_data_sequence_number--;
         }
 
@@ -461,7 +461,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -488,7 +488,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -499,7 +499,7 @@ return_status spdm_requester_heartbeat_test_receive_message(
     }
 }
 
-void test_spdm_requester_heartbeat_case1(void **state)
+void libspdm_test_requester_heartbeat_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -568,7 +568,7 @@ void test_spdm_requester_heartbeat_case1(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case2(void **state)
+void libspdm_test_requester_heartbeat_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -632,27 +632,27 @@ void test_spdm_requester_heartbeat_case2(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -660,7 +660,7 @@ void test_spdm_requester_heartbeat_case2(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case3(void **state)
+void libspdm_test_requester_heartbeat_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -724,27 +724,27 @@ void test_spdm_requester_heartbeat_case3(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -752,7 +752,7 @@ void test_spdm_requester_heartbeat_case3(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case4(void **state)
+void libspdm_test_requester_heartbeat_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -816,27 +816,27 @@ void test_spdm_requester_heartbeat_case4(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -844,7 +844,7 @@ void test_spdm_requester_heartbeat_case4(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case5(void **state)
+void libspdm_test_requester_heartbeat_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -908,27 +908,27 @@ void test_spdm_requester_heartbeat_case5(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -936,7 +936,7 @@ void test_spdm_requester_heartbeat_case5(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case6(void **state)
+void libspdm_test_requester_heartbeat_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1000,27 +1000,27 @@ void test_spdm_requester_heartbeat_case6(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -1028,7 +1028,7 @@ void test_spdm_requester_heartbeat_case6(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case7(void **state)
+void libspdm_test_requester_heartbeat_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1092,27 +1092,27 @@ void test_spdm_requester_heartbeat_case7(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -1122,7 +1122,7 @@ void test_spdm_requester_heartbeat_case7(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case8(void **state)
+void libspdm_test_requester_heartbeat_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1186,27 +1186,27 @@ void test_spdm_requester_heartbeat_case8(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -1214,7 +1214,7 @@ void test_spdm_requester_heartbeat_case8(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case9(void **state)
+void libspdm_test_requester_heartbeat_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1278,27 +1278,27 @@ void test_spdm_requester_heartbeat_case9(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -1306,7 +1306,7 @@ void test_spdm_requester_heartbeat_case9(void **state)
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case10(void **state) {
+void libspdm_test_requester_heartbeat_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1360,20 +1360,21 @@ void test_spdm_requester_heartbeat_case10(void **state) {
         libspdm_secured_message_set_session_state (session_info->secured_message_context,
                                                    LIBSPDM_SESSION_STATE_ESTABLISHED);
         set_mem (m_dummy_key_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_data_encryption_key (
             session_info->secured_message_context, m_dummy_key_buffer,
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
         set_mem (m_dummy_salt_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_data_salt (session_info->secured_message_context,
                                                      m_dummy_salt_buffer,
-                                                     ((spdm_secured_message_context_t*)(session_info
-                                                                                        ->
-                                                                                        secured_message_context))->aead_iv_size);
-        ((spdm_secured_message_context_t*)(session_info->secured_message_context))->
+                                                     ((libspdm_secured_message_context_t*)(
+                                                          session_info
+                                                          ->
+                                                          secured_message_context))->aead_iv_size);
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
         application_secret.response_data_sequence_number = 0;
 
         status = libspdm_heartbeat (spdm_context, session_id);
@@ -1399,7 +1400,7 @@ void test_spdm_requester_heartbeat_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_heartbeat_case11(void **state)
+void libspdm_test_requester_heartbeat_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1463,27 +1464,27 @@ void test_spdm_requester_heartbeat_case11(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     session_info->session_transcript.message_m.buffer_size =
@@ -1514,7 +1515,7 @@ void test_spdm_requester_heartbeat_case11(void **state)
  * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void test_spdm_requester_heartbeat_case12(void **state)
+void libspdm_test_requester_heartbeat_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1578,27 +1579,27 @@ void test_spdm_requester_heartbeat_case12(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_data_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
 
     status = libspdm_heartbeat(spdm_context, session_id);
@@ -1619,29 +1620,29 @@ int spdm_requester_heartbeat_test_main(void)
 {
     const struct CMUnitTest spdm_requester_heartbeat_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case1),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case2),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case3),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case4),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case5),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case6),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case7),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case8),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case9),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case10),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case11),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case11),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(test_spdm_requester_heartbeat_case12),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case12),
     };
 
     setup_spdm_test_context(&m_spdm_requester_heartbeat_test_context);

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -4033,7 +4033,7 @@ return_status spdm_requester_key_exchange_test_receive_message(
     }
 }
 
-void test_spdm_requester_key_exchange_case1(void **state)
+void libspdm_test_requester_key_exchange_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4091,7 +4091,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4100,7 +4100,7 @@ void test_spdm_requester_key_exchange_case1(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case2(void **state)
+void libspdm_test_requester_key_exchange_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4163,7 +4163,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4177,7 +4177,7 @@ void test_spdm_requester_key_exchange_case2(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case3(void **state)
+void libspdm_test_requester_key_exchange_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4237,7 +4237,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4246,7 +4246,7 @@ void test_spdm_requester_key_exchange_case3(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case4(void **state)
+void libspdm_test_requester_key_exchange_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4306,7 +4306,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4315,7 +4315,7 @@ void test_spdm_requester_key_exchange_case4(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case5(void **state)
+void libspdm_test_requester_key_exchange_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4375,7 +4375,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4384,7 +4384,7 @@ void test_spdm_requester_key_exchange_case5(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case6(void **state)
+void libspdm_test_requester_key_exchange_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4444,7 +4444,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4458,7 +4458,7 @@ void test_spdm_requester_key_exchange_case6(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case7(void **state)
+void libspdm_test_requester_key_exchange_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4518,7 +4518,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4529,7 +4529,7 @@ void test_spdm_requester_key_exchange_case7(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case8(void **state)
+void libspdm_test_requester_key_exchange_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4589,7 +4589,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4598,7 +4598,7 @@ void test_spdm_requester_key_exchange_case8(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case9(void **state)
+void libspdm_test_requester_key_exchange_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4658,7 +4658,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4672,7 +4672,7 @@ void test_spdm_requester_key_exchange_case9(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case10(void **state) {
+void libspdm_test_requester_key_exchange_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -4727,10 +4727,10 @@ void test_spdm_requester_key_exchange_case10(void **state) {
 
         heartbeat_period = 0;
         zero_mem(measurement_hash, sizeof(measurement_hash));
-        status = spdm_send_receive_key_exchange (spdm_context,
-                                                 SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-                                                 0, 0, &session_id, &heartbeat_period,
-                                                 &slot_id_param, measurement_hash);
+        status = libspdm_send_receive_key_exchange (spdm_context,
+                                                    SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                                    0, 0, &session_id, &heartbeat_period,
+                                                    &slot_id_param, measurement_hash);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
@@ -4749,7 +4749,7 @@ void test_spdm_requester_key_exchange_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case11(void **state)
+void libspdm_test_requester_key_exchange_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4822,7 +4822,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4842,7 +4842,7 @@ void test_spdm_requester_key_exchange_case11(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case12(void **state)
+void libspdm_test_requester_key_exchange_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -4912,7 +4912,7 @@ void test_spdm_requester_key_exchange_case12(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_KEY_EXCHANGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -4930,7 +4930,7 @@ void test_spdm_requester_key_exchange_case12(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case13(void **state)
+void libspdm_test_requester_key_exchange_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5000,7 +5000,7 @@ void test_spdm_requester_key_exchange_case13(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_KEY_EXCHANGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5018,7 +5018,7 @@ void test_spdm_requester_key_exchange_case13(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case14(void **state)
+void libspdm_test_requester_key_exchange_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5088,7 +5088,7 @@ void test_spdm_requester_key_exchange_case14(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_KEY_EXCHANGE_REQUEST_ALL_MEASUREMENTS_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5106,7 +5106,7 @@ void test_spdm_requester_key_exchange_case14(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case15(void **state)
+void libspdm_test_requester_key_exchange_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5176,7 +5176,7 @@ void test_spdm_requester_key_exchange_case15(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_KEY_EXCHANGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5185,7 +5185,7 @@ void test_spdm_requester_key_exchange_case15(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case16(void **state)
+void libspdm_test_requester_key_exchange_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5255,7 +5255,7 @@ void test_spdm_requester_key_exchange_case16(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_KEY_EXCHANGE_REQUEST_ALL_MEASUREMENTS_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5264,7 +5264,7 @@ void test_spdm_requester_key_exchange_case16(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case17(void **state)
+void libspdm_test_requester_key_exchange_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5334,7 +5334,7 @@ void test_spdm_requester_key_exchange_case17(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5343,7 +5343,7 @@ void test_spdm_requester_key_exchange_case17(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case18(void **state)
+void libspdm_test_requester_key_exchange_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5413,7 +5413,7 @@ void test_spdm_requester_key_exchange_case18(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5422,7 +5422,7 @@ void test_spdm_requester_key_exchange_case18(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case19(void **state)
+void libspdm_test_requester_key_exchange_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5492,7 +5492,7 @@ void test_spdm_requester_key_exchange_case19(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5511,7 +5511,7 @@ void test_spdm_requester_key_exchange_case19(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case20(void **state)
+void libspdm_test_requester_key_exchange_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5582,7 +5582,7 @@ void test_spdm_requester_key_exchange_case20(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5591,7 +5591,7 @@ void test_spdm_requester_key_exchange_case20(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case21(void **state)
+void libspdm_test_requester_key_exchange_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5667,7 +5667,7 @@ void test_spdm_requester_key_exchange_case21(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5687,7 +5687,7 @@ void test_spdm_requester_key_exchange_case21(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case22(void **state)
+void libspdm_test_requester_key_exchange_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5763,7 +5763,7 @@ void test_spdm_requester_key_exchange_case22(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5785,7 +5785,7 @@ void test_spdm_requester_key_exchange_case22(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case23(void **state)
+void libspdm_test_requester_key_exchange_case23(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5861,7 +5861,7 @@ void test_spdm_requester_key_exchange_case23(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5883,7 +5883,7 @@ void test_spdm_requester_key_exchange_case23(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case24(void **state)
+void libspdm_test_requester_key_exchange_case24(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -5959,7 +5959,7 @@ void test_spdm_requester_key_exchange_case24(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -5981,7 +5981,7 @@ void test_spdm_requester_key_exchange_case24(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case25(void **state)
+void libspdm_test_requester_key_exchange_case25(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -6057,7 +6057,7 @@ void test_spdm_requester_key_exchange_case25(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -6079,7 +6079,7 @@ void test_spdm_requester_key_exchange_case25(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case26(void **state)
+void libspdm_test_requester_key_exchange_case26(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -6155,7 +6155,7 @@ void test_spdm_requester_key_exchange_case26(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -6169,7 +6169,7 @@ void test_spdm_requester_key_exchange_case26(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case27(void **state)
+void libspdm_test_requester_key_exchange_case27(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -6245,7 +6245,7 @@ void test_spdm_requester_key_exchange_case27(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -6259,7 +6259,7 @@ void test_spdm_requester_key_exchange_case27(void **state)
     free(data);
 }
 
-void test_spdm_requester_key_exchange_case28(void **state)
+void libspdm_test_requester_key_exchange_case28(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -6335,7 +6335,7 @@ void test_spdm_requester_key_exchange_case28(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_key_exchange(
+    status = libspdm_send_receive_key_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
         &session_id, &heartbeat_period, &slot_id_param,
@@ -6360,61 +6360,61 @@ int spdm_requester_key_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_exchange_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case1),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case2),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case3),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case4),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case5),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case6),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case7),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case8),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case9),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case10),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case11),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case11),
         /* Measurement hash 1, returns a measurement hash*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case12),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case12),
         /* Measurement hash 1, returns a 0x00 array (no TCB components)*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case13),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case13),
         /* Measurement hash FF, returns a measurement_hash*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case14),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case14),
         /* Measurement hash 1, returns no measurement_hash*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case15),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case15),
         /* Measurement hash FF, returns no measurement_hash*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case16),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case16),
         /* Measurement hash not requested, returns a measurement_hash*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case17),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case17),
         /* Wrong signature*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case18),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case18),
         /* Requester and Responder Handshake in the clear set, no ResponderVerifyData*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case19),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case19),
         /* Heartbeat not supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case20),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case20),
         /* Heartbeat supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case21),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case21),
         /* Heartbeat supported, heartbeat period 0 sent NOTE: This should disable heartbeat*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case22),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case22),
         /* Muth Auth requested*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case23),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case23),
         /* Muth Auth requested with Encapsulated request*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case24),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case24),
         /* Muth Auth requested with implicit get digest*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case25),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case25),
         /* Muth Auth requested with Encapsulated request and bit 0 set*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case26),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case26),
         /* Muth Auth requested with implicit get digest and bit 0 set*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case27),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case27),
         /* Muth Auth requested with Encapsulated request and Muth Auth requested with implicit get digest simultaneously*/
-        cmocka_unit_test(test_spdm_requester_key_exchange_case28),
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case28),
 
     };
 

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -67,7 +67,7 @@ static void spdm_set_standard_key_update_test_state(
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill,
     uint8_t *m_req_secret_buffer, uint8_t req_secret_fill)
 {
@@ -159,7 +159,7 @@ return_status spdm_requester_key_update_test_send_message(
 
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
         status = spdm_transport_test_decode_message(spdm_context,
@@ -199,7 +199,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -242,7 +242,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -285,7 +285,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -328,7 +328,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -374,7 +374,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -426,7 +426,7 @@ return_status spdm_requester_key_update_test_send_message(
 
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
         status = spdm_transport_test_decode_message(spdm_context,
@@ -466,7 +466,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -511,7 +511,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -555,7 +555,7 @@ return_status spdm_requester_key_update_test_send_message(
 
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
         status = spdm_transport_test_decode_message(spdm_context,
@@ -592,7 +592,7 @@ return_status spdm_requester_key_update_test_send_message(
 
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
         status = spdm_transport_test_decode_message(spdm_context,
@@ -632,7 +632,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -675,7 +675,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -718,7 +718,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -764,7 +764,7 @@ return_status spdm_requester_key_update_test_send_message(
 
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
             status = spdm_transport_test_decode_message(spdm_context,
@@ -836,7 +836,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -877,7 +877,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -907,7 +907,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -935,7 +935,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -969,7 +969,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         } else if (sub_index == 1) {
@@ -988,7 +988,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         } else if (sub_index == 2) {
@@ -1007,7 +1007,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1038,7 +1038,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -1071,7 +1071,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -1112,7 +1112,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         } else if (sub_index == 1) {
@@ -1131,7 +1131,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         } else if (sub_index == 2) {
@@ -1150,7 +1150,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1191,7 +1191,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1245,7 +1245,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1287,7 +1287,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1328,7 +1328,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1369,7 +1369,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1411,7 +1411,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1453,7 +1453,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -1490,7 +1490,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1508,7 +1508,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1546,7 +1546,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1564,7 +1564,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1602,7 +1602,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1621,7 +1621,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1641,7 +1641,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1679,7 +1679,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1697,7 +1697,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1735,7 +1735,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1758,7 +1758,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1796,7 +1796,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1819,7 +1819,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1839,7 +1839,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                response_size, response);
             /* WALKAROUND: If just use single context to encode
              * message and then decode message */
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
         }
@@ -1883,7 +1883,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                    response_size, response);
                 /* WALKAROUND: If just use single context to encode
                  * message and then decode message */
-                ((spdm_secured_message_context_t
+                ((libspdm_secured_message_context_t
                   *)(session_info->secured_message_context))
                 ->application_secret.response_data_sequence_number--;
             }
@@ -1902,7 +1902,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                                    response_size, response);
                 /* WALKAROUND: If just use single context to encode
                  * message and then decode message */
-                ((spdm_secured_message_context_t
+                ((libspdm_secured_message_context_t
                   *)(session_info->secured_message_context))
                 ->application_secret.response_data_sequence_number--;
 
@@ -1964,7 +1964,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -2006,7 +2006,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -2048,7 +2048,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -2092,7 +2092,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
 
@@ -2105,7 +2105,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
         uint8_t curr_rsp_enc_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
         uint8_t curr_rsp_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
         uint64_t curr_rsp_sequence_number;
@@ -2176,7 +2176,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
         uint8_t curr_rsp_enc_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
         uint8_t curr_rsp_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
         uint64_t curr_rsp_sequence_number;
@@ -2251,7 +2251,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
 
         session_id = 0xFFFFFFFF;
         session_info = libspdm_get_session_info_via_session_id(
@@ -2367,7 +2367,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
         uint8_t curr_rsp_enc_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
         uint8_t curr_rsp_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
         uint64_t curr_rsp_sequence_number;
@@ -2438,7 +2438,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
         uint8_t curr_rsp_enc_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
         uint8_t curr_rsp_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
         uint64_t curr_rsp_sequence_number;
@@ -2515,7 +2515,7 @@ return_status spdm_requester_key_update_test_receive_message(
         uint32_t session_id;
         libspdm_session_info_t    *session_info;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
 
         session_id = 0xFFFFFFFF;
         session_info = libspdm_get_session_info_via_session_id(
@@ -2641,7 +2641,7 @@ return_status spdm_requester_key_update_test_receive_message(
 
         spdm_error_response_t spdm_response;
 
-        spdm_secured_message_context_t *secured_message_context;
+        libspdm_secured_message_context_t *secured_message_context;
         uint8_t curr_rsp_enc_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
         uint8_t curr_rsp_salt[LIBSPDM_MAX_AEAD_IV_SIZE];
         uint64_t curr_rsp_sequence_number;
@@ -2751,7 +2751,7 @@ return_status spdm_requester_key_update_test_receive_message(
                                            &spdm_response, response_size, response);
         /* WALKAROUND: If just use single context to encode
          * message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
@@ -2768,7 +2768,7 @@ return_status spdm_requester_key_update_test_receive_message(
  * returns a device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_key_update_case1(void **state)
+void libspdm_test_requester_key_update_case1(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -2807,7 +2807,7 @@ void test_spdm_requester_key_update_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void test_spdm_requester_key_update_case2(void **state)
+void libspdm_test_requester_key_update_case2(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -2835,7 +2835,7 @@ void test_spdm_requester_key_update_case2(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -2845,15 +2845,15 @@ void test_spdm_requester_key_update_case2(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -2862,7 +2862,7 @@ void test_spdm_requester_key_update_case2(void **state)
  * GET_CAPABILITIES and NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_key_update_case3(void **state)
+void libspdm_test_requester_key_update_case3(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -2905,7 +2905,7 @@ void test_spdm_requester_key_update_case3(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case4(void **state)
+void libspdm_test_requester_key_update_case4(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -2938,15 +2938,15 @@ void test_spdm_requester_key_update_case4(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -2956,7 +2956,7 @@ void test_spdm_requester_key_update_case4(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case5(void **state)
+void libspdm_test_requester_key_update_case5(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -2989,15 +2989,15 @@ void test_spdm_requester_key_update_case5(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_NO_RESPONSE);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3009,7 +3009,7 @@ void test_spdm_requester_key_update_case5(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void test_spdm_requester_key_update_case6(void **state)
+void libspdm_test_requester_key_update_case6(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3037,7 +3037,7 @@ void test_spdm_requester_key_update_case6(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3047,15 +3047,15 @@ void test_spdm_requester_key_update_case6(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3066,7 +3066,7 @@ void test_spdm_requester_key_update_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void test_spdm_requester_key_update_case7(void **state)
+void libspdm_test_requester_key_update_case7(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3108,7 +3108,7 @@ void test_spdm_requester_key_update_case7(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case8(void **state)
+void libspdm_test_requester_key_update_case8(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3141,15 +3141,15 @@ void test_spdm_requester_key_update_case8(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3161,7 +3161,7 @@ void test_spdm_requester_key_update_case8(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void test_spdm_requester_key_update_case9(void **state)
+void libspdm_test_requester_key_update_case9(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3189,7 +3189,7 @@ void test_spdm_requester_key_update_case9(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3199,15 +3199,15 @@ void test_spdm_requester_key_update_case9(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3221,7 +3221,7 @@ void test_spdm_requester_key_update_case9(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case10(void **state)
+void libspdm_test_requester_key_update_case10(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3262,15 +3262,15 @@ void test_spdm_requester_key_update_case10(void **state)
 
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.request_data_secret,
-                            m_req_secret_buffer, ((spdm_secured_message_context_t
+                            m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.response_data_secret,
-                            m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                            m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
 
         error_code++;
@@ -3289,7 +3289,7 @@ void test_spdm_requester_key_update_case10(void **state)
     }
 }
 
-void test_spdm_requester_key_update_case11(void **state)
+void libspdm_test_requester_key_update_case11(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3317,7 +3317,7 @@ void test_spdm_requester_key_update_case11(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3339,15 +3339,15 @@ void test_spdm_requester_key_update_case11(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
@@ -3365,7 +3365,7 @@ void test_spdm_requester_key_update_case11(void **state)
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED,
  * and no keys are updated.
  **/
-void test_spdm_requester_key_update_case12(void **state)
+void libspdm_test_requester_key_update_case12(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3404,15 +3404,15 @@ void test_spdm_requester_key_update_case12(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_UNSUPPORTED);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3422,7 +3422,7 @@ void test_spdm_requester_key_update_case12(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR,
  * no keys are updated.
  **/
-void test_spdm_requester_key_update_case13(void **state)
+void libspdm_test_requester_key_update_case13(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3455,15 +3455,15 @@ void test_spdm_requester_key_update_case13(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3474,7 +3474,7 @@ void test_spdm_requester_key_update_case13(void **state)
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED,
  * and no keys are updated.
  **/
-void test_spdm_requester_key_update_case14(void **state)
+void libspdm_test_requester_key_update_case14(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3512,15 +3512,15 @@ void test_spdm_requester_key_update_case14(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_UNSUPPORTED);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3531,7 +3531,7 @@ void test_spdm_requester_key_update_case14(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case15(void **state)
+void libspdm_test_requester_key_update_case15(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3564,15 +3564,15 @@ void test_spdm_requester_key_update_case15(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3583,7 +3583,7 @@ void test_spdm_requester_key_update_case15(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case16(void **state)
+void libspdm_test_requester_key_update_case16(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3616,15 +3616,15 @@ void test_spdm_requester_key_update_case16(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3634,7 +3634,7 @@ void test_spdm_requester_key_update_case16(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case17(void **state)
+void libspdm_test_requester_key_update_case17(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3662,7 +3662,7 @@ void test_spdm_requester_key_update_case17(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3672,15 +3672,15 @@ void test_spdm_requester_key_update_case17(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3691,7 +3691,7 @@ void test_spdm_requester_key_update_case17(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case18(void **state)
+void libspdm_test_requester_key_update_case18(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3719,7 +3719,7 @@ void test_spdm_requester_key_update_case18(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3729,15 +3729,15 @@ void test_spdm_requester_key_update_case18(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_NO_RESPONSE);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3749,7 +3749,7 @@ void test_spdm_requester_key_update_case18(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case19(void **state)
+void libspdm_test_requester_key_update_case19(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3777,7 +3777,7 @@ void test_spdm_requester_key_update_case19(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3787,15 +3787,15 @@ void test_spdm_requester_key_update_case19(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3806,7 +3806,7 @@ void test_spdm_requester_key_update_case19(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void test_spdm_requester_key_update_case20(void **state)
+void libspdm_test_requester_key_update_case20(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3848,7 +3848,7 @@ void test_spdm_requester_key_update_case20(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case21(void **state)
+void libspdm_test_requester_key_update_case21(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3876,7 +3876,7 @@ void test_spdm_requester_key_update_case21(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3886,15 +3886,15 @@ void test_spdm_requester_key_update_case21(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3905,7 +3905,7 @@ void test_spdm_requester_key_update_case21(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case22(void **state)
+void libspdm_test_requester_key_update_case22(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -3933,7 +3933,7 @@ void test_spdm_requester_key_update_case22(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -3943,15 +3943,15 @@ void test_spdm_requester_key_update_case22(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -3965,7 +3965,7 @@ void test_spdm_requester_key_update_case22(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case23(void **state)
+void libspdm_test_requester_key_update_case23(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4000,7 +4000,7 @@ void test_spdm_requester_key_update_case23(void **state)
             m_req_secret_buffer, (uint8_t)(0xEE));
 
         /*request side updated*/
-        spdm_compute_secret_update(((spdm_secured_message_context_t
+        spdm_compute_secret_update(((libspdm_secured_message_context_t
                                      *)(session_info->secured_message_context))->hash_size,
                                    m_req_secret_buffer, m_req_secret_buffer,
                                    sizeof(m_req_secret_buffer));
@@ -4011,15 +4011,15 @@ void test_spdm_requester_key_update_case23(void **state)
 
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.request_data_secret,
-                            m_req_secret_buffer, ((spdm_secured_message_context_t
+                            m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.response_data_secret,
-                            m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                            m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
 
         error_code++;
@@ -4044,7 +4044,7 @@ void test_spdm_requester_key_update_case23(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case24(void **state)
+void libspdm_test_requester_key_update_case24(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4072,7 +4072,7 @@ void test_spdm_requester_key_update_case24(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -4082,15 +4082,15 @@ void test_spdm_requester_key_update_case24(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4101,7 +4101,7 @@ void test_spdm_requester_key_update_case24(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case25(void **state)
+void libspdm_test_requester_key_update_case25(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4129,7 +4129,7 @@ void test_spdm_requester_key_update_case25(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -4139,15 +4139,15 @@ void test_spdm_requester_key_update_case25(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4158,7 +4158,7 @@ void test_spdm_requester_key_update_case25(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void test_spdm_requester_key_update_case26(void **state)
+void libspdm_test_requester_key_update_case26(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4186,7 +4186,7 @@ void test_spdm_requester_key_update_case26(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
@@ -4196,15 +4196,15 @@ void test_spdm_requester_key_update_case26(void **state)
         spdm_context, session_id, true);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4214,7 +4214,7 @@ void test_spdm_requester_key_update_case26(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void test_spdm_requester_key_update_case27(void **state)
+void libspdm_test_requester_key_update_case27(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4242,12 +4242,12 @@ void test_spdm_requester_key_update_case27(void **state)
         m_req_secret_buffer, (uint8_t)(0xEE));
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
     /*response side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_rsp_secret_buffer, m_rsp_secret_buffer,
                                sizeof(m_rsp_secret_buffer));
@@ -4256,15 +4256,15 @@ void test_spdm_requester_key_update_case27(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4274,7 +4274,7 @@ void test_spdm_requester_key_update_case27(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case28(void **state)
+void libspdm_test_requester_key_update_case28(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4285,7 +4285,7 @@ void test_spdm_requester_key_update_case28(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4322,15 +4322,15 @@ void test_spdm_requester_key_update_case28(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_DEVICE_ERROR);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4341,7 +4341,7 @@ void test_spdm_requester_key_update_case28(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case29(void **state)
+void libspdm_test_requester_key_update_case29(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4352,7 +4352,7 @@ void test_spdm_requester_key_update_case29(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4389,15 +4389,15 @@ void test_spdm_requester_key_update_case29(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_NO_RESPONSE);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4409,7 +4409,7 @@ void test_spdm_requester_key_update_case29(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void test_spdm_requester_key_update_case30(void **state)
+void libspdm_test_requester_key_update_case30(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4420,7 +4420,7 @@ void test_spdm_requester_key_update_case30(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4452,12 +4452,12 @@ void test_spdm_requester_key_update_case30(void **state)
                                   ->application_secret.response_data_sequence_number;
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
     /*response side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_rsp_secret_buffer, m_rsp_secret_buffer,
                                sizeof(m_rsp_secret_buffer));
@@ -4466,15 +4466,15 @@ void test_spdm_requester_key_update_case30(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4485,7 +4485,7 @@ void test_spdm_requester_key_update_case30(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void test_spdm_requester_key_update_case31(void **state)
+void libspdm_test_requester_key_update_case31(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4496,7 +4496,7 @@ void test_spdm_requester_key_update_case31(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4542,7 +4542,7 @@ void test_spdm_requester_key_update_case31(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case32(void **state)
+void libspdm_test_requester_key_update_case32(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4553,7 +4553,7 @@ void test_spdm_requester_key_update_case32(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4590,15 +4590,15 @@ void test_spdm_requester_key_update_case32(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_UNSUPPORTED);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4610,7 +4610,7 @@ void test_spdm_requester_key_update_case32(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void test_spdm_requester_key_update_case33(void **state)
+void libspdm_test_requester_key_update_case33(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4621,7 +4621,7 @@ void test_spdm_requester_key_update_case33(void **state)
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4653,12 +4653,12 @@ void test_spdm_requester_key_update_case33(void **state)
                                   ->application_secret.response_data_sequence_number;
 
     /*request side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_req_secret_buffer, m_req_secret_buffer,
                                sizeof(m_req_secret_buffer));
     /*response side updated*/
-    spdm_compute_secret_update(((spdm_secured_message_context_t
+    spdm_compute_secret_update(((libspdm_secured_message_context_t
                                  *)(session_info->secured_message_context))->hash_size,
                                m_rsp_secret_buffer, m_rsp_secret_buffer,
                                sizeof(m_rsp_secret_buffer));
@@ -4667,15 +4667,15 @@ void test_spdm_requester_key_update_case33(void **state)
         spdm_context, session_id, false);
 
     assert_int_equal(status, RETURN_SUCCESS);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.request_data_secret,
-                        m_req_secret_buffer, ((spdm_secured_message_context_t
+                        m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
-    assert_memory_equal(((spdm_secured_message_context_t
+    assert_memory_equal(((libspdm_secured_message_context_t
                           *)(session_info->secured_message_context))
                         ->application_secret.response_data_secret,
-                        m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                        m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                *)(session_info->secured_message_context))->hash_size);
 }
 
@@ -4689,7 +4689,7 @@ void test_spdm_requester_key_update_case33(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void test_spdm_requester_key_update_case34(void **state)
+void libspdm_test_requester_key_update_case34(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4701,7 +4701,7 @@ void test_spdm_requester_key_update_case34(void **state)
     uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -4745,15 +4745,15 @@ void test_spdm_requester_key_update_case34(void **state)
 
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.request_data_secret,
-                            m_req_secret_buffer, ((spdm_secured_message_context_t
+                            m_req_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
-        assert_memory_equal(((spdm_secured_message_context_t
+        assert_memory_equal(((libspdm_secured_message_context_t
                               *)(session_info->secured_message_context))
                             ->application_secret.response_data_secret,
-                            m_rsp_secret_buffer, ((spdm_secured_message_context_t
+                            m_rsp_secret_buffer, ((libspdm_secured_message_context_t
                                                    *)(session_info->secured_message_context))->hash_size);
 
         error_code++;
@@ -4776,7 +4776,7 @@ void test_spdm_requester_key_update_case34(void **state)
  * Test 35: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void test_spdm_requester_key_update_case35(void **state)
+void libspdm_test_requester_key_update_case35(void **state)
 {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
@@ -4821,74 +4821,74 @@ int spdm_requester_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_update_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_key_update_case1),
+        cmocka_unit_test(libspdm_test_requester_key_update_case1),
         /* update single key
          * Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case2),
+        cmocka_unit_test(libspdm_test_requester_key_update_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_key_update_case3),
+        cmocka_unit_test(libspdm_test_requester_key_update_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_key_update_case4),
+        cmocka_unit_test(libspdm_test_requester_key_update_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case5),
+        cmocka_unit_test(libspdm_test_requester_key_update_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case6),
+        cmocka_unit_test(libspdm_test_requester_key_update_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_key_update_case7),
+        cmocka_unit_test(libspdm_test_requester_key_update_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case8),
+        cmocka_unit_test(libspdm_test_requester_key_update_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case9),
+        cmocka_unit_test(libspdm_test_requester_key_update_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_key_update_case10),
+        cmocka_unit_test(libspdm_test_requester_key_update_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_key_update_case11),
+        cmocka_unit_test(libspdm_test_requester_key_update_case11),
         /* No correct setup*/
-        cmocka_unit_test(test_spdm_requester_key_update_case12),
-        cmocka_unit_test(test_spdm_requester_key_update_case13),
-        cmocka_unit_test(test_spdm_requester_key_update_case14),
+        cmocka_unit_test(libspdm_test_requester_key_update_case12),
+        cmocka_unit_test(libspdm_test_requester_key_update_case13),
+        cmocka_unit_test(libspdm_test_requester_key_update_case14),
         /* Wrong parameters*/
-        cmocka_unit_test(test_spdm_requester_key_update_case15),
-        cmocka_unit_test(test_spdm_requester_key_update_case16),
+        cmocka_unit_test(libspdm_test_requester_key_update_case15),
+        cmocka_unit_test(libspdm_test_requester_key_update_case16),
         /* verify key
          * Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_key_update_case17),
+        cmocka_unit_test(libspdm_test_requester_key_update_case17),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case18),
+        cmocka_unit_test(libspdm_test_requester_key_update_case18),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case19),
+        cmocka_unit_test(libspdm_test_requester_key_update_case19),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_key_update_case20),
+        cmocka_unit_test(libspdm_test_requester_key_update_case20),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case21),
+        cmocka_unit_test(libspdm_test_requester_key_update_case21),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case22),
+        cmocka_unit_test(libspdm_test_requester_key_update_case22),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_key_update_case23),
+        cmocka_unit_test(libspdm_test_requester_key_update_case23),
         /* No correct setup*/
-        cmocka_unit_test(test_spdm_requester_key_update_case24),
+        cmocka_unit_test(libspdm_test_requester_key_update_case24),
         /* Wrong parameters*/
-        cmocka_unit_test(test_spdm_requester_key_update_case25),
-        cmocka_unit_test(test_spdm_requester_key_update_case26),
+        cmocka_unit_test(libspdm_test_requester_key_update_case25),
+        cmocka_unit_test(libspdm_test_requester_key_update_case26),
         /* update all keys
          * Sucessful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case27),
+        cmocka_unit_test(libspdm_test_requester_key_update_case27),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_key_update_case28),
+        cmocka_unit_test(libspdm_test_requester_key_update_case28),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case29),
+        cmocka_unit_test(libspdm_test_requester_key_update_case29),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case30),
+        cmocka_unit_test(libspdm_test_requester_key_update_case30),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_key_update_case31),
+        cmocka_unit_test(libspdm_test_requester_key_update_case31),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_key_update_case32),
+        cmocka_unit_test(libspdm_test_requester_key_update_case32),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_key_update_case33),
+        cmocka_unit_test(libspdm_test_requester_key_update_case33),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_key_update_case34),
+        cmocka_unit_test(libspdm_test_requester_key_update_case34),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(test_spdm_requester_key_update_case35),
+        cmocka_unit_test(libspdm_test_requester_key_update_case35),
     };
 
     setup_spdm_test_context(&m_spdm_requester_key_update_test_context);

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -1037,7 +1037,7 @@ return_status spdm_requester_negotiate_algorithm_test_receive_message(
     }
 }
 
-void test_spdm_requester_negotiate_algorithms_case1(void **state)
+void libspdm_test_requester_negotiate_algorithms_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1056,14 +1056,14 @@ void test_spdm_requester_negotiate_algorithms_case1(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case2(void **state)
+void libspdm_test_requester_negotiate_algorithms_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1082,7 +1082,7 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size,
@@ -1091,7 +1091,7 @@ void test_spdm_requester_negotiate_algorithms_case2(void **state)
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case3(void **state)
+void libspdm_test_requester_negotiate_algorithms_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1110,14 +1110,14 @@ void test_spdm_requester_negotiate_algorithms_case3(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_UNSUPPORTED);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case4(void **state)
+void libspdm_test_requester_negotiate_algorithms_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1136,14 +1136,14 @@ void test_spdm_requester_negotiate_algorithms_case4(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case5(void **state)
+void libspdm_test_requester_negotiate_algorithms_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1162,14 +1162,14 @@ void test_spdm_requester_negotiate_algorithms_case5(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_NO_RESPONSE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size, 0);
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case6(void **state)
+void libspdm_test_requester_negotiate_algorithms_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1188,7 +1188,7 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_a.buffer_size,
@@ -1197,7 +1197,7 @@ void test_spdm_requester_negotiate_algorithms_case6(void **state)
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case7(void **state)
+void libspdm_test_requester_negotiate_algorithms_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1216,7 +1216,7 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -1225,7 +1225,7 @@ void test_spdm_requester_negotiate_algorithms_case7(void **state)
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case8(void **state)
+void libspdm_test_requester_negotiate_algorithms_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1244,11 +1244,11 @@ void test_spdm_requester_negotiate_algorithms_case8(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case9(void **state)
+void libspdm_test_requester_negotiate_algorithms_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1267,14 +1267,14 @@ void test_spdm_requester_negotiate_algorithms_case9(void **state)
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
 /* #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT*/
     /*  assert_int_equal (spdm_context->transcript.message_a.buffer_size, sizeof(spdm_negotiate_algorithms_request_t) + sizeof(spdm_algorithms_response_t));*/
 /* #endif*/
 }
 
-void test_spdm_requester_negotiate_algorithms_case10(void **state)
+void libspdm_test_requester_negotiate_algorithms_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1298,14 +1298,14 @@ void test_spdm_requester_negotiate_algorithms_case10(void **state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(
         spdm_context->connection_info.algorithm.measurement_hash_algo,
         0);
 }
 
-void test_spdm_requester_negotiate_algorithms_case11(void **state)
+void libspdm_test_requester_negotiate_algorithms_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1331,13 +1331,13 @@ void test_spdm_requester_negotiate_algorithms_case11(void **state)
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(spdm_context->connection_info.algorithm.base_asym_algo,
                      0);
 }
 
-void test_spdm_requester_negotiate_algorithms_case12(void **state)
+void libspdm_test_requester_negotiate_algorithms_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1359,13 +1359,13 @@ void test_spdm_requester_negotiate_algorithms_case12(void **state)
     spdm_context->connection_info.algorithm.base_hash_algo = 0;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms(spdm_context);
+    status = libspdm_negotiate_algorithms(spdm_context);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(spdm_context->connection_info.algorithm.base_hash_algo,
                      0);
 }
 
-void test_spdm_requester_negotiate_algorithms_case13(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case13(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1381,11 +1381,11 @@ void test_spdm_requester_negotiate_algorithms_case13(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case14(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1401,11 +1401,11 @@ void test_spdm_requester_negotiate_algorithms_case14(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case15(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case15(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1421,11 +1421,11 @@ void test_spdm_requester_negotiate_algorithms_case15(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case16(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case16(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1441,11 +1441,11 @@ void test_spdm_requester_negotiate_algorithms_case16(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case17(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case17(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1461,11 +1461,11 @@ void test_spdm_requester_negotiate_algorithms_case17(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case18(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case18(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1481,11 +1481,11 @@ void test_spdm_requester_negotiate_algorithms_case18(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case19(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case19(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1501,11 +1501,11 @@ void test_spdm_requester_negotiate_algorithms_case19(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case20(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case20(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1521,11 +1521,11 @@ void test_spdm_requester_negotiate_algorithms_case20(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case21(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case21(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1541,11 +1541,11 @@ void test_spdm_requester_negotiate_algorithms_case21(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case22(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case22(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1561,11 +1561,11 @@ void test_spdm_requester_negotiate_algorithms_case22(void **state) {
     spdm_context->local_context.algorithm.base_hash_algo = m_use_hash_algo;
     libspdm_reset_message_a(spdm_context);
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_requester_negotiate_algorithms_case23(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case23(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1605,7 +1605,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal (spdm_context->transcript.message_a.buffer_size,
@@ -1615,7 +1615,7 @@ void test_spdm_requester_negotiate_algorithms_case23(void **state) {
 #endif
 }
 
-void test_spdm_requester_negotiate_algorithms_case24(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case24(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1655,11 +1655,11 @@ void test_spdm_requester_negotiate_algorithms_case24(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case25(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case25(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1699,11 +1699,11 @@ void test_spdm_requester_negotiate_algorithms_case25(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case26(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case26(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1743,11 +1743,11 @@ void test_spdm_requester_negotiate_algorithms_case26(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case27(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case27(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1787,11 +1787,11 @@ void test_spdm_requester_negotiate_algorithms_case27(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case28(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case28(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1831,11 +1831,11 @@ void test_spdm_requester_negotiate_algorithms_case28(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case29(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case29(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1875,11 +1875,11 @@ void test_spdm_requester_negotiate_algorithms_case29(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case30(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case30(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1919,11 +1919,11 @@ void test_spdm_requester_negotiate_algorithms_case30(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_requester_negotiate_algorithms_case31(void **state) {
+void libspdm_test_requester_negotiate_algorithms_case31(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1963,7 +1963,7 @@ void test_spdm_requester_negotiate_algorithms_case31(void **state) {
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
-    status = spdm_negotiate_algorithms (spdm_context);
+    status = libspdm_negotiate_algorithms (spdm_context);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
@@ -1979,80 +1979,80 @@ int spdm_requester_negotiate_algorithms_test_main(void)
     const struct CMUnitTest spdm_requester_negotiate_algorithms_tests[] = {
         /* SendRequest failed*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case1),
+            libspdm_test_requester_negotiate_algorithms_case1),
         /* Successful response*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case2),
+            libspdm_test_requester_negotiate_algorithms_case2),
         /* connection_state check failed*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case3),
+            libspdm_test_requester_negotiate_algorithms_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case4),
+            libspdm_test_requester_negotiate_algorithms_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case5),
+            libspdm_test_requester_negotiate_algorithms_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case6),
+            libspdm_test_requester_negotiate_algorithms_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case7),
+            libspdm_test_requester_negotiate_algorithms_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case8),
+            libspdm_test_requester_negotiate_algorithms_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case9),
+            libspdm_test_requester_negotiate_algorithms_case9),
         /* When spdm_response.measurement_hash_algo is 0*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case10),
+            libspdm_test_requester_negotiate_algorithms_case10),
         /* When spdm_response.base_asym_sel is 0*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case11),
+            libspdm_test_requester_negotiate_algorithms_case11),
         /* When spdm_response.base_hash_sel is 0*/
         cmocka_unit_test(
-            test_spdm_requester_negotiate_algorithms_case12),
+            libspdm_test_requester_negotiate_algorithms_case12),
         /* When spdm_response has a size of header and SPDM_ALGORITHMS code*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case13),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case13),
         /* When spdm_response has a size greater than header and smaller than algorithm and SPDM_ALGORITHMS code*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case14),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case14),
         /* When spdm_response has ext_asym_sel_count > 1*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case15),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case15),
         /* When spdm_response has ExtAsymHashCount > 1*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case16),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case16),
         /* When spdm_response returns an unlisted measurement_hash_algo
-         * cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case17),
+         * cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case17),
          * When spdm_response returns an unlisted base_asym_sel*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case17),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case17),
         /* When spdm_response returns an unlisted base_hash_sel*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case18),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case18),
         /* When spdm_response returns multiple measurement_hash_algo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case19),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case19),
         /* When spdm_response returns multiple base_asym_sel*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case20),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case20),
         /* When spdm_response returns multiple base_hash_sel*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case21),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case21),
         /* Request and response mismatch version*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case22),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case22),
         /* Successful V1.1 response*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case23),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case23),
         /* When spdm_response returns an unlisted DheAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case24),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case24),
         /* When spdm_response returns an unlisted AEADAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case25),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case25),
         /* When spdm_response returns an unlisted ReqAsymAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case26),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case26),
         /* When spdm_response returns an unlisted key_schedule*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case27),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case27),
         /* When spdm_response returns multiple DheAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case28),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case28),
         /* When spdm_response returns multiple AEADAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case29),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case29),
         /* When spdm_response returns multiple ReqAsymAlgo*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case30),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case30),
         /* When spdm_response returns multiple key_schedule*/
-        cmocka_unit_test(test_spdm_requester_negotiate_algorithms_case31),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case31),
     };
 
     setup_spdm_test_context(

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -937,7 +937,7 @@ return_status spdm_requester_psk_exchange_test_receive_message(
     }
 }
 
-void test_spdm_requester_psk_exchange_case1(void **state)
+void libspdm_test_requester_psk_exchange_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -989,7 +989,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -997,7 +997,7 @@ void test_spdm_requester_psk_exchange_case1(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case2(void **state)
+void libspdm_test_requester_psk_exchange_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1052,7 +1052,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1065,7 +1065,7 @@ void test_spdm_requester_psk_exchange_case2(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case3(void **state)
+void libspdm_test_requester_psk_exchange_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1117,7 +1117,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1125,7 +1125,7 @@ void test_spdm_requester_psk_exchange_case3(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case4(void **state)
+void libspdm_test_requester_psk_exchange_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1177,7 +1177,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1185,7 +1185,7 @@ void test_spdm_requester_psk_exchange_case4(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case5(void **state)
+void libspdm_test_requester_psk_exchange_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1237,7 +1237,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1245,7 +1245,7 @@ void test_spdm_requester_psk_exchange_case5(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case6(void **state)
+void libspdm_test_requester_psk_exchange_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1297,7 +1297,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1310,7 +1310,7 @@ void test_spdm_requester_psk_exchange_case6(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case7(void **state)
+void libspdm_test_requester_psk_exchange_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1362,7 +1362,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1372,7 +1372,7 @@ void test_spdm_requester_psk_exchange_case7(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case8(void **state)
+void libspdm_test_requester_psk_exchange_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1424,7 +1424,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1432,7 +1432,7 @@ void test_spdm_requester_psk_exchange_case8(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case9(void **state)
+void libspdm_test_requester_psk_exchange_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1484,7 +1484,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1497,7 +1497,7 @@ void test_spdm_requester_psk_exchange_case9(void **state)
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case10(void **state) {
+void libspdm_test_requester_psk_exchange_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1542,10 +1542,11 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
 
         heartbeat_period = 0;
         zero_mem(measurement_hash, sizeof(measurement_hash));
-        status = spdm_send_receive_psk_exchange (spdm_context,
-                                                 SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
-                                                 0,
-                                                 &session_id, &heartbeat_period, measurement_hash);
+        status = libspdm_send_receive_psk_exchange (spdm_context,
+                                                    SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                                    0,
+                                                    &session_id, &heartbeat_period,
+                                                    measurement_hash);
         /* assert_int_equal (status, RETURN_DEVICE_ERROR);*/
         ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
 
@@ -1564,7 +1565,7 @@ void test_spdm_requester_psk_exchange_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_psk_exchange_case11(void **state)
+void libspdm_test_requester_psk_exchange_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1628,7 +1629,7 @@ void test_spdm_requester_psk_exchange_case11(void **state)
 
     heartbeat_period = 0;
     zero_mem(measurement_hash, sizeof(measurement_hash));
-    status = spdm_send_receive_psk_exchange(
+    status = libspdm_send_receive_psk_exchange(
         spdm_context,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
@@ -1660,25 +1661,25 @@ int spdm_requester_psk_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_requester_psk_exchange_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case1),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case2),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case3),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case4),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case5),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case6),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case7),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case8),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case9),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_psk_exchange_case10),
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case10),
     };
 
     setup_spdm_test_context(&m_spdm_requester_psk_exchange_test_context);

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -17,7 +17,7 @@ static uint8_t m_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 static void spdm_secured_message_set_dummy_finished_key(
     void *spdm_secured_message_context)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     secured_message_context->finished_key_ready = true;
@@ -26,7 +26,7 @@ static void spdm_secured_message_set_dummy_finished_key(
 void spdm_secured_message_set_response_handshake_encryption_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->aead_key_size);
@@ -39,7 +39,7 @@ void spdm_secured_message_set_response_handshake_salt(
     void *spdm_secured_message_context, const void *salt,
     uintn salt_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(salt_size == secured_message_context->aead_iv_size);
@@ -130,7 +130,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -162,7 +162,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -189,7 +189,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -216,7 +216,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -246,7 +246,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
@@ -277,7 +277,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
@@ -306,7 +306,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -338,7 +338,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -375,7 +375,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
@@ -406,7 +406,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             if (session_info == NULL) {
                 return RETURN_DEVICE_ERROR;
             }
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
@@ -435,7 +435,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
                                                 sizeof(spdm_response), &spdm_response,
                                                 response_size, response);
             session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
             handshake_secret.response_handshake_sequence_number--;
         }
 
@@ -478,7 +478,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -511,7 +511,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -544,7 +544,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -577,7 +577,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
             return RETURN_DEVICE_ERROR;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -605,7 +605,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
         if (session_info == NULL) {
             return RETURN_DEVICE_ERROR;
         }
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
@@ -621,7 +621,7 @@ return_status spdm_requester_psk_finish_test_receive_message(
  * a device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case1(void **state)
+void libspdm_test_requester_psk_finish_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -686,7 +686,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -696,7 +696,7 @@ void test_spdm_requester_psk_finish_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void test_spdm_requester_psk_finish_case2(void **state)
+void libspdm_test_requester_psk_finish_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -760,31 +760,31 @@ void test_spdm_requester_psk_finish_case2(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -798,7 +798,7 @@ void test_spdm_requester_psk_finish_case2(void **state)
  * GET_CAPABILITIES and NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_psk_finish_case3(void **state)
+void libspdm_test_requester_psk_finish_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -862,31 +862,31 @@ void test_spdm_requester_psk_finish_case3(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -896,7 +896,7 @@ void test_spdm_requester_psk_finish_case3(void **state)
  * indicating InvalidParameters.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case4(void **state)
+void libspdm_test_requester_psk_finish_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -960,31 +960,31 @@ void test_spdm_requester_psk_finish_case4(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
     free(data);
@@ -995,7 +995,7 @@ void test_spdm_requester_psk_finish_case4(void **state)
  * indicating the Busy status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case5(void **state)
+void libspdm_test_requester_psk_finish_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1059,31 +1059,31 @@ void test_spdm_requester_psk_finish_case5(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_NO_RESPONSE);
     free(data);
 }
@@ -1095,7 +1095,7 @@ void test_spdm_requester_psk_finish_case5(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and session
  * is established.
  **/
-void test_spdm_requester_psk_finish_case6(void **state)
+void libspdm_test_requester_psk_finish_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1159,31 +1159,31 @@ void test_spdm_requester_psk_finish_case6(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1198,7 +1198,7 @@ void test_spdm_requester_psk_finish_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void test_spdm_requester_psk_finish_case7(void **state)
+void libspdm_test_requester_psk_finish_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1262,31 +1262,31 @@ void test_spdm_requester_psk_finish_case7(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -1298,7 +1298,7 @@ void test_spdm_requester_psk_finish_case7(void **state)
  * indicating the ResponseNotReady status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case8(void **state)
+void libspdm_test_requester_psk_finish_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1362,31 +1362,31 @@ void test_spdm_requester_psk_finish_case8(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -1398,7 +1398,7 @@ void test_spdm_requester_psk_finish_case8(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and session
  * is established.
  **/
-void test_spdm_requester_psk_finish_case9(void **state)
+void libspdm_test_requester_psk_finish_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1462,31 +1462,31 @@ void test_spdm_requester_psk_finish_case9(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1503,7 +1503,7 @@ void test_spdm_requester_psk_finish_case9(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case10(void **state) {
+void libspdm_test_requester_psk_finish_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1556,23 +1556,24 @@ void test_spdm_requester_psk_finish_case10(void **state) {
         libspdm_secured_message_set_session_state (session_info->secured_message_context,
                                                    LIBSPDM_SESSION_STATE_HANDSHAKING);
         set_mem (m_dummy_key_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_handshake_encryption_key (
             session_info->secured_message_context, m_dummy_key_buffer,
-            ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
+            ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size);
         set_mem (m_dummy_salt_buffer,
-                 ((spdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
+                 ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_iv_size,
                  (uint8_t)(0xFF));
         spdm_secured_message_set_response_handshake_salt (session_info->secured_message_context,
                                                           m_dummy_salt_buffer,
-                                                          ((spdm_secured_message_context_t*)(
+                                                          ((libspdm_secured_message_context_t*)(
                                                                session_info->secured_message_context))->aead_iv_size);
-        ((spdm_secured_message_context_t*)(session_info->secured_message_context))->handshake_secret
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
+        handshake_secret
         .response_handshake_sequence_number = 0;
         spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-        status = spdm_send_receive_psk_finish (spdm_context, session_id);
+        status = libspdm_send_receive_psk_finish (spdm_context, session_id);
         if(error_code != SPDM_ERROR_CODE_DECRYPT_ERROR) {
             ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
         } else {
@@ -1594,7 +1595,7 @@ void test_spdm_requester_psk_finish_case10(void **state) {
     free(data);
 }
 
-void test_spdm_requester_psk_finish_case11(void **state)
+void libspdm_test_requester_psk_finish_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1659,27 +1660,27 @@ void test_spdm_requester_psk_finish_case11(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
@@ -1696,7 +1697,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
         spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
@@ -1718,7 +1719,7 @@ void test_spdm_requester_psk_finish_case11(void **state)
  * PSK_FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_psk_finish_case12(void **state)
+void libspdm_test_requester_psk_finish_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1783,31 +1784,31 @@ void test_spdm_requester_psk_finish_case12(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -1817,7 +1818,7 @@ void test_spdm_requester_psk_finish_case12(void **state)
  * code, but all other field correct.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_requester_psk_finish_case13(void **state)
+void libspdm_test_requester_psk_finish_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1882,31 +1883,31 @@ void test_spdm_requester_psk_finish_case13(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_DEVICE_ERROR);
     free(data);
 }
@@ -1917,7 +1918,7 @@ void test_spdm_requester_psk_finish_case13(void **state)
  * return a correct PSK_FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void test_spdm_requester_psk_finish_case14(void **state)
+void libspdm_test_requester_psk_finish_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1982,31 +1983,31 @@ void test_spdm_requester_psk_finish_case14(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_NOT_STARTED);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_UNSUPPORTED);
     free(data);
 }
@@ -2015,7 +2016,7 @@ void test_spdm_requester_psk_finish_case14(void **state)
  * Test 15 the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void test_spdm_requester_psk_finish_case15(void **state)
+void libspdm_test_requester_psk_finish_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -2079,31 +2080,31 @@ void test_spdm_requester_psk_finish_case15(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     set_mem(m_dummy_key_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_key_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_encryption_key(
         session_info->secured_message_context, m_dummy_key_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_key_size);
     set_mem(m_dummy_salt_buffer,
-            ((spdm_secured_message_context_t
+            ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->aead_iv_size,
             (uint8_t)(0xFF));
     spdm_secured_message_set_response_handshake_salt(
         session_info->secured_message_context, m_dummy_salt_buffer,
-        ((spdm_secured_message_context_t
+        ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->aead_iv_size);
-    ((spdm_secured_message_context_t *)(session_info
-                                        ->secured_message_context))
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number = 0;
     spdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
 
-    status = spdm_send_receive_psk_finish(spdm_context, session_id);
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
     assert_int_equal(status, RETURN_SECURITY_VIOLATION);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
     free(data);
@@ -2120,35 +2121,35 @@ int spdm_requester_psk_finish_test_main(void)
 {
     const struct CMUnitTest spdm_requester_psk_finish_tests[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case1),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case1),
         /* Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case2),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case3),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case4),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case5),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case6),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case7),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case8),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case9),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case10),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case10),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case11),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case11),
         /* No correct setup*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case12),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case12),
         /* Wrong response code*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case13),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case13),
         /* Uninitialized session*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case14),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case14),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(test_spdm_requester_psk_finish_case15),
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case15),
     };
 
     setup_spdm_test_context(&m_spdm_requester_psk_finish_test_context);

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -11,18 +11,18 @@
 typedef struct {
     spdm_negotiate_algorithms_request_t spdm_request_version10;
     spdm_negotiate_algorithms_common_struct_table_t struct_table[4];
-} spdm_negotiate_algorithms_request_spdm11_t;
+} libspdm_negotiate_algorithms_request_spdm11_t;
 
 typedef struct {
     spdm_negotiate_algorithms_request_t spdm_request_version10;
     uint32_t extra[21];
     spdm_negotiate_algorithms_common_struct_table_t struct_table[4];
-} spdm_negotiate_algorithms_request_spdm11_oversized_t;
+} libspdm_negotiate_algorithms_request_spdm11_oversized_t;
 
 typedef struct {
     spdm_negotiate_algorithms_request_t spdm_request_version10;
     spdm_negotiate_algorithms_common_struct_table_t struct_table[12];
-} spdm_negotiate_algorithms_request_spdm11_multiple_tables_t;
+} libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t;
 
 typedef struct {
     spdm_message_header_t header;
@@ -40,22 +40,22 @@ typedef struct {
 } spdm_algorithms_response_mine_t;
 #pragma pack()
 
-spdm_negotiate_algorithms_request_t m_spdm_negotiate_algorithms_request1 = {
+spdm_negotiate_algorithms_request_t m_libspdm_negotiate_algorithms_request1 = {
     { SPDM_MESSAGE_VERSION_10, SPDM_NEGOTIATE_ALGORITHMS, 0, 0 },
     sizeof(spdm_negotiate_algorithms_request_t),
     SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
 };
-uintn m_spdm_negotiate_algorithms_request1_size =
-    sizeof(m_spdm_negotiate_algorithms_request1);
+uintn m_libspdm_negotiate_algorithms_request1_size =
+    sizeof(m_libspdm_negotiate_algorithms_request1);
 
-spdm_negotiate_algorithms_request_t m_spdm_negotiate_algorithms_request2 = {
+spdm_negotiate_algorithms_request_t m_libspdm_negotiate_algorithms_request2 = {
     { SPDM_MESSAGE_VERSION_10, SPDM_NEGOTIATE_ALGORITHMS, 0, 0 },
     sizeof(spdm_negotiate_algorithms_request_t),
     SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
 };
-uintn m_spdm_negotiate_algorithms_request2_size = sizeof(spdm_message_header_t);
+uintn m_libspdm_negotiate_algorithms_request2_size = sizeof(spdm_message_header_t);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request3 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request3 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -63,7 +63,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request3 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -91,7 +91,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request3 =
 };
 uintn m_spdm_negotiate_algorithm_request3_size = sizeof(m_spdm_negotiate_algorithm_request3);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request4 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request4 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -99,7 +99,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request4 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -127,7 +127,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request4 =
 };
 uintn m_spdm_negotiate_algorithm_request4_size = sizeof(m_spdm_negotiate_algorithm_request4);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request5 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request5 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -135,7 +135,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request5 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -163,7 +163,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request5 =
 };
 uintn m_spdm_negotiate_algorithm_request5_size = sizeof(m_spdm_negotiate_algorithm_request5);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request6 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request6 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -171,7 +171,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request6 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -199,7 +199,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request6 =
 };
 uintn m_spdm_negotiate_algorithm_request6_size = sizeof(m_spdm_negotiate_algorithm_request6);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request7 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request7 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -207,7 +207,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request7 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -235,7 +235,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request7 =
 };
 uintn m_spdm_negotiate_algorithm_request7_size = sizeof(m_spdm_negotiate_algorithm_request7);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request8 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request8 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -243,7 +243,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request8 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -271,7 +271,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request8 =
 };
 uintn m_spdm_negotiate_algorithm_request8_size = sizeof(m_spdm_negotiate_algorithm_request8);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request9 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request9 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -279,7 +279,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request9 =
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -319,7 +319,7 @@ spdm_negotiate_algorithms_request_t m_spdm_negotiate_algorithm_request10 = {
 };
 uintn m_spdm_negotiate_algorithm_request10_size = 0x44;
 
-spdm_negotiate_algorithms_request_spdm11_oversized_t m_spdm_negotiate_algorithm_request11 = {
+libspdm_negotiate_algorithms_request_spdm11_oversized_t m_spdm_negotiate_algorithm_request11 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -327,7 +327,7 @@ spdm_negotiate_algorithms_request_spdm11_oversized_t m_spdm_negotiate_algorithm_
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_oversized_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_oversized_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {0},
@@ -356,7 +356,8 @@ spdm_negotiate_algorithms_request_spdm11_oversized_t m_spdm_negotiate_algorithm_
 };
 uintn m_spdm_negotiate_algorithm_request11_size = sizeof(m_spdm_negotiate_algorithm_request11);
 
-spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request12 = {
+libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request12 =
+{
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -364,7 +365,7 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
             12,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_multiple_tables_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -432,7 +433,8 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
 };
 uintn m_spdm_negotiate_algorithm_request12_size = sizeof(m_spdm_negotiate_algorithm_request12);
 
-spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request13 = {
+libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request13 =
+{
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -440,7 +442,7 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
             11,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_multiple_tables_t)-
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t)-
         sizeof(spdm_negotiate_algorithms_common_struct_table_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
@@ -511,7 +513,8 @@ uintn m_spdm_negotiate_algorithm_request13_size = sizeof(m_spdm_negotiate_algori
                                                   sizeof(
     spdm_negotiate_algorithms_common_struct_table_t);
 
-spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request14 = {
+libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request14 =
+{
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -519,7 +522,7 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
             13,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_multiple_tables_t)+
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t)+
         sizeof(spdm_negotiate_algorithms_common_struct_table_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
@@ -590,7 +593,8 @@ uintn m_spdm_negotiate_algorithm_request14_size = sizeof(m_spdm_negotiate_algori
                                                   sizeof(
     spdm_negotiate_algorithms_common_struct_table_t);
 
-spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request15 = {
+libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algorithm_request15 =
+{
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -598,7 +602,7 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
             12,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_multiple_tables_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_multiple_tables_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -666,7 +670,7 @@ spdm_negotiate_algorithms_request_spdm11_multiple_tables_t m_spdm_negotiate_algo
 };
 uintn m_spdm_negotiate_algorithm_request15_size = sizeof(m_spdm_negotiate_algorithm_request15);
 
-spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request16 = {
+libspdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request16 = {
     {
         {
             SPDM_MESSAGE_VERSION_11,
@@ -674,7 +678,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request16 
             4,
             0
         },
-        sizeof(spdm_negotiate_algorithms_request_spdm11_t),
+        sizeof(libspdm_negotiate_algorithms_request_spdm11_t),
         SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
     },
     {
@@ -703,7 +707,7 @@ spdm_negotiate_algorithms_request_spdm11_t m_spdm_negotiate_algorithm_request16 
 };
 uintn m_spdm_negotiate_algorithm_request16_size = sizeof(m_spdm_negotiate_algorithm_request16);
 
-void test_spdm_responder_algorithms_case1(void **state)
+void libspdm_test_responder_algorithms_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -723,9 +727,9 @@ void test_spdm_responder_algorithms_case1(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request1_size,
-        &m_spdm_negotiate_algorithms_request1, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request1_size,
+        &m_libspdm_negotiate_algorithms_request1, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_algorithms_response_t));
@@ -734,7 +738,7 @@ void test_spdm_responder_algorithms_case1(void **state)
                      SPDM_ALGORITHMS);
 }
 
-void test_spdm_responder_algorithms_case2(void **state)
+void libspdm_test_responder_algorithms_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -754,9 +758,9 @@ void test_spdm_responder_algorithms_case2(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request2_size,
-        &m_spdm_negotiate_algorithms_request2, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request2_size,
+        &m_libspdm_negotiate_algorithms_request2, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -768,7 +772,7 @@ void test_spdm_responder_algorithms_case2(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case3(void **state)
+void libspdm_test_responder_algorithms_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -789,9 +793,9 @@ void test_spdm_responder_algorithms_case3(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request1_size,
-        &m_spdm_negotiate_algorithms_request1, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request1_size,
+        &m_libspdm_negotiate_algorithms_request1, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -804,7 +808,7 @@ void test_spdm_responder_algorithms_case3(void **state)
                      LIBSPDM_RESPONSE_STATE_BUSY);
 }
 
-void test_spdm_responder_algorithms_case4(void **state)
+void libspdm_test_responder_algorithms_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -825,9 +829,9 @@ void test_spdm_responder_algorithms_case4(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request1_size,
-        &m_spdm_negotiate_algorithms_request1, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request1_size,
+        &m_libspdm_negotiate_algorithms_request1, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -841,7 +845,7 @@ void test_spdm_responder_algorithms_case4(void **state)
                      LIBSPDM_RESPONSE_STATE_NEED_RESYNC);
 }
 
-void test_spdm_responder_algorithms_case5(void **state)
+void libspdm_test_responder_algorithms_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -863,9 +867,9 @@ void test_spdm_responder_algorithms_case5(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request1_size,
-        &m_spdm_negotiate_algorithms_request1, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request1_size,
+        &m_libspdm_negotiate_algorithms_request1, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
@@ -884,7 +888,7 @@ void test_spdm_responder_algorithms_case5(void **state)
     assert_int_equal(error_data->request_code, SPDM_NEGOTIATE_ALGORITHMS);
 }
 
-void test_spdm_responder_algorithms_case6(void **state)
+void libspdm_test_responder_algorithms_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -905,9 +909,9 @@ void test_spdm_responder_algorithms_case6(void **state)
     spdm_context->local_context.algorithm.base_asym_algo = m_use_asym_algo;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms(
-        spdm_context, m_spdm_negotiate_algorithms_request1_size,
-        &m_spdm_negotiate_algorithms_request1, &response_size,
+    status = libspdm_get_response_algorithms(
+        spdm_context, m_libspdm_negotiate_algorithms_request1_size,
+        &m_libspdm_negotiate_algorithms_request1, &response_size,
         response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -919,7 +923,7 @@ void test_spdm_responder_algorithms_case6(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case7(void **state) {
+void libspdm_test_responder_algorithms_case7(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -963,9 +967,10 @@ void test_spdm_responder_algorithms_case7(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request12_size,
-                                           &m_spdm_negotiate_algorithm_request12, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request12_size,
+                                              &m_spdm_negotiate_algorithm_request12, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_algorithms_response_t)+4*
@@ -984,7 +989,7 @@ void test_spdm_responder_algorithms_case7(void **state) {
                       spdm_context->local_context.algorithm.key_schedule);
 }
 
-void test_spdm_responder_algorithms_case8(void **state) {
+void libspdm_test_responder_algorithms_case8(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1031,9 +1036,10 @@ void test_spdm_responder_algorithms_case8(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request4_size,
-                                           &m_spdm_negotiate_algorithm_request4, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request4_size,
+                                              &m_spdm_negotiate_algorithm_request4, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1042,7 +1048,7 @@ void test_spdm_responder_algorithms_case8(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case9(void **state) {
+void libspdm_test_responder_algorithms_case9(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1089,9 +1095,10 @@ void test_spdm_responder_algorithms_case9(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request5_size,
-                                           &m_spdm_negotiate_algorithm_request5, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request5_size,
+                                              &m_spdm_negotiate_algorithm_request5, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1100,7 +1107,7 @@ void test_spdm_responder_algorithms_case9(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case10(void **state) {
+void libspdm_test_responder_algorithms_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1147,9 +1154,10 @@ void test_spdm_responder_algorithms_case10(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request6_size,
-                                           &m_spdm_negotiate_algorithm_request6, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request6_size,
+                                              &m_spdm_negotiate_algorithm_request6, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1158,7 +1166,7 @@ void test_spdm_responder_algorithms_case10(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case11(void **state) {
+void libspdm_test_responder_algorithms_case11(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1205,9 +1213,10 @@ void test_spdm_responder_algorithms_case11(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request7_size,
-                                           &m_spdm_negotiate_algorithm_request7, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request7_size,
+                                              &m_spdm_negotiate_algorithm_request7, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1216,7 +1225,7 @@ void test_spdm_responder_algorithms_case11(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case12(void **state) {
+void libspdm_test_responder_algorithms_case12(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1263,9 +1272,10 @@ void test_spdm_responder_algorithms_case12(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request8_size,
-                                           &m_spdm_negotiate_algorithm_request8, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request8_size,
+                                              &m_spdm_negotiate_algorithm_request8, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1274,7 +1284,7 @@ void test_spdm_responder_algorithms_case12(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case13(void **state) {
+void libspdm_test_responder_algorithms_case13(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1320,13 +1330,14 @@ void test_spdm_responder_algorithms_case13(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request9_size,
-                                           &m_spdm_negotiate_algorithm_request9, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request9_size,
+                                              &m_spdm_negotiate_algorithm_request9, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SECURITY_VIOLATION);
 }
 
-void test_spdm_responder_algorithms_case14(void **state) {
+void libspdm_test_responder_algorithms_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1346,13 +1357,14 @@ void test_spdm_responder_algorithms_case14(void **state) {
     libspdm_reset_message_a(spdm_context);
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request10_size,
-                                           &m_spdm_negotiate_algorithm_request10, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request10_size,
+                                              &m_spdm_negotiate_algorithm_request10, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_responder_algorithms_case15(void **state) {
+void libspdm_test_responder_algorithms_case15(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1395,13 +1407,14 @@ void test_spdm_responder_algorithms_case15(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request11_size,
-                                           &m_spdm_negotiate_algorithm_request11, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request11_size,
+                                              &m_spdm_negotiate_algorithm_request11, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_DEVICE_ERROR);
 }
 
-void test_spdm_responder_algorithms_case16(void **state) {
+void libspdm_test_responder_algorithms_case16(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1445,9 +1458,10 @@ void test_spdm_responder_algorithms_case16(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request12_size,
-                                           &m_spdm_negotiate_algorithm_request12, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request12_size,
+                                              &m_spdm_negotiate_algorithm_request12, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_algorithms_response_t)+4*
@@ -1466,7 +1480,7 @@ void test_spdm_responder_algorithms_case16(void **state) {
                       spdm_context->local_context.algorithm.key_schedule);
 }
 
-void test_spdm_responder_algorithms_case17(void **state) {
+void libspdm_test_responder_algorithms_case17(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1510,9 +1524,10 @@ void test_spdm_responder_algorithms_case17(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request13_size,
-                                           &m_spdm_negotiate_algorithm_request13, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request13_size,
+                                              &m_spdm_negotiate_algorithm_request13, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_algorithms_response_t)+4*
@@ -1531,7 +1546,7 @@ void test_spdm_responder_algorithms_case17(void **state) {
                       spdm_context->local_context.algorithm.key_schedule);
 }
 
-void test_spdm_responder_algorithms_case18(void **state) {
+void libspdm_test_responder_algorithms_case18(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1575,9 +1590,10 @@ void test_spdm_responder_algorithms_case18(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request14_size,
-                                           &m_spdm_negotiate_algorithm_request14, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request14_size,
+                                              &m_spdm_negotiate_algorithm_request14, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1586,7 +1602,7 @@ void test_spdm_responder_algorithms_case18(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_algorithms_case19(void **state) {
+void libspdm_test_responder_algorithms_case19(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1630,9 +1646,10 @@ void test_spdm_responder_algorithms_case19(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request12_size,
-                                           &m_spdm_negotiate_algorithm_request12, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request12_size,
+                                              &m_spdm_negotiate_algorithm_request12, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_algorithms_response_t)+4*
@@ -1652,7 +1669,7 @@ void test_spdm_responder_algorithms_case19(void **state) {
 }
 
 /* When both of requester and responder support multiple algorithms, then defaults to choose the strongest available algorithm*/
-void test_spdm_responder_algorithms_case20(void **state) {
+void libspdm_test_responder_algorithms_case20(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1704,9 +1721,10 @@ void test_spdm_responder_algorithms_case20(void **state) {
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
     response_size = sizeof(response);
-    status = spdm_get_response_algorithms (spdm_context, m_spdm_negotiate_algorithm_request16_size,
-                                           &m_spdm_negotiate_algorithm_request16, &response_size,
-                                           response);
+    status = libspdm_get_response_algorithms (spdm_context,
+                                              m_spdm_negotiate_algorithm_request16_size,
+                                              &m_spdm_negotiate_algorithm_request16, &response_size,
+                                              response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_algorithms_response_t)+4*
@@ -1746,51 +1764,51 @@ int spdm_responder_algorithms_test_main(void)
 {
     const struct CMUnitTest spdm_responder_algorithms_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case1),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case2),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case3),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case4),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case5),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case6),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case6),
         /* Success case V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case7),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case7),
         /* No match for base_asym_algo*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case8),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case8),
         /* No match for base_hash_algo*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case9),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case9),
         /* No match for dhe_named_group*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case10),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case10),
         /* No match for aead_cipher_suite*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case11),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case11),
         /* No match for req_base_asym_alg*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case12),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case12),
         /* No match for key_schedule*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case13),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case13),
         /* Spdm length greater than 64 bytes for V1.0*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case14),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case14),
         /* Spdm length greater than 128 bytes for V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case15),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case15),
         /* Multiple repeated Alg structs for V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case16),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case16),
         /* param1 is smaller than the number of Alg structs for V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case17),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case17),
         /* param1 is bigger than the number of  Alg structs for V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case18),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case18),
         /* Invalid  Alg structs + valid Alg Structs for V1.1*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case19),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case19),
         /* When support multiple algorithms, then defaults to choose the strongest available algorithm*/
-        cmocka_unit_test(test_spdm_responder_algorithms_case20),
+        cmocka_unit_test(libspdm_test_responder_algorithms_case20),
     };
 
-    m_spdm_negotiate_algorithms_request1.base_asym_algo = m_use_asym_algo;
-    m_spdm_negotiate_algorithms_request1.base_hash_algo = m_use_hash_algo;
-    m_spdm_negotiate_algorithms_request2.base_asym_algo = m_use_asym_algo;
-    m_spdm_negotiate_algorithms_request2.base_hash_algo = m_use_hash_algo;
+    m_libspdm_negotiate_algorithms_request1.base_asym_algo = m_use_asym_algo;
+    m_libspdm_negotiate_algorithms_request1.base_hash_algo = m_use_hash_algo;
+    m_libspdm_negotiate_algorithms_request2.base_asym_algo = m_use_asym_algo;
+    m_libspdm_negotiate_algorithms_request2.base_hash_algo = m_use_hash_algo;
     m_spdm_negotiate_algorithm_request3.spdm_request_version10.base_asym_algo = m_use_asym_algo;
     m_spdm_negotiate_algorithm_request3.spdm_request_version10.base_hash_algo = m_use_hash_algo;
     m_spdm_negotiate_algorithm_request4.spdm_request_version10.base_asym_algo =

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -7,7 +7,7 @@
 #include "spdm_unit_test.h"
 #include "internal/libspdm_responder_lib.h"
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request1 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request1 = {
     {
         SPDM_MESSAGE_VERSION_10,
         SPDM_GET_CAPABILITIES,
@@ -17,17 +17,17 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request1 = {
  * However, spdm_get_capabilities_request_t has a size of 0x0c.
  * Therefore, sending a v1.0 request with this structure results in a wrong size request.
  * size information was corrected to reflect the actual size of a get_capabilities 1.0 message.*/
-uintn m_spdm_get_capabilities_request1_size = sizeof(spdm_message_header_t);
+uintn m_libspdm_get_capabilities_request1_size = sizeof(spdm_message_header_t);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request2 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request2 = {
     {
         SPDM_MESSAGE_VERSION_10,
         SPDM_GET_CAPABILITIES,
     },
 };
-uintn m_spdm_get_capabilities_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+uintn m_libspdm_get_capabilities_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request3 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request3 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -37,12 +37,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request3 = {
     0x0000, /*reserved, 2 bytes*/
     0x12345678 /*flags*/
 };
-uintn m_spdm_get_capabilities_request3_size =
-    sizeof(m_spdm_get_capabilities_request3) -
-    sizeof(m_spdm_get_capabilities_request3.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request3.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request3_size =
+    sizeof(m_libspdm_get_capabilities_request3) -
+    sizeof(m_libspdm_get_capabilities_request3.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request3.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request4 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request4 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -62,12 +62,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request4 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request4_size =
-    sizeof(m_spdm_get_capabilities_request4) -
-    sizeof(m_spdm_get_capabilities_request4.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request4.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request4_size =
+    sizeof(m_libspdm_get_capabilities_request4) -
+    sizeof(m_libspdm_get_capabilities_request4.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request4.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request5 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request5 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -87,12 +87,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request5 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request5_size =
-    sizeof(m_spdm_get_capabilities_request5) -
-    sizeof(m_spdm_get_capabilities_request5.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request5.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request5_size =
+    sizeof(m_libspdm_get_capabilities_request5) -
+    sizeof(m_libspdm_get_capabilities_request5.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request5.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request6 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request6 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -113,12 +113,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request6 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request6_size =
-    sizeof(m_spdm_get_capabilities_request6) -
-    sizeof(m_spdm_get_capabilities_request6.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request6.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request6_size =
+    sizeof(m_libspdm_get_capabilities_request6) -
+    sizeof(m_libspdm_get_capabilities_request6.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request6.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request7 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request7 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -139,12 +139,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request7 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request7_size =
-    sizeof(m_spdm_get_capabilities_request7) -
-    sizeof(m_spdm_get_capabilities_request7.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request7.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request7_size =
+    sizeof(m_libspdm_get_capabilities_request7) -
+    sizeof(m_libspdm_get_capabilities_request7.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request7.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request8 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request8 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -164,12 +164,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request8 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request8_size =
-    sizeof(m_spdm_get_capabilities_request8) -
-    sizeof(m_spdm_get_capabilities_request8.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request8.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request8_size =
+    sizeof(m_libspdm_get_capabilities_request8) -
+    sizeof(m_libspdm_get_capabilities_request8.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request8.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request9 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request9 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -190,12 +190,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request9 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request9_size =
-    sizeof(m_spdm_get_capabilities_request9) -
-    sizeof(m_spdm_get_capabilities_request9.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request9.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request9_size =
+    sizeof(m_libspdm_get_capabilities_request9) -
+    sizeof(m_libspdm_get_capabilities_request9.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request9.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request10 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request10 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -215,12 +215,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request10 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request10_size =
-    sizeof(m_spdm_get_capabilities_request10) -
-    sizeof(m_spdm_get_capabilities_request10.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request10.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request10_size =
+    sizeof(m_libspdm_get_capabilities_request10) -
+    sizeof(m_libspdm_get_capabilities_request10.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request10.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request11 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request11 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -240,12 +240,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request11 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request11_size =
-    sizeof(m_spdm_get_capabilities_request11) -
-    sizeof(m_spdm_get_capabilities_request11.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request11.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request11_size =
+    sizeof(m_libspdm_get_capabilities_request11) -
+    sizeof(m_libspdm_get_capabilities_request11.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request11.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request12 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request12 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -266,12 +266,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request12 = {
 
     )
 };
-uintn m_spdm_get_capabilities_request12_size =
-    sizeof(m_spdm_get_capabilities_request12) -
-    sizeof(m_spdm_get_capabilities_request12.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request12.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request12_size =
+    sizeof(m_libspdm_get_capabilities_request12) -
+    sizeof(m_libspdm_get_capabilities_request12.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request12.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request13 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request13 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -292,12 +292,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request13 = {
 
     )
 };
-uintn m_spdm_get_capabilities_request13_size =
-    sizeof(m_spdm_get_capabilities_request13) -
-    sizeof(m_spdm_get_capabilities_request13.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request13.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request13_size =
+    sizeof(m_libspdm_get_capabilities_request13) -
+    sizeof(m_libspdm_get_capabilities_request13.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request13.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request14 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request14 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -317,12 +317,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request14 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request14_size =
-    sizeof(m_spdm_get_capabilities_request14) -
-    sizeof(m_spdm_get_capabilities_request14.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request14.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request14_size =
+    sizeof(m_libspdm_get_capabilities_request14) -
+    sizeof(m_libspdm_get_capabilities_request14.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request14.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request15 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request15 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -343,12 +343,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request15 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP)
 };
-uintn m_spdm_get_capabilities_request15_size =
-    sizeof(m_spdm_get_capabilities_request15) -
-    sizeof(m_spdm_get_capabilities_request15.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request15.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request15_size =
+    sizeof(m_libspdm_get_capabilities_request15) -
+    sizeof(m_libspdm_get_capabilities_request15.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request15.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request16 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request16 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -368,12 +368,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request16 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request16_size =
-    sizeof(m_spdm_get_capabilities_request16) -
-    sizeof(m_spdm_get_capabilities_request16.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request16.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request16_size =
+    sizeof(m_libspdm_get_capabilities_request16) -
+    sizeof(m_libspdm_get_capabilities_request16.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request16.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request17 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request17 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -393,12 +393,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request17 = {
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)
 };
-uintn m_spdm_get_capabilities_request17_size =
-    sizeof(m_spdm_get_capabilities_request17) -
-    sizeof(m_spdm_get_capabilities_request17.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request17.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request17_size =
+    sizeof(m_libspdm_get_capabilities_request17) -
+    sizeof(m_libspdm_get_capabilities_request17.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request17.max_spdm_msg_size);
 
-spdm_get_capabilities_request_t m_spdm_get_capabilities_request18 = {
+spdm_get_capabilities_request_t m_libspdm_get_capabilities_request18 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_CAPABILITIES,
@@ -419,12 +419,12 @@ spdm_get_capabilities_request_t m_spdm_get_capabilities_request18 = {
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP |
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP)
 };
-uintn m_spdm_get_capabilities_request18_size =
-    sizeof(m_spdm_get_capabilities_request18) -
-    sizeof(m_spdm_get_capabilities_request18.data_transfer_size) -
-    sizeof(m_spdm_get_capabilities_request18.max_spdm_msg_size);
+uintn m_libspdm_get_capabilities_request18_size =
+    sizeof(m_libspdm_get_capabilities_request18) -
+    sizeof(m_libspdm_get_capabilities_request18.data_transfer_size) -
+    sizeof(m_libspdm_get_capabilities_request18.max_spdm_msg_size);
 
-void test_spdm_responder_capabilities_case1(void **state)
+void libspdm_test_responder_capabilities_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -444,15 +444,15 @@ void test_spdm_responder_capabilities_case1(void **state)
 #endif
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request1_size,
-        &m_spdm_get_capabilities_request1, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request1_size,
+        &m_libspdm_get_capabilities_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_capabilities_response_t) -
                      sizeof(spdm_response->data_transfer_size) -
                      sizeof(spdm_response->max_spdm_msg_size));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request1.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request1.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CAPABILITIES);
@@ -462,7 +462,7 @@ void test_spdm_responder_capabilities_case1(void **state)
 #endif
 }
 
-void test_spdm_responder_capabilities_case2(void **state)
+void libspdm_test_responder_capabilities_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -478,13 +478,13 @@ void test_spdm_responder_capabilities_case2(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request2_size,
-        &m_spdm_get_capabilities_request2, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request2_size,
+        &m_libspdm_get_capabilities_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request2.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request2.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -493,7 +493,7 @@ void test_spdm_responder_capabilities_case2(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case3(void **state)
+void libspdm_test_responder_capabilities_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -510,13 +510,13 @@ void test_spdm_responder_capabilities_case3(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request1_size,
-        &m_spdm_get_capabilities_request1, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request1_size,
+        &m_libspdm_get_capabilities_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request1.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request1.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -526,7 +526,7 @@ void test_spdm_responder_capabilities_case3(void **state)
                      LIBSPDM_RESPONSE_STATE_BUSY);
 }
 
-void test_spdm_responder_capabilities_case4(void **state)
+void libspdm_test_responder_capabilities_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -543,13 +543,13 @@ void test_spdm_responder_capabilities_case4(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request1_size,
-        &m_spdm_get_capabilities_request1, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request1_size,
+        &m_libspdm_get_capabilities_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request1.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request1.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -561,7 +561,7 @@ void test_spdm_responder_capabilities_case4(void **state)
 }
 
 /* According to spec, a responder shall not answer a get_capabilties with a ResponseNotReady*/
-void test_spdm_responder_capabilities_case5(void **state)
+void libspdm_test_responder_capabilities_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -579,15 +579,15 @@ void test_spdm_responder_capabilities_case5(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request1_size,
-        &m_spdm_get_capabilities_request1, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request1_size,
+        &m_libspdm_get_capabilities_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
                      sizeof(spdm_error_data_response_not_ready_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request1.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request1.header.spdm_version,
                      spdm_response->header.spdm_version);
     error_data =
         (spdm_error_data_response_not_ready_t *)(&spdm_response
@@ -602,7 +602,7 @@ void test_spdm_responder_capabilities_case5(void **state)
     assert_int_equal(error_data->request_code, SPDM_GET_CAPABILITIES);
 }
 
-void test_spdm_responder_capabilities_case6(void **state)
+void libspdm_test_responder_capabilities_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -619,13 +619,13 @@ void test_spdm_responder_capabilities_case6(void **state)
         LIBSPDM_CONNECTION_STATE_NOT_STARTED;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request1_size,
-        &m_spdm_get_capabilities_request1, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request1_size,
+        &m_libspdm_get_capabilities_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request1.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request1.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -634,7 +634,7 @@ void test_spdm_responder_capabilities_case6(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 /*New from here*/
-void test_spdm_responder_capabilities_case7(void **state)
+void libspdm_test_responder_capabilities_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -651,13 +651,13 @@ void test_spdm_responder_capabilities_case7(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request3_size,
-        &m_spdm_get_capabilities_request3, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request3_size,
+        &m_libspdm_get_capabilities_request3, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request3.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request3.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -666,7 +666,7 @@ void test_spdm_responder_capabilities_case7(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case8(void **state)
+void libspdm_test_responder_capabilities_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -682,21 +682,21 @@ void test_spdm_responder_capabilities_case8(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request4_size,
-        &m_spdm_get_capabilities_request4, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request4_size,
+        &m_libspdm_get_capabilities_request4, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_capabilities_response_t) -
                      sizeof(spdm_response->data_transfer_size) -
                      sizeof(spdm_response->max_spdm_msg_size));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request4.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request4.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CAPABILITIES);
 }
 
-void test_spdm_responder_capabilities_case9(void **state)
+void libspdm_test_responder_capabilities_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -712,21 +712,21 @@ void test_spdm_responder_capabilities_case9(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request5_size,
-        &m_spdm_get_capabilities_request5, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request5_size,
+        &m_libspdm_get_capabilities_request5, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_capabilities_response_t) -
                      sizeof(spdm_response->data_transfer_size) -
                      sizeof(spdm_response->max_spdm_msg_size));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request4.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request4.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CAPABILITIES);
 }
 
-void test_spdm_responder_capabilities_case10(void **state)
+void libspdm_test_responder_capabilities_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -742,13 +742,13 @@ void test_spdm_responder_capabilities_case10(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request6_size,
-        &m_spdm_get_capabilities_request6, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request6_size,
+        &m_libspdm_get_capabilities_request6, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request6.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request6.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -757,7 +757,7 @@ void test_spdm_responder_capabilities_case10(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case11(void **state)
+void libspdm_test_responder_capabilities_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -773,13 +773,13 @@ void test_spdm_responder_capabilities_case11(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request7_size,
-        &m_spdm_get_capabilities_request7, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request7_size,
+        &m_libspdm_get_capabilities_request7, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request7.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request7.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -788,7 +788,7 @@ void test_spdm_responder_capabilities_case11(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case12(void **state)
+void libspdm_test_responder_capabilities_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -804,21 +804,21 @@ void test_spdm_responder_capabilities_case12(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request8_size,
-        &m_spdm_get_capabilities_request8, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request8_size,
+        &m_libspdm_get_capabilities_request8, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_capabilities_response_t) -
                      sizeof(spdm_response->data_transfer_size) -
                      sizeof(spdm_response->max_spdm_msg_size));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request4.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request4.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CAPABILITIES);
 }
 
-void test_spdm_responder_capabilities_case13(void **state)
+void libspdm_test_responder_capabilities_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -834,13 +834,13 @@ void test_spdm_responder_capabilities_case13(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request9_size,
-        &m_spdm_get_capabilities_request9, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request9_size,
+        &m_libspdm_get_capabilities_request9, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request9.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request9.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -849,7 +849,7 @@ void test_spdm_responder_capabilities_case13(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case14(void **state)
+void libspdm_test_responder_capabilities_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -865,13 +865,13 @@ void test_spdm_responder_capabilities_case14(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request10_size,
-        &m_spdm_get_capabilities_request10, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request10_size,
+        &m_libspdm_get_capabilities_request10, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request10.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request10.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -880,7 +880,7 @@ void test_spdm_responder_capabilities_case14(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case15(void **state)
+void libspdm_test_responder_capabilities_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -896,13 +896,13 @@ void test_spdm_responder_capabilities_case15(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request11_size,
-        &m_spdm_get_capabilities_request11, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request11_size,
+        &m_libspdm_get_capabilities_request11, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request11.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request11.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -911,7 +911,7 @@ void test_spdm_responder_capabilities_case15(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case16(void **state)
+void libspdm_test_responder_capabilities_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -927,13 +927,13 @@ void test_spdm_responder_capabilities_case16(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request12_size,
-        &m_spdm_get_capabilities_request12, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request12_size,
+        &m_libspdm_get_capabilities_request12, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request12.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request12.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -942,7 +942,7 @@ void test_spdm_responder_capabilities_case16(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case17(void **state)
+void libspdm_test_responder_capabilities_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -958,13 +958,13 @@ void test_spdm_responder_capabilities_case17(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request13_size,
-        &m_spdm_get_capabilities_request13, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request13_size,
+        &m_libspdm_get_capabilities_request13, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request13.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request13.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -973,7 +973,7 @@ void test_spdm_responder_capabilities_case17(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case18(void **state)
+void libspdm_test_responder_capabilities_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -991,13 +991,13 @@ void test_spdm_responder_capabilities_case18(void **state)
     libspdm_reset_message_a(spdm_context);
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request14_size,
-        &m_spdm_get_capabilities_request14, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request14_size,
+        &m_libspdm_get_capabilities_request14, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request14.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request14.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -1006,7 +1006,7 @@ void test_spdm_responder_capabilities_case18(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case19(void **state)
+void libspdm_test_responder_capabilities_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1022,13 +1022,13 @@ void test_spdm_responder_capabilities_case19(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request15_size,
-        &m_spdm_get_capabilities_request15, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request15_size,
+        &m_libspdm_get_capabilities_request15, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request15.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request15.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -1037,7 +1037,7 @@ void test_spdm_responder_capabilities_case19(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case20(void **state)
+void libspdm_test_responder_capabilities_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1053,13 +1053,13 @@ void test_spdm_responder_capabilities_case20(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request16_size,
-        &m_spdm_get_capabilities_request16, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request16_size,
+        &m_libspdm_get_capabilities_request16, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request16.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request16.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -1068,7 +1068,7 @@ void test_spdm_responder_capabilities_case20(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case21(void **state)
+void libspdm_test_responder_capabilities_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1084,13 +1084,13 @@ void test_spdm_responder_capabilities_case21(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request17_size,
-        &m_spdm_get_capabilities_request17, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request17_size,
+        &m_libspdm_get_capabilities_request17, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request17.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request17.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
@@ -1099,7 +1099,7 @@ void test_spdm_responder_capabilities_case21(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void test_spdm_responder_capabilities_case22(void **state)
+void libspdm_test_responder_capabilities_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1115,15 +1115,15 @@ void test_spdm_responder_capabilities_case22(void **state)
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     response_size = sizeof(response);
-    status = spdm_get_response_capabilities(
-        spdm_context, m_spdm_get_capabilities_request18_size,
-        &m_spdm_get_capabilities_request18, &response_size, response);
+    status = libspdm_get_response_capabilities(
+        spdm_context, m_libspdm_get_capabilities_request18_size,
+        &m_libspdm_get_capabilities_request18, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_capabilities_response_t) -
                      sizeof(spdm_response->data_transfer_size) -
                      sizeof(spdm_response->max_spdm_msg_size));
     spdm_response = (void *)response;
-    assert_int_equal(m_spdm_get_capabilities_request18.header.spdm_version,
+    assert_int_equal(m_libspdm_get_capabilities_request18.header.spdm_version,
                      spdm_response->header.spdm_version);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CAPABILITIES);
@@ -1138,49 +1138,49 @@ int spdm_responder_capabilities_test_main(void)
 {
     const struct CMUnitTest spdm_responder_capabilities_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case1),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case2),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case3),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case4),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case5),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case6),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case6),
         /* Invalid requester capabilities flag (random flag)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case7),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case7),
         /* V1.1 Success case, all possible flags set*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case8),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case8),
         /* Requester capabilities flag bit 0 is set. reserved value should ne ignored*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case9),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case9),
         /* meas_cap is set (meas_cap shall be cleared)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case10),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case10),
         /* meas_fresh_cap is set (meas_fresh_cap shall be cleared)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case11),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case11),
         /* Requester capabilities flag byte 2 bit 1 is set. reserved value should ne ignored*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case12),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case12),
         /* pub_key_id_cap and cert_cap set (flags are mutually exclusive)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case13),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case13),
         /* encrypt_cap set and key_ex_cap and psk_cap cleared (encrypt_cap demands key_ex_cap or psk_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case14),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case14),
         /* mac_cap set and key_ex_cap and psk_cap cleared (mac_cap demands key_ex_cap or psk_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case15),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case15),
         /* key_ex_cap set and encrypt_cap and mac_cap cleared (key_ex_cap demands encrypt_cap or mac_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case16),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case16),
         /* psk_cap set and encrypt_cap and mac_cap cleared (psk_cap demands encrypt_cap or mac_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case17),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case17),
         /* encap_cap cleared and MUT_AUTH set (MUT_AUTH demands encap_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case18),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case18),
         /* cert_cap set and pub_key_id_cap set (pub_key_id_cap demands cert_cap to be cleared)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case19),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case19),
         /* key_ex_cap cleared and handshake_in_the_clear_cap set (handshake_in_the_clear_cap demands key_ex_cap to be set)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case20),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case20),
         /* encrypt_cap and mac_cap cleared and handshake_in_the_clear_cap set (handshake_in_the_clear_cap shall be cleared if encrypt_cap and mac_cap are cleared)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case21),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case21),
         /* cert_cap cleared and pub_key_id_cap set (pub_key_id_cap demands cert_cap to be cleared)*/
-        cmocka_unit_test(test_spdm_responder_capabilities_case22),
+        cmocka_unit_test(libspdm_test_responder_capabilities_case22),
     };
 
     setup_spdm_test_context(&m_spdm_responder_capabilities_test_context);

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -43,7 +43,7 @@ uintn m_spdm_get_certificate_request3_size =
  * Test 1: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the certificate chain
  * Expected Behavior: generate a correctly formed Certficate message, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case1(void **state)
+void libspdm_test_responder_certificate_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -78,7 +78,7 @@ void test_spdm_responder_certificate_case1(void **state)
 #endif
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request1_size,
         &m_spdm_get_certificate_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -103,7 +103,7 @@ void test_spdm_responder_certificate_case1(void **state)
  * Test 2: Wrong GET_CERTIFICATE message size (larger than expected)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void test_spdm_responder_certificate_case2(void **state)
+void libspdm_test_responder_certificate_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -134,7 +134,7 @@ void test_spdm_responder_certificate_case2(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request2_size,
         &m_spdm_get_certificate_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -152,7 +152,7 @@ void test_spdm_responder_certificate_case2(void **state)
  * Test 3: Force response_state = LIBSPDM_RESPONSE_STATE_BUSY when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
  **/
-void test_spdm_responder_certificate_case3(void **state)
+void libspdm_test_responder_certificate_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -184,7 +184,7 @@ void test_spdm_responder_certificate_case3(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request1_size,
         &m_spdm_get_certificate_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -203,7 +203,7 @@ void test_spdm_responder_certificate_case3(void **state)
  * Test 4: Force response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  **/
-void test_spdm_responder_certificate_case4(void **state)
+void libspdm_test_responder_certificate_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -235,7 +235,7 @@ void test_spdm_responder_certificate_case4(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request1_size,
         &m_spdm_get_certificate_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -255,7 +255,7 @@ void test_spdm_responder_certificate_case4(void **state)
  * Test 5: Force response_state = LIBSPDM_RESPONSE_STATE_NOT_READY when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_RESPONSE_NOT_READY and correct error_data
  **/
-void test_spdm_responder_certificate_case5(void **state)
+void libspdm_test_responder_certificate_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -288,7 +288,7 @@ void test_spdm_responder_certificate_case5(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request1_size,
         &m_spdm_get_certificate_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -313,7 +313,7 @@ void test_spdm_responder_certificate_case5(void **state)
  * Test 6: simulate wrong connection_state when asked GET_CERTIFICATE (missing SPDM_GET_DIGESTS_RECEIVE_FLAG and SPDM_GET_CAPABILITIES_RECEIVE_FLAG)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNEXPECTED_REQUEST
  **/
-void test_spdm_responder_certificate_case6(void **state)
+void libspdm_test_responder_certificate_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -345,7 +345,7 @@ void test_spdm_responder_certificate_case6(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_certificate(
+    status = libspdm_get_response_certificate(
         spdm_context, m_spdm_get_certificate_request1_size,
         &m_spdm_get_certificate_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -363,7 +363,7 @@ void test_spdm_responder_certificate_case6(void **state)
  * Test 7: request length at the boundary of maximum integer values, while keeping offset 0
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case7(void **state)
+void libspdm_test_responder_certificate_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -415,7 +415,7 @@ void test_spdm_responder_certificate_case7(void **state)
         /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
-        status = spdm_get_response_certificate(
+        status = libspdm_get_response_certificate(
             spdm_context, m_spdm_get_certificate_request3_size,
             &m_spdm_get_certificate_request3, &response_size,
             response);
@@ -439,7 +439,7 @@ void test_spdm_responder_certificate_case7(void **state)
  * Test 8: request offset at the boundary of maximum integer values, while keeping length 0
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case8(void **state)
+void libspdm_test_responder_certificate_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -498,7 +498,7 @@ void test_spdm_responder_certificate_case8(void **state)
         /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
-        status = spdm_get_response_certificate(
+        status = libspdm_get_response_certificate(
             spdm_context, m_spdm_get_certificate_request3_size,
             &m_spdm_get_certificate_request3, &response_size,
             response);
@@ -536,7 +536,7 @@ void test_spdm_responder_certificate_case8(void **state)
  * Test 9: request offset and length at the boundary of maximum integer values
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case9(void **state)
+void libspdm_test_responder_certificate_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -609,7 +609,7 @@ void test_spdm_responder_certificate_case9(void **state)
             /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
             libspdm_reset_message_b(spdm_context);
             response_size = sizeof(response);
-            status = spdm_get_response_certificate(
+            status = libspdm_get_response_certificate(
                 spdm_context,
                 m_spdm_get_certificate_request3_size,
                 &m_spdm_get_certificate_request3,
@@ -669,7 +669,7 @@ void test_spdm_responder_certificate_case9(void **state)
  * Test 10: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of long certificate chains, with the largest valid offset
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case10(void **state)
+void libspdm_test_responder_certificate_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -727,7 +727,7 @@ void test_spdm_responder_certificate_case10(void **state)
         /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
-        status = spdm_get_response_certificate(
+        status = libspdm_get_response_certificate(
             spdm_context, m_spdm_get_certificate_request3_size,
             &m_spdm_get_certificate_request3, &response_size,
             response);
@@ -784,7 +784,7 @@ void test_spdm_responder_certificate_case10(void **state)
  * Test 11: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of a short certificate chain (fits in 1 message)
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case11(void **state)
+void libspdm_test_responder_certificate_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -840,7 +840,7 @@ void test_spdm_responder_certificate_case11(void **state)
         /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
-        status = spdm_get_response_certificate(
+        status = libspdm_get_response_certificate(
             spdm_context, m_spdm_get_certificate_request3_size,
             &m_spdm_get_certificate_request3, &response_size,
             response);
@@ -893,7 +893,7 @@ void test_spdm_responder_certificate_case11(void **state)
  * Test 12: request a whole certificate chain byte by byte
  * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
  **/
-void test_spdm_responder_certificate_case12(void **state)
+void libspdm_test_responder_certificate_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -941,7 +941,7 @@ void test_spdm_responder_certificate_case12(void **state)
         m_spdm_get_certificate_request3.offset = (uint16_t)offset;
 
         response_size = sizeof(response);
-        status = spdm_get_response_certificate(
+        status = libspdm_get_response_certificate(
             spdm_context, m_spdm_get_certificate_request3_size,
             &m_spdm_get_certificate_request3, &response_size,
             response);
@@ -1001,29 +1001,29 @@ int spdm_responder_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_responder_certificate_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_certificate_case1),
+        cmocka_unit_test(libspdm_test_responder_certificate_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_certificate_case2),
+        cmocka_unit_test(libspdm_test_responder_certificate_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_certificate_case3),
+        cmocka_unit_test(libspdm_test_responder_certificate_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_certificate_case4),
+        cmocka_unit_test(libspdm_test_responder_certificate_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_certificate_case5),
+        cmocka_unit_test(libspdm_test_responder_certificate_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_certificate_case6),
+        cmocka_unit_test(libspdm_test_responder_certificate_case6),
         /* Tests varying length*/
-        cmocka_unit_test(test_spdm_responder_certificate_case7),
+        cmocka_unit_test(libspdm_test_responder_certificate_case7),
         /* Tests varying offset*/
-        cmocka_unit_test(test_spdm_responder_certificate_case8),
+        cmocka_unit_test(libspdm_test_responder_certificate_case8),
         /* Tests varying length and offset*/
-        cmocka_unit_test(test_spdm_responder_certificate_case9),
+        cmocka_unit_test(libspdm_test_responder_certificate_case9),
         /* Tests large certificate chains*/
-        cmocka_unit_test(test_spdm_responder_certificate_case10),
+        cmocka_unit_test(libspdm_test_responder_certificate_case10),
         /* Certificate fits in one single message*/
-        cmocka_unit_test(test_spdm_responder_certificate_case11),
+        cmocka_unit_test(libspdm_test_responder_certificate_case11),
         /* Requests byte by byte*/
-        cmocka_unit_test(test_spdm_responder_certificate_case12),
+        cmocka_unit_test(libspdm_test_responder_certificate_case12),
 
     };
 

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -53,7 +53,7 @@ uint8_t m_opaque_challenge_auth_rsp[9] = "openspdm";
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case1(void **state)
+void libspdm_test_responder_challenge_auth_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -100,7 +100,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request1_size,
         &m_spdm_challenge_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -126,7 +126,7 @@ void test_spdm_responder_challenge_auth_case1(void **state)
  * Expected behavior: the responder refuses the CHALLENGE message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_challenge_auth_case2(void **state)
+void libspdm_test_responder_challenge_auth_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -169,7 +169,7 @@ void test_spdm_responder_challenge_auth_case2(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request2.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request2_size,
         &m_spdm_challenge_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -189,7 +189,7 @@ void test_spdm_responder_challenge_auth_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Busy state.
  **/
-void test_spdm_responder_challenge_auth_case3(void **state)
+void libspdm_test_responder_challenge_auth_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -233,7 +233,7 @@ void test_spdm_responder_challenge_auth_case3(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request1_size,
         &m_spdm_challenge_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -254,7 +254,7 @@ void test_spdm_responder_challenge_auth_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the NeedResynch state.
  **/
-void test_spdm_responder_challenge_auth_case4(void **state)
+void libspdm_test_responder_challenge_auth_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -298,7 +298,7 @@ void test_spdm_responder_challenge_auth_case4(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request1_size,
         &m_spdm_challenge_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -320,7 +320,7 @@ void test_spdm_responder_challenge_auth_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the ResponseNotReady state.
  **/
-void test_spdm_responder_challenge_auth_case5(void **state)
+void libspdm_test_responder_challenge_auth_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -365,7 +365,7 @@ void test_spdm_responder_challenge_auth_case5(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request1_size,
         &m_spdm_challenge_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -393,7 +393,7 @@ void test_spdm_responder_challenge_auth_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void test_spdm_responder_challenge_auth_case6(void **state)
+void libspdm_test_responder_challenge_auth_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -437,7 +437,7 @@ void test_spdm_responder_challenge_auth_case6(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth(
+    status = libspdm_get_response_challenge_auth(
         spdm_context, m_spdm_challenge_request1_size,
         &m_spdm_challenge_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -457,7 +457,7 @@ void test_spdm_responder_challenge_auth_case6(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case7(void **state) {
+void libspdm_test_responder_challenge_auth_case7(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -490,9 +490,9 @@ void test_spdm_responder_challenge_auth_case7(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request1_size,
-                                               &m_spdm_challenge_request1, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request1_size,
+                                                  &m_spdm_challenge_request1, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -508,7 +508,7 @@ void test_spdm_responder_challenge_auth_case7(void **state) {
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void test_spdm_responder_challenge_auth_case8(void **state) {
+void libspdm_test_responder_challenge_auth_case8(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -541,9 +541,9 @@ void test_spdm_responder_challenge_auth_case8(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request3_size,
-                                               &m_spdm_challenge_request3, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request3_size,
+                                                  &m_spdm_challenge_request3, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -559,7 +559,7 @@ void test_spdm_responder_challenge_auth_case8(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case9(void **state) {
+void libspdm_test_responder_challenge_auth_case9(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -592,9 +592,9 @@ void test_spdm_responder_challenge_auth_case9(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request4_size,
-                                               &m_spdm_challenge_request4, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request4_size,
+                                                  &m_spdm_challenge_request4, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_challenge_auth_response_t) + libspdm_get_hash_size (
                           m_use_hash_algo) + SPDM_NONCE_SIZE + 0 + sizeof(uint16_t) + 0 + libspdm_get_asym_signature_size (
@@ -612,7 +612,7 @@ void test_spdm_responder_challenge_auth_case9(void **state) {
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void test_spdm_responder_challenge_auth_case10(void **state) {
+void libspdm_test_responder_challenge_auth_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -645,9 +645,9 @@ void test_spdm_responder_challenge_auth_case10(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request3_size,
-                                               &m_spdm_challenge_request3, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request3_size,
+                                                  &m_spdm_challenge_request3, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -663,7 +663,7 @@ void test_spdm_responder_challenge_auth_case10(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case11(void **state) {
+void libspdm_test_responder_challenge_auth_case11(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -697,9 +697,9 @@ void test_spdm_responder_challenge_auth_case11(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request1_size,
-                                               &m_spdm_challenge_request1, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request1_size,
+                                                  &m_spdm_challenge_request1, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_challenge_auth_response_t) + libspdm_get_hash_size (
                           m_use_hash_algo) + SPDM_NONCE_SIZE + 0 + sizeof(uint16_t) + 8 + libspdm_get_asym_signature_size (
@@ -717,7 +717,7 @@ void test_spdm_responder_challenge_auth_case11(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case12(void **state) {
+void libspdm_test_responder_challenge_auth_case12(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -751,9 +751,9 @@ void test_spdm_responder_challenge_auth_case12(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request5_size,
-                                               &m_spdm_challenge_request5, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request5_size,
+                                                  &m_spdm_challenge_request5, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_challenge_auth_response_t) + libspdm_get_hash_size (
                           m_use_hash_algo) + SPDM_NONCE_SIZE +
@@ -772,7 +772,7 @@ void test_spdm_responder_challenge_auth_case12(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_spdm_responder_challenge_auth_case13(void **state) {
+void libspdm_test_responder_challenge_auth_case13(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -806,9 +806,9 @@ void test_spdm_responder_challenge_auth_case13(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request6_size,
-                                               &m_spdm_challenge_request6, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request6_size,
+                                                  &m_spdm_challenge_request6, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_challenge_auth_response_t) + libspdm_get_hash_size (
                           m_use_hash_algo) + SPDM_NONCE_SIZE +
@@ -828,7 +828,7 @@ void test_spdm_responder_challenge_auth_case13(void **state) {
  * Expected behavior: the responder refuses the CHALLENGE message and produces an
  * ERROR message indicating the UnsupportedRequest.
  **/
-void test_spdm_responder_challenge_auth_case14(void **state) {
+void libspdm_test_responder_challenge_auth_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -862,9 +862,9 @@ void test_spdm_responder_challenge_auth_case14(void **state) {
 
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request1.nonce);
-    status = spdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request6_size,
-                                               &m_spdm_challenge_request6, &response_size,
-                                               response);
+    status = libspdm_get_response_challenge_auth (spdm_context, m_spdm_challenge_request6_size,
+                                                  &m_spdm_challenge_request6, &response_size,
+                                                  response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -883,25 +883,25 @@ int spdm_responder_challenge_auth_test_main(void)
 {
     const struct CMUnitTest spdm_responder_challenge_auth_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case1),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case2),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case3),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case4),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case5),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case6),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case7),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case8),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case9),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case10),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case11),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case12),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case13),
-        cmocka_unit_test(test_spdm_responder_challenge_auth_case14),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case6),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case7),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case8),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case9),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case10),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case11),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case12),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case13),
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case14),
     };
 
     setup_spdm_test_context(&m_spdm_responder_challenge_auth_test_context);

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -31,7 +31,7 @@ static uint8_t m_local_certificate_chain[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
  * Test 1: receives a valid GET_DIGESTS request message from Requester
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void test_spdm_responder_digests_case1(void **state)
+void libspdm_test_responder_digests_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -64,10 +64,10 @@ void test_spdm_responder_digests_case1(void **state)
 #endif
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(
         response_size,
@@ -87,7 +87,7 @@ void test_spdm_responder_digests_case1(void **state)
  * Test 2: receives a GET_DIGESTS request message with bad size from Requester
  * Expected Behavior: produces an ERROR response message with error code = InvalidRequest
  **/
-void test_spdm_responder_digests_case2(void **state)
+void libspdm_test_responder_digests_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -116,10 +116,10 @@ void test_spdm_responder_digests_case2(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request2_size,
-                                       &m_spdm_get_digests_request2,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request2_size,
+                                          &m_spdm_get_digests_request2,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -135,7 +135,7 @@ void test_spdm_responder_digests_case2(void **state)
  * request message (is busy) and may be able to process the request message if it is sent again in the future
  * Expected Behavior: produces an ERROR response message with error code = Busy
  **/
-void test_spdm_responder_digests_case3(void **state)
+void libspdm_test_responder_digests_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -165,10 +165,10 @@ void test_spdm_responder_digests_case3(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -184,7 +184,7 @@ void test_spdm_responder_digests_case3(void **state)
  * Test 4: receives a valid GET_DIGESTS request message from Requester, but Responder needs the Requester to reissue GET_VERSION to resynchronize
  * Expected Behavior: produces an ERROR response message with error code = RequestResynch
  **/
-void test_spdm_responder_digests_case4(void **state)
+void libspdm_test_responder_digests_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -214,10 +214,10 @@ void test_spdm_responder_digests_case4(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -234,7 +234,7 @@ void test_spdm_responder_digests_case4(void **state)
  * Test 5: receives a valid GET_DIGESTS request message from Requester, but Responder cannot produce the response message in time
  * Expected Behavior: produces an ERROR response message with error code = ResponseNotReady
  **/
-void test_spdm_responder_digests_case5(void **state)
+void libspdm_test_responder_digests_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -265,10 +265,10 @@ void test_spdm_responder_digests_case5(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -291,7 +291,7 @@ void test_spdm_responder_digests_case5(void **state)
  * meaning that steps GET_CAPABILITIES-CAPABILITIES and NEGOTIATE_ALGORITHMS-ALGORITHMS of the protocol were not previously completed
  * Expected Behavior: produces an ERROR response message with error code = UnexpectedRequest
  **/
-void test_spdm_responder_digests_case6(void **state)
+void libspdm_test_responder_digests_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -321,10 +321,10 @@ void test_spdm_responder_digests_case6(void **state)
     spdm_context->local_context.slot_count = 1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -339,7 +339,7 @@ void test_spdm_responder_digests_case6(void **state)
  * Test 7: receives a valid GET_DIGESTS request message from Requester, but the request message cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void test_spdm_responder_digests_case7(void **state)
+void libspdm_test_responder_digests_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -373,10 +373,10 @@ void test_spdm_responder_digests_case7(void **state)
     spdm_context->transcript.message_b.buffer_size =
         spdm_context->transcript.message_b.max_buffer_size;
 #endif
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -395,7 +395,7 @@ void test_spdm_responder_digests_case7(void **state)
  * Test 8: receives a valid GET_DIGESTS request message from Requester, but the response message cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void test_spdm_responder_digests_case8(void **state)
+void libspdm_test_responder_digests_case8(void **state)
 {
     spdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -432,10 +432,10 @@ void test_spdm_responder_digests_case8(void **state)
 #endif
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     response_size = sizeof(response);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
 #endif
@@ -453,7 +453,7 @@ void test_spdm_responder_digests_case8(void **state)
  * Test 9: receives a valid GET_DIGESTS request message from Requester, but there is no local certificate chain, i.e. there is no digest to send
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void test_spdm_responder_digests_case9(void **state)
+void libspdm_test_responder_digests_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -485,10 +485,10 @@ void test_spdm_responder_digests_case9(void **state)
 
     response_size = sizeof(response);
     libspdm_reset_message_b(spdm_context);
-    status = spdm_get_response_digests(spdm_context,
-                                       m_spdm_get_digests_request1_size,
-                                       &m_spdm_get_digests_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_digests(spdm_context,
+                                          m_spdm_get_digests_request1_size,
+                                          &m_spdm_get_digests_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -508,23 +508,23 @@ int spdm_responder_digests_test_main(void)
 {
     const struct CMUnitTest spdm_responder_digests_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_digests_case1),
+        cmocka_unit_test(libspdm_test_responder_digests_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_digests_case2),
+        cmocka_unit_test(libspdm_test_responder_digests_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_digests_case3),
+        cmocka_unit_test(libspdm_test_responder_digests_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_digests_case4),
+        cmocka_unit_test(libspdm_test_responder_digests_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_digests_case5),
+        cmocka_unit_test(libspdm_test_responder_digests_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_digests_case6),
+        cmocka_unit_test(libspdm_test_responder_digests_case6),
         /* Internal cache full (request message)*/
-        cmocka_unit_test(test_spdm_responder_digests_case7),
+        cmocka_unit_test(libspdm_test_responder_digests_case7),
         /* Internal cache full (response message)*/
-        cmocka_unit_test(test_spdm_responder_digests_case8),
+        cmocka_unit_test(libspdm_test_responder_digests_case8),
         /* No digest to send*/
-        cmocka_unit_test(test_spdm_responder_digests_case9),
+        cmocka_unit_test(libspdm_test_responder_digests_case9),
     };
 
     setup_spdm_test_context(&m_spdm_responder_digests_test_context);

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -20,7 +20,7 @@ uintn m_spdm_end_session_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 
 static uint8_t m_local_psk_hint[32];
 
-void test_spdm_responder_end_session_case1(void **state)
+void libspdm_test_responder_end_session_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -86,10 +86,10 @@ void test_spdm_responder_end_session_case1(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_end_session_response_t));
     spdm_response = (void *)response;
@@ -98,7 +98,7 @@ void test_spdm_responder_end_session_case1(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case2(void **state)
+void libspdm_test_responder_end_session_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -164,10 +164,10 @@ void test_spdm_responder_end_session_case2(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request2_size,
-                                           &m_spdm_end_session_request2,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request2_size,
+                                              &m_spdm_end_session_request2,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -179,7 +179,7 @@ void test_spdm_responder_end_session_case2(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case3(void **state)
+void libspdm_test_responder_end_session_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -246,10 +246,10 @@ void test_spdm_responder_end_session_case3(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -262,7 +262,7 @@ void test_spdm_responder_end_session_case3(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case4(void **state)
+void libspdm_test_responder_end_session_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -329,10 +329,10 @@ void test_spdm_responder_end_session_case4(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -346,7 +346,7 @@ void test_spdm_responder_end_session_case4(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case5(void **state)
+void libspdm_test_responder_end_session_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -414,10 +414,10 @@ void test_spdm_responder_end_session_case5(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -436,7 +436,7 @@ void test_spdm_responder_end_session_case5(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case6(void **state)
+void libspdm_test_responder_end_session_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -503,10 +503,10 @@ void test_spdm_responder_end_session_case6(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -518,7 +518,7 @@ void test_spdm_responder_end_session_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_end_session_case7(void **state)
+void libspdm_test_responder_end_session_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -596,10 +596,10 @@ void test_spdm_responder_end_session_case7(void **state)
 #endif
 
     response_size = sizeof(response);
-    status = spdm_get_response_end_session(spdm_context,
-                                           m_spdm_end_session_request1_size,
-                                           &m_spdm_end_session_request1,
-                                           &response_size, response);
+    status = libspdm_get_response_end_session(spdm_context,
+                                              m_spdm_end_session_request1_size,
+                                              &m_spdm_end_session_request1,
+                                              &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_end_session_response_t));
     spdm_response = (void *)response;
@@ -625,19 +625,19 @@ int spdm_responder_end_session_test_main(void)
 {
     const struct CMUnitTest spdm_responder_end_session_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_end_session_case1),
+        cmocka_unit_test(libspdm_test_responder_end_session_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_end_session_case2),
+        cmocka_unit_test(libspdm_test_responder_end_session_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_end_session_case3),
+        cmocka_unit_test(libspdm_test_responder_end_session_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_end_session_case4),
+        cmocka_unit_test(libspdm_test_responder_end_session_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_end_session_case5),
+        cmocka_unit_test(libspdm_test_responder_end_session_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_end_session_case6),
+        cmocka_unit_test(libspdm_test_responder_end_session_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_end_session_case7),
+        cmocka_unit_test(libspdm_test_responder_end_session_case7),
     };
 
     setup_spdm_test_context(&m_spdm_responder_end_session_test_context);

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -40,7 +40,7 @@ uint8_t m_dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
 void spdm_secured_message_set_request_finished_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -57,7 +57,7 @@ void spdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void test_spdm_responder_finish_case1(void **state)
+void libspdm_test_responder_finish_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -150,10 +150,10 @@ void test_spdm_responder_finish_case1(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_finish_response_t) + hmac_size);
@@ -168,7 +168,7 @@ void test_spdm_responder_finish_case1(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_finish_case2(void **state)
+void libspdm_test_responder_finish_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -258,10 +258,10 @@ void test_spdm_responder_finish_case2(void **state)
                      libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
                      hash_size, ptr);
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request2_size,
-                                      &m_spdm_finish_request2,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request2_size,
+                                         &m_spdm_finish_request2,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -279,7 +279,7 @@ void test_spdm_responder_finish_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state.
  **/
-void test_spdm_responder_finish_case3(void **state)
+void libspdm_test_responder_finish_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -373,10 +373,10 @@ void test_spdm_responder_finish_case3(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -395,7 +395,7 @@ void test_spdm_responder_finish_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state.
  **/
-void test_spdm_responder_finish_case4(void **state)
+void libspdm_test_responder_finish_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -489,10 +489,10 @@ void test_spdm_responder_finish_case4(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -512,7 +512,7 @@ void test_spdm_responder_finish_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the ResponseNotReady state.
  **/
-void test_spdm_responder_finish_case5(void **state)
+void libspdm_test_responder_finish_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -607,10 +607,10 @@ void test_spdm_responder_finish_case5(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -637,7 +637,7 @@ void test_spdm_responder_finish_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest.
  **/
-void test_spdm_responder_finish_case6(void **state)
+void libspdm_test_responder_finish_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -731,10 +731,10 @@ void test_spdm_responder_finish_case6(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -746,7 +746,7 @@ void test_spdm_responder_finish_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_finish_case7(void **state)
+void libspdm_test_responder_finish_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -852,10 +852,10 @@ void test_spdm_responder_finish_case7(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_finish_response_t) + hmac_size);
@@ -880,7 +880,7 @@ void test_spdm_responder_finish_case7(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void test_spdm_responder_finish_case8(void **state)
+void libspdm_test_responder_finish_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1022,10 +1022,10 @@ void test_spdm_responder_finish_case8(void **state)
     m_spdm_finish_request3_size = sizeof(spdm_finish_request_t) +
                                   req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request3_size,
-                                      &m_spdm_finish_request3,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request3_size,
+                                         &m_spdm_finish_request3,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_finish_response_t) + hmac_size);
@@ -1042,7 +1042,7 @@ void test_spdm_responder_finish_case8(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the UnsupportedRequest.
  **/
-void test_spdm_responder_finish_case9(void **state)
+void libspdm_test_responder_finish_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1136,10 +1136,10 @@ void test_spdm_responder_finish_case9(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1158,7 +1158,7 @@ void test_spdm_responder_finish_case9(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the UnsupportedRequest.
  **/
-void test_spdm_responder_finish_case10(void **state)
+void libspdm_test_responder_finish_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1251,10 +1251,10 @@ void test_spdm_responder_finish_case10(void **state)
                      hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1272,7 +1272,7 @@ void test_spdm_responder_finish_case10(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_finish_case11(void **state)
+void libspdm_test_responder_finish_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1347,10 +1347,10 @@ void test_spdm_responder_finish_case11(void **state)
     set_mem(ptr, hmac_size, (uint8_t)(0x00)); /*all-zero MAC*/
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1368,7 +1368,7 @@ void test_spdm_responder_finish_case11(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_finish_case12(void **state)
+void libspdm_test_responder_finish_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1449,10 +1449,10 @@ void test_spdm_responder_finish_case12(void **state)
                      request_finished_key, hash_size, ptr);
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1470,7 +1470,7 @@ void test_spdm_responder_finish_case12(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_finish_case13(void **state)
+void libspdm_test_responder_finish_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1565,10 +1565,10 @@ void test_spdm_responder_finish_case13(void **state)
                ptr + hmac_size, hmac_size); /* 2x HMAC size*/
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + 2*hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1586,7 +1586,7 @@ void test_spdm_responder_finish_case13(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_finish_case14(void **state)
+void libspdm_test_responder_finish_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1680,10 +1680,10 @@ void test_spdm_responder_finish_case14(void **state)
     set_mem(ptr + hmac_size/2, hmac_size/2, (uint8_t) 0x00); /* half HMAC size*/
     m_spdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size/2;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request1_size,
-                                      &m_spdm_finish_request1,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request1_size,
+                                         &m_spdm_finish_request1,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1701,7 +1701,7 @@ void test_spdm_responder_finish_case14(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_finish_case15(void **state)
+void libspdm_test_responder_finish_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1832,10 +1832,10 @@ void test_spdm_responder_finish_case15(void **state)
     m_spdm_finish_request3_size = sizeof(spdm_finish_request_t) +
                                   req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request3_size,
-                                      &m_spdm_finish_request3,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request3_size,
+                                         &m_spdm_finish_request3,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1854,7 +1854,7 @@ void test_spdm_responder_finish_case15(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_finish_case16(void **state)
+void libspdm_test_responder_finish_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1985,10 +1985,10 @@ void test_spdm_responder_finish_case16(void **state)
     m_spdm_finish_request3_size = sizeof(spdm_finish_request_t) +
                                   req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_finish(spdm_context,
-                                      m_spdm_finish_request3_size,
-                                      &m_spdm_finish_request3,
-                                      &response_size, response);
+    status = libspdm_get_response_finish(spdm_context,
+                                         m_spdm_finish_request3_size,
+                                         &m_spdm_finish_request3,
+                                         &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -2010,34 +2010,34 @@ int spdm_responder_finish_test_main(void)
 {
     const struct CMUnitTest spdm_responder_finish_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_finish_case1),
+        cmocka_unit_test(libspdm_test_responder_finish_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_finish_case2),
+        cmocka_unit_test(libspdm_test_responder_finish_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_finish_case3),
+        cmocka_unit_test(libspdm_test_responder_finish_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_finish_case4),
+        cmocka_unit_test(libspdm_test_responder_finish_case4),
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_finish_case5),
+        cmocka_unit_test(libspdm_test_responder_finish_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_finish_case6),
+        cmocka_unit_test(libspdm_test_responder_finish_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_finish_case7),
+        cmocka_unit_test(libspdm_test_responder_finish_case7),
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_finish_case8),
+        cmocka_unit_test(libspdm_test_responder_finish_case8),
         /* Unsupported KEY_EX capabilities*/
-        cmocka_unit_test(test_spdm_responder_finish_case9),
+        cmocka_unit_test(libspdm_test_responder_finish_case9),
         /* Uninitialized session*/
-        cmocka_unit_test(test_spdm_responder_finish_case10),
+        cmocka_unit_test(libspdm_test_responder_finish_case10),
         /* Incorrect MAC*/
-        cmocka_unit_test(test_spdm_responder_finish_case11),
-        cmocka_unit_test(test_spdm_responder_finish_case12),
+        cmocka_unit_test(libspdm_test_responder_finish_case11),
+        cmocka_unit_test(libspdm_test_responder_finish_case12),
         /* Incorrect MAC size*/
-        cmocka_unit_test(test_spdm_responder_finish_case13),
-        cmocka_unit_test(test_spdm_responder_finish_case14),
+        cmocka_unit_test(libspdm_test_responder_finish_case13),
+        cmocka_unit_test(libspdm_test_responder_finish_case14),
         /* Incorrect signature*/
-        cmocka_unit_test(test_spdm_responder_finish_case15),
-        cmocka_unit_test(test_spdm_responder_finish_case16),
+        cmocka_unit_test(libspdm_test_responder_finish_case15),
+        cmocka_unit_test(libspdm_test_responder_finish_case16),
     };
 
     setup_spdm_test_context(&m_spdm_responder_finish_test_context);

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -20,7 +20,7 @@ uintn m_spdm_heartbeat_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 
 static uint8_t m_local_psk_hint[32];
 
-void test_spdm_responder_heartbeat_case1(void **state)
+void libspdm_test_responder_heartbeat_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -86,10 +86,10 @@ void test_spdm_responder_heartbeat_case1(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_heartbeat_response_t));
     spdm_response = (void *)response;
@@ -98,7 +98,7 @@ void test_spdm_responder_heartbeat_case1(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case2(void **state)
+void libspdm_test_responder_heartbeat_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -164,10 +164,10 @@ void test_spdm_responder_heartbeat_case2(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request2_size,
-                                         &m_spdm_heartbeat_request2,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request2_size,
+                                            &m_spdm_heartbeat_request2,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -179,7 +179,7 @@ void test_spdm_responder_heartbeat_case2(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case3(void **state)
+void libspdm_test_responder_heartbeat_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -246,10 +246,10 @@ void test_spdm_responder_heartbeat_case3(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -262,7 +262,7 @@ void test_spdm_responder_heartbeat_case3(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case4(void **state)
+void libspdm_test_responder_heartbeat_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -329,10 +329,10 @@ void test_spdm_responder_heartbeat_case4(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -346,7 +346,7 @@ void test_spdm_responder_heartbeat_case4(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case5(void **state)
+void libspdm_test_responder_heartbeat_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -414,10 +414,10 @@ void test_spdm_responder_heartbeat_case5(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -436,7 +436,7 @@ void test_spdm_responder_heartbeat_case5(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case6(void **state)
+void libspdm_test_responder_heartbeat_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -503,10 +503,10 @@ void test_spdm_responder_heartbeat_case6(void **state)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     response_size = sizeof(response);
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -518,7 +518,7 @@ void test_spdm_responder_heartbeat_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_heartbeat_case7(void **state)
+void libspdm_test_responder_heartbeat_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -596,10 +596,10 @@ void test_spdm_responder_heartbeat_case7(void **state)
     spdm_context->transcript.message_mut_c.buffer_size =
         spdm_context->transcript.message_mut_c.max_buffer_size;
 #endif
-    status = spdm_get_response_heartbeat(spdm_context,
-                                         m_spdm_heartbeat_request1_size,
-                                         &m_spdm_heartbeat_request1,
-                                         &response_size, response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_spdm_heartbeat_request1_size,
+                                            &m_spdm_heartbeat_request1,
+                                            &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_heartbeat_response_t));
     spdm_response = (void *)response;
@@ -625,19 +625,19 @@ int spdm_responder_heartbeat_test_main(void)
 {
     const struct CMUnitTest spdm_responder_heartbeat_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case1),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case2),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case3),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case4),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case5),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case6),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_heartbeat_case7),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case7),
     };
 
     setup_spdm_test_context(&m_spdm_responder_heartbeat_test_context);

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -71,7 +71,7 @@ spdm_key_exchange_request_mine_t m_spdm_key_exchange_request7 = {
 };
 uintn m_spdm_key_exchange_request7_size = sizeof(m_spdm_key_exchange_request7);
 
-void test_spdm_responder_key_exchange_case1(void **state)
+void libspdm_test_responder_key_exchange_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -137,7 +137,7 @@ void test_spdm_responder_key_exchange_case1(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -152,7 +152,7 @@ void test_spdm_responder_key_exchange_case1(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case2(void **state)
+void libspdm_test_responder_key_exchange_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -218,7 +218,7 @@ void test_spdm_responder_key_exchange_case2(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request2_size,
         &m_spdm_key_exchange_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -232,7 +232,7 @@ void test_spdm_responder_key_exchange_case2(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case3(void **state)
+void libspdm_test_responder_key_exchange_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -299,7 +299,7 @@ void test_spdm_responder_key_exchange_case3(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -314,7 +314,7 @@ void test_spdm_responder_key_exchange_case3(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case4(void **state)
+void libspdm_test_responder_key_exchange_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -381,7 +381,7 @@ void test_spdm_responder_key_exchange_case4(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -397,7 +397,7 @@ void test_spdm_responder_key_exchange_case4(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case5(void **state)
+void libspdm_test_responder_key_exchange_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -465,7 +465,7 @@ void test_spdm_responder_key_exchange_case5(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -486,7 +486,7 @@ void test_spdm_responder_key_exchange_case5(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case6(void **state)
+void libspdm_test_responder_key_exchange_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -553,7 +553,7 @@ void test_spdm_responder_key_exchange_case6(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -567,7 +567,7 @@ void test_spdm_responder_key_exchange_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case7(void **state)
+void libspdm_test_responder_key_exchange_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -645,7 +645,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -667,7 +667,7 @@ void test_spdm_responder_key_exchange_case7(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case8(void **state)
+void libspdm_test_responder_key_exchange_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -743,7 +743,7 @@ void test_spdm_responder_key_exchange_case8(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request3_size,
         &m_spdm_key_exchange_request3, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -776,7 +776,7 @@ void test_spdm_responder_key_exchange_case8(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case9(void **state)
+void libspdm_test_responder_key_exchange_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -852,7 +852,7 @@ void test_spdm_responder_key_exchange_case9(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request4_size,
         &m_spdm_key_exchange_request4, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -885,7 +885,7 @@ void test_spdm_responder_key_exchange_case9(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case10(void **state)
+void libspdm_test_responder_key_exchange_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -959,7 +959,7 @@ void test_spdm_responder_key_exchange_case10(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request5_size,
         &m_spdm_key_exchange_request5, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -972,7 +972,7 @@ void test_spdm_responder_key_exchange_case10(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case11(void **state)
+void libspdm_test_responder_key_exchange_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1050,7 +1050,7 @@ void test_spdm_responder_key_exchange_case11(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request3_size,
         &m_spdm_key_exchange_request3, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1063,7 +1063,7 @@ void test_spdm_responder_key_exchange_case11(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case12(void **state)
+void libspdm_test_responder_key_exchange_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1135,7 +1135,7 @@ void test_spdm_responder_key_exchange_case12(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request6_size,
         &m_spdm_key_exchange_request6, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1148,7 +1148,7 @@ void test_spdm_responder_key_exchange_case12(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case13(void **state)
+void libspdm_test_responder_key_exchange_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1221,7 +1221,7 @@ void test_spdm_responder_key_exchange_case13(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request7_size,
         &m_spdm_key_exchange_request7, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1234,7 +1234,7 @@ void test_spdm_responder_key_exchange_case13(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case14(void **state)
+void libspdm_test_responder_key_exchange_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1307,7 +1307,7 @@ void test_spdm_responder_key_exchange_case14(void **state)
         spdm_context, &opaque_key_exchange_req_size, ptr);
     ptr += opaque_key_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request7_size,
         &m_spdm_key_exchange_request7, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1322,7 +1322,7 @@ void test_spdm_responder_key_exchange_case14(void **state)
     free(data1);
 }
 
-void test_spdm_responder_key_exchange_case15(void **state)
+void libspdm_test_responder_key_exchange_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1406,7 +1406,7 @@ void test_spdm_responder_key_exchange_case15(void **state)
     opaque_key_exchange_rsp_size =
         libspdm_get_opaque_data_version_selection_data_size(spdm_context);
 
-    status = spdm_get_response_key_exchange(
+    status = libspdm_get_response_key_exchange(
         spdm_context, m_spdm_key_exchange_request1_size,
         &m_spdm_key_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1439,35 +1439,35 @@ int spdm_responder_key_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_responder_key_exchange_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case1),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case2),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case3),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case4),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case5),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case6),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_key_exchange_case7),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case7),
         /* TCB measurement hash requested */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case8),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case8),
         /* All measurement hash requested */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case9),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case9),
         /* Reserved value in Measurement summary. Error + Invalid */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case10),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case10),
         /* TCB measurement hash requested, measurement flag not set */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case11),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case11),
         /* Request Slot id 1, no slot id 1 present */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case12),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case12),
         /* Request previously provisioned certificate, no certificate provisioned */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case13),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case13),
         /* Request previously provisioned certificate, certificate in slot 0 */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case14),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case14),
         /* HANDSHAKE_IN_THE_CLEAR set for requester and responder */
-        cmocka_unit_test(test_spdm_responder_key_exchange_case15),
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case15),
     };
 
     setup_spdm_test_context(&m_spdm_responder_key_exchange_test_context);

--- a/unit_test/test_spdm_responder/key_update.c
+++ b/unit_test/test_spdm_responder/key_update.c
@@ -112,7 +112,7 @@ static void spdm_set_standard_key_update_test_state(
 }
 
 static void spdm_set_standard_key_update_test_secrets(
-    spdm_secured_message_context_t *secured_message_context,
+    libspdm_secured_message_context_t *secured_message_context,
     uint8_t *m_rsp_secret_buffer, uint8_t rsp_secret_fill,
     uint8_t *m_req_secret_buffer, uint8_t req_secret_fill)
 {
@@ -179,14 +179,14 @@ static void spdm_compute_secret_update(uintn hash_size,
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void test_spdm_responder_key_update_case1(void **state)
+void libspdm_test_responder_key_update_case1(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -219,10 +219,10 @@ void test_spdm_responder_key_update_case1(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -248,14 +248,14 @@ void test_spdm_responder_key_update_case1(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_spdm_responder_key_update_case2(void **state)
+void libspdm_test_responder_key_update_case2(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -284,10 +284,10 @@ void test_spdm_responder_key_update_case2(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request2_size,
-                                          &m_spdm_key_update_request2,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request2_size,
+                                             &m_spdm_key_update_request2,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -311,14 +311,14 @@ void test_spdm_responder_key_update_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state. No keys are updated.
  **/
-void test_spdm_responder_key_update_case3(void **state)
+void libspdm_test_responder_key_update_case3(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -350,10 +350,10 @@ void test_spdm_responder_key_update_case3(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -378,14 +378,14 @@ void test_spdm_responder_key_update_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state. No keys are updated.
  **/
-void test_spdm_responder_key_update_case4(void **state)
+void libspdm_test_responder_key_update_case4(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -417,10 +417,10 @@ void test_spdm_responder_key_update_case4(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -447,14 +447,14 @@ void test_spdm_responder_key_update_case4(void **state)
  * ERROR message indicating the ResponseNotReady state. No keys are
  * updated.
  **/
-void test_spdm_responder_key_update_case5(void **state)
+void libspdm_test_responder_key_update_case5(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -487,10 +487,10 @@ void test_spdm_responder_key_update_case5(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
@@ -523,14 +523,14 @@ void test_spdm_responder_key_update_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest. No keys are updated.
  **/
-void test_spdm_responder_key_update_case6(void **state)
+void libspdm_test_responder_key_update_case6(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -563,10 +563,10 @@ void test_spdm_responder_key_update_case6(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -584,14 +584,14 @@ void test_spdm_responder_key_update_case6(void **state)
                         m_rsp_secret_buffer, secured_message_context->hash_size);
 }
 
-void test_spdm_responder_key_update_case7(void **state)
+void libspdm_test_responder_key_update_case7(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -638,10 +638,10 @@ void test_spdm_responder_key_update_case7(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -674,14 +674,14 @@ void test_spdm_responder_key_update_case7(void **state)
  * produces an ERROR message indicating the UnsupportedRequest. No keys are
  * updated.
  **/
-void test_spdm_responder_key_update_case8(void **state)
+void libspdm_test_responder_key_update_case8(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -716,10 +716,10 @@ void test_spdm_responder_key_update_case8(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -744,14 +744,14 @@ void test_spdm_responder_key_update_case8(void **state)
  * Expected behavior: the responder refuses the KEY_UPDATE message and produces
  * an ERROR message indicating the UnsupportedRequest. No keys are updated.
  **/
-void test_spdm_responder_key_update_case9(void **state)
+void libspdm_test_responder_key_update_case9(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -785,10 +785,10 @@ void test_spdm_responder_key_update_case9(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -813,14 +813,14 @@ void test_spdm_responder_key_update_case9(void **state)
  * KEY_UPDATE_ACK response message, and both the request data key and the
  * response data key are updated.
  **/
-void test_spdm_responder_key_update_case10(void **state)
+void libspdm_test_responder_key_update_case10(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -856,10 +856,10 @@ void test_spdm_responder_key_update_case10(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request3_size,
-                                          &m_spdm_key_update_request3,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request3_size,
+                                             &m_spdm_key_update_request3,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -885,14 +885,14 @@ void test_spdm_responder_key_update_case10(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_spdm_responder_key_update_case11(void **state)
+void libspdm_test_responder_key_update_case11(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -921,10 +921,10 @@ void test_spdm_responder_key_update_case11(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request4_size,
-                                          &m_spdm_key_update_request4,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request4_size,
+                                             &m_spdm_key_update_request4,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -949,14 +949,14 @@ void test_spdm_responder_key_update_case11(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void test_spdm_responder_key_update_case12(void **state)
+void libspdm_test_responder_key_update_case12(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1007,10 +1007,10 @@ void test_spdm_responder_key_update_case12(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request5_size,
-                                          &m_spdm_key_update_request5,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request5_size,
+                                             &m_spdm_key_update_request5,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1037,14 +1037,14 @@ void test_spdm_responder_key_update_case12(void **state)
  * produces an ERROR message indicating the InvalidRequest. The request
  * data key is not rolled back to before the UpdateKey.
  **/
-void test_spdm_responder_key_update_case13(void **state)
+void libspdm_test_responder_key_update_case13(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1095,10 +1095,10 @@ void test_spdm_responder_key_update_case13(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request6_size,
-                                          &m_spdm_key_update_request6,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request6_size,
+                                             &m_spdm_key_update_request6,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -1124,14 +1124,14 @@ void test_spdm_responder_key_update_case13(void **state)
  * KEY_UPDATE_ACK response message, and both the request data key and the
  * response data key are updated.
  **/
-void test_spdm_responder_key_update_case14(void **state)
+void libspdm_test_responder_key_update_case14(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1195,10 +1195,10 @@ void test_spdm_responder_key_update_case14(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request5_size,
-                                          &m_spdm_key_update_request5,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request5_size,
+                                             &m_spdm_key_update_request5,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1226,14 +1226,14 @@ void test_spdm_responder_key_update_case14(void **state)
  * request data key nor the response data key are rolled back to before
  * the UpdateAllKeys.
  **/
-void test_spdm_responder_key_update_case15(void **state)
+void libspdm_test_responder_key_update_case15(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1297,10 +1297,10 @@ void test_spdm_responder_key_update_case15(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request6_size,
-                                          &m_spdm_key_update_request6,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request6_size,
+                                             &m_spdm_key_update_request6,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -1327,14 +1327,14 @@ void test_spdm_responder_key_update_case15(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void test_spdm_responder_key_update_case16(void **state)
+void libspdm_test_responder_key_update_case16(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1365,10 +1365,10 @@ void test_spdm_responder_key_update_case16(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request5_size,
-                                          &m_spdm_key_update_request5,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request5_size,
+                                             &m_spdm_key_update_request5,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -1393,14 +1393,14 @@ void test_spdm_responder_key_update_case16(void **state)
  * KEY_UPDATE_ACK response message. The request data key is kept updated, as
  * from the original request.
  **/
-void test_spdm_responder_key_update_case17(void **state)
+void libspdm_test_responder_key_update_case17(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1451,10 +1451,10 @@ void test_spdm_responder_key_update_case17(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1480,14 +1480,14 @@ void test_spdm_responder_key_update_case17(void **state)
  * KEY_UPDATE_ACK response message. Both the request data key and the response
  * data key are kept updated, as from the original request.
  **/
-void test_spdm_responder_key_update_case18(void **state)
+void libspdm_test_responder_key_update_case18(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1551,10 +1551,10 @@ void test_spdm_responder_key_update_case18(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request3_size,
-                                          &m_spdm_key_update_request3,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request3_size,
+                                             &m_spdm_key_update_request3,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1582,14 +1582,14 @@ void test_spdm_responder_key_update_case18(void **state)
  * KEY_UPDATE_ACK response message. The request data key is kept updated, as
  * from the original request.
  **/
-void test_spdm_responder_key_update_case19(void **state)
+void libspdm_test_responder_key_update_case19(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1624,10 +1624,10 @@ void test_spdm_responder_key_update_case19(void **state)
     /*no keys updated (already activated)*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request5_size,
-                                          &m_spdm_key_update_request5,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request5_size,
+                                             &m_spdm_key_update_request5,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1655,14 +1655,14 @@ void test_spdm_responder_key_update_case19(void **state)
  * KEY_UPDATE_ACK response message. Both the request data key and the
  * response data key are kept updated, as from the original request.
  **/
-void test_spdm_responder_key_update_case20(void **state)
+void libspdm_test_responder_key_update_case20(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1726,10 +1726,10 @@ void test_spdm_responder_key_update_case20(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request5_size,
-                                          &m_spdm_key_update_request5,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request5_size,
+                                             &m_spdm_key_update_request5,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_key_update_response_t));
@@ -1757,14 +1757,14 @@ void test_spdm_responder_key_update_case20(void **state)
  * produces an ERROR message indicating the InvalidRequest. Only the request
  * data key is kept updated, as from the original request.
  **/
-void test_spdm_responder_key_update_case21(void **state)
+void libspdm_test_responder_key_update_case21(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1815,10 +1815,10 @@ void test_spdm_responder_key_update_case21(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request3_size,
-                                          &m_spdm_key_update_request3,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request3_size,
+                                             &m_spdm_key_update_request3,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -1846,14 +1846,14 @@ void test_spdm_responder_key_update_case21(void **state)
  * data key and the response data key are kept updated, as from the original
  * request.
  **/
-void test_spdm_responder_key_update_case22(void **state)
+void libspdm_test_responder_key_update_case22(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -1917,10 +1917,10 @@ void test_spdm_responder_key_update_case22(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request1_size,
-                                          &m_spdm_key_update_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request1_size,
+                                             &m_spdm_key_update_request1,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -1945,14 +1945,14 @@ void test_spdm_responder_key_update_case22(void **state)
  * produces an ERROR message indicating the InvalidRequest. The request
  * data key is kept updated, as from the original request.
  **/
-void test_spdm_responder_key_update_case23(void **state)
+void libspdm_test_responder_key_update_case23(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -2003,10 +2003,10 @@ void test_spdm_responder_key_update_case23(void **state)
     /*response side *not* updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request7_size,
-                                          &m_spdm_key_update_request7,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request7_size,
+                                             &m_spdm_key_update_request7,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -2032,14 +2032,14 @@ void test_spdm_responder_key_update_case23(void **state)
  * data key and the response data key are kept updated, as from the original
  * request.
  **/
-void test_spdm_responder_key_update_case24(void **state)
+void libspdm_test_responder_key_update_case24(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -2103,10 +2103,10 @@ void test_spdm_responder_key_update_case24(void **state)
                                secured_message_context->hash_size);
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request8_size,
-                                          &m_spdm_key_update_request8,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request8_size,
+                                             &m_spdm_key_update_request8,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -2131,14 +2131,14 @@ void test_spdm_responder_key_update_case24(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated, as they were previously activated by the last VerifyNewKey.
  **/
-void test_spdm_responder_key_update_case25(void **state)
+void libspdm_test_responder_key_update_case25(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -2173,10 +2173,10 @@ void test_spdm_responder_key_update_case25(void **state)
     /*no keys updated (already activated)*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request9_size,
-                                          &m_spdm_key_update_request9,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request9_size,
+                                             &m_spdm_key_update_request9,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -2200,14 +2200,14 @@ void test_spdm_responder_key_update_case25(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_spdm_responder_key_update_case26(void **state)
+void libspdm_test_responder_key_update_case26(void **state)
 {
     return_status status;
     spdm_test_context_t            *spdm_test_context;
     libspdm_context_t                 *spdm_context;
     uint32_t session_id;
     libspdm_session_info_t            *session_info;
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     uintn response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
@@ -2236,10 +2236,10 @@ void test_spdm_responder_key_update_case26(void **state)
     /*no keys are updated*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_key_update(spdm_context,
-                                          m_spdm_key_update_request10_size,
-                                          &m_spdm_key_update_request10,
-                                          &response_size, response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_spdm_key_update_request10_size,
+                                             &m_spdm_key_update_request10,
+                                             &response_size, response);
 
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
@@ -2266,54 +2266,54 @@ int spdm_responder_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_responder_key_update_tests[] = {
         /* Success Case -- UpdateKey*/
-        cmocka_unit_test(test_spdm_responder_key_update_case1),
+        cmocka_unit_test(libspdm_test_responder_key_update_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_key_update_case2),
+        cmocka_unit_test(libspdm_test_responder_key_update_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_key_update_case3),
+        cmocka_unit_test(libspdm_test_responder_key_update_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_key_update_case4),
+        cmocka_unit_test(libspdm_test_responder_key_update_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_key_update_case5),
+        cmocka_unit_test(libspdm_test_responder_key_update_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_key_update_case6),
+        cmocka_unit_test(libspdm_test_responder_key_update_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_key_update_case7),
+        cmocka_unit_test(libspdm_test_responder_key_update_case7),
         /* Unsupported KEY_UPD capabilities*/
-        cmocka_unit_test(test_spdm_responder_key_update_case8),
+        cmocka_unit_test(libspdm_test_responder_key_update_case8),
         /* Uninitialized session*/
-        cmocka_unit_test(test_spdm_responder_key_update_case9),
+        cmocka_unit_test(libspdm_test_responder_key_update_case9),
         /* Success Case -- UpdateAllKeys*/
-        cmocka_unit_test(test_spdm_responder_key_update_case10),
+        cmocka_unit_test(libspdm_test_responder_key_update_case10),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_key_update_case11),
+        cmocka_unit_test(libspdm_test_responder_key_update_case11),
         /* Success Case -- VerifyNewKey (from UpdateKey)*/
-        cmocka_unit_test(test_spdm_responder_key_update_case12),
+        cmocka_unit_test(libspdm_test_responder_key_update_case12),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_key_update_case13),
+        cmocka_unit_test(libspdm_test_responder_key_update_case13),
         /* Success Case -- VerifyNewKey (from UpdateAllKeys)*/
-        cmocka_unit_test(test_spdm_responder_key_update_case14),
+        cmocka_unit_test(libspdm_test_responder_key_update_case14),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_key_update_case15),
+        cmocka_unit_test(libspdm_test_responder_key_update_case15),
         /* Uninitialized key update*/
-        cmocka_unit_test(test_spdm_responder_key_update_case16),
+        cmocka_unit_test(libspdm_test_responder_key_update_case16),
         /* Retry -- UpdateKey*/
-        cmocka_unit_test(test_spdm_responder_key_update_case17),
+        cmocka_unit_test(libspdm_test_responder_key_update_case17),
         /* Retry -- UpdateAllKeys*/
-        cmocka_unit_test(test_spdm_responder_key_update_case18),
+        cmocka_unit_test(libspdm_test_responder_key_update_case18),
         /* Retry -- VerifyNewKey (from UpdateKey)*/
-        cmocka_unit_test(test_spdm_responder_key_update_case19),
+        cmocka_unit_test(libspdm_test_responder_key_update_case19),
         /* Retry -- VerifyNewKey (from UpdateAllKeys)*/
-        cmocka_unit_test(test_spdm_responder_key_update_case20),
+        cmocka_unit_test(libspdm_test_responder_key_update_case20),
         /* VerifyNewKey expected*/
-        cmocka_unit_test(test_spdm_responder_key_update_case21),
-        cmocka_unit_test(test_spdm_responder_key_update_case22),
+        cmocka_unit_test(libspdm_test_responder_key_update_case21),
+        cmocka_unit_test(libspdm_test_responder_key_update_case22),
         /* Retry -- wrong token*/
-        cmocka_unit_test(test_spdm_responder_key_update_case23),
-        cmocka_unit_test(test_spdm_responder_key_update_case24),
-        cmocka_unit_test(test_spdm_responder_key_update_case25),
+        cmocka_unit_test(libspdm_test_responder_key_update_case23),
+        cmocka_unit_test(libspdm_test_responder_key_update_case24),
+        cmocka_unit_test(libspdm_test_responder_key_update_case25),
         /* Invalid operation*/
-        cmocka_unit_test(test_spdm_responder_key_update_case26),
+        cmocka_unit_test(libspdm_test_responder_key_update_case26),
     };
 
     setup_spdm_test_context(&m_spdm_responder_key_update_test_context);

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -102,7 +102,7 @@ static uint8_t m_local_psk_hint[32];
  * Test 1: Successful response to get a number of measurements without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case1(void **state)
+void libspdm_test_responder_measurements_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -135,7 +135,7 @@ void test_spdm_responder_measurements_case1(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request1.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request1_size,
         &m_spdm_get_measurements_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -159,7 +159,7 @@ void test_spdm_responder_measurements_case1(void **state)
  * Test 2: Error case, Bad request size (LIBSPDM_MAX_MESSAGE_BUFFER_SIZE) to get measurement number without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case2(void **state)
+void libspdm_test_responder_measurements_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -192,7 +192,7 @@ void test_spdm_responder_measurements_case2(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request2.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request2_size,
         &m_spdm_get_measurements_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -212,7 +212,7 @@ void test_spdm_responder_measurements_case2(void **state)
  * Test 3: Force response_state = SPDM_RESPONSE_STATE_BUSY when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
  **/
-void test_spdm_responder_measurements_case3(void **state)
+void libspdm_test_responder_measurements_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -246,7 +246,7 @@ void test_spdm_responder_measurements_case3(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request1.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request1_size,
         &m_spdm_get_measurements_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -267,7 +267,7 @@ void test_spdm_responder_measurements_case3(void **state)
  * Test 4: Force response_state = SPDM_RESPONSE_STATE_NEED_RESYNC when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  **/
-void test_spdm_responder_measurements_case4(void **state)
+void libspdm_test_responder_measurements_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -301,7 +301,7 @@ void test_spdm_responder_measurements_case4(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request1.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request1_size,
         &m_spdm_get_measurements_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -323,7 +323,7 @@ void test_spdm_responder_measurements_case4(void **state)
  * Test 5: Force response_state = SPDM_RESPONSE_STATE_NOT_READY when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  **/
-void test_spdm_responder_measurements_case5(void **state)
+void libspdm_test_responder_measurements_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -358,7 +358,7 @@ void test_spdm_responder_measurements_case5(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request1.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request1_size,
         &m_spdm_get_measurements_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -386,7 +386,7 @@ void test_spdm_responder_measurements_case5(void **state)
  *        (missing SPDM_GET_DIGESTS_RECEIVE_FLAG, SPDM_GET_CAPABILITIES_RECEIVE_FLAG and SPDM_NEGOTIATE_ALGORITHMS_RECEIVE_FLAG)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNEXPECTED_REQUEST
  **/
-void test_spdm_responder_measurements_case6(void **state)
+void libspdm_test_responder_measurements_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -420,7 +420,7 @@ void test_spdm_responder_measurements_case6(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request1.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request1_size,
         &m_spdm_get_measurements_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -440,7 +440,7 @@ void test_spdm_responder_measurements_case6(void **state)
  * Test 7: Successful response to get a number of measurements with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case7(void **state)
+void libspdm_test_responder_measurements_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -476,7 +476,7 @@ void test_spdm_responder_measurements_case7(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request5.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request5_size,
         &m_spdm_get_measurements_request5, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -496,7 +496,7 @@ void test_spdm_responder_measurements_case7(void **state)
  * Test 8: Successful response to get one measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case8(void **state)
+void libspdm_test_responder_measurements_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -531,7 +531,7 @@ void test_spdm_responder_measurements_case8(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request3.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request3_size,
         &m_spdm_get_measurements_request3, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -553,7 +553,7 @@ void test_spdm_responder_measurements_case8(void **state)
  * Test 9: Error case, Bad request size (sizeof(spdm_message_header_t)x) to get measurement number with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case9(void **state)
+void libspdm_test_responder_measurements_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -586,7 +586,7 @@ void test_spdm_responder_measurements_case9(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request4.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request4_size,
         &m_spdm_get_measurements_request4, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -606,7 +606,7 @@ void test_spdm_responder_measurements_case9(void **state)
  * Test 10: Successful response to get one measurement without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case10(void **state)
+void libspdm_test_responder_measurements_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -639,7 +639,7 @@ void test_spdm_responder_measurements_case10(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request6.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request6_size,
         &m_spdm_get_measurements_request6, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -667,7 +667,7 @@ void test_spdm_responder_measurements_case10(void **state)
  * Test 11: Successful response to get all measurements with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case11(void **state)
+void libspdm_test_responder_measurements_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -703,7 +703,7 @@ void test_spdm_responder_measurements_case11(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request8.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request8_size,
         &m_spdm_get_measurements_request8, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -734,7 +734,7 @@ void test_spdm_responder_measurements_case11(void **state)
  * Test 12: Successful response to get all measurements without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case12(void **state)
+void libspdm_test_responder_measurements_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -767,7 +767,7 @@ void test_spdm_responder_measurements_case12(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request7.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request7_size,
         &m_spdm_get_measurements_request7, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -811,7 +811,7 @@ void test_spdm_responder_measurements_case12(void **state)
  * Test 13: Error case, even though signature was not required, there is nonce and/or slotID
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case13(void **state)
+void libspdm_test_responder_measurements_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -858,7 +858,7 @@ void test_spdm_responder_measurements_case13(void **state)
     for (int i = 0; i < sizeof(TestMsgSizes) / sizeof(TestMsgSizes[0]);
          i++) {
         response_size = sizeof(response);
-        status = spdm_get_response_measurements(
+        status = libspdm_get_response_measurements(
             spdm_context, TestMsgSizes[i],
             &m_spdm_get_measurements_request9, &response_size,
             response);
@@ -881,7 +881,7 @@ void test_spdm_responder_measurements_case13(void **state)
  * Test 14: Error case, signature was required, but there is no nonce and/or slotID
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case14(void **state)
+void libspdm_test_responder_measurements_case14(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -928,7 +928,7 @@ void test_spdm_responder_measurements_case14(void **state)
     for (int i = 0; i < sizeof(TestMsgSizes) / sizeof(TestMsgSizes[0]);
          i++) {
         response_size = sizeof(response);
-        status = spdm_get_response_measurements(
+        status = libspdm_get_response_measurements(
             spdm_context, TestMsgSizes[i],
             &m_spdm_get_measurements_request10, &response_size,
             response);
@@ -951,7 +951,7 @@ void test_spdm_responder_measurements_case14(void **state)
  * Test 15: Error case, meas_cap = 01b, but signature was requested (request message includes nonce and slotID)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case15(void **state)
+void libspdm_test_responder_measurements_case15(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -986,7 +986,7 @@ void test_spdm_responder_measurements_case15(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request10.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request10_size,
         &m_spdm_get_measurements_request10, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1006,7 +1006,7 @@ void test_spdm_responder_measurements_case15(void **state)
  * Test 16: Error case, meas_cap = 01b, but signature was requested (request message does not include nonce and slotID)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case16(void **state)
+void libspdm_test_responder_measurements_case16(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1039,7 +1039,7 @@ void test_spdm_responder_measurements_case16(void **state)
     /* measurment_sig_size = SPDM_NONCE_SIZE + sizeof(uint16_t) + 0 + libspdm_get_asym_signature_size (m_use_asym_algo);*/
 
     response_size = sizeof(response);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request9_size,
         &m_spdm_get_measurements_request10, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1059,7 +1059,7 @@ void test_spdm_responder_measurements_case16(void **state)
  * Test 17: Error case, meas_cap = 00
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case17(void **state)
+void libspdm_test_responder_measurements_case17(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1093,7 +1093,7 @@ void test_spdm_responder_measurements_case17(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request9.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request9_size,
         &m_spdm_get_measurements_request9, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1115,7 +1115,7 @@ void test_spdm_responder_measurements_case17(void **state)
  * Test 18: Successful response to get one measurement with signature, SlotId different from default
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void test_spdm_responder_measurements_case18(void **state)
+void libspdm_test_responder_measurements_case18(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1162,7 +1162,7 @@ void test_spdm_responder_measurements_case18(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request11.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request11_size,
         &m_spdm_get_measurements_request11, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1189,7 +1189,7 @@ void test_spdm_responder_measurements_case18(void **state)
  * Test 19: Error case, invalid SlotId parameter (SlotId >= SPDM_MAX_SLOT_COUNT)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case19(void **state)
+void libspdm_test_responder_measurements_case19(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1223,7 +1223,7 @@ void test_spdm_responder_measurements_case19(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request12.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request12_size,
         &m_spdm_get_measurements_request12, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1243,7 +1243,7 @@ void test_spdm_responder_measurements_case19(void **state)
  * Test 19: Error case, invalid SlotId parameter (slot_count < SlotId < SPDM_MAX_SLOT_COUNT)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case20(void **state)
+void libspdm_test_responder_measurements_case20(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1277,7 +1277,7 @@ void test_spdm_responder_measurements_case20(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request11.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request11_size,
         &m_spdm_get_measurements_request11, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1297,7 +1297,7 @@ void test_spdm_responder_measurements_case20(void **state)
  * Test 21: Error case, request a measurement index not found
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void test_spdm_responder_measurements_case21(void **state)
+void libspdm_test_responder_measurements_case21(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1329,7 +1329,7 @@ void test_spdm_responder_measurements_case21(void **state)
     response_size = sizeof(response);
     libspdm_get_random_number(SPDM_NONCE_SIZE,
                               m_spdm_get_measurements_request13.nonce);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request13_size,
         &m_spdm_get_measurements_request13, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1350,7 +1350,7 @@ void test_spdm_responder_measurements_case21(void **state)
  * Expected Behavior: while transcript.message_m is not full, get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  *                    if transcript.message_m has no more room, an error response is expected
  **/
-void test_spdm_responder_measurements_case22(void **state)
+void libspdm_test_responder_measurements_case22(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1386,7 +1386,7 @@ void test_spdm_responder_measurements_case22(void **state)
         libspdm_get_random_number(SPDM_NONCE_SIZE,
                                   m_spdm_get_measurements_request6.nonce);
         response_size = sizeof(response);
-        status = spdm_get_response_measurements(
+        status = libspdm_get_response_measurements(
             spdm_context, m_spdm_get_measurements_request6_size,
             &m_spdm_get_measurements_request6, &response_size,
             response);
@@ -1433,7 +1433,7 @@ void test_spdm_responder_measurements_case22(void **state)
  * Test 23: Successful response to get a session based measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
  **/
-void test_spdm_responder_measurements_case23(void **state)
+void libspdm_test_responder_measurements_case23(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1487,7 +1487,7 @@ void test_spdm_responder_measurements_case23(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
-    status = spdm_get_response_measurements(
+    status = libspdm_get_response_measurements(
         spdm_context, m_spdm_get_measurements_request5_size,
         &m_spdm_get_measurements_request5, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -1515,51 +1515,51 @@ int spdm_responder_measurements_test_main(void)
 
     const struct CMUnitTest spdm_responder_measurements_tests[] = {
         /* Success Case to get measurement number without signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case1),
+        cmocka_unit_test(libspdm_test_responder_measurements_case1),
         /* Bad request size to get measurement number without signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case2),
+        cmocka_unit_test(libspdm_test_responder_measurements_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_measurements_case3),
+        cmocka_unit_test(libspdm_test_responder_measurements_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_measurements_case4),
+        cmocka_unit_test(libspdm_test_responder_measurements_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_measurements_case5),
+        cmocka_unit_test(libspdm_test_responder_measurements_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_measurements_case6),
+        cmocka_unit_test(libspdm_test_responder_measurements_case6),
         /* Success Case to get measurement number with signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case7),
+        cmocka_unit_test(libspdm_test_responder_measurements_case7),
         /* Success Case to get one measurement with signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case8),
+        cmocka_unit_test(libspdm_test_responder_measurements_case8),
         /* Bad request size to get one measurement with signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case9),
+        cmocka_unit_test(libspdm_test_responder_measurements_case9),
         /* Success Case to get one measurement without signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case10),
+        cmocka_unit_test(libspdm_test_responder_measurements_case10),
         /* Success Case to get all measurements with signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case11),
+        cmocka_unit_test(libspdm_test_responder_measurements_case11),
         /* Success Case to get all measurements without signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case12),
+        cmocka_unit_test(libspdm_test_responder_measurements_case12),
         /* Error Case: no sig required, but there is nonce and/or slotID (special case of Test Case 2)*/
-        cmocka_unit_test(test_spdm_responder_measurements_case13),
+        cmocka_unit_test(libspdm_test_responder_measurements_case13),
         /* Error Case: sig required, but no nonce and/or SlotID*/
-        cmocka_unit_test(test_spdm_responder_measurements_case14),
+        cmocka_unit_test(libspdm_test_responder_measurements_case14),
         /* Error Case: sig required, but meas_cap = 01b (including nonce and SlotId on request)*/
-        cmocka_unit_test(test_spdm_responder_measurements_case15),
+        cmocka_unit_test(libspdm_test_responder_measurements_case15),
         /* Error Case: sig required, but meas_cap = 01b (not including nonce and SlotId on request)*/
-        cmocka_unit_test(test_spdm_responder_measurements_case16),
+        cmocka_unit_test(libspdm_test_responder_measurements_case16),
         /* Error Case: meas_cap = 00b*/
-        cmocka_unit_test(test_spdm_responder_measurements_case17),
+        cmocka_unit_test(libspdm_test_responder_measurements_case17),
         /* Success Case: SlotId different from default*/
-        cmocka_unit_test(test_spdm_responder_measurements_case18),
+        cmocka_unit_test(libspdm_test_responder_measurements_case18),
         /* Bad SlotId parameter (>= SPDM_MAX_SLOT_COUNT)*/
-        cmocka_unit_test(test_spdm_responder_measurements_case19),
+        cmocka_unit_test(libspdm_test_responder_measurements_case19),
         /* Bad SlotId parameter (slot_count < SlotId < SPDM_MAX_SLOT_COUNT)*/
-        cmocka_unit_test(test_spdm_responder_measurements_case20),
+        cmocka_unit_test(libspdm_test_responder_measurements_case20),
         /* Error Case: request a measurement out of bounds*/
-        cmocka_unit_test(test_spdm_responder_measurements_case21),
+        cmocka_unit_test(libspdm_test_responder_measurements_case21),
         /* Large number of requests before requiring a signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case22),
+        cmocka_unit_test(libspdm_test_responder_measurements_case22),
         /* Successful response to get a session based measurement with signature*/
-        cmocka_unit_test(test_spdm_responder_measurements_case23),
+        cmocka_unit_test(libspdm_test_responder_measurements_case23),
     };
 
     setup_spdm_test_context(&m_spdm_responder_measurements_test_context);

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -38,7 +38,7 @@ spdm_psk_exchange_request_mine_t m_spdm_psk_exchange_request2 = {
 };
 uintn m_spdm_psk_exchange_request2_size = sizeof(spdm_psk_exchange_request_t);
 
-void test_spdm_responder_psk_exchange_case1(void **state)
+void libspdm_test_responder_psk_exchange_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -115,7 +115,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
 #endif
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -134,7 +134,7 @@ void test_spdm_responder_psk_exchange_case1(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case2(void **state)
+void libspdm_test_responder_psk_exchange_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -207,7 +207,7 @@ void test_spdm_responder_psk_exchange_case2(void **state)
         spdm_context, &opaque_psk_exchange_req_size, ptr);
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request2_size,
         &m_spdm_psk_exchange_request2, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -221,7 +221,7 @@ void test_spdm_responder_psk_exchange_case2(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case3(void **state)
+void libspdm_test_responder_psk_exchange_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -295,7 +295,7 @@ void test_spdm_responder_psk_exchange_case3(void **state)
         spdm_context, &opaque_psk_exchange_req_size, ptr);
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -310,7 +310,7 @@ void test_spdm_responder_psk_exchange_case3(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case4(void **state)
+void libspdm_test_responder_psk_exchange_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -384,7 +384,7 @@ void test_spdm_responder_psk_exchange_case4(void **state)
         spdm_context, &opaque_psk_exchange_req_size, ptr);
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -400,7 +400,7 @@ void test_spdm_responder_psk_exchange_case4(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case5(void **state)
+void libspdm_test_responder_psk_exchange_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -475,7 +475,7 @@ void test_spdm_responder_psk_exchange_case5(void **state)
         spdm_context, &opaque_psk_exchange_req_size, ptr);
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -496,7 +496,7 @@ void test_spdm_responder_psk_exchange_case5(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case6(void **state)
+void libspdm_test_responder_psk_exchange_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -570,7 +570,7 @@ void test_spdm_responder_psk_exchange_case6(void **state)
         spdm_context, &opaque_psk_exchange_req_size, ptr);
     ptr += opaque_psk_exchange_req_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -584,7 +584,7 @@ void test_spdm_responder_psk_exchange_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_exchange_case7(void **state)
+void libspdm_test_responder_psk_exchange_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -671,7 +671,7 @@ void test_spdm_responder_psk_exchange_case7(void **state)
 #endif
 
     response_size = sizeof(response);
-    status = spdm_get_response_psk_exchange(
+    status = libspdm_get_response_psk_exchange(
         spdm_context, m_spdm_psk_exchange_request1_size,
         &m_spdm_psk_exchange_request1, &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
@@ -702,19 +702,19 @@ int spdm_responder_psk_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_responder_psk_exchange_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case1),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case2),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case3),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case4),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case5),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case6),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_psk_exchange_case7),
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case7),
     };
 
     setup_spdm_test_context(&m_spdm_responder_psk_exchange_test_context);

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -33,7 +33,7 @@ static uint8_t m_local_psk_hint[32];
 static void spdm_secured_message_set_request_finished_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -49,7 +49,7 @@ static void spdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid
  * PSK_FINISH_RSP response message.
  **/
-void test_spdm_responder_psk_finish_case1(void **state)
+void libspdm_test_responder_psk_finish_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -139,10 +139,10 @@ void test_spdm_responder_psk_finish_case1(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_psk_finish_response_t));
     spdm_response = (void *)response;
@@ -156,7 +156,7 @@ void test_spdm_responder_psk_finish_case1(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_psk_finish_case2(void **state)
+void libspdm_test_responder_psk_finish_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -242,10 +242,10 @@ void test_spdm_responder_psk_finish_case2(void **state)
                      libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
                      hash_size, ptr);
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request2_size,
-                                          &m_spdm_psk_finish_request2,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request2_size,
+                                             &m_spdm_psk_finish_request2,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -263,7 +263,7 @@ void test_spdm_responder_psk_finish_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state.
  **/
-void test_spdm_responder_psk_finish_case3(void **state)
+void libspdm_test_responder_psk_finish_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -354,10 +354,10 @@ void test_spdm_responder_psk_finish_case3(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -376,7 +376,7 @@ void test_spdm_responder_psk_finish_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state.
  **/
-void test_spdm_responder_psk_finish_case4(void **state)
+void libspdm_test_responder_psk_finish_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -467,10 +467,10 @@ void test_spdm_responder_psk_finish_case4(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -490,7 +490,7 @@ void test_spdm_responder_psk_finish_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the ResponseNotReady state.
  **/
-void test_spdm_responder_psk_finish_case5(void **state)
+void libspdm_test_responder_psk_finish_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -582,10 +582,10 @@ void test_spdm_responder_psk_finish_case5(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -612,7 +612,7 @@ void test_spdm_responder_psk_finish_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest.
  **/
-void test_spdm_responder_psk_finish_case6(void **state)
+void libspdm_test_responder_psk_finish_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -703,10 +703,10 @@ void test_spdm_responder_psk_finish_case6(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -718,7 +718,7 @@ void test_spdm_responder_psk_finish_case6(void **state)
     free(data1);
 }
 
-void test_spdm_responder_psk_finish_case7(void **state)
+void libspdm_test_responder_psk_finish_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -822,10 +822,10 @@ void test_spdm_responder_psk_finish_case7(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_psk_finish_response_t));
     spdm_response = (void *)response;
@@ -848,7 +848,7 @@ void test_spdm_responder_psk_finish_case7(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the UnsupportedRequest.
  **/
-void test_spdm_responder_psk_finish_case8(void **state)
+void libspdm_test_responder_psk_finish_case8(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -938,10 +938,10 @@ void test_spdm_responder_psk_finish_case8(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -960,7 +960,7 @@ void test_spdm_responder_psk_finish_case8(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_psk_finish_case9(void **state)
+void libspdm_test_responder_psk_finish_case9(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1050,10 +1050,10 @@ void test_spdm_responder_psk_finish_case9(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1071,7 +1071,7 @@ void test_spdm_responder_psk_finish_case9(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_psk_finish_case10(void **state)
+void libspdm_test_responder_psk_finish_case10(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1151,10 +1151,10 @@ void test_spdm_responder_psk_finish_case10(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1172,7 +1172,7 @@ void test_spdm_responder_psk_finish_case10(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the DecryptError.
  **/
-void test_spdm_responder_psk_finish_case11(void **state)
+void libspdm_test_responder_psk_finish_case11(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1258,10 +1258,10 @@ void test_spdm_responder_psk_finish_case11(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1279,7 +1279,7 @@ void test_spdm_responder_psk_finish_case11(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_psk_finish_case12(void **state)
+void libspdm_test_responder_psk_finish_case12(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1371,10 +1371,10 @@ void test_spdm_responder_psk_finish_case12(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + 2*hmac_size;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1392,7 +1392,7 @@ void test_spdm_responder_psk_finish_case12(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_psk_finish_case13(void **state)
+void libspdm_test_responder_psk_finish_case13(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -1483,10 +1483,10 @@ void test_spdm_responder_psk_finish_case13(void **state)
     m_spdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size/2;
     response_size = sizeof(response);
-    status = spdm_get_response_psk_finish(spdm_context,
-                                          m_spdm_psk_finish_request1_size,
-                                          &m_spdm_psk_finish_request1,
-                                          &response_size, response);
+    status = libspdm_get_response_psk_finish(spdm_context,
+                                             m_spdm_psk_finish_request1_size,
+                                             &m_spdm_psk_finish_request1,
+                                             &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1507,29 +1507,29 @@ int spdm_responder_psk_finish_test_main(void)
 {
     const struct CMUnitTest spdm_responder_psk_finish_tests[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case1),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case2),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case3),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case4),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case5),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case5),
         /* connection_state Check*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case6),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case6),
         /* Buffer reset*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case7),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case7),
         /* Unsupported PSK capabilities*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case8),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case8),
         /* Uninitialized session*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case9),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case9),
         /* Incorrect MAC*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case10),
-        cmocka_unit_test(test_spdm_responder_psk_finish_case11),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case10),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case11),
         /* Incorrect MAC size*/
-        cmocka_unit_test(test_spdm_responder_psk_finish_case12),
-        cmocka_unit_test(test_spdm_responder_psk_finish_case13),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case12),
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case13),
     };
 
     setup_spdm_test_context(&m_spdm_responder_psk_finish_test_context);

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -270,7 +270,7 @@ static uint8_t m_local_certificate_chain[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static void spdm_secured_message_set_request_finished_key(
     void *spdm_secured_message_context, const void *key, uintn key_size)
 {
-    spdm_secured_message_context_t *secured_message_context;
+    libspdm_secured_message_context_t *secured_message_context;
 
     secured_message_context = spdm_secured_message_context;
     ASSERT(key_size == secured_message_context->hash_size);
@@ -287,7 +287,7 @@ static void spdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid DIGESTS
  * response message.
  **/
-void test_spdm_responder_respond_if_ready_case1(void **state) {
+void libspdm_test_responder_respond_if_ready_case1(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -329,9 +329,11 @@ void test_spdm_responder_respond_if_ready_case1(void **state) {
 
     /*check DIGESTS response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request1_size,
-                                                &m_spdm_respond_if_ready_request1, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request1_size,
+                                                   &m_spdm_respond_if_ready_request1,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_digest_response_t) +
@@ -351,7 +353,7 @@ void test_spdm_responder_respond_if_ready_case1(void **state) {
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-void test_spdm_responder_respond_if_ready_case2(void **state) {
+void libspdm_test_responder_respond_if_ready_case2(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -396,9 +398,11 @@ void test_spdm_responder_respond_if_ready_case2(void **state) {
 
     /*check CERTIFICATE response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request2_size,
-                                                &m_spdm_respond_if_ready_request2, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request2_size,
+                                                   &m_spdm_respond_if_ready_request2,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_certificate_response_t) + LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
@@ -420,7 +424,7 @@ void test_spdm_responder_respond_if_ready_case2(void **state) {
  * response message.
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-void test_spdm_responder_respond_if_ready_case3(void **state) {
+void libspdm_test_responder_respond_if_ready_case3(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -470,9 +474,11 @@ void test_spdm_responder_respond_if_ready_case3(void **state) {
     /*check CHALLENGE response*/
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_challenge_request.nonce);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request3_size,
-                                                &m_spdm_respond_if_ready_request3, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request3_size,
+                                                   &m_spdm_respond_if_ready_request3,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_challenge_auth_response_t) + libspdm_get_hash_size (
                           m_use_hash_algo) + SPDM_NONCE_SIZE + 0 + sizeof(uint16_t) + 0 + libspdm_get_asym_signature_size (
@@ -494,7 +500,7 @@ void test_spdm_responder_respond_if_ready_case3(void **state) {
 
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
 
-void test_spdm_responder_respond_if_ready_case4(void **state) {
+void libspdm_test_responder_respond_if_ready_case4(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -538,9 +544,11 @@ void test_spdm_responder_respond_if_ready_case4(void **state) {
     /*check MEASUREMENT response*/
     response_size = sizeof(response);
     libspdm_get_random_number (SPDM_NONCE_SIZE, m_spdm_get_measurements_request.nonce);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request4_size,
-                                                &m_spdm_respond_if_ready_request4, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request4_size,
+                                                   &m_spdm_respond_if_ready_request4,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_measurements_response_t) + sizeof(uint16_t) + SPDM_NONCE_SIZE);
@@ -559,7 +567,7 @@ void test_spdm_responder_respond_if_ready_case4(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-void test_spdm_responder_respond_if_ready_case5(void **state) {
+void libspdm_test_responder_respond_if_ready_case5(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -633,9 +641,11 @@ void test_spdm_responder_respond_if_ready_case5(void **state) {
 
     /*check KEY_EXCHANGE_RSP response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request5_size,
-                                                &m_spdm_respond_if_ready_request5, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request5_size,
+                                                   &m_spdm_respond_if_ready_request5,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_key_exchange_response_t) + dhe_key_size + 2 + libspdm_get_opaque_data_version_selection_data_size(
                           spdm_context) + libspdm_get_asym_signature_size (m_use_asym_algo) +
@@ -660,7 +670,7 @@ void test_spdm_responder_respond_if_ready_case5(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-void test_spdm_responder_respond_if_ready_case6(void **state) {
+void libspdm_test_responder_respond_if_ready_case6(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -757,9 +767,11 @@ void test_spdm_responder_respond_if_ready_case6(void **state) {
 
     /*check FINISH_RSP response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request6_size,
-                                                &m_spdm_respond_if_ready_request6, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request6_size,
+                                                   &m_spdm_respond_if_ready_request6,
+                                                   &response_size,
+                                                   response);
     /* status = SpdmGetResponseFinish (spdm_context, mSpdmFinishRequest1_size, &mSpdmFinishRequest1, &response_size, response);*/
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_finish_response_t) + hmac_size);
@@ -778,7 +790,7 @@ void test_spdm_responder_respond_if_ready_case6(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 
-void test_spdm_responder_respond_if_ready_case7(void **state) {
+void libspdm_test_responder_respond_if_ready_case7(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -854,9 +866,11 @@ void test_spdm_responder_respond_if_ready_case7(void **state) {
 
     /*check PSK_EXCHANGE_RSP response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request7_size,
-                                                &m_spdm_respond_if_ready_request7, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request7_size,
+                                                   &m_spdm_respond_if_ready_request7,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_psk_exchange_response_t) + LIBSPDM_PSK_CONTEXT_LENGTH + libspdm_get_opaque_data_version_selection_data_size(
                           spdm_context) + libspdm_get_hash_size (m_use_hash_algo));
@@ -878,7 +892,7 @@ void test_spdm_responder_respond_if_ready_case7(void **state) {
  * response message.
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-void test_spdm_responder_respond_if_ready_case8(void **state) {
+void libspdm_test_responder_respond_if_ready_case8(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -974,9 +988,11 @@ void test_spdm_responder_respond_if_ready_case8(void **state) {
 
     /*check FINISH_PSK_RSP response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request8_size,
-                                                &m_spdm_respond_if_ready_request8, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request8_size,
+                                                   &m_spdm_respond_if_ready_request8,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_psk_finish_response_t));
     spdm_response = (void *)response;
@@ -994,7 +1010,7 @@ void test_spdm_responder_respond_if_ready_case8(void **state) {
  * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_respond_if_ready_case9(void **state) {
+void libspdm_test_responder_respond_if_ready_case9(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1031,9 +1047,11 @@ void test_spdm_responder_respond_if_ready_case9(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request9_size,
-                                                &m_spdm_respond_if_ready_request9, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request9_size,
+                                                   &m_spdm_respond_if_ready_request9,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1051,7 +1069,7 @@ void test_spdm_responder_respond_if_ready_case9(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Busy state.
  **/
-void test_spdm_responder_respond_if_ready_case10(void **state) {
+void libspdm_test_responder_respond_if_ready_case10(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1088,9 +1106,11 @@ void test_spdm_responder_respond_if_ready_case10(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request1_size,
-                                                &m_spdm_respond_if_ready_request1, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request1_size,
+                                                   &m_spdm_respond_if_ready_request1,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1109,7 +1129,7 @@ void test_spdm_responder_respond_if_ready_case10(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the NeedResynch state.
  **/
-void test_spdm_responder_respond_if_ready_case11(void **state) {
+void libspdm_test_responder_respond_if_ready_case11(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1146,9 +1166,11 @@ void test_spdm_responder_respond_if_ready_case11(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request1_size,
-                                                &m_spdm_respond_if_ready_request1, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request1_size,
+                                                   &m_spdm_respond_if_ready_request1,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1168,7 +1190,7 @@ void test_spdm_responder_respond_if_ready_case11(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the ResponseNotReady state, with the same token as the request.
  **/
-void test_spdm_responder_respond_if_ready_case12(void **state) {
+void libspdm_test_responder_respond_if_ready_case12(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1206,9 +1228,11 @@ void test_spdm_responder_respond_if_ready_case12(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context, m_spdm_respond_if_ready_request1_size,
-                                                &m_spdm_respond_if_ready_request1, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request1_size,
+                                                   &m_spdm_respond_if_ready_request1,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size,
                       sizeof(spdm_error_response_t) + sizeof(spdm_error_data_response_not_ready_t));
@@ -1232,7 +1256,7 @@ void test_spdm_responder_respond_if_ready_case12(void **state) {
  * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_respond_if_ready_case13(void **state) {
+void libspdm_test_responder_respond_if_ready_case13(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1269,10 +1293,11 @@ void test_spdm_responder_respond_if_ready_case13(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context,
-                                                m_spdm_respond_if_ready_request10_size,
-                                                &m_spdm_respond_if_ready_request10, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request10_size,
+                                                   &m_spdm_respond_if_ready_request10,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1289,7 +1314,7 @@ void test_spdm_responder_respond_if_ready_case13(void **state) {
  * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_respond_if_ready_case14(void **state) {
+void libspdm_test_responder_respond_if_ready_case14(void **state) {
     return_status status;
     spdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1326,10 +1351,11 @@ void test_spdm_responder_respond_if_ready_case14(void **state) {
 
     /*check ERROR response*/
     response_size = sizeof(response);
-    status = spdm_get_response_respond_if_ready(spdm_context,
-                                                m_spdm_respond_if_ready_request11_size,
-                                                &m_spdm_respond_if_ready_request11, &response_size,
-                                                response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_spdm_respond_if_ready_request11_size,
+                                                   &m_spdm_respond_if_ready_request11,
+                                                   &response_size,
+                                                   response);
     assert_int_equal (status, RETURN_SUCCESS);
     assert_int_equal (response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -1348,35 +1374,35 @@ int spdm_responder_respond_if_ready_test_main(void) {
     const struct CMUnitTest spdm_responder_respond_if_ready_tests[] = {
         /* Success Case*/
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case1),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case2),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case1),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case2),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case3),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case3),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case4),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case4),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case5),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case6),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case5),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case6),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case7),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case8),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case7),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case8),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case9),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case10),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case11),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case12),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case13),
-        cmocka_unit_test(test_spdm_responder_respond_if_ready_case14),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case9),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case10),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case11),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case12),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case13),
+        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case14),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     };

--- a/unit_test/test_spdm_responder/version.c
+++ b/unit_test/test_spdm_responder/version.c
@@ -18,44 +18,44 @@ typedef struct {
 } spdm_version_response_mine_t;
 #pragma pack()
 
-spdm_get_version_request_t m_spdm_get_version_request1 = {
+spdm_get_version_request_t m_libspdm_get_version_request1 = {
     {
         SPDM_MESSAGE_VERSION_10,
         SPDM_GET_VERSION,
     },
 };
-uintn m_spdm_get_version_request1_size = sizeof(m_spdm_get_version_request1);
+uintn m_libspdm_get_version_request1_size = sizeof(m_libspdm_get_version_request1);
 
-spdm_get_version_request_t m_spdm_get_version_request2 = {
+spdm_get_version_request_t m_libspdm_get_version_request2 = {
     {
         SPDM_MESSAGE_VERSION_10,
         SPDM_GET_VERSION,
     },
 };
-uintn m_spdm_get_version_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+uintn m_libspdm_get_version_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 
-spdm_get_version_request_t m_spdm_get_version_request3 = {
+spdm_get_version_request_t m_libspdm_get_version_request3 = {
     {
         SPDM_MESSAGE_VERSION_11,
         SPDM_GET_VERSION,
     },
 };
-uintn m_spdm_get_version_request3_size = sizeof(m_spdm_get_version_request3);
+uintn m_libspdm_get_version_request3_size = sizeof(m_libspdm_get_version_request3);
 
-spdm_get_version_request_t m_spdm_get_version_request4 = {
+spdm_get_version_request_t m_libspdm_get_version_request4 = {
     {
         SPDM_MESSAGE_VERSION_10,
         SPDM_VERSION,
     },
 };
-uintn m_spdm_get_version_request4_size = sizeof(m_spdm_get_version_request4);
+uintn m_libspdm_get_version_request4_size = sizeof(m_libspdm_get_version_request4);
 
 /**
  * Test 1: receiving a correct GET_VERSION from the requester.
  * Expected behavior: the responder accepts the request and produces a valid VERSION
  * response message.
  **/
-void test_spdm_responder_version_case1(void **state)
+void libspdm_test_responder_version_case1(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -69,10 +69,10 @@ void test_spdm_responder_version_case1(void **state)
     spdm_test_context->case_id = 0x1;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request1_size,
-                                       &m_spdm_get_version_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request1_size,
+                                          &m_libspdm_get_version_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_version_response_t) +
@@ -89,7 +89,7 @@ void test_spdm_responder_version_case1(void **state)
  * Expected behavior: the responder refuses the GET_VERSION message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_version_case2(void **state)
+void libspdm_test_responder_version_case2(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -103,10 +103,10 @@ void test_spdm_responder_version_case2(void **state)
     spdm_test_context->case_id = 0x2;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request2_size,
-                                       &m_spdm_get_version_request2,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request2_size,
+                                          &m_libspdm_get_version_request2,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -123,7 +123,7 @@ void test_spdm_responder_version_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Buse state.
  **/
-void test_spdm_responder_version_case3(void **state)
+void libspdm_test_responder_version_case3(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -138,10 +138,10 @@ void test_spdm_responder_version_case3(void **state)
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request1_size,
-                                       &m_spdm_get_version_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request1_size,
+                                          &m_libspdm_get_version_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -159,7 +159,7 @@ void test_spdm_responder_version_case3(void **state)
  * Expected behavior: the requester resets the communication upon receiving the GET_VERSION
  * message, fulfilling the resynchronization. A valid VERSION message is produced.
  **/
-void test_spdm_responder_version_case4(void **state)
+void libspdm_test_responder_version_case4(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -174,10 +174,10 @@ void test_spdm_responder_version_case4(void **state)
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request1_size,
-                                       &m_spdm_get_version_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request1_size,
+                                          &m_libspdm_get_version_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_version_response_t) +
@@ -196,7 +196,7 @@ void test_spdm_responder_version_case4(void **state)
  * TODO: As from version 1.0.0, a GET_VERSION message should not receive an ERROR message
  * indicating the ResponseNotReady. No timing parameters have been agreed yet.
  **/
-void test_spdm_responder_version_case5(void **state)
+void libspdm_test_responder_version_case5(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -212,10 +212,10 @@ void test_spdm_responder_version_case5(void **state)
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NOT_READY;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request1_size,
-                                       &m_spdm_get_version_request1,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request1_size,
+                                          &m_libspdm_get_version_request1,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size,
                      sizeof(spdm_error_response_t) +
@@ -240,7 +240,7 @@ void test_spdm_responder_version_case5(void **state)
  * Expected behavior: the responder refuses the GET_VERSION message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_version_case6(void **state)
+void libspdm_test_responder_version_case6(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -255,10 +255,10 @@ void test_spdm_responder_version_case6(void **state)
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request3_size,
-                                       &m_spdm_get_version_request3,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request3_size,
+                                          &m_libspdm_get_version_request3,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -275,7 +275,7 @@ void test_spdm_responder_version_case6(void **state)
  * Expected behavior: the responder refuses the VERSION message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void test_spdm_responder_version_case7(void **state)
+void libspdm_test_responder_version_case7(void **state)
 {
     return_status status;
     spdm_test_context_t *spdm_test_context;
@@ -289,10 +289,10 @@ void test_spdm_responder_version_case7(void **state)
     spdm_test_context->case_id = 0x6;
 
     response_size = sizeof(response);
-    status = spdm_get_response_version(spdm_context,
-                                       m_spdm_get_version_request3_size,
-                                       &m_spdm_get_version_request3,
-                                       &response_size, response);
+    status = libspdm_get_response_version(spdm_context,
+                                          m_libspdm_get_version_request3_size,
+                                          &m_libspdm_get_version_request3,
+                                          &response_size, response);
     assert_int_equal(status, RETURN_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
     spdm_response = (void *)response;
@@ -311,17 +311,17 @@ spdm_test_context_t m_spdm_responder_version_test_context = {
 int spdm_responder_version_test_main(void)
 {
     const struct CMUnitTest spdm_responder_version_tests[] = {
-        cmocka_unit_test(test_spdm_responder_version_case1),
+        cmocka_unit_test(libspdm_test_responder_version_case1),
         /* Invalid request*/
-        cmocka_unit_test(test_spdm_responder_version_case2),
+        cmocka_unit_test(libspdm_test_responder_version_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(test_spdm_responder_version_case3),
+        cmocka_unit_test(libspdm_test_responder_version_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(test_spdm_responder_version_case4),
+        cmocka_unit_test(libspdm_test_responder_version_case4),
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(test_spdm_responder_version_case5),
+        cmocka_unit_test(libspdm_test_responder_version_case5),
         /* Invalid request*/
-        cmocka_unit_test(test_spdm_responder_version_case6),
+        cmocka_unit_test(libspdm_test_responder_version_case6),
     };
 
     setup_spdm_test_context(&m_spdm_responder_version_test_context);


### PR DESCRIPTION
in libspdm_requester_lib, libspdm_responder_lib and
 libspdm_secured_message_lib.

Fix: #576 

Signed-off-by: Qi Zhang <qi1.zhang@intel.com>