### PR TITLE
Transition GET_VERSION to new error codes

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -21,6 +21,7 @@
 #include "library/spdm_crypt_lib.h"
 #include "library/spdm_secured_message_lib.h"
 #include "library/spdm_device_secret_lib.h"
+#include "library/spdm_return_status.h"
 
 
 /* Connection: When a host sends messgages to a device, they create a connection.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -23,7 +23,6 @@
 #include "library/spdm_device_secret_lib.h"
 #include "library/spdm_return_status.h"
 
-
 /* Connection: When a host sends messgages to a device, they create a connection.
  *             The host can and only can create one connection with one device.
  *             The host may create multiple connections with multiple devices at same time.
@@ -35,8 +34,7 @@
  *          A session can be unique identified by a session ID, returned from the device.
  *          The message exchange in a session is cipher text.*/
 
-
-#define LIBSPDM_STATUS_SUCCESS 0
+/* #define LIBSPDM_STATUS_SUCCESS 0 */
 #define LIBSPDM_STATUS_ERROR BIT31
 #define LIBSPDM_STATUS_ERROR_DEVICE_NO_CAPABILITIES (LIBSPDM_STATUS_ERROR + 0x10)
 #define LIBSPDM_STATUS_ERROR_DEVICE_ERROR (LIBSPDM_STATUS_ERROR + 0x11)
@@ -47,6 +45,7 @@
 #define LIBSPDM_STATUS_ERROR_NO_CERT_PROVISION (LIBSPDM_STATUS_ERROR + 0x32)
 #define LIBSPDM_STATUS_ERROR_KEY_EXCHANGE_FAILURE (LIBSPDM_STATUS_ERROR + 0x40)
 #define LIBSPDM_STATUS_ERROR_NO_MUTUAL_AUTH (LIBSPDM_STATUS_ERROR + 0x41)
+
 
 typedef enum {
 

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -43,6 +43,14 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_STATUS_SUCCESS \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_SUCCESS, LIBSPDM_SOURCE_SUCCESS, 0x0000)
 
+#define LIBSPDM_RET_ON_ERR(status) \
+    do { \
+        if (LIBSPDM_STATUS_IS_ERROR(status)) { \
+            return (status); \
+        } \
+    } \
+    while (0)
+
 /* Core errors. */
 
 /* Unable to complete operation due to unsupported capabilities by the caller. */
@@ -68,6 +76,14 @@ typedef uint32_t libspdm_return_t;
 /* The received message contains one or more invalid message fields. */
 #define LIBSPDM_STATUS_INVALID_MESS_FIELD \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0005)
+
+/* The received message's size is invalid. */
+#define LIBSPDM_STATUS_INVALID_MESS_SIZE \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0006)
+
+/* Unable to derive a common set of versions, algorithms, etc. */
+#define LIBSPDM_STATUS_NEGOTIATION_FAIL \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0007)
 
 /* Cryptography errors. */
 

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -86,6 +86,14 @@ typedef uintn libspdm_return_t;
 #define LIBSPDM_STATUS_NEGOTIATION_FAIL \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0007)
 
+/* Received a Busy error message. */
+#define LIBSPDM_STATUS_BUSY_PEER \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0008)
+
+/* Received an unexpected error message. */
+#define LIBSPDM_STATUS_ERROR_PEER \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0009)
+
 /* Cryptography errors. */
 
 /* Verification of the provided signature failed. */
@@ -109,7 +117,6 @@ typedef uintn libspdm_return_t;
 /* Unable to receive message from peer. */
 #define LIBSPDM_STATUS_RECEIVE_FAIL \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPSM_SOURCE_TRANSPORT, 0x0001)
-
 
 /* Random number generation errors. */
 

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -9,7 +9,8 @@
  * [23:16] - source
  * [15:00] - code
  **/
-typedef uint32_t libspdm_return_t;
+/* TODO: Change to uint32_t once conversion has completed */
+typedef uintn libspdm_return_t;
 
 /* Returns 1 if severity is LIBSPDM_SEVERITY_SUCCESS else it returns 0. */
 #define LIBSPDM_STATUS_IS_SUCCESS(status) \
