### PR TITLE
remove msg_buf_ptr field in release_buffer.

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1103,12 +1103,11 @@ return_status libspdm_acquire_sender_buffer (
  * Release a device sender buffer for transport layer message.
  *
  * @param  context                       A pointer to the SPDM context.
- * @param  msg_buf_ptr                   A pointer to a sender buffer.
  *
  * @retval RETURN_SUCCESS               The sender buffer is Released.
  **/
 void libspdm_release_sender_buffer (
-    libspdm_context_t *spdm_context, const void *msg_buf_ptr);
+    libspdm_context_t *spdm_context);
 
 /**
  * Get the sender buffer.
@@ -1139,12 +1138,11 @@ return_status libspdm_acquire_receiver_buffer (
  * Release a device receiver buffer for transport layer message.
  *
  * @param  context                       A pointer to the SPDM context.
- * @param  msg_buf_ptr                   A pointer to a receiver buffer.
  *
  * @retval RETURN_SUCCESS               The receiver buffer is Released.
  **/
 void libspdm_release_receiver_buffer (
-    libspdm_context_t *spdm_context, const void *msg_buf_ptr);
+    libspdm_context_t *spdm_context);
 
 /**
  * Get the receiver buffer.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2007,19 +2007,12 @@ return_status libspdm_acquire_sender_buffer (
  * Release a device sender buffer for transport layer message.
  *
  * @param  context                       A pointer to the SPDM context.
- * @param  msg_buf_ptr                   A pointer to a sender buffer.
  *
  * @retval RETURN_SUCCESS               The sender buffer is Released.
  **/
 void libspdm_release_sender_buffer (
-    libspdm_context_t *spdm_context, const void *msg_buf_ptr)
+    libspdm_context_t *spdm_context)
 {
-    if (msg_buf_ptr == NULL) {
-        return;
-    }
-    LIBSPDM_ASSERT ((uintn)spdm_context->sender_buffer <= (uintn)msg_buf_ptr &&
-                    (uintn)spdm_context->sender_buffer + spdm_context->sender_buffer_size >
-                    (uintn)msg_buf_ptr);
     spdm_context->release_sender_buffer (spdm_context, spdm_context->sender_buffer);
     spdm_context->sender_buffer = NULL;
     spdm_context->sender_buffer_size = 0;
@@ -2071,19 +2064,12 @@ return_status libspdm_acquire_receiver_buffer (
  * Release a device receiver buffer for transport layer message.
  *
  * @param  context                       A pointer to the SPDM context.
- * @param  msg_buf_ptr                   A pointer to a receiver buffer.
  *
  * @retval RETURN_SUCCESS               The receiver buffer is Released.
  **/
 void libspdm_release_receiver_buffer (
-    libspdm_context_t *spdm_context, const void *msg_buf_ptr)
+    libspdm_context_t *spdm_context)
 {
-    if (msg_buf_ptr == NULL) {
-        return;
-    }
-    LIBSPDM_ASSERT ((uintn)spdm_context->receiver_buffer <= (uintn)msg_buf_ptr &&
-                    (uintn)spdm_context->receiver_buffer + spdm_context->receiver_buffer_size >
-                    (uintn)msg_buf_ptr);
     spdm_context->release_receiver_buffer (spdm_context, spdm_context->receiver_buffer);
     spdm_context->receiver_buffer = NULL;
     spdm_context->receiver_buffer_size = 0;

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -109,7 +109,7 @@ return_status libspdm_try_challenge(void *context, uint8_t slot_id,
     spdm_request_size = sizeof(spdm_challenge_request_t);
     if (requester_nonce_in == NULL) {
         if(!libspdm_get_random_number(SPDM_NONCE_SIZE, spdm_request->nonce)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
     } else {
@@ -127,10 +127,10 @@ return_status libspdm_try_challenge(void *context, uint8_t slot_id,
     status = libspdm_send_spdm_request(spdm_context, NULL,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -316,7 +316,7 @@ return_status libspdm_try_challenge(void *context, uint8_t slot_id,
 
     if ((auth_attribute & SPDM_CHALLENGE_AUTH_RESPONSE_ATTRIBUTE_BASIC_MUT_AUTH_REQ) != 0) {
         /* we must release it here, because libspdm_encapsulated_request() will acquire again. */
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
 
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "BasicMutAuth :\n"));
         status = libspdm_encapsulated_request(spdm_context, NULL, 0, NULL);
@@ -339,7 +339,7 @@ return_status libspdm_try_challenge(void *context, uint8_t slot_id,
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_communication.c
+++ b/library/spdm_requester_lib/libspdm_req_communication.c
@@ -412,10 +412,10 @@ return_status libspdm_send_receive_data(void *context, const uint32_t *session_i
     status = libspdm_send_request(spdm_context, session_id, is_app_message,
                                   spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
 
     /* receive */
 
@@ -427,7 +427,7 @@ return_status libspdm_send_receive_data(void *context, const uint32_t *session_i
     status = libspdm_receive_response(spdm_context, session_id, is_app_message,
                                       &spdm_response_size, (void **)&spdm_response);
     if (RETURN_ERROR(status)) {
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
 
@@ -435,7 +435,7 @@ return_status libspdm_send_receive_data(void *context, const uint32_t *session_i
         if ((spdm_response->header.param1 == SPDM_ERROR_CODE_DECRYPT_ERROR) &&
             (session_id != NULL)) {
             libspdm_free_session_id(spdm_context, *session_id);
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_SECURITY_VIOLATION;
         }
     }
@@ -445,11 +445,11 @@ return_status libspdm_send_receive_data(void *context, const uint32_t *session_i
         *response_size = spdm_response_size;
     } else {
         *response_size = spdm_response_size;
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return RETURN_BUFFER_TOO_SMALL;
     }
 
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
 
     return RETURN_SUCCESS;
 }

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -254,10 +254,10 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             spdm_context, session_id, spdm_request_size,
             spdm_request);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return status;
         }
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         spdm_get_encapsulated_request_request = (void *)spdm_context->last_spdm_request;
 
         /* receive */
@@ -273,30 +273,30 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             (void **)&spdm_response);
         libspdm_encapsulated_request_response = (void *)spdm_response;
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
         if (libspdm_encapsulated_request_response->header
             .request_response_code !=
             SPDM_ENCAPSULATED_REQUEST) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (libspdm_encapsulated_request_response->header.spdm_version !=
             spdm_get_encapsulated_request_request->header.spdm_version) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response_size <
             sizeof(spdm_encapsulated_request_response_t)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response_size ==
             sizeof(spdm_encapsulated_request_response_t)) {
 
             /* Done*/
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_SUCCESS;
         }
         request_id = libspdm_encapsulated_request_response->header.param1;
@@ -315,7 +315,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
         spdm_context->last_spdm_request_size = encapsulated_request_size;
         encapsulated_request = (void *)spdm_context->last_spdm_request;
 
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
     }
 
     while (true) {
@@ -349,7 +349,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             encapsulated_request, &encapsulated_response_size,
             encapsulated_response);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
 
@@ -360,10 +360,10 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             spdm_context, session_id, spdm_request_size,
             spdm_request);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return status;
         }
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         spdm_deliver_encapsulated_response_request = (void *)spdm_context->last_spdm_request;
 
         /* receive */
@@ -380,18 +380,18 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             (void **)&spdm_response);
         spdm_encapsulated_response_ack_response = (void *)spdm_response;
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
         if (spdm_encapsulated_response_ack_response->header
             .request_response_code !=
             SPDM_ENCAPSULATED_RESPONSE_ACK) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_encapsulated_response_ack_response->header.spdm_version !=
             spdm_deliver_encapsulated_response_request->header.spdm_version) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_encapsulated_response_ack_response->header.spdm_version >=
@@ -401,7 +401,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             ack_header_size = sizeof(spdm_message_header_t);
         }
         if (spdm_response_size < ack_header_size) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
 
@@ -409,7 +409,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             SPDM_MESSAGE_VERSION_12) {
             if (spdm_encapsulated_response_ack_response->ack_request_id !=
                 spdm_deliver_encapsulated_response_request->header.param1) {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return RETURN_DEVICE_ERROR;
             }
         }
