### PR TITLE
Remove copy_mem_s name from memlib. All to use copy_mem.

### DIFF
--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -51,9 +51,6 @@
  * @return   0 on success. non-zero on error.
  *
  **/
-int copy_mem_s(void *restrict dst_buf, uintn dst_len,
-               const void *restrict src_buf, uintn src_len);
-
 int copy_mem(void *restrict dst_buf, uintn dst_len,
              const void *restrict src_buf, uintn src_len);
 

--- a/os_stub/memlib/copy_mem.c
+++ b/os_stub/memlib/copy_mem.c
@@ -48,8 +48,8 @@
  * @return   0 on success. non-zero on error.
  *
  **/
-int copy_mem_s(void *restrict dst_buf, uintn dst_len,
-               const void *restrict src_buf, uintn src_len)
+int copy_mem(void *restrict dst_buf, uintn dst_len,
+             const void *restrict src_buf, uintn src_len)
 {
     volatile uint8_t* dst;
     const volatile uint8_t* src;
@@ -92,10 +92,4 @@ int copy_mem_s(void *restrict dst_buf, uintn dst_len,
     }
 
     return 0;
-}
-
-int copy_mem(void *restrict dst_buf, uintn dst_len,
-             const void *restrict src_buf, uintn src_len)
-{
-    return copy_mem_s(dst_buf, dst_len, src_buf, src_len);
 }


### PR DESCRIPTION
Get rid of copy_mem_s name. All to use copy_mem with same parameters.
Signed-off-by: Kong, Richard <richard.kong@intel.com>