@@ -37,7 +38,7 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_SOURCE_RNG 0x06
 
 #define LIBSPDM_STATUS_CONSTRUCT(severity, source, code) \
-    (((severity) << 28) | ((source) << 16) | (code))
+    ((libspdm_return_t)(((severity) << 28) | ((source) << 16) | (code)))
 
 /* Success status is always 0x00000000. */
 #define LIBSPDM_STATUS_SUCCESS \
@@ -74,11 +75,11 @@ typedef uint32_t libspdm_return_t;
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0004)
 
 /* The received message contains one or more invalid message fields. */
-#define LIBSPDM_STATUS_INVALID_MESS_FIELD \
+#define LIBSPDM_STATUS_INVALID_MSG_FIELD \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0005)
 
 /* The received message's size is invalid. */
-#define LIBSPDM_STATUS_INVALID_MESS_SIZE \
+#define LIBSPDM_STATUS_INVALID_MSG_SIZE \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0006)
 
 /* Unable to derive a common set of versions, algorithms, etc. */

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -67,10 +67,7 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
     if (spdm_response.header.spdm_version != SPDM_MESSAGE_VERSION_10) {
         return LIBSPDM_STATUS_INVALID_MSG_FIELD;
     }
-    if (spdm_response.header.request_response_code == SPDM_ERROR) {
-        status = libspdm_handle_simple_error_response(spdm_context, spdm_response.header.param1);
-        LIBSPDM_RET_ON_ERR(status);
-    } else if (spdm_response.header.request_response_code != SPDM_VERSION) {
+    if (spdm_response.header.request_response_code != SPDM_VERSION) {
         return LIBSPDM_STATUS_INVALID_MSG_FIELD;
     }
     if (spdm_response_size < sizeof(spdm_version_response_t)) {

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -70,8 +70,8 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
     if (spdm_response.header.request_response_code == SPDM_ERROR) {
         status = libspdm_handle_simple_error_response(spdm_context, spdm_response.header.param1);
 
-        // TODO: Replace this with LIBSPDM_RET_ON_ERR once libspdm_handle_simple_error_response
-        // uses the new error codes.
+        /* TODO: Replace this with LIBSPDM_RET_ON_ERR once libspdm_handle_simple_error_response
+         * uses the new error codes. */
         if (status == RETURN_DEVICE_ERROR) {
             return LIBSPDM_STATUS_ERROR_PEER;
         }
@@ -166,8 +166,8 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  **/
 libspdm_return_t libspdm_get_version(libspdm_context_t *spdm_context,
-                                  uint8_t *version_number_entry_count,
-                                  spdm_version_number_t *version_number_entry)
+                                     uint8_t *version_number_entry_count,
+                                     spdm_version_number_t *version_number_entry)
 {
     uintn retry;
     libspdm_return_t status;

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -18,10 +18,22 @@ typedef struct {
 /**
  * This function sends GET_VERSION and receives VERSION.
  *
- * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  version_count        The number of SPDM versions that the Responder supports.
+ * @param  VersionNumberEntries The list of SPDM versions that the Responder supports.
  *
- * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval LIBSPDM_STATUS_SUCCESS
+ *         GET_VERSION was sent and VERSION was received.
+ * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE
+ *         The size of the VERSION response is invalid.
+ * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD
+ *         The VERSION response contains one or more invalid fields.
+ * @retval LIBSPDM_STATUS_ERROR_PEER
+ *         The Responder returned an unexpected error.
+ * @retval LIBSPDM_STATUS_BUSY_PEER
+ *         The Responder continually returned Busy error messages.
+ * @retval LIBSPDM_STATUS_NEGOTIATION_FAIL
+ *         The Requester and Responder do not support a common SPDM version.
  **/
 libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
                                          uint8_t *version_number_entry_count,
@@ -156,14 +168,25 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
 }
 
 /**
- * This function sends GET_VERSION and receives VERSION.
+ * This function sends GET_VERSION and receives VERSION. It may retry GET_VERSION multiple times
+ * if the Responder replies with a Busy error.
  *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  version_count                 version_count from the VERSION response.
- * @param  VersionNumberEntries         VersionNumberEntries from the VERSION response.
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  version_count        The number of SPDM versions that the Responder supports.
+ * @param  VersionNumberEntries The list of SPDM versions that the Responder supports.
  *
- * @retval RETURN_SUCCESS               The GET_VERSION is sent and the VERSION is received.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval LIBSPDM_STATUS_SUCCESS
+ *         GET_VERSION was sent and VERSION was received.
+ * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE
+ *         The size of the VERSION response is invalid.
+ * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD
+ *         The VERSION response contains one or more invalid fields.
+ * @retval LIBSPDM_STATUS_ERROR_PEER
+ *         The Responder returned an unexpected error.
+ * @retval LIBSPDM_STATUS_BUSY_PEER
+ *         The Responder continually returned Busy error messages.
+ * @retval LIBSPDM_STATUS_NEGOTIATION_FAIL
+ *         The Requester and Responder do not support a common SPDM version.
  **/
 libspdm_return_t libspdm_get_version(libspdm_context_t *spdm_context,
                                      uint8_t *version_number_entry_count,

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -25,35 +25,35 @@ return_status libspdm_requester_get_version_test_send_message(
     spdm_test_context = libspdm_get_test_context();
     switch (spdm_test_context->case_id) {
     case 0x1:
-        return RETURN_DEVICE_ERROR;
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
     case 0x2:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x3:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x4:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x5:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x6:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x7:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x8:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0x9:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xA:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xB:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xC:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xD:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xE:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     case 0xF:
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -68,7 +68,7 @@ return_status libspdm_requester_get_version_test_receive_message(
     spdm_test_context = libspdm_get_test_context();
     switch (spdm_test_context->case_id) {
     case 0x1:
-        return RETURN_DEVICE_ERROR;
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
 
     case 0x2: {
         libspdm_version_response_mine_t spdm_response;
@@ -87,7 +87,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x3: {
         spdm_version_response_t spdm_response;
@@ -104,7 +104,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x4: {
         spdm_error_response_t spdm_response;
@@ -120,7 +120,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x5: {
         spdm_error_response_t spdm_response;
@@ -136,7 +136,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x6: {
         static uintn sub_index1 = 0;
@@ -175,7 +175,7 @@ return_status libspdm_requester_get_version_test_receive_message(
         }
         sub_index1++;
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x7: {
         spdm_error_response_t spdm_response;
@@ -191,7 +191,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x8: {
         spdm_error_response_data_response_not_ready_t spdm_response;
@@ -212,7 +212,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0x9: {
         static uintn sub_index2 = 0;
@@ -258,7 +258,7 @@ return_status libspdm_requester_get_version_test_receive_message(
         }
         sub_index2++;
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xA: {
         libspdm_version_response_mine_t spdm_response;
@@ -278,7 +278,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xB: {
         libspdm_version_response_mine_t spdm_response;
@@ -297,7 +297,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xC: {
         libspdm_version_response_mine_t spdm_response;
@@ -316,7 +316,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xD: {
         libspdm_version_response_mine_t spdm_response;
@@ -335,7 +335,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xE:
     {
@@ -365,7 +365,7 @@ return_status libspdm_requester_get_version_test_receive_message(
             error_code = LIBSPDM_ERROR_CODE_RESERVED_FD;
         }
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
 
     case 0xF: {
         libspdm_version_response_mine_t spdm_response;
@@ -387,7 +387,7 @@ return_status libspdm_requester_get_version_test_receive_message(
                                               &spdm_response,
                                               response_size, response);
     }
-        return RETURN_SUCCESS;
+        return LIBSPDM_STATUS_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -395,7 +395,7 @@ return_status libspdm_requester_get_version_test_receive_message(
 
 /**
  * Test 1: when no VERSION message is received, and the client returns a device error.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case1(void **state)
 {
@@ -408,12 +408,12 @@ void libspdm_test_requester_get_version_case1(void **state)
     spdm_test_context->case_id = 0x1;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
  * Test 2: receiving a correct VERSION message with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 void libspdm_test_requester_get_version_case2(void **state)
 {
@@ -426,12 +426,12 @@ void libspdm_test_requester_get_version_case2(void **state)
     spdm_test_context->case_id = 0x2;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
 /**
  * Test 3: receiving a correct VERSION message header, but with 0 versions available.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case3(void **state)
 {
@@ -444,12 +444,12 @@ void libspdm_test_requester_get_version_case3(void **state)
     spdm_test_context->case_id = 0x3;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
  * Test 4: receiving an InvalidRequest ERROR message from the responder.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case4(void **state)
 {
@@ -462,12 +462,12 @@ void libspdm_test_requester_get_version_case4(void **state)
     spdm_test_context->case_id = 0x4;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
- * Test 5: receiving an Busy ERROR message correct VERSION message from the responder.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Test 5: receiving a Busy ERROR message correct VERSION message from the responder.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case5(void **state)
 {
@@ -480,13 +480,13 @@ void libspdm_test_requester_get_version_case5(void **state)
     spdm_test_context->case_id = 0x5;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_NO_RESPONSE);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
  * Test 6: on the first try, receiving a Busy ERROR message, and on retry, receiving
  * a correct VERSION message with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 void libspdm_test_requester_get_version_case6(void **state)
 {
@@ -499,15 +499,13 @@ void libspdm_test_requester_get_version_case6(void **state)
     spdm_test_context->case_id = 0x6;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
 /**
  * Test 7: receiving a RequestResynch ERROR message from the responder.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD, and the
  * internal state should be reset.
- * Note: As from 1.1.c, this is an unexpected behavior, as the responder should not
- * respond a GET_VERSION message with a RequestResynch. It should expect a GET_VERSION.
  **/
 void libspdm_test_requester_get_version_case7(void **state)
 {
@@ -520,16 +518,14 @@ void libspdm_test_requester_get_version_case7(void **state)
     spdm_test_context->case_id = 0x7;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
 }
 
 /**
  * Test 8: receiving a ResponseNotReady ERROR message from the responder.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
- * Note: As from 1.0.0, this is an unexpected behavior, as the responder should not
- * respond a GET_VERSION message with a ResponseNotReady.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case8(void **state)
 {
@@ -542,7 +538,7 @@ void libspdm_test_requester_get_version_case8(void **state)
     spdm_test_context->case_id = 0x8;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
@@ -570,7 +566,7 @@ void libspdm_test_requester_get_version_case9(void **state)
  * Test 10: receiving a VERSION message with a larger list of available versions than indicated.
  * The presence of only two versions are indicated, but the VERSION message presents a list
  * with 3 versions: 1.0, 1.1 and 1.2.
- * Expected behavior: client returns a status of RETURN_SUCCESS, but truncate the message
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS, but truncate the message
  * to consider only the two first versions, as indicated in the message.
  **/
 void libspdm_test_requester_get_version_case10(void **state)
@@ -584,13 +580,13 @@ void libspdm_test_requester_get_version_case10(void **state)
     spdm_test_context->case_id = 0xA;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
 /**
- * Test 11: receiving a correct VERSION message with available version 10.0 and 10.1, but
+ * Test 11: receiving a correct VERSION message with available version 1.0 and 1.1, but
  * the requester do not have compatible versions with the responder.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_NEGOTIATION_FAIL.
  **/
 void libspdm_test_requester_get_version_case11(void **state)
 {
@@ -603,13 +599,13 @@ void libspdm_test_requester_get_version_case11(void **state)
     spdm_test_context->case_id = 0xB;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_NEGOTIATION_FAIL);
 }
 
 /**
  * Test 12: receiving a VERSION message in SPDM version 1.1 (in the header), but correct
  * 1.0-version format, with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case12(void **state)
 {
@@ -622,14 +618,14 @@ void libspdm_test_requester_get_version_case12(void **state)
     spdm_test_context->case_id = 0xC;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
  * Test 13: receiving a VERSION message with wrong SPDM request_response_code (in this
  * case, GET_VERSION 0x84 instead of VERSION 0x04). The remaining data is a correct
  * VERSION message, with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case13(void **state)
 {
@@ -642,7 +638,7 @@ void libspdm_test_requester_get_version_case13(void **state)
     spdm_test_context->case_id = 0xD;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
 /**
@@ -651,7 +647,7 @@ void libspdm_test_requester_get_version_case13(void **state)
  * (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
  * However, for having specific test cases, it is excluded from this case:
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 void libspdm_test_requester_get_version_case14(void **state) {
     return_status status;
@@ -667,7 +663,7 @@ void libspdm_test_requester_get_version_case14(void **state) {
     while(error_code <= 0xff) {
         /* no additional state control is necessary as a new GET_VERSION resets the state*/
         status = libspdm_get_version (spdm_context, NULL, NULL);
-        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, RETURN_DEVICE_ERROR, error_code);
+        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_INVALID_MSG_FIELD, error_code);
 
         error_code++;
         if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
@@ -686,7 +682,7 @@ void libspdm_test_requester_get_version_case14(void **state) {
  * Test 15: receiving a VERSION message with unordered vesion list.
  * Requester list:5.5, 4.5, 0.9, 1.0, 1.1
  * Responder list:4.2, 5.2, 1.2, 1.1, 1.0
- * Expected behavior: client returns a status of RETURN_SUCCESS and right negotiated version 1.1.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and right negotiated version 1.1.
  **/
 void libspdm_test_requester_get_version_case15(void **state)
 {
@@ -704,7 +700,7 @@ void libspdm_test_requester_get_version_case15(void **state)
     spdm_context->local_context.version.spdm_version[3] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->local_context.version.spdm_version[4] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(
         spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT, 0x11);
 }

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -16,7 +16,7 @@ typedef struct {
 } libspdm_version_response_mine_t;
 #pragma pack()
 
-return_status libspdm_requester_get_version_test_send_message(
+libspdm_return_t libspdm_requester_get_version_test_send_message(
     void *spdm_context, uintn request_size, const void *request,
     uint64_t timeout)
 {
@@ -59,7 +59,7 @@ return_status libspdm_requester_get_version_test_send_message(
     }
 }
 
-return_status libspdm_requester_get_version_test_receive_message(
+libspdm_return_t libspdm_requester_get_version_test_receive_message(
     void *spdm_context, uintn *response_size,
     void *response, uint64_t timeout)
 {
@@ -399,7 +399,7 @@ return_status libspdm_requester_get_version_test_receive_message(
  **/
 void libspdm_test_requester_get_version_case1(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -417,7 +417,7 @@ void libspdm_test_requester_get_version_case1(void **state)
  **/
 void libspdm_test_requester_get_version_case2(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -435,7 +435,7 @@ void libspdm_test_requester_get_version_case2(void **state)
  **/
 void libspdm_test_requester_get_version_case3(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -449,11 +449,11 @@ void libspdm_test_requester_get_version_case3(void **state)
 
 /**
  * Test 4: receiving an InvalidRequest ERROR message from the responder.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
 void libspdm_test_requester_get_version_case4(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -462,16 +462,16 @@ void libspdm_test_requester_get_version_case4(void **state)
     spdm_test_context->case_id = 0x4;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
 /**
  * Test 5: receiving a Busy ERROR message correct VERSION message from the responder.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_BUSY_PEER.
  **/
 void libspdm_test_requester_get_version_case5(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -480,7 +480,7 @@ void libspdm_test_requester_get_version_case5(void **state)
     spdm_test_context->case_id = 0x5;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
 }
 
 /**
@@ -490,7 +490,7 @@ void libspdm_test_requester_get_version_case5(void **state)
  **/
 void libspdm_test_requester_get_version_case6(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -504,12 +504,12 @@ void libspdm_test_requester_get_version_case6(void **state)
 
 /**
  * Test 7: receiving a RequestResynch ERROR message from the responder.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD, and the
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER, and the
  * internal state should be reset.
  **/
 void libspdm_test_requester_get_version_case7(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -518,18 +518,18 @@ void libspdm_test_requester_get_version_case7(void **state)
     spdm_test_context->case_id = 0x7;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
 }
 
 /**
  * Test 8: receiving a ResponseNotReady ERROR message from the responder.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
 void libspdm_test_requester_get_version_case8(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -538,19 +538,19 @@ void libspdm_test_requester_get_version_case8(void **state)
     spdm_test_context->case_id = 0x8;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
 /**
  * Test 9: on the first try, receiving a ResponseNotReady ERROR message, and on retry,
  * receiving a correct VERSION message with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  * Note: The responder should not
  * respond a GET_VERSION message with a ResponseNotReady.
  **/
 void libspdm_test_requester_get_version_case9(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -559,7 +559,7 @@ void libspdm_test_requester_get_version_case9(void **state)
     spdm_test_context->case_id = 0x9;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, RETURN_DEVICE_ERROR);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
 /**
@@ -571,7 +571,7 @@ void libspdm_test_requester_get_version_case9(void **state)
  **/
 void libspdm_test_requester_get_version_case10(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -590,7 +590,7 @@ void libspdm_test_requester_get_version_case10(void **state)
  **/
 void libspdm_test_requester_get_version_case11(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -609,7 +609,7 @@ void libspdm_test_requester_get_version_case11(void **state)
  **/
 void libspdm_test_requester_get_version_case12(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -629,7 +629,7 @@ void libspdm_test_requester_get_version_case12(void **state)
  **/
 void libspdm_test_requester_get_version_case13(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 
@@ -647,10 +647,10 @@ void libspdm_test_requester_get_version_case13(void **state)
  * (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
  * However, for having specific test cases, it is excluded from this case:
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
 void libspdm_test_requester_get_version_case14(void **state) {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
     uint16_t error_code;
@@ -663,7 +663,7 @@ void libspdm_test_requester_get_version_case14(void **state) {
     while(error_code <= 0xff) {
         /* no additional state control is necessary as a new GET_VERSION resets the state*/
         status = libspdm_get_version (spdm_context, NULL, NULL);
-        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_INVALID_MSG_FIELD, error_code);
+        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
 
         error_code++;
         if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
@@ -686,7 +686,7 @@ void libspdm_test_requester_get_version_case14(void **state) {
  **/
 void libspdm_test_requester_get_version_case15(void **state)
 {
-    return_status status;
+    libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
 

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -214,50 +214,7 @@ libspdm_return_t libspdm_requester_get_version_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
-    case 0x9: {
-        static uintn sub_index2 = 0;
-        if (sub_index2 == 0) {
-            spdm_error_response_data_response_not_ready_t
-                spdm_response;
-
-            libspdm_zero_mem(&spdm_response, sizeof(spdm_response));
-            spdm_response.header.spdm_version =
-                SPDM_MESSAGE_VERSION_10;
-            spdm_response.header.request_response_code = SPDM_ERROR;
-            spdm_response.header.param1 =
-                SPDM_ERROR_CODE_RESPONSE_NOT_READY;
-            spdm_response.header.param2 = 0;
-            spdm_response.extend_error_data.rd_exponent = 1;
-            spdm_response.extend_error_data.rd_tm = 1;
-            spdm_response.extend_error_data.request_code =
-                SPDM_GET_VERSION;
-            spdm_response.extend_error_data.token = 1;
-
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false,
-                sizeof(spdm_response), &spdm_response,
-                response_size, response);
-        } else if (sub_index2 == 1) {
-            libspdm_version_response_mine_t spdm_response;
-
-            libspdm_zero_mem(&spdm_response, sizeof(spdm_response));
-            spdm_response.header.spdm_version =
-                SPDM_MESSAGE_VERSION_10;
-            spdm_response.header.request_response_code =
-                SPDM_VERSION;
-            spdm_response.header.param1 = 0;
-            spdm_response.header.param2 = 0;
-            spdm_response.version_number_entry_count = 2;
-            spdm_response.version_number_entry[0] = 0x10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
-            spdm_response.version_number_entry[1] = 0x11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
-
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false,
-                sizeof(spdm_response), &spdm_response,
-                response_size, response);
-        }
-        sub_index2++;
-    }
+    case 0x9:
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0xA: {
@@ -542,24 +499,10 @@ void libspdm_test_requester_get_version_case8(void **state)
 }
 
 /**
- * Test 9: on the first try, receiving a ResponseNotReady ERROR message, and on retry,
- * receiving a correct VERSION message with available version 1.0 and 1.1.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
- * Note: The responder should not
- * respond a GET_VERSION message with a ResponseNotReady.
+ * Test 9: Can be populated with new test.
  **/
 void libspdm_test_requester_get_version_case9(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x9;
-
-    status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
 /**


### PR DESCRIPTION
Add spdm_return_status.h to library\spdm_common_lib.h.
Create a new macro to check and return on error.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>