@@ -417,10 +417,10 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
         switch (spdm_encapsulated_response_ack_response->header.param2) {
         case SPDM_ENCAPSULATED_RESPONSE_ACK_RESPONSE_PAYLOAD_TYPE_ABSENT:
             if (spdm_response_size == ack_header_size) {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return RETURN_SUCCESS;
             } else {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return RETURN_DEVICE_ERROR;
             }
             break;
@@ -435,19 +435,19 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
                     if (*req_slot_id_param >=
                         spdm_context->local_context
                         .slot_count) {
-                        libspdm_release_receiver_buffer (spdm_context, message);
+                        libspdm_release_receiver_buffer (spdm_context);
                         return RETURN_DEVICE_ERROR;
                     }
                 }
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return RETURN_SUCCESS;
             } else {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return RETURN_DEVICE_ERROR;
             }
             break;
         default:
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         request_id =
@@ -465,7 +465,7 @@ return_status libspdm_encapsulated_request(libspdm_context_t *spdm_context,
         spdm_context->last_spdm_request_size = encapsulated_request_size;
         encapsulated_request = (void *)spdm_context->last_spdm_request;
 
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
     }
 
     return RETURN_SUCCESS;

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -79,14 +79,14 @@ return_status libspdm_try_send_receive_end_session(libspdm_context_t *spdm_conte
     status = libspdm_send_spdm_request(spdm_context, &session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
 
     libspdm_reset_message_buffer_via_request_code(spdm_context, session_info,
                                                   SPDM_END_SESSION);
 
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -139,7 +139,7 @@ return_status libspdm_try_send_receive_end_session(libspdm_context_t *spdm_conte
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -142,7 +142,7 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
     status = libspdm_append_message_f(spdm_context, session_info, true, (uint8_t *)spdm_request,
                                       sizeof(spdm_finish_request_t));
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
@@ -150,14 +150,14 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
         result = libspdm_generate_finish_req_signature(spdm_context,
                                                        session_info, ptr);
         if (!result) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             status = RETURN_SECURITY_VIOLATION;
             goto error;
         }
         status = libspdm_append_message_f(spdm_context, session_info, true, ptr,
                                           signature_size);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             status = RETURN_SECURITY_VIOLATION;
             goto error;
         }
@@ -166,14 +166,14 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
 
     result = libspdm_generate_finish_req_hmac(spdm_context, session_info, ptr);
     if (!result) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
 
     status = libspdm_append_message_f(spdm_context, session_info, true, ptr, hmac_size);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
@@ -181,14 +181,14 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
     status = libspdm_send_spdm_request(spdm_context, &session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         goto error;
     }
 
     libspdm_reset_message_buffer_via_request_code(spdm_context, session_info,
                                                   SPDM_FINISH);
 
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -297,11 +297,11 @@ return_status libspdm_try_send_receive_finish(libspdm_context_t *spdm_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     spdm_context->error_state = LIBSPDM_STATUS_SUCCESS;
 
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
 error:
     if (RETURN_NO_RESPONSE != status) {
         libspdm_free_session_id(spdm_context, session_id);

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -151,10 +151,10 @@ libspdm_return_t libspdm_try_get_capabilities(libspdm_context_t *spdm_context)
     spdm_request->max_spdm_msg_size = spdm_context->local_context.capability.max_spdm_msg_size;
     status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size, spdm_request);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -262,7 +262,7 @@ libspdm_return_t libspdm_try_get_capabilities(libspdm_context_t *spdm_context)
     status = LIBSPDM_STATUS_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -119,10 +119,10 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
                                            spdm_request_size,
                                            spdm_request);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             goto done;
         }
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         spdm_request = (void *)spdm_context->last_spdm_request;
 
         /* receive */
