### PR TITLE
add LIBSPDM_ or libspdm_ for any external symbol or MACRO.

### DIFF
--- a/library/spdm_crypt_lib/libspdm_crypt_crypt.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_crypt.c
@@ -39,7 +39,7 @@ uint32_t libspdm_get_hash_size(uint32_t base_hash_algo)
  *
  * @return hash cipher ID
  **/
-uintn get_spdm_hash_nid(uint32_t base_hash_algo)
+uintn libspdm_get_hash_nid(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -68,7 +68,7 @@ uintn get_spdm_hash_nid(uint32_t base_hash_algo)
  *
  * @return hash new function
  **/
-libspdm_hash_new_func get_spdm_hash_new_func(uint32_t base_hash_algo)
+libspdm_hash_new_func libspdm_get_hash_new_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -135,7 +135,7 @@ libspdm_hash_new_func get_spdm_hash_new_func(uint32_t base_hash_algo)
  *
  * @return hash free function
  **/
-libspdm_hash_free_func get_spdm_hash_free_func(uint32_t base_hash_algo)
+libspdm_hash_free_func libspdm_get_hash_free_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -202,7 +202,7 @@ libspdm_hash_free_func get_spdm_hash_free_func(uint32_t base_hash_algo)
  *
  * @return hash init function
  **/
-libspdm_hash_init_func get_spdm_hash_init_func(uint32_t base_hash_algo)
+libspdm_hash_init_func libspdm_get_hash_init_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -270,7 +270,7 @@ libspdm_hash_init_func get_spdm_hash_init_func(uint32_t base_hash_algo)
  *
  * @return hash duplicate function
  **/
-libspdm_hash_duplicate_func get_spdm_hash_duplicate_func(uint32_t base_hash_algo)
+libspdm_hash_duplicate_func libspdm_get_hash_duplicate_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -337,7 +337,7 @@ libspdm_hash_duplicate_func get_spdm_hash_duplicate_func(uint32_t base_hash_algo
  *
  * @return hash update function
  **/
-libspdm_hash_update_func get_spdm_hash_update_func(uint32_t base_hash_algo)
+libspdm_hash_update_func libspdm_get_hash_update_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -403,7 +403,7 @@ libspdm_hash_update_func get_spdm_hash_update_func(uint32_t base_hash_algo)
  *
  * @return hash final function
  **/
-libspdm_hash_final_func get_spdm_hash_final_func(uint32_t base_hash_algo)
+libspdm_hash_final_func libspdm_get_hash_final_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -470,7 +470,7 @@ libspdm_hash_final_func get_spdm_hash_final_func(uint32_t base_hash_algo)
  *
  * @return hash function
  **/
-libspdm_hash_all_func get_spdm_hash_all_func(uint32_t base_hash_algo)
+libspdm_hash_all_func libspdm_get_hash_all_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -541,7 +541,7 @@ libspdm_hash_all_func get_spdm_hash_all_func(uint32_t base_hash_algo)
 void *libspdm_hash_new(uint32_t base_hash_algo)
 {
     libspdm_hash_new_func hash_function;
-    hash_function = get_spdm_hash_new_func(base_hash_algo);
+    hash_function = libspdm_get_hash_new_func(base_hash_algo);
     if (hash_function == NULL) {
         return NULL;
     }
@@ -557,7 +557,7 @@ void *libspdm_hash_new(uint32_t base_hash_algo)
 void libspdm_hash_free(uint32_t base_hash_algo, void *hash_context)
 {
     libspdm_hash_free_func hash_function;
-    hash_function = get_spdm_hash_free_func(base_hash_algo);
+    hash_function = libspdm_get_hash_free_func(base_hash_algo);
     if (hash_function == NULL) {
         return;
     }
@@ -577,7 +577,7 @@ void libspdm_hash_free(uint32_t base_hash_algo, void *hash_context)
 bool libspdm_hash_init(uint32_t base_hash_algo, void *hash_context)
 {
     libspdm_hash_init_func hash_function;
-    hash_function = get_spdm_hash_init_func(base_hash_algo);
+    hash_function = libspdm_get_hash_init_func(base_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -601,7 +601,7 @@ bool libspdm_hash_duplicate(uint32_t base_hash_algo,
                             const void *hash_ctx, void *new_hash_ctx)
 {
     libspdm_hash_duplicate_func hash_function;
-    hash_function = get_spdm_hash_duplicate_func(base_hash_algo);
+    hash_function = libspdm_get_hash_duplicate_func(base_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -629,7 +629,7 @@ bool libspdm_hash_update(uint32_t base_hash_algo, void *hash_context,
                          const void *data, uintn data_size)
 {
     libspdm_hash_update_func hash_function;
-    hash_function = get_spdm_hash_update_func(base_hash_algo);
+    hash_function = libspdm_get_hash_update_func(base_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -658,7 +658,7 @@ bool libspdm_hash_final(uint32_t base_hash_algo, void *hash_context,
                         uint8_t *hash_value)
 {
     libspdm_hash_final_func hash_function;
-    hash_function = get_spdm_hash_final_func(base_hash_algo);
+    hash_function = libspdm_get_hash_final_func(base_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -682,7 +682,7 @@ bool libspdm_hash_all(uint32_t base_hash_algo, const void *data,
                       uintn data_size, uint8_t *hash_value)
 {
     libspdm_hash_all_func hash_function;
-    hash_function = get_spdm_hash_all_func(base_hash_algo);
+    hash_function = libspdm_get_hash_all_func(base_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -725,7 +725,7 @@ uint32_t libspdm_get_measurement_hash_size(uint32_t measurement_hash_algo)
  *
  * @return hash function
  **/
-libspdm_hash_all_func get_spdm_measurement_hash_func(uint32_t measurement_hash_algo)
+libspdm_hash_all_func libspdm_spdm_measurement_hash_func(uint32_t measurement_hash_algo)
 {
     switch (measurement_hash_algo) {
     case SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_TPM_ALG_SHA_256:
@@ -803,7 +803,7 @@ bool libspdm_measurement_hash_all(uint32_t measurement_hash_algo,
                                   uint8_t *hash_value)
 {
     libspdm_hash_all_func hash_function;
-    hash_function = get_spdm_measurement_hash_func(measurement_hash_algo);
+    hash_function = libspdm_spdm_measurement_hash_func(measurement_hash_algo);
     if (hash_function == NULL) {
         return false;
     }
@@ -817,7 +817,7 @@ bool libspdm_measurement_hash_all(uint32_t measurement_hash_algo,
  *
  * @return HMAC new function
  **/
-libspdm_hmac_new_func get_spdm_hmac_new_func(uint32_t base_hash_algo)
+libspdm_hmac_new_func libspdm_get_hmac_new_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -884,7 +884,7 @@ libspdm_hmac_new_func get_spdm_hmac_new_func(uint32_t base_hash_algo)
  *
  * @return HMAC free function
  **/
-libspdm_hmac_free_func get_spdm_hmac_free_func(uint32_t base_hash_algo)
+libspdm_hmac_free_func libspdm_get_hmac_free_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -951,7 +951,7 @@ libspdm_hmac_free_func get_spdm_hmac_free_func(uint32_t base_hash_algo)
  *
  * @return HMAC init function
  **/
-libspdm_hmac_set_key_func get_spdm_hmac_init_func(uint32_t base_hash_algo)
+libspdm_hmac_set_key_func libspdm_get_hmac_init_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -1018,7 +1018,7 @@ libspdm_hmac_set_key_func get_spdm_hmac_init_func(uint32_t base_hash_algo)
  *
  * @return HMAC duplicate function
  **/
-libspdm_hmac_duplicate_func get_spdm_hmac_duplicate_func(uint32_t base_hash_algo)
+libspdm_hmac_duplicate_func libspdm_get_hmac_duplicate_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -1085,7 +1085,7 @@ libspdm_hmac_duplicate_func get_spdm_hmac_duplicate_func(uint32_t base_hash_algo
  *
  * @return HMAC update function
  **/
-libspdm_hmac_update_func get_spdm_hmac_update_func(uint32_t base_hash_algo)
+libspdm_hmac_update_func libspdm_get_hmac_update_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -1151,7 +1151,7 @@ libspdm_hmac_update_func get_spdm_hmac_update_func(uint32_t base_hash_algo)
  *
  * @return HMAC final function
  **/
-libspdm_hmac_final_func get_spdm_hmac_final_func(uint32_t base_hash_algo)
+libspdm_hmac_final_func libspdm_get_hmac_final_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -1218,7 +1218,7 @@ libspdm_hmac_final_func get_spdm_hmac_final_func(uint32_t base_hash_algo)
  *
  * @return HMAC function
  **/
-libspdm_hmac_all_func get_spdm_hmac_all_func(uint32_t base_hash_algo)
+libspdm_hmac_all_func libspdm_get_hmac_all_func(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
@@ -1289,7 +1289,7 @@ libspdm_hmac_all_func get_spdm_hmac_all_func(uint32_t base_hash_algo)
 void *libspdm_hmac_new(uint32_t base_hash_algo)
 {
     libspdm_hmac_new_func hmac_function;
-    hmac_function = get_spdm_hmac_new_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_new_func(base_hash_algo);
     if (hmac_function == NULL) {
         return NULL;
     }
@@ -1305,7 +1305,7 @@ void *libspdm_hmac_new(uint32_t base_hash_algo)
 void libspdm_hmac_free(uint32_t base_hash_algo, void *hmac_ctx)
 {
     libspdm_hmac_free_func hmac_function;
-    hmac_function = get_spdm_hmac_free_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_free_func(base_hash_algo);
     if (hmac_function == NULL) {
         return;
     }
@@ -1331,7 +1331,7 @@ bool libspdm_hmac_init(uint32_t base_hash_algo,
                        uintn key_size)
 {
     libspdm_hmac_set_key_func hmac_function;
-    hmac_function = get_spdm_hmac_init_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_init_func(base_hash_algo);
     if (hmac_function == NULL) {
         return false;
     }
@@ -1355,7 +1355,7 @@ bool libspdm_hmac_duplicate(uint32_t base_hash_algo,
                             const void *hmac_ctx, void *new_hmac_ctx)
 {
     libspdm_hmac_duplicate_func hmac_function;
-    hmac_function = get_spdm_hmac_duplicate_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_duplicate_func(base_hash_algo);
     if (hmac_function == NULL) {
         return false;
     }
@@ -1385,7 +1385,7 @@ bool libspdm_hmac_update(uint32_t base_hash_algo,
                          uintn data_size)
 {
     libspdm_hmac_update_func hmac_function;
-    hmac_function = get_spdm_hmac_update_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_update_func(base_hash_algo);
     if (hmac_function == NULL) {
         return false;
     }
@@ -1414,7 +1414,7 @@ bool libspdm_hmac_final(uint32_t base_hash_algo,
                         void *hmac_ctx,  uint8_t *hmac_value)
 {
     libspdm_hmac_final_func hmac_function;
-    hmac_function = get_spdm_hmac_final_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_final_func(base_hash_algo);
     if (hmac_function == NULL) {
         return false;
     }
@@ -1441,7 +1441,7 @@ bool libspdm_hmac_all(uint32_t base_hash_algo, const void *data,
                       uintn key_size, uint8_t *hmac_value)
 {
     libspdm_hmac_all_func hmac_function;
-    hmac_function = get_spdm_hmac_all_func(base_hash_algo);
+    hmac_function = libspdm_get_hmac_all_func(base_hash_algo);
     if (hmac_function == NULL) {
         return false;
     }
@@ -1548,9 +1548,9 @@ typedef struct {
     void    *context;
     uintn context_size;
     uintn zero_pad_size;
-} spdm_signing_context_str_t;
+} libspdm_signing_context_str_t;
 
-spdm_signing_context_str_t m_spdm_signing_context_str_table[]={
+libspdm_signing_context_str_t m_libspdm_signing_context_str_table[]={
     {false, SPDM_CHALLENGE_AUTH, SPDM_CHALLENGE_AUTH_SIGN_CONTEXT,
      SPDM_CHALLENGE_AUTH_SIGN_CONTEXT_SIZE, 36 - SPDM_CHALLENGE_AUTH_SIGN_CONTEXT_SIZE},
     {true, SPDM_CHALLENGE_AUTH, SPDM_MUT_CHALLENGE_AUTH_SIGN_CONTEXT,
@@ -1573,7 +1573,7 @@ spdm_signing_context_str_t m_spdm_signing_context_str_table[]={
  * @param  context_size                         SPDM signing context size
  **/
 void *
-get_spdm_signing_context_string (
+libspdm_get_signing_context_string (
     spdm_version_number_t spdm_version,
     uint8_t op_code,
     bool is_requester,
@@ -1584,11 +1584,11 @@ get_spdm_signing_context_string (
     /* It is introduced in SPDM 1.2*/
     ASSERT((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) > SPDM_MESSAGE_VERSION_11);
 
-    for (index = 0; index < ARRAY_SIZE(m_spdm_signing_context_str_table); index++) {
-        if (m_spdm_signing_context_str_table[index].is_requester == is_requester &&
-            m_spdm_signing_context_str_table[index].op_code == op_code) {
-            *context_size = m_spdm_signing_context_str_table[index].context_size;
-            return m_spdm_signing_context_str_table[index].context;
+    for (index = 0; index < ARRAY_SIZE(m_libspdm_signing_context_str_table); index++) {
+        if (m_libspdm_signing_context_str_table[index].is_requester == is_requester &&
+            m_libspdm_signing_context_str_table[index].op_code == op_code) {
+            *context_size = m_libspdm_signing_context_str_table[index].context_size;
+            return m_libspdm_signing_context_str_table[index].context;
         }
     }
     ASSERT(false);
@@ -1604,7 +1604,7 @@ get_spdm_signing_context_string (
  * @param  spdm_signing_context                 SPDM signing context
  **/
 void
-create_spdm_signing_context (
+libspdm_create_signing_context (
     spdm_version_number_t spdm_version,
     uint8_t op_code,
     bool is_requester,
@@ -1632,16 +1632,16 @@ create_spdm_signing_context (
         context_str[15] = (char)('*');
         context_str += SPDM_VERSION_1_2_SIGNING_PREFIX_CONTEXT_SIZE;
     }
-    for (index = 0; index < ARRAY_SIZE(m_spdm_signing_context_str_table); index++) {
-        if (m_spdm_signing_context_str_table[index].is_requester == is_requester &&
-            m_spdm_signing_context_str_table[index].op_code == op_code) {
+    for (index = 0; index < ARRAY_SIZE(m_libspdm_signing_context_str_table); index++) {
+        if (m_libspdm_signing_context_str_table[index].is_requester == is_requester &&
+            m_libspdm_signing_context_str_table[index].op_code == op_code) {
             zero_mem (
                 context_str,
-                m_spdm_signing_context_str_table[index].zero_pad_size);
-            copy_mem(context_str + m_spdm_signing_context_str_table[index].zero_pad_size,
-                     m_spdm_signing_context_str_table[index].context_size,
-                     m_spdm_signing_context_str_table[index].context,
-                     m_spdm_signing_context_str_table[index].context_size);
+                m_libspdm_signing_context_str_table[index].zero_pad_size);
+            copy_mem(context_str + m_libspdm_signing_context_str_table[index].zero_pad_size,
+                     m_libspdm_signing_context_str_table[index].context_size,
+                     m_libspdm_signing_context_str_table[index].context,
+                     m_libspdm_signing_context_str_table[index].context_size);
             return;
         }
     }
@@ -1692,7 +1692,7 @@ uint32_t libspdm_get_asym_signature_size(uint32_t base_asym_algo)
  * @return asymmetric GET_PUBLIC_KEY_FROM_X509 function
  **/
 libspdm_asym_get_public_key_from_x509_func
-get_spdm_asym_get_public_key_from_x509(uint32_t base_asym_algo)
+libspdm_get_asym_get_public_key_from_x509(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
@@ -1759,7 +1759,7 @@ bool libspdm_asym_get_public_key_from_x509(uint32_t base_asym_algo,
 {
     libspdm_asym_get_public_key_from_x509_func get_public_key_from_x509_function;
     get_public_key_from_x509_function =
-        get_spdm_asym_get_public_key_from_x509(base_asym_algo);
+        libspdm_get_asym_get_public_key_from_x509(base_asym_algo);
     if (get_public_key_from_x509_function == NULL) {
         return false;
     }
@@ -1773,7 +1773,7 @@ bool libspdm_asym_get_public_key_from_x509(uint32_t base_asym_algo,
  *
  * @return asymmetric free function
  **/
-libspdm_asym_free_func get_spdm_asym_free(uint32_t base_asym_algo)
+libspdm_asym_free_func libspdm_get_asym_free(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
@@ -1830,7 +1830,7 @@ libspdm_asym_free_func get_spdm_asym_free(uint32_t base_asym_algo)
 void libspdm_asym_free(uint32_t base_asym_algo, void *context)
 {
     libspdm_asym_free_func free_function;
-    free_function = get_spdm_asym_free(base_asym_algo);
+    free_function = libspdm_get_asym_free(base_asym_algo);
     if (free_function == NULL) {
         return;
     }
@@ -1845,7 +1845,7 @@ void libspdm_asym_free(uint32_t base_asym_algo, void *context)
  * @retval true  asymmetric function need message hash
  * @retval false asymmetric function need raw message
  **/
-bool spdm_asym_func_need_hash(uint32_t base_asym_algo)
+bool libspdm_asym_func_need_hash(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
@@ -1872,60 +1872,60 @@ bool spdm_asym_func_need_hash(uint32_t base_asym_algo)
 }
 
 bool
-rsa_pkcs1_verify_with_nid_wrap (void *context, uintn hash_nid,
-                                const uint8_t *param, uintn param_size,
-                                const uint8_t *message,
-                                uintn message_size,
-                                const uint8_t *signature,
-                                uintn sig_size)
+libspdm_rsa_pkcs1_verify_with_nid_wrap (void *context, uintn hash_nid,
+                                        const uint8_t *param, uintn param_size,
+                                        const uint8_t *message,
+                                        uintn message_size,
+                                        const uint8_t *signature,
+                                        uintn sig_size)
 {
     return rsa_pkcs1_verify_with_nid (context, hash_nid,
                                       message, message_size, signature, sig_size);
 }
 
 bool
-rsa_pss_verify_wrap (void *context, uintn hash_nid,
-                     const uint8_t *param, uintn param_size,
-                     const uint8_t *message,
-                     uintn message_size,
-                     const uint8_t *signature,
-                     uintn sig_size)
+libspdm_rsa_pss_verify_wrap (void *context, uintn hash_nid,
+                             const uint8_t *param, uintn param_size,
+                             const uint8_t *message,
+                             uintn message_size,
+                             const uint8_t *signature,
+                             uintn sig_size)
 {
     return rsa_pss_verify (context, hash_nid,
                            message, message_size, signature, sig_size);
 }
 
 bool
-ecdsa_verify_wrap (void *context, uintn hash_nid,
-                   const uint8_t *param, uintn param_size,
-                   const uint8_t *message,
-                   uintn message_size,
-                   const uint8_t *signature,
-                   uintn sig_size)
+libspdm_ecdsa_verify_wrap (void *context, uintn hash_nid,
+                           const uint8_t *param, uintn param_size,
+                           const uint8_t *message,
+                           uintn message_size,
+                           const uint8_t *signature,
+                           uintn sig_size)
 {
     return ecdsa_verify (context, hash_nid,
                          message, message_size, signature, sig_size);
 }
 
 bool
-eddsa_verify_wrap (void *context, uintn hash_nid,
-                   const uint8_t *param, uintn param_size,
-                   const uint8_t *message,
-                   uintn message_size,
-                   const uint8_t *signature,
-                   uintn sig_size)
+libspdm_eddsa_verify_wrap (void *context, uintn hash_nid,
+                           const uint8_t *param, uintn param_size,
+                           const uint8_t *message,
+                           uintn message_size,
+                           const uint8_t *signature,
+                           uintn sig_size)
 {
     return eddsa_verify (context, hash_nid, param, param_size,
                          message, message_size, signature, sig_size);
 }
 
 bool
-sm2_dsa_verify_wrap (void *context, uintn hash_nid,
-                     const uint8_t *param, uintn param_size,
-                     const uint8_t *message,
-                     uintn message_size,
-                     const uint8_t *signature,
-                     uintn sig_size)
+libspdm_sm2_dsa_verify_wrap (void *context, uintn hash_nid,
+                             const uint8_t *param, uintn param_size,
+                             const uint8_t *message,
+                             uintn message_size,
+                             const uint8_t *signature,
+                             uintn sig_size)
 {
     return sm2_dsa_verify (context, hash_nid, param, param_size,
                            message, message_size, signature, sig_size);
@@ -1938,14 +1938,14 @@ sm2_dsa_verify_wrap (void *context, uintn hash_nid,
  *
  * @return asymmetric verify function
  **/
-libspdm_asym_verify_func get_spdm_asym_verify(uint32_t base_asym_algo)
+libspdm_asym_verify_func libspdm_get_asym_verify(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_3072:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_4096:
 #if LIBSPDM_RSA_SSA_SUPPORT == 1
-        return rsa_pkcs1_verify_with_nid_wrap;
+        return libspdm_rsa_pkcs1_verify_with_nid_wrap;
 #else
         ASSERT(false);
         break;
@@ -1954,7 +1954,7 @@ libspdm_asym_verify_func get_spdm_asym_verify(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_3072:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_4096:
 #if LIBSPDM_RSA_PSS_SUPPORT == 1
-        return rsa_pss_verify_wrap;
+        return libspdm_rsa_pss_verify_wrap;
 #else
         ASSERT(false);
         break;
@@ -1963,7 +1963,7 @@ libspdm_asym_verify_func get_spdm_asym_verify(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P521:
 #if LIBSPDM_ECDSA_SUPPORT == 1
-        return ecdsa_verify_wrap;
+        return libspdm_ecdsa_verify_wrap;
 #else
         ASSERT(false);
         break;
@@ -1971,14 +1971,14 @@ libspdm_asym_verify_func get_spdm_asym_verify(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED25519:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
 #if (LIBSPDM_EDDSA_ED25519_SUPPORT == 1) || (LIBSPDM_EDDSA_ED448_SUPPORT == 1)
-        return eddsa_verify_wrap;
+        return libspdm_eddsa_verify_wrap;
 #else
         ASSERT(false);
         break;
 #endif
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_SM2_ECC_SM2_P256:
 #if LIBSPDM_SM2_DSA_SUPPORT == 1
-        return sm2_dsa_verify_wrap;
+        return libspdm_sm2_dsa_verify_wrap;
 #else
         ASSERT(false);
         break;
@@ -2024,10 +2024,10 @@ bool libspdm_asym_verify(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_asym_func_need_hash(base_asym_algo);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_asym_func_need_hash(base_asym_algo);
 
-    verify_function = get_spdm_asym_verify(base_asym_algo);
+    verify_function = libspdm_get_asym_verify(base_asym_algo);
     if (verify_function == NULL) {
         return false;
     }
@@ -2049,15 +2049,15 @@ bool libspdm_asym_verify(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, false, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, false, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, false,
-                                     spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, false,
+                                        spdm12_signing_context_with_hash);
         hash_size = libspdm_get_hash_size(base_hash_algo);
         result = libspdm_hash_all(base_hash_algo, message, message_size,
                                   &spdm12_signing_context_with_hash[
@@ -2125,11 +2125,11 @@ bool libspdm_asym_verify_hash(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_asym_func_need_hash(base_asym_algo);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_asym_func_need_hash(base_asym_algo);
     ASSERT (hash_size == libspdm_get_hash_size(base_hash_algo));
 
-    verify_function = get_spdm_asym_verify(base_asym_algo);
+    verify_function = libspdm_get_asym_verify(base_asym_algo);
     if (verify_function == NULL) {
         return false;
     }
@@ -2151,15 +2151,15 @@ bool libspdm_asym_verify_hash(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, false, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, false, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, false,
-                                     spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, false,
+                                        spdm12_signing_context_with_hash);
         copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
                  sizeof(spdm12_signing_context_with_hash)
                  - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
@@ -2205,7 +2205,7 @@ bool libspdm_asym_verify_hash(
  * @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
  **/
 libspdm_asym_get_private_key_from_pem_func
-get_spdm_asym_get_private_key_from_pem(uint32_t base_asym_algo)
+libspdm_get_asym_get_private_key_from_pem(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
@@ -2273,7 +2273,7 @@ bool libspdm_asym_get_private_key_from_pem(uint32_t base_asym_algo,
 {
     libspdm_asym_get_private_key_from_pem_func asym_get_private_key_from_pem;
     asym_get_private_key_from_pem =
-        get_spdm_asym_get_private_key_from_pem(base_asym_algo);
+        libspdm_get_asym_get_private_key_from_pem(base_asym_algo);
     if (asym_get_private_key_from_pem == NULL) {
         return false;
     }
@@ -2282,55 +2282,55 @@ bool libspdm_asym_get_private_key_from_pem(uint32_t base_asym_algo,
 }
 
 bool
-rsa_pkcs1_sign_with_nid_wrap (void *context, uintn hash_nid,
-                              const uint8_t *param, uintn param_size,
-                              const uint8_t *message,
-                              uintn message_size, uint8_t *signature,
-                              uintn *sig_size)
+libspdm_rsa_pkcs1_sign_with_nid_wrap (void *context, uintn hash_nid,
+                                      const uint8_t *param, uintn param_size,
+                                      const uint8_t *message,
+                                      uintn message_size, uint8_t *signature,
+                                      uintn *sig_size)
 {
     return rsa_pkcs1_sign_with_nid (context, hash_nid,
                                     message, message_size, signature, sig_size);
 }
 
 bool
-rsa_pss_sign_wrap (void *context, uintn hash_nid,
-                   const uint8_t *param, uintn param_size,
-                   const uint8_t *message,
-                   uintn message_size, uint8_t *signature,
-                   uintn *sig_size)
+libspdm_rsa_pss_sign_wrap (void *context, uintn hash_nid,
+                           const uint8_t *param, uintn param_size,
+                           const uint8_t *message,
+                           uintn message_size, uint8_t *signature,
+                           uintn *sig_size)
 {
     return rsa_pss_sign (context, hash_nid,
                          message, message_size, signature, sig_size);
 }
 
 bool
-ecdsa_sign_wrap (void *context, uintn hash_nid,
-                 const uint8_t *param, uintn param_size,
-                 const uint8_t *message,
-                 uintn message_size, uint8_t *signature,
-                 uintn *sig_size)
+libspdm_ecdsa_sign_wrap (void *context, uintn hash_nid,
+                         const uint8_t *param, uintn param_size,
+                         const uint8_t *message,
+                         uintn message_size, uint8_t *signature,
+                         uintn *sig_size)
 {
     return ecdsa_sign (context, hash_nid,
                        message, message_size, signature, sig_size);
 }
 
 bool
-eddsa_sign_wrap (void *context, uintn hash_nid,
-                 const uint8_t *param, uintn param_size,
-                 const uint8_t *message,
-                 uintn message_size, uint8_t *signature,
-                 uintn *sig_size)
+libspdm_eddsa_sign_wrap (void *context, uintn hash_nid,
+                         const uint8_t *param, uintn param_size,
+                         const uint8_t *message,
+                         uintn message_size, uint8_t *signature,
+                         uintn *sig_size)
 {
     return eddsa_sign (context, hash_nid, param, param_size,
                        message, message_size, signature, sig_size);
 }
 
 bool
-sm2_dsa_sign_wrap (void *context, uintn hash_nid,
-                   const uint8_t *param, uintn param_size,
-                   const uint8_t *message,
-                   uintn message_size, uint8_t *signature,
-                   uintn *sig_size)
+libspdm_sm2_dsa_sign_wrap (void *context, uintn hash_nid,
+                           const uint8_t *param, uintn param_size,
+                           const uint8_t *message,
+                           uintn message_size, uint8_t *signature,
+                           uintn *sig_size)
 {
     return sm2_dsa_sign (context, hash_nid, param, param_size,
                          message, message_size, signature, sig_size);
@@ -2343,14 +2343,14 @@ sm2_dsa_sign_wrap (void *context, uintn hash_nid,
  *
  * @return asymmetric sign function
  **/
-libspdm_asym_sign_func get_spdm_asym_sign(uint32_t base_asym_algo)
+libspdm_asym_sign_func libspdm_get_asym_sign(uint32_t base_asym_algo)
 {
     switch (base_asym_algo) {
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_3072:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_4096:
 #if LIBSPDM_RSA_SSA_SUPPORT == 1
-        return rsa_pkcs1_sign_with_nid_wrap;
+        return libspdm_rsa_pkcs1_sign_with_nid_wrap;
 #else
         ASSERT(false);
         break;
@@ -2359,7 +2359,7 @@ libspdm_asym_sign_func get_spdm_asym_sign(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_3072:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_4096:
 #if LIBSPDM_RSA_PSS_SUPPORT == 1
-        return rsa_pss_sign_wrap;
+        return libspdm_rsa_pss_sign_wrap;
 #else
         ASSERT(false);
         break;
@@ -2368,7 +2368,7 @@ libspdm_asym_sign_func get_spdm_asym_sign(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P521:
 #if LIBSPDM_ECDSA_SUPPORT == 1
-        return ecdsa_sign_wrap;
+        return libspdm_ecdsa_sign_wrap;
 #else
         ASSERT(false);
         break;
@@ -2376,14 +2376,14 @@ libspdm_asym_sign_func get_spdm_asym_sign(uint32_t base_asym_algo)
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED25519:
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
 #if (LIBSPDM_EDDSA_ED25519_SUPPORT == 1) || (LIBSPDM_EDDSA_ED448_SUPPORT == 1)
-        return eddsa_sign_wrap;
+        return libspdm_eddsa_sign_wrap;
 #else
         ASSERT(false);
         break;
 #endif
     case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_SM2_ECC_SM2_P256:
 #if LIBSPDM_SM2_DSA_SUPPORT == 1
-        return sm2_dsa_sign_wrap;
+        return libspdm_sm2_dsa_sign_wrap;
 #else
         ASSERT(false);
         break;
@@ -2433,10 +2433,10 @@ bool libspdm_asym_sign(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_asym_func_need_hash(base_asym_algo);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_asym_func_need_hash(base_asym_algo);
 
-    asym_sign = get_spdm_asym_sign(base_asym_algo);
+    asym_sign = libspdm_get_asym_sign(base_asym_algo);
     if (asym_sign == NULL) {
         return false;
     }
@@ -2458,15 +2458,15 @@ bool libspdm_asym_sign(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, false, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, false, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, false,
-                                     spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, false,
+                                        spdm12_signing_context_with_hash);
         hash_size = libspdm_get_hash_size(base_hash_algo);
         result = libspdm_hash_all(base_hash_algo, message, message_size,
                                   &spdm12_signing_context_with_hash[
@@ -2538,11 +2538,11 @@ bool libspdm_asym_sign_hash(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_asym_func_need_hash(base_asym_algo);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_asym_func_need_hash(base_asym_algo);
     ASSERT (hash_size == libspdm_get_hash_size(base_hash_algo));
 
-    asym_sign = get_spdm_asym_sign(base_asym_algo);
+    asym_sign = libspdm_get_asym_sign(base_asym_algo);
     if (asym_sign == NULL) {
         return false;
     }
@@ -2564,15 +2564,15 @@ bool libspdm_asym_sign_hash(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, false, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, false, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, false,
-                                     spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, false,
+                                        spdm12_signing_context_with_hash);
         copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
                  sizeof(spdm12_signing_context_with_hash)
                  - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
@@ -2630,9 +2630,9 @@ uint32_t libspdm_get_req_asym_signature_size(uint16_t req_base_asym_alg)
  * @return requester asymmetric GET_PUBLIC_KEY_FROM_X509 function
  **/
 libspdm_asym_get_public_key_from_x509_func
-get_spdm_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg)
+libspdm_get_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg)
 {
-    return get_spdm_asym_get_public_key_from_x509(req_base_asym_alg);
+    return libspdm_get_asym_get_public_key_from_x509(req_base_asym_alg);
 }
 
 /**
@@ -2655,7 +2655,7 @@ bool libspdm_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg,
 {
     libspdm_asym_get_public_key_from_x509_func get_public_key_from_x509_function;
     get_public_key_from_x509_function =
-        get_spdm_req_asym_get_public_key_from_x509(req_base_asym_alg);
+        libspdm_get_req_asym_get_public_key_from_x509(req_base_asym_alg);
     if (get_public_key_from_x509_function == NULL) {
         return false;
     }
@@ -2669,9 +2669,9 @@ bool libspdm_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg,
  *
  * @return requester asymmetric free function
  **/
-libspdm_asym_free_func get_spdm_req_asym_free(uint16_t req_base_asym_alg)
+libspdm_asym_free_func libspdm_get_req_asym_free(uint16_t req_base_asym_alg)
 {
-    return get_spdm_asym_free(req_base_asym_alg);
+    return libspdm_get_asym_free(req_base_asym_alg);
 }
 
 /**
@@ -2684,7 +2684,7 @@ libspdm_asym_free_func get_spdm_req_asym_free(uint16_t req_base_asym_alg)
 void libspdm_req_asym_free(uint16_t req_base_asym_alg, void *context)
 {
     libspdm_asym_free_func free_function;
-    free_function = get_spdm_req_asym_free(req_base_asym_alg);
+    free_function = libspdm_get_req_asym_free(req_base_asym_alg);
     if (free_function == NULL) {
         return;
     }
@@ -2699,9 +2699,9 @@ void libspdm_req_asym_free(uint16_t req_base_asym_alg, void *context)
  * @retval true  requester asymmetric function need message hash
  * @retval false requester asymmetric function need raw message
  **/
-bool spdm_req_asym_func_need_hash(uint16_t req_base_asym_alg)
+bool libspdm_req_asym_func_need_hash(uint16_t req_base_asym_alg)
 {
-    return spdm_asym_func_need_hash(req_base_asym_alg);
+    return libspdm_asym_func_need_hash(req_base_asym_alg);
 }
 
 /**
@@ -2711,9 +2711,9 @@ bool spdm_req_asym_func_need_hash(uint16_t req_base_asym_alg)
  *
  * @return requester asymmetric verify function
  **/
-libspdm_asym_verify_func get_spdm_req_asym_verify(uint16_t req_base_asym_alg)
+libspdm_asym_verify_func libspdm_get_req_asym_verify(uint16_t req_base_asym_alg)
 {
-    return get_spdm_asym_verify(req_base_asym_alg);
+    return libspdm_get_asym_verify(req_base_asym_alg);
 }
 
 /**
@@ -2749,10 +2749,10 @@ bool libspdm_req_asym_verify(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_req_asym_func_need_hash(req_base_asym_alg);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_req_asym_func_need_hash(req_base_asym_alg);
 
-    verify_function = get_spdm_req_asym_verify(req_base_asym_alg);
+    verify_function = libspdm_get_req_asym_verify(req_base_asym_alg);
     if (verify_function == NULL) {
         return false;
     }
@@ -2774,14 +2774,15 @@ bool libspdm_req_asym_verify(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, true, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, true, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, true,
+                                        spdm12_signing_context_with_hash);
         hash_size = libspdm_get_hash_size(base_hash_algo);
         result = libspdm_hash_all(base_hash_algo, message, message_size,
                                   &spdm12_signing_context_with_hash[
@@ -2849,11 +2850,11 @@ bool libspdm_req_asym_verify_hash(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_req_asym_func_need_hash(req_base_asym_alg);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_req_asym_func_need_hash(req_base_asym_alg);
     ASSERT (hash_size == libspdm_get_hash_size(base_hash_algo));
 
-    verify_function = get_spdm_req_asym_verify(req_base_asym_alg);
+    verify_function = libspdm_get_req_asym_verify(req_base_asym_alg);
     if (verify_function == NULL) {
         return false;
     }
@@ -2875,14 +2876,15 @@ bool libspdm_req_asym_verify_hash(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, true, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, true, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, true,
+                                        spdm12_signing_context_with_hash);
         copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
                  sizeof(spdm12_signing_context_with_hash)
                  - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
@@ -2928,9 +2930,9 @@ bool libspdm_req_asym_verify_hash(
  * @return asymmetric GET_PRIVATE_KEY_FROM_PEM function
  **/
 libspdm_asym_get_private_key_from_pem_func
-get_spdm_req_asym_get_private_key_from_pem(uint16_t req_base_asym_alg)
+libspdm_get_req_asym_get_private_key_from_pem(uint16_t req_base_asym_alg)
 {
-    return get_spdm_asym_get_private_key_from_pem(req_base_asym_alg);
+    return libspdm_get_asym_get_private_key_from_pem(req_base_asym_alg);
 }
 
 /**
@@ -2954,7 +2956,7 @@ bool libspdm_req_asym_get_private_key_from_pem(uint16_t req_base_asym_alg,
 {
     libspdm_asym_get_private_key_from_pem_func asym_get_private_key_from_pem;
     asym_get_private_key_from_pem =
-        get_spdm_req_asym_get_private_key_from_pem(req_base_asym_alg);
+        libspdm_get_req_asym_get_private_key_from_pem(req_base_asym_alg);
     if (asym_get_private_key_from_pem == NULL) {
         return false;
     }
@@ -2969,9 +2971,9 @@ bool libspdm_req_asym_get_private_key_from_pem(uint16_t req_base_asym_alg,
  *
  * @return asymmetric sign function
  **/
-libspdm_asym_sign_func get_spdm_req_asym_sign(uint16_t req_base_asym_alg)
+libspdm_asym_sign_func libspdm_get_req_asym_sign(uint16_t req_base_asym_alg)
 {
-    return get_spdm_asym_sign(req_base_asym_alg);
+    return libspdm_get_asym_sign(req_base_asym_alg);
 }
 
 /**
@@ -3011,10 +3013,10 @@ bool libspdm_req_asym_sign(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_req_asym_func_need_hash(req_base_asym_alg);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_req_asym_func_need_hash(req_base_asym_alg);
 
-    asym_sign = get_spdm_req_asym_sign(req_base_asym_alg);
+    asym_sign = libspdm_get_req_asym_sign(req_base_asym_alg);
     if (asym_sign == NULL) {
         return false;
     }
@@ -3036,14 +3038,15 @@ bool libspdm_req_asym_sign(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, true, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, true, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, true,
+                                        spdm12_signing_context_with_hash);
         hash_size = libspdm_get_hash_size(base_hash_algo);
         result = libspdm_hash_all(base_hash_algo, message, message_size,
                                   &spdm12_signing_context_with_hash[
@@ -3115,11 +3118,11 @@ bool libspdm_req_asym_sign_hash(
     void *param;
     uintn param_size;
 
-    hash_nid = get_spdm_hash_nid(base_hash_algo);
-    need_hash = spdm_req_asym_func_need_hash(req_base_asym_alg);
+    hash_nid = libspdm_get_hash_nid(base_hash_algo);
+    need_hash = libspdm_req_asym_func_need_hash(req_base_asym_alg);
     ASSERT (hash_size == libspdm_get_hash_size(base_hash_algo));
 
-    asym_sign = get_spdm_req_asym_sign(req_base_asym_alg);
+    asym_sign = libspdm_get_req_asym_sign(req_base_asym_alg);
     if (asym_sign == NULL) {
         return false;
     }
@@ -3141,14 +3144,15 @@ bool libspdm_req_asym_sign_hash(
             break;
         case SPDM_ALGORITHMS_BASE_ASYM_ALGO_EDDSA_ED448:
             hash_nid = CRYPTO_NID_NULL;
-            param = get_spdm_signing_context_string (spdm_version, op_code, true, &param_size);
+            param = libspdm_get_signing_context_string (spdm_version, op_code, true, &param_size);
             break;
         default:
             /* pass thru for rest algorithm */
             break;
         }
 
-        create_spdm_signing_context (spdm_version, op_code, true, spdm12_signing_context_with_hash);
+        libspdm_create_signing_context (spdm_version, op_code, true,
+                                        spdm12_signing_context_with_hash);
         copy_mem(&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE],
                  sizeof(spdm12_signing_context_with_hash)
                  - (&spdm12_signing_context_with_hash[SPDM_VERSION_1_2_SIGNING_CONTEXT_SIZE]
@@ -3222,7 +3226,7 @@ uint32_t libspdm_get_dhe_pub_key_size(uint16_t dhe_named_group)
  *
  * @return DHE cipher ID
  **/
-uintn get_spdm_dhe_nid(uint16_t dhe_named_group)
+uintn libspdm_get_dhe_nid(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
     case SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048:
@@ -3251,7 +3255,7 @@ uintn get_spdm_dhe_nid(uint16_t dhe_named_group)
  *
  * @return DHE new by NID function
  **/
-libspdm_dhe_new_by_nid_func get_spdm_dhe_new(uint16_t dhe_named_group)
+libspdm_dhe_new_by_nid_func libspdm_get_dhe_new(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
     case SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048:
@@ -3305,11 +3309,11 @@ void *libspdm_dhe_new(spdm_version_number_t spdm_version,
     uintn nid;
     void *context;
 
-    new_function = get_spdm_dhe_new(dhe_named_group);
+    new_function = libspdm_get_dhe_new(dhe_named_group);
     if (new_function == NULL) {
         return NULL;
     }
-    nid = get_spdm_dhe_nid(dhe_named_group);
+    nid = libspdm_get_dhe_nid(dhe_named_group);
     if (nid == 0) {
         return NULL;
     }
@@ -3363,7 +3367,7 @@ void *libspdm_dhe_new(spdm_version_number_t spdm_version,
  *
  * @return DHE free function
  **/
-libspdm_dhe_free_func get_spdm_dhe_free(uint16_t dhe_named_group)
+libspdm_dhe_free_func libspdm_get_dhe_free(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
     case SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048:
@@ -3409,7 +3413,7 @@ libspdm_dhe_free_func get_spdm_dhe_free(uint16_t dhe_named_group)
 void libspdm_dhe_free(uint16_t dhe_named_group, void *context)
 {
     libspdm_dhe_free_func free_function;
-    free_function = get_spdm_dhe_free(dhe_named_group);
+    free_function = libspdm_get_dhe_free(dhe_named_group);
     if (free_function == NULL) {
         return;
     }
@@ -3423,7 +3427,7 @@ void libspdm_dhe_free(uint16_t dhe_named_group, void *context)
  *
  * @return DHE generate key function
  **/
-libspdm_dhe_generate_key_func get_spdm_dhe_generate_key(uint16_t dhe_named_group)
+libspdm_dhe_generate_key_func libspdm_get_dhe_generate_key(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
     case SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048:
@@ -3483,7 +3487,7 @@ bool libspdm_dhe_generate_key(uint16_t dhe_named_group, void *context,
                               uintn *public_key_size)
 {
     libspdm_dhe_generate_key_func generate_key_function;
-    generate_key_function = get_spdm_dhe_generate_key(dhe_named_group);
+    generate_key_function = libspdm_get_dhe_generate_key(dhe_named_group);
     if (generate_key_function == NULL) {
         return false;
     }
@@ -3497,7 +3501,7 @@ bool libspdm_dhe_generate_key(uint16_t dhe_named_group, void *context,
  *
  * @return DHE compute key function
  **/
-libspdm_dhe_compute_key_func get_spdm_dhe_compute_key(uint16_t dhe_named_group)
+libspdm_dhe_compute_key_func libspdm_get_dhe_compute_key(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
     case SPDM_ALGORITHMS_DHE_NAMED_GROUP_FFDHE_2048:
@@ -3558,7 +3562,7 @@ bool libspdm_dhe_compute_key(uint16_t dhe_named_group, void *context,
                              uintn *key_size)
 {
     libspdm_dhe_compute_key_func compute_key_function;
-    compute_key_function = get_spdm_dhe_compute_key(dhe_named_group);
+    compute_key_function = libspdm_get_dhe_compute_key(dhe_named_group);
     if (compute_key_function == NULL) {
         return false;
     }
@@ -3649,7 +3653,7 @@ uint32_t libspdm_get_aead_tag_size(uint16_t aead_cipher_suite)
  *
  * @return AEAD encryption function
  **/
-libspdm_aead_encrypt_func get_spdm_aead_enc_func(uint16_t aead_cipher_suite)
+libspdm_aead_encrypt_func libspdm_get_aead_enc_func(uint16_t aead_cipher_suite)
 {
     switch (aead_cipher_suite) {
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM:
@@ -3719,7 +3723,7 @@ bool libspdm_aead_encryption(const spdm_version_number_t secured_message_version
                              uintn *data_out_size)
 {
     libspdm_aead_encrypt_func aead_enc_function;
-    aead_enc_function = get_spdm_aead_enc_func(aead_cipher_suite);
+    aead_enc_function = libspdm_get_aead_enc_func(aead_cipher_suite);
     if (aead_enc_function == NULL) {
         return false;
     }
@@ -3735,7 +3739,7 @@ bool libspdm_aead_encryption(const spdm_version_number_t secured_message_version
  *
  * @return AEAD decryption function
  **/
-libspdm_aead_decrypt_func get_spdm_aead_dec_func(uint16_t aead_cipher_suite)
+libspdm_aead_decrypt_func libspdm_get_aead_dec_func(uint16_t aead_cipher_suite)
 {
     switch (aead_cipher_suite) {
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM:
@@ -3805,7 +3809,7 @@ bool libspdm_aead_decryption(const spdm_version_number_t secured_message_version
                              uintn *data_out_size)
 {
     libspdm_aead_decrypt_func aead_dec_function;
-    aead_dec_function = get_spdm_aead_dec_func(aead_cipher_suite);
+    aead_dec_function = libspdm_get_aead_dec_func(aead_cipher_suite);
     if (aead_dec_function == NULL) {
         return false;
     }
@@ -3838,10 +3842,10 @@ bool libspdm_get_random_number(uintn size, uint8_t *rand)
  * @retval  true   verification pass.
  * @retval  false  verification fail.
  **/
-static bool internal_spdm_x509_date_time_check(const uint8_t *from,
-                                               uintn from_size,
-                                               const uint8_t *to,
-                                               uintn to_size)
+static bool libspdm_internal_x509_date_time_check(const uint8_t *from,
+                                                  uintn from_size,
+                                                  const uint8_t *to,
+                                                  uintn to_size)
 {
     intn ret;
     return_status status;
@@ -3983,7 +3987,7 @@ bool libspdm_x509_certificate_check(const uint8_t *cert, uintn cert_size)
         goto cleanup;
     }
 
-    status = internal_spdm_x509_date_time_check(
+    status = libspdm_internal_x509_date_time_check(
         end_cert_from, end_cert_from_len, end_cert_to, end_cert_to_len);
     if (!status) {
         goto cleanup;
@@ -4108,7 +4112,7 @@ bool libspdm_is_root_certificate(const uint8_t *cert, uintn cert_size)
     return true;
 }
 
-static uint8_t m_oid_subject_alt_name[] = { 0x55, 0x1D, 0x11 };
+static uint8_t m_libspdm_oid_subject_alt_name[] = { 0x55, 0x1D, 0x11 };
 
 /**
  * Retrieve the SubjectAltName from SubjectAltName Bytes.
@@ -4239,8 +4243,8 @@ libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const intn cert_size,
 
     extension_data_size = 0;
     status = x509_get_extension_data(cert, cert_size,
-                                     m_oid_subject_alt_name,
-                                     sizeof(m_oid_subject_alt_name), NULL,
+                                     m_libspdm_oid_subject_alt_name,
+                                     sizeof(m_libspdm_oid_subject_alt_name), NULL,
                                      &extension_data_size);
     if (status != RETURN_BUFFER_TOO_SMALL) {
         return RETURN_NOT_FOUND;
@@ -4251,8 +4255,8 @@ libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const intn cert_size,
     }
     status =
         x509_get_extension_data(cert, cert_size,
-                                m_oid_subject_alt_name,
-                                sizeof(m_oid_subject_alt_name),
+                                m_libspdm_oid_subject_alt_name,
+                                sizeof(m_libspdm_oid_subject_alt_name),
                                 (uint8_t *)name_buffer, name_buffer_size);
     if (RETURN_ERROR(status)) {
         return status;

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -16,7 +16,7 @@ typedef struct {
     uint16_t opaque_length;
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
     uint8_t signature[LIBSPDM_MAX_ASYM_KEY_SIZE];
-} spdm_challenge_auth_response_max_t;
+} libspdm_challenge_auth_response_max_t;
 
 #pragma pack()
 
@@ -44,18 +44,18 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_challenge(void *context, uint8_t slot_id,
-                                 uint8_t measurement_hash_type,
-                                 void *measurement_hash,
-                                 uint8_t *slot_mask,
-                                 const void *requester_nonce_in,
-                                 void *requester_nonce,
-                                 void *responder_nonce)
+return_status libspdm_try_challenge(void *context, uint8_t slot_id,
+                                    uint8_t measurement_hash_type,
+                                    void *measurement_hash,
+                                    uint8_t *slot_mask,
+                                    const void *requester_nonce_in,
+                                    void *requester_nonce,
+                                    void *responder_nonce)
 {
     return_status status;
     bool result;
     spdm_challenge_request_t spdm_request;
-    spdm_challenge_auth_response_max_t spdm_response;
+    libspdm_challenge_auth_response_max_t spdm_response;
     uintn spdm_response_size;
     uint8_t *ptr;
     void *cert_chain_hash;
@@ -136,7 +136,7 @@ return_status try_spdm_challenge(void *context, uint8_t slot_id,
             spdm_context, NULL,
             &spdm_response_size,
             &spdm_response, SPDM_CHALLENGE, SPDM_CHALLENGE_AUTH,
-            sizeof(spdm_challenge_auth_response_max_t));
+            sizeof(libspdm_challenge_auth_response_max_t));
         if (RETURN_ERROR(status)) {
             return status;
         }
@@ -332,9 +332,9 @@ return_status libspdm_challenge(void *context, uint8_t slot_id,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_challenge(spdm_context, slot_id,
-                                    measurement_hash_type,
-                                    measurement_hash, slot_mask, NULL, NULL, NULL);
+        status = libspdm_try_challenge(spdm_context, slot_id,
+                                       measurement_hash_type,
+                                       measurement_hash, slot_mask, NULL, NULL, NULL);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }
@@ -381,12 +381,12 @@ return_status libspdm_challenge_ex(void *context, uint8_t slot_id,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_challenge(spdm_context, slot_id,
-                                    measurement_hash_type,
-                                    measurement_hash,
-                                    slot_mask,
-                                    requester_nonce_in,
-                                    requester_nonce, responder_nonce);
+        status = libspdm_try_challenge(spdm_context, slot_id,
+                                       measurement_hash_type,
+                                       measurement_hash,
+                                       slot_mask,
+                                       requester_nonce_in,
+                                       requester_nonce, responder_nonce);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -9,9 +9,9 @@
 typedef struct {
     uint8_t request_response_code;
     libspdm_get_encap_response_func get_encap_response_func;
-} spdm_get_encap_response_struct_t;
+} libspdm_get_encap_response_struct_t;
 
-spdm_get_encap_response_struct_t m_spdm_get_encap_response_struct[] = {
+libspdm_get_encap_response_struct_t m_libspdm_get_encap_response_struct[] = {
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
     { SPDM_GET_DIGESTS, libspdm_get_encap_response_digest },
@@ -54,18 +54,18 @@ void libspdm_register_get_encap_response_func(void *context,
  * @return GET_ENCAP_RESPONSE function according to the request code.
  **/
 libspdm_get_encap_response_func
-SpdmGetEncapResponseFuncViaRequestCode(uint8_t request_response_code)
+libspdm_get_encap_response_func_via_request_code(uint8_t request_response_code)
 {
     uintn index;
 
     for (index = 0;
-         index < sizeof(m_spdm_get_encap_response_struct) /
-         sizeof(m_spdm_get_encap_response_struct[0]);
+         index < sizeof(m_libspdm_get_encap_response_struct) /
+         sizeof(m_libspdm_get_encap_response_struct[0]);
          index++) {
         if (request_response_code ==
-            m_spdm_get_encap_response_struct[index]
+            m_libspdm_get_encap_response_struct[index]
             .request_response_code) {
-            return m_spdm_get_encap_response_struct[index]
+            return m_libspdm_get_encap_response_struct[index]
                    .get_encap_response_func;
         }
     }
@@ -84,11 +84,11 @@ SpdmGetEncapResponseFuncViaRequestCode(uint8_t request_response_code)
  * @retval RETURN_SUCCESS               The SPDM response is processed successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is sent to the device.
  **/
-return_status SpdmProcessEncapsulatedRequest(libspdm_context_t *spdm_context,
-                                             uintn encap_request_size,
-                                             void *encap_request,
-                                             uintn *encap_response_size,
-                                             void *encap_response)
+return_status libspdm_process_encapsulated_request(libspdm_context_t *spdm_context,
+                                                   uintn encap_request_size,
+                                                   void *encap_request,
+                                                   uintn *encap_response_size,
+                                                   void *encap_response)
 {
     libspdm_get_encap_response_func get_encap_response_func;
     return_status status;
@@ -102,7 +102,7 @@ return_status SpdmProcessEncapsulatedRequest(libspdm_context_t *spdm_context,
             encap_response_size, encap_response);
     }
 
-    get_encap_response_func = SpdmGetEncapResponseFuncViaRequestCode(
+    get_encap_response_func = libspdm_get_encap_response_func_via_request_code(
         spdm_requester->request_response_code);
     if (get_encap_response_func == NULL) {
         get_encap_response_func =
@@ -298,7 +298,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             sizeof(request) -
             sizeof(spdm_deliver_encapsulated_response_request_t);
 
-        status = SpdmProcessEncapsulatedRequest(
+        status = libspdm_process_encapsulated_request(
             spdm_context, encapsulated_request_size,
             encapsulated_request, &encapsulated_response_size,
             encapsulated_response);

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -11,7 +11,7 @@
 typedef struct {
     spdm_message_header_t header;
     uint8_t dummy_data[sizeof(spdm_error_data_response_not_ready_t)];
-} spdm_end_session_response_mine_t;
+} libspdm_end_session_response_mine_t;
 
 #pragma pack()
 
@@ -32,7 +32,7 @@ return_status libspdm_try_send_receive_end_session(libspdm_context_t *spdm_conte
     return_status status;
     spdm_end_session_request_t spdm_request;
     uintn spdm_request_size;
-    spdm_end_session_response_mine_t spdm_response;
+    libspdm_end_session_response_mine_t spdm_response;
     uintn spdm_response_size;
     libspdm_session_info_t *session_info;
     libspdm_session_state_t session_state;
@@ -93,7 +93,7 @@ return_status libspdm_try_send_receive_end_session(libspdm_context_t *spdm_conte
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_END_SESSION, SPDM_END_SESSION_ACK,
-            sizeof(spdm_end_session_response_mine_t));
+            sizeof(libspdm_end_session_response_mine_t));
         if (RETURN_ERROR(status)) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -12,12 +12,12 @@ typedef struct {
     spdm_message_header_t header;
     uint8_t signature[LIBSPDM_MAX_ASYM_KEY_SIZE];
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
-} spdm_finish_request_mine_t;
+} libspdm_finish_request_mine_t;
 
 typedef struct {
     spdm_message_header_t header;
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
-} spdm_finish_response_mine_t;
+} libspdm_finish_response_mine_t;
 
 #pragma pack()
 
@@ -38,11 +38,11 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
                                               uint8_t req_slot_id_param)
 {
     return_status status;
-    spdm_finish_request_mine_t spdm_request;
+    libspdm_finish_request_mine_t spdm_request;
     uintn spdm_request_size;
     uintn signature_size;
     uintn hmac_size;
-    spdm_finish_response_mine_t spdm_response;
+    libspdm_finish_response_mine_t spdm_response;
     uintn spdm_response_size;
     libspdm_session_info_t *session_info;
     uint8_t *ptr;
@@ -200,7 +200,7 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_FINISH, SPDM_FINISH_RSP,
-            sizeof(spdm_finish_response_mine_t));
+            sizeof(libspdm_finish_response_mine_t));
         if (RETURN_ERROR(status)) {
             goto error;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -17,8 +17,8 @@
  * @retval True                         The received Capabilities flag is valid.
  * @retval False                        The received Capabilities flag is invalid.
  **/
-bool spdm_check_response_flag_compability(uint32_t capabilities_flag,
-                                          uint8_t version)
+bool libspdm_check_response_flag_compability(uint32_t capabilities_flag,
+                                             uint8_t version)
 {
     /*uint8_t cache_cap = (uint8_t)(capabilities_flag)&0x01;*/
     uint8_t cert_cap = (uint8_t)(capabilities_flag >> 1) & 0x01;
@@ -182,7 +182,7 @@ return_status libspdm_try_get_capabilities(libspdm_context_t *spdm_context)
                              sizeof(spdm_response.max_spdm_msg_size);
     }
 
-    if (!spdm_check_response_flag_compability(
+    if (!libspdm_check_response_flag_compability(
             spdm_response.flags, spdm_response.header.spdm_version)) {
         return RETURN_DEVICE_ERROR;
     }

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -15,7 +15,7 @@ typedef struct {
     uint16_t portion_length;
     uint16_t remainder_length;
     uint8_t cert_chain[LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN];
-} spdm_certificate_response_max_t;
+} libspdm_certificate_response_max_t;
 
 #pragma pack()
 
@@ -42,17 +42,17 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
-                                       uint16_t length,
-                                       uintn *cert_chain_size,
-                                       void *cert_chain,
-                                       void **trust_anchor,
-                                       uintn *trust_anchor_size)
+return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
+                                          uint16_t length,
+                                          uintn *cert_chain_size,
+                                          void *cert_chain,
+                                          void **trust_anchor,
+                                          uintn *trust_anchor_size)
 {
     bool result;
     return_status status;
     spdm_get_certificate_request_t spdm_request;
-    spdm_certificate_response_max_t spdm_response;
+    libspdm_certificate_response_max_t spdm_response;
     uintn spdm_response_size;
     libspdm_large_managed_buffer_t certificate_chain_buffer;
     libspdm_context_t *spdm_context;
@@ -129,7 +129,7 @@ return_status try_spdm_get_certificate(void *context, uint8_t slot_id,
                 &spdm_response_size,
                 &spdm_response, SPDM_GET_CERTIFICATE,
                 SPDM_CERTIFICATE,
-                sizeof(spdm_certificate_response_max_t));
+                sizeof(libspdm_certificate_response_max_t));
             if (RETURN_ERROR(status)) {
                 goto done;
             }
@@ -388,8 +388,8 @@ return_status libspdm_get_certificate_choose_length(void *context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_certificate(spdm_context, slot_id, length,
-                                          cert_chain_size, cert_chain, NULL, NULL);
+        status = libspdm_try_get_certificate(spdm_context, slot_id, length,
+                                             cert_chain_size, cert_chain, NULL, NULL);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }
@@ -437,9 +437,9 @@ return_status libspdm_get_certificate_choose_length_ex(void *context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_certificate(spdm_context, slot_id, length,
-                                          cert_chain_size, cert_chain, trust_anchor,
-                                          trust_anchor_size);
+        status = libspdm_try_get_certificate(spdm_context, slot_id, length,
+                                             cert_chain_size, cert_chain, trust_anchor,
+                                             trust_anchor_size);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -11,7 +11,7 @@
 typedef struct {
     spdm_message_header_t header;
     uint8_t digest[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-} spdm_digests_response_max_t;
+} libspdm_digests_response_max_t;
 
 #pragma pack()
 
@@ -34,13 +34,13 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_get_digest(void *context, uint8_t *slot_mask,
-                                  void *total_digest_buffer)
+return_status libspdm_try_get_digest(void *context, uint8_t *slot_mask,
+                                     void *total_digest_buffer)
 {
     bool result;
     return_status status;
     spdm_get_digest_request_t spdm_request;
-    spdm_digests_response_max_t spdm_response;
+    libspdm_digests_response_max_t spdm_response;
     uintn spdm_response_size;
     uintn digest_size;
     uintn digest_count;
@@ -89,7 +89,7 @@ return_status try_spdm_get_digest(void *context, uint8_t *slot_mask,
             spdm_context, NULL,
             &spdm_response_size,
             &spdm_response, SPDM_GET_DIGESTS, SPDM_DIGESTS,
-            sizeof(spdm_digests_response_max_t));
+            sizeof(libspdm_digests_response_max_t));
         if (RETURN_ERROR(status)) {
             return status;
         }
@@ -193,8 +193,8 @@ return_status libspdm_get_digest(void *context, uint8_t *slot_mask,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_digest(spdm_context, slot_mask,
-                                     total_digest_buffer);
+        status = libspdm_try_get_digest(spdm_context, slot_mask,
+                                        total_digest_buffer);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -18,7 +18,7 @@ typedef struct {
     uint16_t opaque_length;
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
     uint8_t signature[LIBSPDM_MAX_ASYM_KEY_SIZE];
-} spdm_measurements_response_max_t;
+} libspdm_measurements_response_max_t;
 #pragma pack()
 
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
@@ -49,23 +49,23 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_get_measurement(void *context, const uint32_t *session_id,
-                                       uint8_t request_attribute,
-                                       uint8_t measurement_operation,
-                                       uint8_t slot_id_param,
-                                       uint8_t *content_changed,
-                                       uint8_t *number_of_blocks,
-                                       uint32_t *measurement_record_length,
-                                       void *measurement_record,
-                                       const void *requester_nonce_in,
-                                       void *requester_nonce,
-                                       void *responder_nonce)
+return_status libspdm_try_get_measurement(void *context, const uint32_t *session_id,
+                                          uint8_t request_attribute,
+                                          uint8_t measurement_operation,
+                                          uint8_t slot_id_param,
+                                          uint8_t *content_changed,
+                                          uint8_t *number_of_blocks,
+                                          uint32_t *measurement_record_length,
+                                          void *measurement_record,
+                                          const void *requester_nonce_in,
+                                          void *requester_nonce,
+                                          void *responder_nonce)
 {
     bool result;
     return_status status;
     spdm_get_measurements_request_t spdm_request;
     uintn spdm_request_size;
-    spdm_measurements_response_max_t spdm_response;
+    libspdm_measurements_response_max_t spdm_response;
     uintn spdm_response_size;
     uint32_t measurement_record_data_length;
     uint8_t *measurement_record_data;
@@ -200,7 +200,7 @@ return_status try_spdm_get_measurement(void *context, const uint32_t *session_id
             spdm_context, session_id,
             &spdm_response_size, &spdm_response,
             SPDM_GET_MEASUREMENTS, SPDM_MEASUREMENTS,
-            sizeof(spdm_measurements_response_max_t));
+            sizeof(libspdm_measurements_response_max_t));
         if (RETURN_ERROR(status)) {
             return status;
         }
@@ -515,7 +515,7 @@ return_status libspdm_get_measurement(void *context, const uint32_t *session_id,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_measurement(
+        status = libspdm_try_get_measurement(
             spdm_context, session_id, request_attribute,
             measurement_operation, slot_id_param, content_changed, number_of_blocks,
             measurement_record_length, measurement_record, NULL, NULL, NULL);
@@ -572,7 +572,7 @@ return_status libspdm_get_measurement_ex(void *context, const uint32_t *session_
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_get_measurement(
+        status = libspdm_try_get_measurement(
             spdm_context, session_id, request_attribute,
             measurement_operation, slot_id_param, content_changed, number_of_blocks,
             measurement_record_length, measurement_record,

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -12,7 +12,7 @@ typedef struct {
     uint8_t reserved;
     uint8_t version_number_entry_count;
     spdm_version_number_t version_number_entry[LIBSPDM_MAX_VERSION_COUNT];
-} spdm_version_response_max_t;
+} libspdm_version_response_max_t;
 #pragma pack()
 
 
@@ -31,7 +31,7 @@ return_status libspdm_try_get_version(libspdm_context_t *spdm_context,
     return_status status;
     bool result;
     spdm_get_version_request_t spdm_request;
-    spdm_version_response_max_t spdm_response;
+    libspdm_version_response_max_t spdm_response;
     uintn spdm_response_size;
     spdm_version_number_t common_version;
 

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -21,12 +21,12 @@
  * @retval RETURN_SUCCESS               The RESPOND_IF_READY is sent and an expected SPDM response is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_requester_respond_if_ready(libspdm_context_t *spdm_context,
-                                              const uint32_t *session_id,
-                                              uintn *response_size,
-                                              void *response,
-                                              uint8_t expected_response_code,
-                                              uintn expected_response_size)
+return_status libspdm_requester_respond_if_ready(libspdm_context_t *spdm_context,
+                                                 const uint32_t *session_id,
+                                                 uintn *response_size,
+                                                 void *response,
+                                                 uint8_t expected_response_code,
+                                                 uintn expected_response_size)
 {
     return_status status;
     spdm_response_if_ready_request_t spdm_request;
@@ -119,13 +119,13 @@ return_status libspdm_handle_simple_error_response(void *context,
  * @retval RETURN_SUCCESS               The RESPOND_IF_READY is sent and an expected SPDM response is received.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
-return_status spdm_handle_response_not_ready(libspdm_context_t *spdm_context,
-                                             const uint32_t *session_id,
-                                             uintn *response_size,
-                                             void *response,
-                                             uint8_t original_request_code,
-                                             uint8_t expected_response_code,
-                                             uintn expected_response_size)
+return_status libspdm_handle_response_not_ready(libspdm_context_t *spdm_context,
+                                                const uint32_t *session_id,
+                                                uintn *response_size,
+                                                void *response,
+                                                uint8_t original_request_code,
+                                                uint8_t expected_response_code,
+                                                uintn expected_response_size)
 {
     spdm_error_response_t *spdm_response;
     spdm_error_data_response_not_ready_t *extend_error_data;
@@ -151,10 +151,10 @@ return_status spdm_handle_response_not_ready(libspdm_context_t *spdm_context,
     spdm_context->error_data.rd_tm = extend_error_data->rd_tm;
 
     libspdm_sleep((2 << extend_error_data->rd_exponent)/1000);
-    return spdm_requester_respond_if_ready(spdm_context, session_id,
-                                           response_size, response,
-                                           expected_response_code,
-                                           expected_response_size);
+    return libspdm_requester_respond_if_ready(spdm_context, session_id,
+                                              response_size, response,
+                                              expected_response_code,
+                                              expected_response_size);
 }
 
 /**
@@ -201,11 +201,11 @@ return_status libspdm_handle_error_response_main(
         libspdm_free_session_id(spdm_context, *session_id);
         return RETURN_SECURITY_VIOLATION;
     } else if(spdm_response->param1 == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
-        return spdm_handle_response_not_ready(spdm_context, session_id,
-                                              response_size, response,
-                                              original_request_code,
-                                              expected_response_code,
-                                              expected_response_size);
+        return libspdm_handle_response_not_ready(spdm_context, session_id,
+                                                 response_size, response,
+                                                 original_request_code,
+                                                 expected_response_code,
+                                                 expected_response_size);
     } else {
         return libspdm_handle_simple_error_response(spdm_context,
                                                     spdm_response->param1);

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -11,7 +11,7 @@
 typedef struct {
     spdm_message_header_t header;
     uint8_t dummy_data[sizeof(spdm_error_data_response_not_ready_t)];
-} spdm_heartbeat_response_mine_t;
+} libspdm_heartbeat_response_mine_t;
 
 #pragma pack()
 
@@ -26,11 +26,11 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_heartbeat(void *context, uint32_t session_id)
+return_status libspdm_try_heartbeat(void *context, uint32_t session_id)
 {
     return_status status;
     spdm_heartbeat_request_t spdm_request;
-    spdm_heartbeat_response_mine_t spdm_response;
+    libspdm_heartbeat_response_mine_t spdm_response;
     uintn spdm_response_size;
     libspdm_context_t *spdm_context;
     libspdm_session_info_t *session_info;
@@ -90,7 +90,7 @@ return_status try_spdm_heartbeat(void *context, uint32_t session_id)
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
             &spdm_response, SPDM_HEARTBEAT, SPDM_HEARTBEAT_ACK,
-            sizeof(spdm_heartbeat_response_mine_t));
+            sizeof(libspdm_heartbeat_response_mine_t));
         if (RETURN_ERROR(status)) {
             return status;
         }
@@ -115,7 +115,7 @@ return_status libspdm_heartbeat(void *context, uint32_t session_id)
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_heartbeat(spdm_context, session_id);
+        status = libspdm_try_heartbeat(spdm_context, session_id);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -19,7 +19,7 @@ typedef struct {
     uint8_t exchange_data[LIBSPDM_MAX_DHE_KEY_SIZE];
     uint16_t opaque_length;
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
-} spdm_key_exchange_request_mine_t;
+} libspdm_key_exchange_request_mine_t;
 
 typedef struct {
     spdm_message_header_t header;
@@ -33,7 +33,7 @@ typedef struct {
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
     uint8_t signature[LIBSPDM_MAX_ASYM_KEY_SIZE];
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
-} spdm_key_exchange_response_max_t;
+} libspdm_key_exchange_response_max_t;
 
 #pragma pack()
 
@@ -66,9 +66,9 @@ return_status libspdm_try_send_receive_key_exchange(
 {
     bool result;
     return_status status;
-    spdm_key_exchange_request_mine_t spdm_request;
+    libspdm_key_exchange_request_mine_t spdm_request;
     uintn spdm_request_size;
-    spdm_key_exchange_response_max_t spdm_response;
+    libspdm_key_exchange_response_max_t spdm_response;
     uintn spdm_response_size;
     uintn dhe_key_size;
     uint32_t measurement_summary_hash_size;
@@ -207,7 +207,7 @@ return_status libspdm_try_send_receive_key_exchange(
             spdm_context, NULL, &spdm_response_size,
             &spdm_response, SPDM_KEY_EXCHANGE,
             SPDM_KEY_EXCHANGE_RSP,
-            sizeof(spdm_key_exchange_response_max_t));
+            sizeof(libspdm_key_exchange_response_max_t));
         if (RETURN_ERROR(status)) {
             libspdm_secured_message_dhe_free(
                 spdm_context->connection_info.algorithm

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -11,7 +11,7 @@
 typedef struct {
     spdm_message_header_t header;
     uint8_t dummy_data[sizeof(spdm_error_data_response_not_ready_t)];
-} spdm_key_update_response_mine_t;
+} libspdm_key_update_response_mine_t;
 
 #pragma pack()
 
@@ -32,13 +32,13 @@ typedef struct {
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-return_status try_spdm_key_update(void *context, uint32_t session_id,
-                                  bool single_direction, bool *key_updated)
+return_status libspdm_try_key_update(void *context, uint32_t session_id,
+                                     bool single_direction, bool *key_updated)
 {
     return_status status;
     return_status temp_status;
     spdm_key_update_request_t spdm_request;
-    spdm_key_update_response_mine_t spdm_response;
+    libspdm_key_update_response_mine_t spdm_response;
     uintn spdm_response_size;
     libspdm_context_t *spdm_context;
     libspdm_session_info_t *session_info;
@@ -138,7 +138,7 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
                 spdm_context, &session_id,
                 &spdm_response_size, &spdm_response,
                 SPDM_KEY_UPDATE, SPDM_KEY_UPDATE_ACK,
-                sizeof(spdm_key_update_response_mine_t));
+                sizeof(libspdm_key_update_response_mine_t));
             if (RETURN_ERROR(status)) {
                 if (!single_direction) {
                     DEBUG((DEBUG_INFO,
@@ -246,7 +246,7 @@ return_status try_spdm_key_update(void *context, uint32_t session_id,
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_KEY_UPDATE, SPDM_KEY_UPDATE_ACK,
-            sizeof(spdm_key_update_response_mine_t));
+            sizeof(libspdm_key_update_response_mine_t));
         if (RETURN_ERROR(status)) {
             DEBUG((DEBUG_INFO, "SpdmVerifyKey[%x] Failed\n", session_id));
             return status;
@@ -278,8 +278,8 @@ return_status libspdm_key_update(void *context, uint32_t session_id,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = try_spdm_key_update(context, session_id,
-                                     single_direction, &key_updated);
+        status = libspdm_try_key_update(context, session_id,
+                                        single_direction, &key_updated);
         if (RETURN_NO_RESPONSE != status) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -42,7 +42,7 @@ typedef struct {
     uint32_t ext_asym_sel;
     uint32_t ext_hash_sel;
     spdm_negotiate_algorithms_common_struct_table_t struct_table[4];
-} spdm_algorithms_response_max_t;
+} libspdm_algorithms_response_max_t;
 #pragma pack()
 
 /**
@@ -57,7 +57,7 @@ return_status libspdm_try_negotiate_algorithms(libspdm_context_t *spdm_context)
 {
     return_status status;
     libspdm_negotiate_algorithms_request_mine_t spdm_request;
-    spdm_algorithms_response_max_t spdm_response;
+    libspdm_algorithms_response_max_t spdm_response;
     uintn spdm_response_size;
     uint32_t algo_size;
     uintn index;

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -19,7 +19,7 @@ typedef struct {
     uint8_t psk_hint[LIBSPDM_PSK_MAX_HINT_LENGTH];
     uint8_t context[LIBSPDM_PSK_CONTEXT_LENGTH];
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
-} spdm_psk_exchange_request_mine_t;
+} libspdm_psk_exchange_request_mine_t;
 
 typedef struct {
     spdm_message_header_t header;
@@ -31,7 +31,7 @@ typedef struct {
     uint8_t context[LIBSPDM_PSK_CONTEXT_LENGTH];
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
-} spdm_psk_exchange_response_max_t;
+} libspdm_psk_exchange_response_max_t;
 
 #pragma pack()
 
@@ -73,9 +73,9 @@ return_status libspdm_try_send_receive_psk_exchange(
 {
     bool result;
     return_status status;
-    spdm_psk_exchange_request_mine_t spdm_request;
+    libspdm_psk_exchange_request_mine_t spdm_request;
     uintn spdm_request_size;
-    spdm_psk_exchange_response_max_t spdm_response;
+    libspdm_psk_exchange_response_max_t spdm_response;
     uintn spdm_response_size;
     uint32_t measurement_summary_hash_size;
     uint32_t hmac_size;
@@ -218,7 +218,7 @@ return_status libspdm_try_send_receive_psk_exchange(
             spdm_context, NULL, &spdm_response_size,
             &spdm_response, SPDM_PSK_EXCHANGE,
             SPDM_PSK_EXCHANGE_RSP,
-            sizeof(spdm_psk_exchange_response_max_t));
+            sizeof(libspdm_psk_exchange_response_max_t));
         if (RETURN_ERROR(status)) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -13,12 +13,12 @@
 typedef struct {
     spdm_message_header_t header;
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
-} spdm_psk_finish_request_mine_t;
+} libspdm_psk_finish_request_mine_t;
 
 typedef struct {
     spdm_message_header_t header;
     uint8_t dummy_data[sizeof(spdm_error_data_response_not_ready_t)];
-} spdm_psk_finish_response_max_t;
+} libspdm_psk_finish_response_max_t;
 
 #pragma pack()
 
@@ -35,10 +35,10 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
                                                   uint32_t session_id)
 {
     return_status status;
-    spdm_psk_finish_request_mine_t spdm_request;
+    libspdm_psk_finish_request_mine_t spdm_request;
     uintn spdm_request_size;
     uintn hmac_size;
-    spdm_psk_finish_response_max_t spdm_response;
+    libspdm_psk_finish_response_max_t spdm_response;
     uintn spdm_response_size;
     libspdm_session_info_t *session_info;
     uint8_t th2_hash_data[64];
@@ -140,7 +140,7 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
             spdm_context, &session_id,
             &spdm_response_size, &spdm_response,
             SPDM_PSK_FINISH, SPDM_PSK_FINISH_RSP,
-            sizeof(spdm_psk_finish_response_max_t));
+            sizeof(libspdm_psk_finish_response_max_t));
         if (RETURN_ERROR(status)) {
             goto error;
         }

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -26,10 +26,10 @@ typedef struct {
     uint8_t ext_hash_sel_count;
     uint16_t reserved3;
     spdm_negotiate_algorithms_common_struct_table_t struct_table[4];
-} spdm_algorithms_response_mine_t;
+} libspdm_algorithms_response_mine_t;
 #pragma pack()
 
-uint32_t m_hash_priority_table[] = {
+uint32_t m_libspdm_hash_priority_table[] = {
 #if LIBSPDM_SHA512_SUPPORT == 1
     SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512,
 #endif
@@ -53,7 +53,7 @@ uint32_t m_hash_priority_table[] = {
 #endif
 };
 
-uint32_t m_asym_priority_table[] = {
+uint32_t m_libspdm_asym_priority_table[] = {
 #if LIBSPDM_ECDSA_SUPPORT == 1
     SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P521,
     SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
@@ -80,7 +80,7 @@ uint32_t m_asym_priority_table[] = {
 #endif
 };
 
-uint32_t m_req_asym_priority_table[] = {
+uint32_t m_libspdm_req_asym_priority_table[] = {
 #if LIBSPDM_ECDSA_SUPPORT == 1
     SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P521,
     SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
@@ -107,7 +107,7 @@ uint32_t m_req_asym_priority_table[] = {
 #endif
 };
 
-uint32_t m_dhe_priority_table[] = {
+uint32_t m_libspdm_dhe_priority_table[] = {
 #if LIBSPDM_ECDHE_SUPPORT == 1
     SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_521_R1,
     SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1,
@@ -123,7 +123,7 @@ uint32_t m_dhe_priority_table[] = {
 #endif
 };
 
-uint32_t m_aead_priority_table[] = {
+uint32_t m_libspdm_aead_priority_table[] = {
 #if LIBSPDM_AEAD_GCM_SUPPORT == 1
     SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM,
     SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM,
@@ -136,11 +136,11 @@ uint32_t m_aead_priority_table[] = {
 #endif
 };
 
-uint32_t m_key_schedule_priority_table[] = {
+uint32_t m_libspdm_key_schedule_priority_table[] = {
     SPDM_ALGORITHMS_KEY_SCHEDULE_HMAC_HASH,
 };
 
-uint32_t m_measurement_hash_priority_table[] = {
+uint32_t m_libspdm_measurement_hash_priority_table[] = {
 #if LIBSPDM_SHA512_SUPPORT == 1
     SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_TPM_ALG_SHA_512,
 #endif
@@ -165,11 +165,11 @@ uint32_t m_measurement_hash_priority_table[] = {
     SPDM_ALGORITHMS_MEASUREMENT_HASH_ALGO_RAW_BIT_STREAM_ONLY,
 };
 
-uint32_t m_measurement_spec_priority_table[] = {
+uint32_t m_libspdm_measurement_spec_priority_table[] = {
     SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF,
 };
 
-uint32_t m_other_params_support_priority_table[] = {
+uint32_t m_libspdm_other_params_support_priority_table[] = {
     SPDM_ALGORITHMS_OPAQUE_DATA_FORMAT_1,
 };
 
@@ -183,9 +183,9 @@ uint32_t m_other_params_support_priority_table[] = {
  *
  * @return final preferred supported algorithm
  **/
-uint32_t spdm_prioritize_algorithm(const uint32_t *priority_table,
-                                   uintn priority_table_count,
-                                   uint32_t local_algo, uint32_t peer_algo)
+uint32_t libspdm_prioritize_algorithm(const uint32_t *priority_table,
+                                      uintn priority_table_count,
+                                      uint32_t local_algo, uint32_t peer_algo)
 {
     uint32_t common_algo;
     uintn index;
@@ -225,7 +225,7 @@ return_status libspdm_get_response_algorithms(void *context,
 {
     const spdm_negotiate_algorithms_request_t *spdm_request;
     uintn spdm_request_size;
-    spdm_algorithms_response_mine_t *spdm_response;
+    libspdm_algorithms_response_mine_t *spdm_response;
     spdm_negotiate_algorithms_common_struct_table_t *struct_table;
     uintn index;
     libspdm_context_t *spdm_context;
@@ -352,8 +352,8 @@ return_status libspdm_get_response_algorithms(void *context,
     libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
                                                   spdm_request->header.request_response_code);
 
-    ASSERT(*response_size >= sizeof(spdm_algorithms_response_mine_t));
-    *response_size = sizeof(spdm_algorithms_response_mine_t);
+    ASSERT(*response_size >= sizeof(libspdm_algorithms_response_mine_t));
+    *response_size = sizeof(libspdm_algorithms_response_mine_t);
     zero_mem(response, *response_size);
     spdm_response = response;
 
@@ -364,7 +364,7 @@ return_status libspdm_get_response_algorithms(void *context,
     } else {
         spdm_response->header.param1 = 0;
         *response_size =
-            sizeof(spdm_algorithms_response_mine_t) -
+            sizeof(libspdm_algorithms_response_mine_t) -
             sizeof(spdm_negotiate_algorithms_common_struct_table_t) *
             4;
     }
@@ -425,64 +425,64 @@ return_status libspdm_get_response_algorithms(void *context,
     }
 
     spdm_response->measurement_specification_sel =
-        (uint8_t)spdm_prioritize_algorithm(
-            m_measurement_spec_priority_table,
-            ARRAY_SIZE(m_measurement_spec_priority_table),
+        (uint8_t)libspdm_prioritize_algorithm(
+            m_libspdm_measurement_spec_priority_table,
+            ARRAY_SIZE(m_libspdm_measurement_spec_priority_table),
             spdm_context->local_context.algorithm.measurement_spec,
             spdm_context->connection_info.algorithm
             .measurement_spec);
-    spdm_response->measurement_hash_algo = spdm_prioritize_algorithm(
-        m_measurement_hash_priority_table,
-        ARRAY_SIZE(m_measurement_hash_priority_table),
+    spdm_response->measurement_hash_algo = libspdm_prioritize_algorithm(
+        m_libspdm_measurement_hash_priority_table,
+        ARRAY_SIZE(m_libspdm_measurement_hash_priority_table),
         spdm_context->local_context.algorithm.measurement_hash_algo,
         spdm_context->connection_info.algorithm.measurement_hash_algo);
-    spdm_response->base_asym_sel = spdm_prioritize_algorithm(
-        m_asym_priority_table, ARRAY_SIZE(m_asym_priority_table),
+    spdm_response->base_asym_sel = libspdm_prioritize_algorithm(
+        m_libspdm_asym_priority_table, ARRAY_SIZE(m_libspdm_asym_priority_table),
         spdm_context->local_context.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_asym_algo);
-    spdm_response->base_hash_sel = spdm_prioritize_algorithm(
-        m_hash_priority_table, ARRAY_SIZE(m_hash_priority_table),
+    spdm_response->base_hash_sel = libspdm_prioritize_algorithm(
+        m_libspdm_hash_priority_table, ARRAY_SIZE(m_libspdm_hash_priority_table),
         spdm_context->local_context.algorithm.base_hash_algo,
         spdm_context->connection_info.algorithm.base_hash_algo);
     spdm_response->struct_table[0].alg_type =
         SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE;
     spdm_response->struct_table[0].alg_count = 0x20;
     spdm_response->struct_table[0].alg_supported =
-        (uint16_t)spdm_prioritize_algorithm(
-            m_dhe_priority_table, ARRAY_SIZE(m_dhe_priority_table),
+        (uint16_t)libspdm_prioritize_algorithm(
+            m_libspdm_dhe_priority_table, ARRAY_SIZE(m_libspdm_dhe_priority_table),
             spdm_context->local_context.algorithm.dhe_named_group,
             spdm_context->connection_info.algorithm.dhe_named_group);
     spdm_response->struct_table[1].alg_type =
         SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD;
     spdm_response->struct_table[1].alg_count = 0x20;
     spdm_response->struct_table[1]
-    .alg_supported = (uint16_t)spdm_prioritize_algorithm(
-        m_aead_priority_table, ARRAY_SIZE(m_aead_priority_table),
+    .alg_supported = (uint16_t)libspdm_prioritize_algorithm(
+        m_libspdm_aead_priority_table, ARRAY_SIZE(m_libspdm_aead_priority_table),
         spdm_context->local_context.algorithm.aead_cipher_suite,
         spdm_context->connection_info.algorithm.aead_cipher_suite);
     spdm_response->struct_table[2].alg_type =
         SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG;
     spdm_response->struct_table[2].alg_count = 0x20;
     spdm_response->struct_table[2]
-    .alg_supported = (uint16_t)spdm_prioritize_algorithm(
-        m_req_asym_priority_table,
-        ARRAY_SIZE(m_req_asym_priority_table),
+    .alg_supported = (uint16_t)libspdm_prioritize_algorithm(
+        m_libspdm_req_asym_priority_table,
+        ARRAY_SIZE(m_libspdm_req_asym_priority_table),
         spdm_context->local_context.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.req_base_asym_alg);
     spdm_response->struct_table[3].alg_type =
         SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEY_SCHEDULE;
     spdm_response->struct_table[3].alg_count = 0x20;
     spdm_response->struct_table[3].alg_supported =
-        (uint16_t)spdm_prioritize_algorithm(
-            m_key_schedule_priority_table,
-            ARRAY_SIZE(m_key_schedule_priority_table),
+        (uint16_t)libspdm_prioritize_algorithm(
+            m_libspdm_key_schedule_priority_table,
+            ARRAY_SIZE(m_libspdm_key_schedule_priority_table),
             spdm_context->local_context.algorithm.key_schedule,
             spdm_context->connection_info.algorithm.key_schedule);
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
         spdm_response->other_params_support =
-            (uint8_t)spdm_prioritize_algorithm(
-                m_other_params_support_priority_table,
-                ARRAY_SIZE(m_other_params_support_priority_table),
+            (uint8_t)libspdm_prioritize_algorithm(
+                m_libspdm_other_params_support_priority_table,
+                ARRAY_SIZE(m_libspdm_other_params_support_priority_table),
                 spdm_context->local_context.algorithm.other_params_support,
                 spdm_context->connection_info.algorithm.other_params_support);
     }

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -17,7 +17,7 @@
  * @retval True                         The received SPDM version is valid.
  * @retval False                        The received SPDM version is invalid.
  **/
-bool spdm_check_request_version_compability(libspdm_context_t *spdm_context, uint8_t version)
+bool libspdm_check_request_version_compability(libspdm_context_t *spdm_context, uint8_t version)
 {
     uint8_t local_ver;
     uintn index;
@@ -46,8 +46,8 @@ bool spdm_check_request_version_compability(libspdm_context_t *spdm_context, uin
  * @retval True                         The received Capabilities flag is valid.
  * @retval False                        The received Capabilities flag is invalid.
  **/
-bool spdm_check_request_flag_compability(uint32_t capabilities_flag,
-                                         uint8_t version)
+bool libspdm_check_request_flag_compability(uint32_t capabilities_flag,
+                                            uint8_t version)
 {
     uint8_t cert_cap = (uint8_t)(capabilities_flag >> 1) & 0x01;
     /*uint8_t chal_cap = (uint8_t)(capabilities_flag>>2)&0x01;*/
@@ -169,7 +169,7 @@ return_status libspdm_get_response_capabilities(void *context,
                                                0, response_size, response);
     }
 
-    if (!spdm_check_request_version_compability(
+    if (!libspdm_check_request_version_compability(
             spdm_context, spdm_request->header.spdm_version)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_VERSION_MISMATCH, 0,
@@ -198,7 +198,7 @@ return_status libspdm_get_response_capabilities(void *context,
         }
     }
 
-    if (!spdm_check_request_flag_compability(
+    if (!libspdm_check_request_flag_compability(
             spdm_request->flags, spdm_request->header.spdm_version)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -19,7 +19,7 @@
  * @retval RETURN_SUCCESS               The encapsulated request is returned.
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
-typedef return_status (*spdm_get_encap_request_func)(
+typedef return_status (*libspdm_get_encap_request_func)(
     libspdm_context_t *spdm_context, uintn *encap_request_size,
     void *encap_request);
 
@@ -35,17 +35,17 @@ typedef return_status (*spdm_get_encap_request_func)(
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-typedef return_status (*spdm_process_encap_response_func)(
+typedef return_status (*libspdm_process_encap_response_func)(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, bool *need_continue);
 
 typedef struct {
     uint8_t request_op_code;
-    spdm_get_encap_request_func get_encap_request;
-    spdm_process_encap_response_func process_encap_response;
-} spdm_encap_response_struct_t;
+    libspdm_get_encap_request_func get_encap_request;
+    libspdm_process_encap_response_func process_encap_response;
+} libspdm_libspdm_encap_response_struct_t;
 
-spdm_encap_response_struct_t m_encap_response_struct[] = {
+libspdm_libspdm_encap_response_struct_t m_libspdm_encap_response_struct[] = {
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
     { SPDM_GET_DIGESTS, libspdm_get_encap_request_get_digest,
       libspdm_process_encap_response_digest },
@@ -63,22 +63,22 @@ spdm_encap_response_struct_t m_encap_response_struct[] = {
       libspdm_process_encap_response_key_update },
 };
 
-spdm_encap_response_struct_t *
-spdm_get_encap_struct_via_op_code(uint8_t request_op_code)
+libspdm_libspdm_encap_response_struct_t *
+libspdm_get_encap_struct_via_op_code(uint8_t request_op_code)
 {
     uintn index;
 
-    for (index = 0; index < ARRAY_SIZE(m_encap_response_struct); index++) {
-        if (m_encap_response_struct[index].request_op_code ==
+    for (index = 0; index < ARRAY_SIZE(m_libspdm_encap_response_struct); index++) {
+        if (m_libspdm_encap_response_struct[index].request_op_code ==
             request_op_code) {
-            return &m_encap_response_struct[index];
+            return &m_libspdm_encap_response_struct[index];
         }
     }
     ASSERT(false);
     return NULL;
 }
 
-void spdm_encap_move_to_next_op_code(libspdm_context_t *spdm_context)
+void libspdm_encap_move_to_next_op_code(libspdm_context_t *spdm_context)
 {
     uint8_t index;
 
@@ -115,20 +115,20 @@ void spdm_encap_move_to_next_op_code(libspdm_context_t *spdm_context)
  * @retval RETURN_SUCCESS               The SPDM encapsulated request is generated successfully.
  * @retval RETURN_UNSUPPORTED           Do not know how to process the request.
  **/
-return_status spdm_process_encapsulated_response(
+return_status libspdm_process_encapsulated_response(
     libspdm_context_t *spdm_context, uintn encap_response_size,
     const void *encap_response, uintn *encap_request_size,
     void *encap_request)
 {
     return_status status;
     bool need_continue;
-    spdm_encap_response_struct_t *encap_response_struct;
+    libspdm_libspdm_encap_response_struct_t *encap_response_struct;
 
     /* Process previous response*/
     need_continue = false;
 
     if (spdm_context->encap_context.current_request_op_code != 0) {
-        encap_response_struct = spdm_get_encap_struct_via_op_code(
+        encap_response_struct = libspdm_get_encap_struct_via_op_code(
             spdm_context->encap_context.current_request_op_code);
         ASSERT(encap_response_struct != NULL);
         if (encap_response_struct == NULL) {
@@ -150,7 +150,7 @@ return_status spdm_process_encapsulated_response(
 
     /* Move to next request*/
     if (!need_continue) {
-        spdm_encap_move_to_next_op_code(spdm_context);
+        libspdm_encap_move_to_next_op_code(spdm_context);
     }
 
     if (spdm_context->encap_context.current_request_op_code == 0) {
@@ -161,7 +161,7 @@ return_status spdm_process_encapsulated_response(
     }
 
     /* Process the next request*/
-    encap_response_struct = spdm_get_encap_struct_via_op_code(
+    encap_response_struct = libspdm_get_encap_struct_via_op_code(
         spdm_context->encap_context.current_request_op_code);
     ASSERT(encap_response_struct != NULL);
     if (encap_response_struct == NULL) {
@@ -396,7 +396,7 @@ return_status libspdm_get_response_encapsulated_request(
         *response_size - sizeof(spdm_encapsulated_request_response_t);
     encap_request = spdm_response + 1;
 
-    status = spdm_process_encapsulated_response(
+    status = libspdm_process_encapsulated_response(
         context, 0, NULL, &encap_request_size, encap_request);
     if (RETURN_ERROR(status)) {
         spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
@@ -523,7 +523,7 @@ return_status libspdm_get_response_encapsulated_response_ack(
     libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
                                                   spdm_request->header.request_response_code);
 
-    status = spdm_process_encapsulated_response(
+    status = libspdm_process_encapsulated_response(
         context, encap_response_size, encap_response,
         &encap_request_size, encap_request);
     if (RETURN_ERROR(status)) {

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -21,10 +21,10 @@
  * @retval true  measurement signature is created.
  * @retval false measurement signature is not created.
  **/
-bool spdm_create_measurement_signature(libspdm_context_t *spdm_context,
-                                       libspdm_session_info_t *session_info,
-                                       void *response_message,
-                                       uintn response_message_size)
+bool libspdm_create_measurement_signature(libspdm_context_t *spdm_context,
+                                          libspdm_session_info_t *session_info,
+                                          void *response_message,
+                                          uintn response_message_size)
 {
     uint8_t *ptr;
     uintn measurment_sig_size;
@@ -76,9 +76,9 @@ bool spdm_create_measurement_signature(libspdm_context_t *spdm_context,
  * @param  response_message              The measurement response message with empty signature to be filled.
  * @param  response_message_size          Total size in bytes of the response message including signature.
  **/
-bool spdm_create_measurement_opaque(libspdm_context_t *spdm_context,
-                                    void *response_message,
-                                    uintn response_message_size)
+bool libspdm_create_measurement_opaque(libspdm_context_t *spdm_context,
+                                       void *response_message,
+                                       uintn response_message_size)
 {
     uint8_t *ptr;
     uintn measurment_no_sig_size;
@@ -425,8 +425,8 @@ return_status libspdm_get_response_measurements(void *context,
             }
         }
     } else {
-        if(!spdm_create_measurement_opaque(spdm_context, spdm_response,
-                                           spdm_response_size)) {
+        if(!libspdm_create_measurement_opaque(spdm_context, spdm_response,
+                                              spdm_response_size)) {
             return RETURN_DEVICE_ERROR;
         }
     }
@@ -447,7 +447,7 @@ return_status libspdm_get_response_measurements(void *context,
          SPDM_GET_MEASUREMENTS_REQUEST_ATTRIBUTES_GENERATE_SIGNATURE) !=
         0) {
 
-        ret = spdm_create_measurement_signature(
+        ret = libspdm_create_measurement_signature(
             spdm_context, session_info, spdm_response,
             spdm_response_size);
         if (!ret) {

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -10,9 +10,9 @@
 typedef struct {
     uint8_t request_response_code;
     libspdm_get_spdm_response_func get_response_func;
-} spdm_get_response_struct_t;
+} libspdm_get_response_struct_t;
 
-spdm_get_response_struct_t mSpdmGetResponseStruct[] = {
+libspdm_get_response_struct_t m_libspdm_get_response_struct[] = {
     { SPDM_GET_VERSION, libspdm_get_response_version },
     { SPDM_GET_CAPABILITIES, libspdm_get_response_capabilities },
     { SPDM_NEGOTIATE_ALGORITHMS, libspdm_get_response_algorithms },
@@ -75,12 +75,12 @@ libspdm_get_response_func_via_request_code(uint8_t request_code)
     uintn index;
 
     ASSERT(request_code != SPDM_RESPOND_IF_READY);
-    for (index = 0; index < sizeof(mSpdmGetResponseStruct) /
-         sizeof(mSpdmGetResponseStruct[0]);
+    for (index = 0; index < sizeof(m_libspdm_get_response_struct) /
+         sizeof(m_libspdm_get_response_struct[0]);
          index++) {
         if (request_code ==
-            mSpdmGetResponseStruct[index].request_response_code) {
-            return mSpdmGetResponseStruct[index].get_response_func;
+            m_libspdm_get_response_struct[index].request_response_code) {
+            return m_libspdm_get_response_struct[index].get_response_func;
         }
     }
     return NULL;
@@ -94,7 +94,7 @@ libspdm_get_response_func_via_request_code(uint8_t request_code)
  * @return GET_SPDM_RESPONSE function according to the last request.
  **/
 libspdm_get_spdm_response_func
-spdm_get_response_func_via_last_request(libspdm_context_t *spdm_context)
+libspdm_get_response_func_via_last_request(libspdm_context_t *spdm_context)
 {
     spdm_message_header_t *spdm_request;
 
@@ -200,9 +200,9 @@ return_status libspdm_process_request(void *context, uint32_t **session_id,
  * @param  session_id                    The session_id of a session.
  * @param  session_state                 The state of a session.
  **/
-void spdm_trigger_session_state_callback(libspdm_context_t *spdm_context,
-                                         uint32_t session_id,
-                                         libspdm_session_state_t session_state)
+void libspdm_trigger_session_state_callback(libspdm_context_t *spdm_context,
+                                            uint32_t session_id,
+                                            libspdm_session_state_t session_state)
 {
     uintn index;
 
@@ -241,7 +241,7 @@ void libspdm_set_session_state(libspdm_context_t *spdm_context,
     if (old_session_state != session_state) {
         libspdm_secured_message_set_session_state(
             session_info->secured_message_context, session_state);
-        spdm_trigger_session_state_callback(
+        libspdm_trigger_session_state_callback(
             spdm_context, session_info->session_id, session_state);
     }
 }
@@ -252,9 +252,9 @@ void libspdm_set_session_state(libspdm_context_t *spdm_context,
  * @param  spdm_context                  A pointer to the SPDM context.
  * @param  connection_state              Indicate the SPDM connection state.
  **/
-void spdm_trigger_connection_state_callback(libspdm_context_t *spdm_context,
-                                            const libspdm_connection_state_t
-                                            connection_state)
+void libspdm_trigger_connection_state_callback(libspdm_context_t *spdm_context,
+                                               const libspdm_connection_state_t
+                                               connection_state)
 {
     uintn index;
 
@@ -281,8 +281,8 @@ void libspdm_set_connection_state(libspdm_context_t *spdm_context,
         connection_state) {
         spdm_context->connection_info.connection_state =
             connection_state;
-        spdm_trigger_connection_state_callback(spdm_context,
-                                               connection_state);
+        libspdm_trigger_connection_state_callback(spdm_context,
+                                                  connection_state);
     }
 }
 
@@ -413,7 +413,7 @@ return_status libspdm_build_response(void *context, const uint32_t *session_id,
     get_response_func = NULL;
     if (!is_app_message) {
         get_response_func =
-            spdm_get_response_func_via_last_request(spdm_context);
+            libspdm_get_response_func_via_last_request(spdm_context);
         if (get_response_func != NULL) {
             status = get_response_func(
                 spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_version.c
+++ b/library/spdm_responder_lib/libspdm_rsp_version.c
@@ -12,7 +12,7 @@ typedef struct {
     uint8_t reserved;
     uint8_t version_number_entry_count;
     spdm_version_number_t version_number_entry[SPDM_MAX_VERSION_COUNT];
-} spdm_version_response_mine_t;
+} libspdm_version_response_mine_t;
 #pragma pack()
 
 /**
@@ -38,7 +38,7 @@ return_status libspdm_get_response_version(void *context, uintn request_size,
                                            void *response)
 {
     const spdm_get_version_request_t *spdm_request;
-    spdm_version_response_mine_t *spdm_response;
+    libspdm_version_response_mine_t *spdm_response;
     libspdm_context_t *spdm_context;
     return_status status;
 
@@ -91,7 +91,7 @@ return_status libspdm_get_response_version(void *context, uintn request_size,
     }
 
     libspdm_reset_context(spdm_context);
-    ASSERT(*response_size >= sizeof(spdm_version_response_mine_t));
+    ASSERT(*response_size >= sizeof(libspdm_version_response_mine_t));
     *response_size =
         sizeof(spdm_version_response_t) +
         spdm_context->local_context.version.spdm_version_count *

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -308,9 +308,9 @@ libspdm_secured_message_export_session_keys(void *spdm_secured_message_context,
  * @retval RETURN_SUCCESS  SessionKeys are imported.
  */
 return_status
-spdm_secured_message_import_session_keys(void *spdm_secured_message_context,
-                                         const void *SessionKeys,
-                                         uintn SessionKeysSize)
+libspdm_secured_message_import_session_keys(void *spdm_secured_message_context,
+                                            const void *SessionKeys,
+                                            uintn SessionKeysSize)
 {
     libspdm_secured_message_context_t *secured_message_context;
     uintn struct_size;

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -94,7 +94,7 @@ return_status libspdm_bin_concat(const char *label, uintn label_size,
  *
  * @retval RETURN_SUCCESS  SPDM AEAD key and IV for a session is generated.
  **/
-return_status spdm_generate_aead_key_and_iv(
+return_status libspdm_generate_aead_key_and_iv(
     libspdm_secured_message_context_t *secured_message_context,
     const uint8_t *major_secret, uint8_t *key, uint8_t *iv)
 {
@@ -154,7 +154,7 @@ return_status spdm_generate_aead_key_and_iv(
  *
  * @retval RETURN_SUCCESS  SPDM finished_key for a session is generated.
  **/
-return_status spdm_generate_finished_key(
+return_status libspdm_generate_finished_key(
     libspdm_secured_message_context_t *secured_message_context,
     const uint8_t *handshake_secret, uint8_t *finished_key)
 {
@@ -312,7 +312,7 @@ libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
                                hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    status = spdm_generate_finished_key(
+    status = libspdm_generate_finished_key(
         secured_message_context,
         secured_message_context->handshake_secret
         .request_handshake_secret,
@@ -321,7 +321,7 @@ libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
         return status;
     }
 
-    status = spdm_generate_finished_key(
+    status = libspdm_generate_finished_key(
         secured_message_context,
         secured_message_context->handshake_secret
         .response_handshake_secret,
@@ -330,20 +330,20 @@ libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
         return status;
     }
 
-    status = spdm_generate_aead_key_and_iv(secured_message_context,
-                                           secured_message_context->handshake_secret
-                                           .request_handshake_secret,
-                                           secured_message_context->handshake_secret
-                                           .request_handshake_encryption_key,
-                                           secured_message_context->handshake_secret
-                                           .request_handshake_salt);
+    status = libspdm_generate_aead_key_and_iv(secured_message_context,
+                                              secured_message_context->handshake_secret
+                                              .request_handshake_secret,
+                                              secured_message_context->handshake_secret
+                                              .request_handshake_encryption_key,
+                                              secured_message_context->handshake_secret
+                                              .request_handshake_salt);
     if (RETURN_ERROR(status)) {
         return status;
     }
     secured_message_context->handshake_secret
     .request_handshake_sequence_number = 0;
 
-    status = spdm_generate_aead_key_and_iv(
+    status = libspdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->handshake_secret
         .response_handshake_secret,
@@ -531,7 +531,7 @@ libspdm_generate_session_data_key(void *spdm_secured_message_context,
         hash_size);
     DEBUG((DEBUG_INFO, "\n"));
 
-    status = spdm_generate_aead_key_and_iv(
+    status = libspdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->application_secret.request_data_secret,
         secured_message_context->application_secret
@@ -543,7 +543,7 @@ libspdm_generate_session_data_key(void *spdm_secured_message_context,
     secured_message_context->application_secret
     .request_data_sequence_number = 0;
 
-    status = spdm_generate_aead_key_and_iv(
+    status = libspdm_generate_aead_key_and_iv(
         secured_message_context,
         secured_message_context->application_secret.response_data_secret,
         secured_message_context->application_secret
@@ -638,7 +638,7 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
                                    hash_size);
         DEBUG((DEBUG_INFO, "\n"));
 
-        status = spdm_generate_aead_key_and_iv(
+        status = libspdm_generate_aead_key_and_iv(
             secured_message_context,
             secured_message_context->application_secret
             .request_data_secret,
@@ -699,7 +699,7 @@ libspdm_create_update_session_data_key(void *spdm_secured_message_context,
                                    hash_size);
         DEBUG((DEBUG_INFO, "\n"));
 
-        status = spdm_generate_aead_key_and_iv(
+        status = libspdm_generate_aead_key_and_iv(
             secured_message_context,
             secured_message_context->application_secret
             .response_data_secret,

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -21,10 +21,10 @@
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status mctp_encode_message(const uint32_t *session_id, uintn message_size,
-                                  const void *message,
-                                  uintn *transport_message_size,
-                                  void *transport_message);
+return_status libspdm_mctp_encode_message(const uint32_t *session_id, uintn message_size,
+                                          const void *message,
+                                          uintn *transport_message_size,
+                                          void *transport_message);
 
 /**
  * Decode a transport message to a normal message or secured message.
@@ -39,11 +39,11 @@ return_status mctp_encode_message(const uint32_t *session_id, uintn message_size
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status mctp_decode_message(uint32_t **session_id,
-                                  uintn transport_message_size,
-                                  const void *transport_message,
-                                  uintn *message_size,
-                                  void *message);
+return_status libspdm_mctp_decode_message(uint32_t **session_id,
+                                          uintn transport_message_size,
+                                          const void *transport_message,
+                                          uintn *message_size,
+                                          void *message);
 
 /**
  * Encode a normal message or secured message to a transport message.
@@ -59,7 +59,7 @@ return_status mctp_decode_message(uint32_t **session_id,
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-typedef return_status (*transport_encode_message_func)(
+typedef return_status (*libspdm_mctp_encode_message_func)(
     const uint32_t *session_id, uintn message_size, const void *message,
     uintn *transport_message_size, void *transport_message);
 
@@ -76,7 +76,7 @@ typedef return_status (*transport_encode_message_func)(
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-typedef return_status (*transport_decode_message_func)(
+typedef return_status (*libspdm_mctp_decode_message_func)(
     uint32_t **session_id, uintn transport_message_size,
     const void *transport_message, uintn *message_size,
     void *message);
@@ -112,7 +112,7 @@ return_status libspdm_transport_mctp_encode_message(
     uintn *transport_message_size, void *transport_message)
 {
     return_status status;
-    transport_encode_message_func transport_encode_message;
+    libspdm_mctp_encode_message_func transport_encode_message;
     uint8_t app_message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     void *app_message;
     uintn app_message_size;
@@ -132,7 +132,7 @@ return_status libspdm_transport_mctp_encode_message(
         return RETURN_UNSUPPORTED;
     }
 
-    transport_encode_message = mctp_encode_message;
+    transport_encode_message = libspdm_mctp_encode_message;
     if (session_id != NULL) {
         secured_message_context =
             libspdm_get_secured_message_context_via_session_id(
@@ -228,7 +228,7 @@ return_status libspdm_transport_mctp_decode_message(
     uintn *message_size, void *message)
 {
     return_status status;
-    transport_decode_message_func transport_decode_message;
+    libspdm_mctp_decode_message_func transport_decode_message;
     uint32_t *secured_message_session_id;
     uint8_t secured_message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uintn secured_message_size;
@@ -253,7 +253,7 @@ return_status libspdm_transport_mctp_decode_message(
         return RETURN_UNSUPPORTED;
     }
 
-    transport_decode_message = mctp_decode_message;
+    transport_decode_message = libspdm_mctp_decode_message;
 
     secured_message_session_id = NULL;
     /* Detect received message*/

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -59,10 +59,10 @@ uint32_t libspdm_mctp_get_max_random_number_count(void)
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status mctp_encode_message(const uint32_t *session_id, uintn message_size,
-                                  const void *message,
-                                  uintn *transport_message_size,
-                                  void *transport_message)
+return_status libspdm_mctp_encode_message(const uint32_t *session_id, uintn message_size,
+                                          const void *message,
+                                          uintn *transport_message_size,
+                                          void *transport_message)
 {
     uintn aligned_message_size;
     uintn alignment;
@@ -116,10 +116,10 @@ return_status mctp_encode_message(const uint32_t *session_id, uintn message_size
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status mctp_decode_message(uint32_t **session_id,
-                                  uintn transport_message_size,
-                                  const void *transport_message,
-                                  uintn *message_size, void *message)
+return_status libspdm_mctp_decode_message(uint32_t **session_id,
+                                          uintn transport_message_size,
+                                          const void *transport_message,
+                                          uintn *message_size, void *message)
 {
     uintn alignment;
     const mctp_message_header_t *mctp_message_header;

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
@@ -21,10 +21,10 @@
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status pci_doe_encode_message(const uint32_t *session_id,
-                                     uintn message_size, const void *message,
-                                     uintn *transport_message_size,
-                                     void *transport_message);
+return_status libspdm_pci_doe_encode_message(const uint32_t *session_id,
+                                             uintn message_size, const void *message,
+                                             uintn *transport_message_size,
+                                             void *transport_message);
 
 /**
  * Decode a transport message to a normal message or secured message.
@@ -39,11 +39,11 @@ return_status pci_doe_encode_message(const uint32_t *session_id,
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status pci_doe_decode_message(uint32_t **session_id,
-                                     uintn transport_message_size,
-                                     const void *transport_message,
-                                     uintn *message_size,
-                                     void *message);
+return_status libspdm_pci_doe_decode_message(uint32_t **session_id,
+                                             uintn transport_message_size,
+                                             const void *transport_message,
+                                             uintn *message_size,
+                                             void *message);
 
 /**
  * Encode a normal message or secured message to a transport message.
@@ -59,7 +59,7 @@ return_status pci_doe_decode_message(uint32_t **session_id,
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-typedef return_status (*transport_encode_message_func)(
+typedef return_status (*libspdm_pci_doe_encode_message_func)(
     const uint32_t *session_id, uintn message_size, const void *message,
     uintn *transport_message_size, void *transport_message);
 
@@ -76,7 +76,7 @@ typedef return_status (*transport_encode_message_func)(
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-typedef return_status (*transport_decode_message_func)(
+typedef return_status (*libspdm_pci_doe_decode_message_func)(
     uint32_t **session_id, uintn transport_message_size,
     const void *transport_message, uintn *message_size,
     void *message);
@@ -112,7 +112,7 @@ return_status libspdm_transport_pci_doe_encode_message(
     uintn *transport_message_size, void *transport_message)
 {
     return_status status;
-    transport_encode_message_func transport_encode_message;
+    libspdm_pci_doe_encode_message_func transport_encode_message;
     uint8_t secured_message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uintn secured_message_size;
     libspdm_secured_message_callbacks_t spdm_secured_message_callbacks;
@@ -129,7 +129,7 @@ return_status libspdm_transport_pci_doe_encode_message(
         return RETURN_UNSUPPORTED;
     }
 
-    transport_encode_message = pci_doe_encode_message;
+    transport_encode_message = libspdm_pci_doe_encode_message;
     if (session_id != NULL) {
         secured_message_context =
             libspdm_get_secured_message_context_via_session_id(
@@ -207,7 +207,7 @@ return_status libspdm_transport_pci_doe_decode_message(
     uintn *message_size, void *message)
 {
     return_status status;
-    transport_decode_message_func transport_decode_message;
+    libspdm_pci_doe_decode_message_func transport_decode_message;
     uint32_t *secured_message_session_id;
     uint8_t secured_message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     uintn secured_message_size;
@@ -231,7 +231,7 @@ return_status libspdm_transport_pci_doe_decode_message(
     }
     *is_app_message = false;
 
-    transport_decode_message = pci_doe_decode_message;
+    transport_decode_message = libspdm_pci_doe_decode_message;
 
     secured_message_session_id = NULL;
     /* Detect received message*/

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -59,10 +59,10 @@ uint32_t libspdm_pci_doe_get_max_random_number_count(void)
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status pci_doe_encode_message(const uint32_t *session_id,
-                                     uintn message_size, const void *message,
-                                     uintn *transport_message_size,
-                                     void *transport_message)
+return_status libspdm_pci_doe_encode_message(const uint32_t *session_id,
+                                             uintn message_size, const void *message,
+                                             uintn *transport_message_size,
+                                             void *transport_message)
 {
     uintn aligned_message_size;
     uintn alignment;
@@ -128,11 +128,11 @@ return_status pci_doe_encode_message(const uint32_t *session_id,
  * @retval RETURN_SUCCESS               The message is encoded successfully.
  * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
-return_status pci_doe_decode_message(uint32_t **session_id,
-                                     uintn transport_message_size,
-                                     const void *transport_message,
-                                     uintn *message_size,
-                                     void *message)
+return_status libspdm_pci_doe_decode_message(uint32_t **session_id,
+                                             uintn transport_message_size,
+                                             const void *transport_message,
+                                             uintn *message_size,
+                                             void *message)
 {
     uintn alignment;
     const pci_doe_data_object_header_t *pci_doe_header;


### PR DESCRIPTION
Fix: #576 

in spdm_crypt_lib, spdm_requester_lib, spdm_responder_lib,
 spdm_secured_message_lib, spdm_secured_message_lib and
 spdm_transport_mctp_lib, spdm_transport_pcidoe_lib

Signed-off-by: Qi Zhang <qi1.zhang@intel.com>