@@ -137,16 +137,16 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
                                                &spdm_response_size,
                                                (void **)&spdm_response);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             goto done;
         }
         if (spdm_response_size < sizeof(spdm_message_header_t)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
         if (spdm_response->header.spdm_version != spdm_request->header.spdm_version) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
@@ -158,34 +158,34 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
                 SPDM_CERTIFICATE,
                 sizeof(libspdm_certificate_response_max_t));
             if (RETURN_ERROR(status)) {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 goto done;
             }
         } else if (spdm_response->header.request_response_code !=
                    SPDM_CERTIFICATE) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
         if (spdm_response_size < sizeof(spdm_certificate_response_t)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
         if ((spdm_response->portion_length > spdm_request->length) ||
             (spdm_response->portion_length == 0)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
         if ((spdm_response->header.param1 & SPDM_CERTIFICATE_RESPONSE_SLOT_ID_MASK) != slot_id) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
         if (spdm_response_size < sizeof(spdm_certificate_response_t) +
             spdm_response->portion_length) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
@@ -194,7 +194,7 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
                                                        spdm_response->remainder_length;
         } else if (spdm_request->offset + spdm_response->portion_length +
                    spdm_response->remainder_length != total_responder_cert_chain_buffer_length) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_DEVICE_ERROR;
             goto done;
         }
@@ -208,14 +208,14 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
         status = libspdm_append_message_b(spdm_context, spdm_request,
                                           spdm_request_size);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_SECURITY_VIOLATION;
             goto done;
         }
         status = libspdm_append_message_b(spdm_context, spdm_response,
                                           spdm_response_size);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_SECURITY_VIOLATION;
             goto done;
         }
@@ -229,14 +229,14 @@ return_status libspdm_try_get_certificate(void *context, uint8_t slot_id,
                                                spdm_response->cert_chain,
                                                spdm_response->portion_length);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             status = RETURN_SECURITY_VIOLATION;
             goto done;
         }
         spdm_context->connection_info.connection_state =
             LIBSPDM_CONNECTION_STATE_AFTER_CERTIFICATE;
 
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
     } while (remainder_length != 0);
 
     if (spdm_context->local_context.verify_peer_spdm_cert_chain != NULL) {

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -80,10 +80,10 @@ return_status libspdm_try_get_digest(void *context, uint8_t *slot_mask,
     status = libspdm_send_spdm_request(spdm_context, NULL,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -192,7 +192,7 @@ return_status libspdm_try_get_digest(void *context, uint8_t *slot_mask,
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -163,7 +163,7 @@ return_status libspdm_try_get_measurement(void *context, const uint32_t *session
 
         if (requester_nonce_in == NULL) {
             if(!libspdm_get_random_number(SPDM_NONCE_SIZE, spdm_request->nonce)) {
-                libspdm_release_sender_buffer (spdm_context, message);
+                libspdm_release_sender_buffer (spdm_context);
                 return RETURN_DEVICE_ERROR;
             }
         } else {
@@ -189,10 +189,10 @@ return_status libspdm_try_get_measurement(void *context, const uint32_t *session
     status = libspdm_send_spdm_request(spdm_context, session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -523,7 +523,7 @@ return_status libspdm_try_get_measurement(void *context, const uint32_t *session
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -76,10 +76,10 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
     status = libspdm_send_spdm_request(spdm_context, NULL,
                                        spdm_request_size, spdm_request);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -204,7 +204,7 @@ libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
     status = LIBSPDM_STATUS_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -39,14 +39,7 @@ return_status libspdm_requester_respond_if_ready(libspdm_context_t *spdm_context
     /* the response might be in response buffer in normal SPDM message
      * or it is in scratch buffer in case of secure SPDM message
      * the response buffer is in acquired state, so we release it*/
-    if (session_id == NULL) {
-        libspdm_release_receiver_buffer (spdm_context, *response);
-    } else {
-        void *receiver_buffer;
-        uintn receiver_buffer_size;
-        libspdm_get_receiver_buffer (spdm_context, &receiver_buffer, &receiver_buffer_size);
-        libspdm_release_receiver_buffer (spdm_context, receiver_buffer);
-    }
+    libspdm_release_receiver_buffer (spdm_context);
 
     /* now we can get sender buffer */
     transport_header_size = spdm_context->transport_get_header_size(spdm_context);
@@ -64,12 +57,12 @@ return_status libspdm_requester_respond_if_ready(libspdm_context_t *spdm_context
     status = libspdm_send_spdm_request(spdm_context, session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         /* need acquire response buffer, so that the caller can release it */
         libspdm_acquire_receiver_buffer (spdm_context, response_size, response);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -78,10 +78,10 @@ return_status libspdm_try_heartbeat(void *context, uint32_t session_id)
     status = libspdm_send_spdm_request(spdm_context, &session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     libspdm_reset_message_buffer_via_request_code(spdm_context, session_info,
@@ -128,7 +128,7 @@ return_status libspdm_try_heartbeat(void *context, uint32_t session_id)
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -123,7 +123,7 @@ return_status libspdm_try_send_receive_key_exchange(
     spdm_request->header.param2 = slot_id;
     if (requester_random_in == NULL) {
         if(!libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE, spdm_request->random_data)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
     } else {
@@ -155,7 +155,7 @@ return_status libspdm_try_send_receive_key_exchange(
         spdm_context->connection_info.version,
         spdm_context->connection_info.algorithm.dhe_named_group, true);
     if (dhe_context == NULL) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
 
@@ -166,7 +166,7 @@ return_status libspdm_try_send_receive_key_exchange(
         libspdm_secured_message_dhe_free(
             spdm_context->connection_info.algorithm.dhe_named_group,
             dhe_context);
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ClientKey (0x%x):\n", dhe_key_size));
@@ -189,10 +189,10 @@ return_status libspdm_try_send_receive_key_exchange(
         libspdm_secured_message_dhe_free(
             spdm_context->connection_info.algorithm.dhe_named_group,
             dhe_context);
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -529,7 +529,7 @@ return_status libspdm_try_send_receive_key_exchange(
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -97,7 +97,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
         spdm_request->header.param2 = 0;
         if(!libspdm_get_random_number(sizeof(spdm_request->header.param2),
                                       &spdm_request->header.param2)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         spdm_request_size = sizeof(spdm_key_update_request_t);
@@ -111,7 +111,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
                 session_info->secured_message_context,
                 LIBSPDM_KEY_UPDATE_ACTION_RESPONDER);
             if (RETURN_ERROR(status)) {
-                libspdm_release_sender_buffer (spdm_context, message);
+                libspdm_release_sender_buffer (spdm_context);
                 return status;
             }
         }
@@ -119,11 +119,11 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
         status = libspdm_send_spdm_request(spdm_context, &session_id,
                                            spdm_request_size, spdm_request);
         if (RETURN_ERROR(status)) {
-            libspdm_release_sender_buffer (spdm_context, message);
+            libspdm_release_sender_buffer (spdm_context);
             return status;
         }
 
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         spdm_request = (void *)spdm_context->last_spdm_request;
 
         /* receive */
@@ -147,16 +147,16 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
                     session_info->secured_message_context,
                     LIBSPDM_KEY_UPDATE_ACTION_RESPONDER, false);
                 if (RETURN_ERROR(status)) {
-                    libspdm_release_receiver_buffer (spdm_context, message);
+                    libspdm_release_receiver_buffer (spdm_context);
                     return status;
                 }
             }
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
 
         if (spdm_response->header.spdm_version != spdm_request->header.spdm_version) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
         if (spdm_response->header.request_response_code == SPDM_ERROR) {
@@ -175,11 +175,11 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
                         LIBSPDM_KEY_UPDATE_ACTION_RESPONDER, false);
                     /* Try and return most relevant error*/
                     if (RETURN_ERROR(temp_status)) {
-                        libspdm_release_receiver_buffer (spdm_context, message);
+                        libspdm_release_receiver_buffer (spdm_context);
                         return temp_status;
                     }
                 }
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return status;
             }
         }
@@ -196,11 +196,11 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
                     session_info->secured_message_context,
                     LIBSPDM_KEY_UPDATE_ACTION_RESPONDER, false);
                 if (RETURN_ERROR(status)) {
-                    libspdm_release_receiver_buffer (spdm_context, message);
+                    libspdm_release_receiver_buffer (spdm_context);
                     return status;
                 }
             }
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return RETURN_DEVICE_ERROR;
         }
 
@@ -212,7 +212,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
                 session_info->secured_message_context,
                 LIBSPDM_KEY_UPDATE_ACTION_RESPONDER, true);
             if (RETURN_ERROR(status)) {
-                libspdm_release_receiver_buffer (spdm_context, message);
+                libspdm_release_receiver_buffer (spdm_context);
                 return status;
             }
         }
@@ -224,7 +224,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
             session_info->secured_message_context,
             LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
@@ -234,11 +234,11 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
             session_info->secured_message_context,
             LIBSPDM_KEY_UPDATE_ACTION_REQUESTER, true);
         if (RETURN_ERROR(status)) {
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
 
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
     }
 
     *key_updated = true;
@@ -259,7 +259,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
     spdm_request->header.param2 = 1;
     if(!libspdm_get_random_number(sizeof(spdm_request->header.param2),
                                   &spdm_request->header.param2)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
     spdm_request_size = sizeof(spdm_key_update_request_t);
@@ -267,10 +267,10 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
     status = libspdm_send_spdm_request(spdm_context, &session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -284,16 +284,16 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
     status = libspdm_receive_spdm_response(
         spdm_context, &session_id, &spdm_response_size, (void **)&spdm_response);
     if (RETURN_ERROR(status)) {
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return status;
     } else if (spdm_response_size < sizeof(spdm_message_header_t)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmVerifyKey[%x] Failed\n", session_id));
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
 
     if (spdm_response->header.spdm_version != spdm_request->header.spdm_version) {
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
@@ -304,7 +304,7 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
             sizeof(libspdm_key_update_response_mine_t));
         if (RETURN_ERROR(status)) {
             LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmVerifyKey[%x] Failed\n", session_id));
-            libspdm_release_receiver_buffer (spdm_context, message);
+            libspdm_release_receiver_buffer (spdm_context);
             return status;
         }
     }
@@ -314,12 +314,12 @@ return_status libspdm_try_key_update(void *context, uint32_t session_id,
         (spdm_response->header.param1 != spdm_request->header.param1) ||
         (spdm_response->header.param2 != spdm_request->header.param2)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmVerifyKey[%x] Failed\n", session_id));
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return RETURN_DEVICE_ERROR;
     }
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmVerifyKey[%x] Success\n", session_id));
 
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return RETURN_SUCCESS;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -138,10 +138,10 @@ libspdm_return_t libspdm_try_negotiate_algorithms(libspdm_context_t *spdm_contex
 
     status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size, spdm_request);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -461,7 +461,7 @@ libspdm_return_t libspdm_try_negotiate_algorithms(libspdm_context_t *spdm_contex
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -206,10 +206,10 @@ return_status libspdm_try_send_receive_psk_exchange(
     status = libspdm_send_spdm_request(spdm_context, NULL, spdm_request_size,
                                        spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -430,7 +430,7 @@ return_status libspdm_try_send_receive_psk_exchange(
     status = RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return status;
 }
 

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -96,7 +96,7 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
     status = libspdm_append_message_f(spdm_context, session_info, true, (uint8_t *)spdm_request,
                                       spdm_request_size - hmac_size);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
@@ -104,7 +104,7 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
     result = libspdm_generate_psk_exchange_req_hmac(spdm_context, session_info,
                                                     spdm_request->verify_data);
     if (!result) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
@@ -114,7 +114,7 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
                                       spdm_request_size - hmac_size,
                                       hmac_size);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         status = RETURN_SECURITY_VIOLATION;
         goto error;
     }
@@ -122,14 +122,14 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
     status = libspdm_send_spdm_request(spdm_context, &session_id,
                                        spdm_request_size, spdm_request);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         goto error;
     }
 
     libspdm_reset_message_buffer_via_request_code(spdm_context, session_info,
                                                   SPDM_PSK_FINISH);
 
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
     spdm_request = (void *)spdm_context->last_spdm_request;
 
     /* receive */
@@ -202,11 +202,11 @@ return_status libspdm_try_send_receive_psk_finish(libspdm_context_t *spdm_contex
         LIBSPDM_SESSION_STATE_ESTABLISHED);
     spdm_context->error_state = LIBSPDM_STATUS_SUCCESS;
 
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     return RETURN_SUCCESS;
 
 receive_done:
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
 error:
     if (RETURN_NO_RESPONSE != status) {
         libspdm_free_session_id(spdm_context, session_id);

--- a/library/spdm_responder_lib/libspdm_rsp_communication.c
+++ b/library/spdm_responder_lib/libspdm_rsp_communication.c
@@ -43,12 +43,12 @@ return_status libspdm_responder_dispatch_message(void *context)
     status = spdm_context->receive_message(spdm_context, &request_size,
                                            (void **)&request, 0);
     if (RETURN_ERROR(status)) {
-        libspdm_release_receiver_buffer (spdm_context, message);
+        libspdm_release_receiver_buffer (spdm_context);
         return status;
     }
     status = libspdm_process_request(spdm_context, &session_id, &is_app_message,
                                      request_size, request);
-    libspdm_release_receiver_buffer (spdm_context, message);
+    libspdm_release_receiver_buffer (spdm_context);
     if (RETURN_ERROR(status)) {
         return status;
     }
@@ -70,13 +70,13 @@ return_status libspdm_responder_dispatch_message(void *context)
     status = libspdm_build_response(spdm_context, session_id_ptr, is_app_message,
                                     &response_size, (void **)&response);
     if (RETURN_ERROR(status)) {
-        libspdm_release_sender_buffer (spdm_context, message);
+        libspdm_release_sender_buffer (spdm_context);
         return status;
     }
 
     status = spdm_context->send_message(spdm_context, response_size,
                                         response, 0);
-    libspdm_release_sender_buffer (spdm_context, message);
+    libspdm_release_sender_buffer (spdm_context);
 
     return status;
 }


### PR DESCRIPTION
It is unnecessary, because libspdm context already cached it.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>