### PR TITLE
New test cases to verify transcript buffers contents

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -95,6 +95,24 @@ return_status libspdm_requester_challenge_test_send_message(void *spdm_context,
                          request_size - 1);
         m_libspdm_local_buffer_size += (request_size - 1);
         return RETURN_SUCCESS;
+    case 0x16: {
+        /* arbitrary data must be inserted in the message buffer for computing
+         * the response hash */
+        m_libspdm_local_buffer_size = 0;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        libspdm_set_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size], 10, (uint8_t) 0xFF);
+        m_libspdm_local_buffer_size += 10;
+        libspdm_set_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size], 8, (uint8_t) 0xEE);
+        m_libspdm_local_buffer_size += 8;
+        libspdm_set_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size], 12, (uint8_t) 0xDD);
+        m_libspdm_local_buffer_size += 12;
+#endif
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         &ptr[1], request_size - 1);
+        m_libspdm_local_buffer_size += (request_size - 1);
+    }
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -1286,6 +1304,81 @@ return_status libspdm_requester_challenge_test_receive_message(
         ptr += sig_size;
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
                                                spdm_response, response_size, response);
+    }
+        return RETURN_SUCCESS;
+
+    case 0x16: { /*correct CHALLENGE_AUTH message*/
+        spdm_challenge_auth_response_t *spdm_response;
+        void *data;
+        size_t data_size;
+        uint8_t *ptr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        size_t sig_size;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        libspdm_read_responder_public_certificate_chain (m_libspdm_use_hash_algo,
+                                                         m_libspdm_use_asym_algo,
+                                                         &data,
+                                                         &data_size, NULL, NULL);
+        ((libspdm_context_t *)spdm_context)->local_context.local_cert_chain_provision_size[0] =
+            data_size;
+        ((libspdm_context_t *)spdm_context)->local_context.local_cert_chain_provision[0] = data;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        spdm_response_size = sizeof(spdm_challenge_auth_response_t) +
+                             libspdm_get_hash_size(m_libspdm_use_hash_algo) +
+                             SPDM_NONCE_SIZE + 0 + sizeof(uint16_t) + 0 +
+                             libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =SPDM_CHALLENGE_AUTH;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = (1 << 0);
+        ptr = (void *)(spdm_response + 1);
+        libspdm_hash_all(m_libspdm_use_hash_algo,
+                         ((libspdm_context_t *)spdm_context)
+                         ->local_context.local_cert_chain_provision[0],
+                         ((libspdm_context_t *)spdm_context)
+                         ->local_context.local_cert_chain_provision_size[0],
+                         ptr);
+        free(data);
+        ptr += libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+        ptr += SPDM_NONCE_SIZE;
+        /* libspdm_zero_mem (ptr, spdm_get_hash_size (m_libspdm_use_hash_algo));
+         * ptr += spdm_get_hash_size (m_libspdm_use_hash_algo);*/
+        *(uint16_t *)ptr = 0;
+        ptr += sizeof(uint16_t);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_buffer,
+                         m_libspdm_local_buffer_size, hash_data);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
+                       libspdm_get_hash_size(m_libspdm_use_hash_algo)));
+        libspdm_dump_hex(hash_data, libspdm_get_hash_size(m_libspdm_use_hash_algo));
+        sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
+        libspdm_responder_data_sign(spdm_response->header.spdm_version <<
+                                    SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                                    false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
+                                    ptr, &sig_size);
+        ptr += sig_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
     }
         return RETURN_SUCCESS;
 
@@ -2680,6 +2773,100 @@ void libspdm_test_requester_challenge_case21(void **state) {
     free(data);
 }
 
+/**
+ * Test 22: a request message is successfully sent and a response message is successfully received.
+ * Buffer C already has arbitrary data.
+ * Expected Behavior: requester returns the status RETURN_SUCCESS and a CHALLENGE_AUTH message is
+ * received, buffer C appends the exchanged CHALLENGE and CHALLENGE_AUTH messages.
+ **/
+void libspdm_test_requester_challenge_case22(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    size_t arbitrary_size;
+    size_t c_arbitrary_size;
+#endif
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x16;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_b(spdm_context);
+    libspdm_reset_message_c(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /*filling all buffers with arbitrary data*/
+    libspdm_set_mem(spdm_context->transcript.message_a.buffer, 10, (uint8_t) 0xFF);
+    spdm_context->transcript.message_a.buffer_size = 10;
+    libspdm_set_mem(spdm_context->transcript.message_b.buffer, 8, (uint8_t) 0xEE);
+    spdm_context->transcript.message_b.buffer_size = 8;
+    libspdm_set_mem(spdm_context->transcript.message_c.buffer, 12, (uint8_t) 0xDD);
+    spdm_context->transcript.message_c.buffer_size = 12;
+    arbitrary_size = 10 + 8 + 12;
+    c_arbitrary_size = 12;
+#endif
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain_buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.base_asym_algo,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_leaf_cert_public_key);
+#endif
+
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_challenge(
+        spdm_context, 0,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+        measurement_hash, NULL);
+    assert_int_equal(status, RETURN_SUCCESS);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* buffer C and m_libspdm_local_buffer contain arbitrary data */
+    assert_int_equal(spdm_context->transcript.message_c.buffer_size - c_arbitrary_size,
+                     m_libspdm_local_buffer_size - arbitrary_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->transcript.message_c.buffer + c_arbitrary_size,
+                        m_libspdm_local_buffer + arbitrary_size, m_libspdm_local_buffer_size);
+#endif
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_requester_challenge_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -2726,6 +2913,8 @@ int libspdm_requester_challenge_test_main(void)
         cmocka_unit_test(libspdm_test_requester_challenge_case19),
         /* Unexpected errors*/
         cmocka_unit_test(libspdm_test_requester_challenge_case20),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_challenge_case22),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_challenge_test_context);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -166,6 +166,12 @@ return_status libspdm_requester_finish_test_send_message(void *spdm_context,
                          request_size - 1);
         m_libspdm_local_buffer_size += (request_size - 1);
         return RETURN_SUCCESS;
+    case 0x16:
+        m_libspdm_local_buffer_size = 0;
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer), &ptr[1],
+                         request_size - 1);
+        m_libspdm_local_buffer_size += (request_size - 1);
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -1381,6 +1387,85 @@ return_status libspdm_requester_finish_test_receive_message(
                                               false, spdm_response_size,
                                               spdm_response,
                                               response_size, response);
+    }
+        return RETURN_SUCCESS;
+
+    case 0x16: {
+        spdm_finish_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        void *data;
+        size_t data_size;
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.req_base_asym_alg =
+            m_libspdm_use_req_asym_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        spdm_response_size = sizeof(spdm_finish_response_t) + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_FINISH_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        ptr = (void *)(spdm_response + 1);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, sizeof(spdm_finish_response_t));
+        m_libspdm_local_buffer_size += sizeof(spdm_finish_response_t);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        cert_buffer = (uint8_t *)data;
+        cert_buffer_size = data_size;
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size, cert_buffer_hash);
+        libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_req_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer = (uint8_t *)data;
+        cert_buffer_size = data_size;
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         req_cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, cert_buffer_hash, hash_size);
+        /* session_transcript.message_k is 0*/
+        libspdm_append_managed_buffer(&th_curr, req_cert_buffer_hash, hash_size);
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         ptr, hmac_size);
+        m_libspdm_local_buffer_size += hmac_size;
+        ptr += hmac_size;
+        free(data);
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
     }
         return RETURN_SUCCESS;
 
@@ -3466,6 +3551,121 @@ void libspdm_test_requester_finish_case21(void **state)
     free(data);
 }
 
+/**
+ * Test 22: a FINISH request message is successfully sent and a FINISH_RSP response message is
+ * successfully received.
+ * Expected Behavior: requester returns the status RETURN_SUCCESS and a FINISH_RSP message is
+ * received, buffer F appends the exchanged FINISH and FINISH_RSP
+ **/
+void libspdm_test_requester_finish_case22(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t req_slot_id_param;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+    libspdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x16;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain_buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.base_asym_algo,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_leaf_cert_public_key);
+#endif
+
+    req_slot_id_param = 0;
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    spdm_context->local_context.
+    local_cert_chain_provision_size[req_slot_id_param] = data_size;
+    spdm_context->local_context.
+    local_cert_chain_provision[req_slot_id_param] = data;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, false);
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    libspdm_set_mem(m_libspdm_dummy_buffer, hash_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_finished_key(
+        session_info->secured_message_context, m_libspdm_dummy_buffer,
+        hash_size);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    session_info->mut_auth_requested = 1;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+    spdm_context->local_context.slot_count = 1;
+    status = libspdm_send_receive_finish(spdm_context, session_id,
+                                         req_slot_id_param);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_f.buffer_size,
+                     m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_requester_finish_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -3513,6 +3713,8 @@ int libspdm_requester_finish_test_main(void)
         cmocka_unit_test(libspdm_test_requester_finish_case20),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
         cmocka_unit_test(libspdm_test_requester_finish_case21),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_finish_case22),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_finish_test_context);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -11,6 +11,9 @@
 
 static uint8_t m_libspdm_local_certificate_chain[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 
+static size_t m_libspdm_local_buffer_size;
+static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
 libspdm_return_t libspdm_requester_get_digests_test_send_message(
     void *spdm_context, size_t request_size, const void *request,
     uint64_t timeout)
@@ -62,6 +65,15 @@ libspdm_return_t libspdm_requester_get_digests_test_send_message(
     case 0x15:
         return LIBSPDM_STATUS_SUCCESS;
     case 0x16:
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x17: {
+        uint8_t *ptr = (uint8_t *)request;
+
+        m_libspdm_local_buffer_size = 0;
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         &ptr[1], request_size - 1);
+        m_libspdm_local_buffer_size += (request_size - 1);
+    }
         return LIBSPDM_STATUS_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
@@ -687,6 +699,49 @@ libspdm_return_t libspdm_requester_get_digests_test_receive_message(
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x17: {
+        spdm_digest_response_t *spdm_response;
+        uint8_t *digest;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        spdm_response_size = sizeof(spdm_digest_response_t) +
+                             libspdm_get_hash_size(m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.request_response_code = SPDM_DIGESTS;
+        spdm_response->header.param2 = 0;
+        libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                        (uint8_t)(0xFF));
+
+        digest = (void *)(spdm_response + 1);
+        /*send all eight certchains digest
+         * but only No.7 is right*/
+        digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
+        libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
+                         LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, &digest[0]);
+        spdm_response->header.param2 |= (0xFF << 0);
+
+        spdm_response_size = sizeof(spdm_digest_response_t) +
+                             libspdm_get_hash_size(m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT;
+
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, spdm_response_size);
+        m_libspdm_local_buffer_size += spdm_response_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return RETURN_SUCCESS;
 
     default:
         return RETURN_DEVICE_ERROR;
@@ -1468,6 +1523,57 @@ void libspdm_test_requester_get_digests_case22(void **state) {
     }
 }
 
+/**
+ * Test 23: a request message is successfully sent and a response message is successfully received.
+ * Buffer B already has arbitrary data.
+ * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is
+ * received, buffer B appends the exchanged GET_DIGESTS and DIGESTS messages.
+ **/
+void libspdm_test_requester_get_digests_case23(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    size_t arbitrary_size;
+#endif
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x17;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /*filling B with arbitrary data*/
+    arbitrary_size = 8;
+    libspdm_set_mem(spdm_context->transcript.message_b.buffer, arbitrary_size, (uint8_t) 0xEE);
+    spdm_context->transcript.message_b.buffer_size = arbitrary_size;
+#endif
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     arbitrary_size + m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->transcript.message_b.buffer + arbitrary_size,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+}
+
 libspdm_test_context_t m_libspdm_requester_get_digests_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -1524,6 +1630,8 @@ int libspdm_requester_get_digests_test_main(void)
          * cmocka_unit_test(libspdm_test_requester_get_digests_case21),
          * Unexpected errors*/
         cmocka_unit_test(libspdm_test_requester_get_digests_case22),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_get_digests_case23),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_get_digests_test_context);

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -321,6 +321,15 @@ return_status libspdm_requester_key_exchange_test_send_message(
                          (uint8_t *)request + header_size, message_size);
         m_libspdm_local_buffer_size += message_size;
         return RETURN_SUCCESS;
+    case 0x1D:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_key_exchange_request_size(
+            spdm_context, (uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (uint8_t *)request + header_size,  message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -4160,6 +4169,154 @@ return_status libspdm_requester_key_exchange_test_receive_message(
     }
         return RETURN_SUCCESS;
 
+    case 0x1D: {
+        spdm_key_exchange_response_t *spdm_response;
+        size_t dhe_key_size;
+        uint32_t hash_size;
+        size_t signature_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        void *dhe_context;
+        uint8_t final_key[LIBSPDM_MAX_DHE_KEY_SIZE];
+        size_t final_key_size;
+        size_t opaque_key_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t THCurrHashData[64];
+        uint8_t bin_str0[128];
+        size_t bin_str0_size;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        signature_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        dhe_key_size = libspdm_get_dhe_pub_key_size(m_libspdm_use_dhe_algo);
+        opaque_key_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(spdm_context);
+        spdm_response_size = sizeof(spdm_key_exchange_response_t) +
+                             dhe_key_size + 0 + sizeof(uint16_t) +
+                             opaque_key_exchange_rsp_size + signature_size +
+                             hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_KEY_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->rsp_session_id = libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->mut_auth_requested = 0;
+        spdm_response->req_slot_id_param = 0;
+        libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE, spdm_response->random_data);
+        ptr = (void *)(spdm_response + 1);
+        dhe_context = libspdm_dhe_new(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_dhe_algo, true);
+        libspdm_dhe_generate_key(m_libspdm_use_dhe_algo, dhe_context, ptr, &dhe_key_size);
+        final_key_size = sizeof(final_key);
+        libspdm_dhe_compute_key(
+            m_libspdm_use_dhe_algo, dhe_context,
+            (uint8_t *)&m_libspdm_local_buffer[0] + sizeof(spdm_key_exchange_request_t),
+            dhe_key_size, final_key, &final_key_size);
+        libspdm_dhe_free(m_libspdm_use_dhe_algo, dhe_context);
+        ptr += dhe_key_size;
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        *(uint16_t *)ptr = (uint16_t)opaque_key_exchange_rsp_size;
+        ptr += sizeof(uint16_t);
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_key_exchange_rsp_size, ptr);
+        ptr += opaque_key_exchange_rsp_size;
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        cert_buffer = (uint8_t *)data;
+        cert_buffer_size = data_size;
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, cert_buffer_hash, hash_size);
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        libspdm_responder_data_sign(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                false, libspdm_get_managed_buffer(&th_curr),
+                libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         ptr, signature_size);
+        m_libspdm_local_buffer_size += signature_size;
+        libspdm_append_managed_buffer(&th_curr, ptr, signature_size);
+        ptr += signature_size;
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), THCurrHashData);
+        bin_str0_size = sizeof(bin_str0);
+        libspdm_bin_concat(SPDM_BIN_STR_0_LABEL, sizeof(SPDM_BIN_STR_0_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str0, &bin_str0_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, m_libspdm_zero_filled_buffer, hash_size,
+                         final_key, final_key_size, handshake_secret);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           THCurrHashData, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, handshake_secret, hash_size,
+                            bin_str2, bin_str2_size,
+                            response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         ptr, hmac_size);
+        m_libspdm_local_buffer_size += hmac_size;
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return RETURN_SUCCESS;
+
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -6483,6 +6640,91 @@ void libspdm_test_requester_key_exchange_case28(void **state)
     free(data);
 }
 
+void libspdm_test_requester_key_exchange_case29(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t slot_id_param;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x1D;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain_buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.base_asym_algo,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_leaf_cert_public_key);
+#endif
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_key_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0,
+        &session_id, &heartbeat_period, &slot_id_param,
+        measurement_hash);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_k.buffer_size,
+                     m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_requester_key_exchange_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -6549,6 +6791,8 @@ int libspdm_requester_key_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_requester_key_exchange_case27),
         /* Muth Auth requested with Encapsulated request and Muth Auth requested with implicit get digest simultaneously*/
         cmocka_unit_test(libspdm_test_requester_key_exchange_case28),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_key_exchange_case29),
 
     };
 

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -24,6 +24,9 @@ typedef struct {
 } libspdm_algorithms_response_spdm11_t;
 #pragma pack()
 
+static size_t m_libspdm_local_buffer_size;
+static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_SMALL_BUFFER_SIZE];
+
 libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message(
     void *spdm_context, size_t request_size, const void *request,
     uint64_t timeout)
@@ -94,7 +97,14 @@ libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message(
         return LIBSPDM_STATUS_SUCCESS;
     case 0x1F:
         return LIBSPDM_STATUS_SUCCESS;
-    case 0x20:
+    case 0x20: {
+        uint8_t *ptr = (uint8_t *)request;
+
+        m_libspdm_local_buffer_size = 0;
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         &ptr[1], request_size - 1);
+        m_libspdm_local_buffer_size += (request_size - 1);
+    }
         return LIBSPDM_STATUS_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
@@ -1158,6 +1168,57 @@ libspdm_return_t libspdm_requester_negotiate_algorithm_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
+    case 0x20:
+    {
+        libspdm_algorithms_response_spdm11_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(libspdm_algorithms_response_spdm11_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_ALGORITHMS;
+        spdm_response->header.param1 = 4;
+        spdm_response->header.param2 = 0;
+        spdm_response->length = sizeof(libspdm_algorithms_response_spdm11_t);
+        spdm_response->measurement_specification_sel =
+            SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+        spdm_response->measurement_hash_algo = m_libspdm_use_measurement_hash_algo;
+        spdm_response->base_asym_sel = m_libspdm_use_asym_algo;
+        spdm_response->base_hash_sel = m_libspdm_use_hash_algo;
+        spdm_response->ext_asym_sel_count = 0;
+        spdm_response->ext_hash_sel_count = 0;
+        spdm_response->struct_table[0].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE;
+        spdm_response->struct_table[0].alg_count = 0x20;
+        spdm_response->struct_table[0].alg_supported = m_libspdm_use_dhe_algo;
+        spdm_response->struct_table[1].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD;
+        spdm_response->struct_table[1].alg_count = 0x20;
+        spdm_response->struct_table[1].alg_supported = m_libspdm_use_aead_algo;
+        spdm_response->struct_table[2].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG;
+        spdm_response->struct_table[2].alg_count = 0x20;
+        spdm_response->struct_table[2].alg_supported = m_libspdm_use_req_asym_algo;
+        spdm_response->struct_table[3].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEY_SCHEDULE;
+        spdm_response->struct_table[3].alg_count = 0x20;
+        spdm_response->struct_table[3].alg_supported = m_libspdm_use_key_schedule_algo;
+
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         (uint8_t *)spdm_response, spdm_response_size);
+        m_libspdm_local_buffer_size += spdm_response_size;
+
+        libspdm_transport_test_encode_message (spdm_context, NULL, false, false,
+                                               spdm_response_size,
+                                               spdm_response, response_size, response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -2090,6 +2151,77 @@ void libspdm_test_requester_negotiate_algorithms_case31(void **state) {
     assert_int_equal (status, LIBSPDM_STATUS_NEGOTIATION_FAIL);
 }
 
+void libspdm_test_requester_negotiate_algorithms_case32(void **state) {
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    size_t arbitrary_size;
+#endif
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x20;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /*filling A with arbitrary data*/
+    arbitrary_size = 10;
+    libspdm_set_mem(spdm_context->transcript.message_a.buffer, arbitrary_size, (uint8_t) 0xFF);
+    spdm_context->transcript.message_a.buffer_size = arbitrary_size;
+#endif
+
+    status = libspdm_negotiate_algorithms (spdm_context);
+    assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal (spdm_context->transcript.message_a.buffer_size,
+                      arbitrary_size + m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->transcript.message_a.buffer + arbitrary_size,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+}
+
 libspdm_test_context_t m_libspdm_requester_negotiate_algorithms_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -2176,6 +2308,8 @@ int libspdm_requester_negotiate_algorithms_test_main(void)
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case30),
         /* When spdm_response returns multiple key_schedule*/
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case31),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case32),
     };
 
     libspdm_setup_test_context(

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -157,6 +157,14 @@ return_status libspdm_requester_psk_exchange_test_send_message(
                          (uint8_t *)request + header_size, message_size);
         m_libspdm_local_buffer_size += message_size;
         return RETURN_SUCCESS;
+    case 0xC:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (uint8_t *)request + header_size, request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -984,6 +992,117 @@ return_status libspdm_requester_psk_exchange_test_receive_message(
     }
         return RETURN_SUCCESS;
 
+    case 0xC: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id = libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length = (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer = (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size = data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2, bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7, &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         ptr, hmac_size);
+        m_libspdm_local_buffer_size += hmac_size;
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return RETURN_SUCCESS;
+
     default:
         return RETURN_DEVICE_ERROR;
     }
@@ -1704,6 +1823,80 @@ void libspdm_test_requester_psk_exchange_case11(void **state)
     free(data);
 }
 
+void libspdm_test_requester_psk_exchange_case12(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0xC;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_k.buffer_size,
+                     m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_requester_psk_exchange_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -1734,6 +1927,8 @@ int libspdm_requester_psk_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case9),
         /* Unexpected errors*/
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case10),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case12),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_psk_exchange_test_context);

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -14,6 +14,9 @@ static uint8_t m_libspdm_local_psk_hint[32];
 static uint8_t m_libspdm_dummy_key_buffer[LIBSPDM_MAX_AEAD_KEY_SIZE];
 static uint8_t m_libspdm_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 
+static size_t m_libspdm_local_buffer_size;
+static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
 static void libspdm_secured_message_set_dummy_finished_key(
     void *spdm_secured_message_context)
 {
@@ -87,6 +90,43 @@ return_status libspdm_requester_psk_finish_test_send_message(void *spdm_context,
     case 0xE:
         return RETURN_SUCCESS;
     case 0xF:
+        return RETURN_SUCCESS;
+    case 0x10: {
+        return_status status;
+        uint8_t *decoded_message;
+        size_t decoded_message_size;
+        uint32_t session_id;
+        uint32_t *message_session_id;
+        bool is_app_message;
+        libspdm_session_info_t *session_info;
+
+        message_session_id = NULL;
+        session_id = 0xFFFFFFFF;
+        decoded_message = (uint8_t *) &m_libspdm_local_buffer[0];
+        decoded_message_size = sizeof(m_libspdm_local_buffer);
+
+        session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+        if (session_info == NULL) {
+            return RETURN_DEVICE_ERROR;
+        }
+
+        /* WALKAROUND: If just use single context to encode
+         * message and then decode message */
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
+        ->handshake_secret.request_handshake_sequence_number--;
+        m_libspdm_local_buffer_size = 0;
+        status = libspdm_transport_test_decode_message(
+            spdm_context,
+            &message_session_id, &is_app_message, true, request_size, request,
+            &decoded_message_size, (void **)&decoded_message);
+        if (RETURN_ERROR(status)) {
+            return RETURN_DEVICE_ERROR;
+        }
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         decoded_message, decoded_message_size);
+        m_libspdm_local_buffer_size += decoded_message_size;
+    }
         return RETURN_SUCCESS;
     default:
         return RETURN_DEVICE_ERROR;
@@ -813,6 +853,53 @@ return_status libspdm_requester_psk_finish_test_receive_message(
         }
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
+        ->handshake_secret.response_handshake_sequence_number--;
+    }
+        return RETURN_SUCCESS;
+
+    case 0x10: {
+        spdm_psk_finish_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+        uint32_t session_id;
+        libspdm_session_info_t *session_info;
+        uint8_t *scratch_buffer;
+        size_t scratch_buffer_size;
+
+        session_id = 0xFFFFFFFF;
+        spdm_response_size = sizeof(spdm_psk_finish_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_FINISH_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+
+        /* For secure message, message is in sender buffer, we need copy it to scratch buffer.
+         * transport_message is always in sender buffer. */
+        libspdm_get_scratch_buffer (spdm_context, (void **)&scratch_buffer, &scratch_buffer_size);
+        libspdm_copy_mem (scratch_buffer + transport_header_size,
+                          scratch_buffer_size - transport_header_size,
+                          spdm_response, spdm_response_size);
+        spdm_response = (void *)(scratch_buffer + transport_header_size);
+
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
+                         spdm_response, spdm_response_size);
+        m_libspdm_local_buffer_size += spdm_response_size;
+
+        libspdm_transport_test_encode_message(spdm_context, &session_id,
+                                              false, false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+        session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+        if (session_info == NULL) {
+            return RETURN_DEVICE_ERROR;
+        }
+        /* WALKAROUND: If just use single context to encode message and then decode message */
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
     }
         return RETURN_SUCCESS;
@@ -2319,6 +2406,108 @@ void libspdm_test_requester_psk_finish_case15(void **state)
     free(data);
 }
 
+/**
+ * Test 16: a request message is successfully sent and a response message is successfully received.
+ * Expected Behavior: requester returns the status RETURN_SUCCESS and a PSK_FINISH_RSP message is
+ * received, buffer F appends the exchanged PSK_FINISH and PSK_FINISH_RSP messages.
+ **/
+void libspdm_test_requester_psk_finish_case16(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+    libspdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x10;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    libspdm_set_mem(m_libspdm_dummy_key_buffer,
+                    ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                    ->aead_key_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_handshake_encryption_key(
+        session_info->secured_message_context, m_libspdm_dummy_key_buffer,
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+        ->aead_key_size);
+    libspdm_set_mem(m_libspdm_dummy_salt_buffer,
+                    ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                    ->aead_iv_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_handshake_salt(
+        session_info->secured_message_context, m_libspdm_dummy_salt_buffer,
+        ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+        ->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
+    ->handshake_secret.response_handshake_sequence_number = 0;
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
+    ->handshake_secret.request_handshake_sequence_number = 0;
+    libspdm_secured_message_set_dummy_finished_key (session_info->secured_message_context);
+
+    status = libspdm_send_receive_psk_finish(spdm_context, session_id);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_f.buffer_size,
+                     m_libspdm_local_buffer_size);
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
+                   m_libspdm_local_buffer_size));
+    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer,
+                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+#endif
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_requester_psk_finish_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     true,
@@ -2359,6 +2548,8 @@ int libspdm_requester_psk_finish_test_main(void)
         cmocka_unit_test(libspdm_test_requester_psk_finish_case14),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
         cmocka_unit_test(libspdm_test_requester_psk_finish_case15),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_requester_psk_finish_case16),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_psk_finish_test_context);

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -994,6 +994,77 @@ void libspdm_test_responder_certificate_case12(void **state)
     free(data);
 }
 
+/**
+ * Test 13: receiving a correct GET_CERTIFICATE from the requester. Buffer B
+ * already has arbitrary data.
+ * Expected behavior: the responder accepts the request and produces a valid
+ * CERTIFICATE response message, and buffer B receives the exchanged
+ * GET_CERTIFICATE and CERTIFICATE messages.
+ **/
+void libspdm_test_responder_certificate_case13(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_certificate_response_t *spdm_response;
+    void *data;
+    size_t data_size;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    size_t arbitrary_size;
+#endif
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xD;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+    spdm_context->local_context.slot_count = 1;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /*filling buffer B with arbitrary data*/
+    arbitrary_size = 8;
+    libspdm_set_mem(spdm_context->transcript.message_b.buffer, arbitrary_size, (uint8_t) 0xEE);
+    spdm_context->transcript.message_b.buffer_size = arbitrary_size;
+#endif
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_certificate(
+        spdm_context, m_libspdm_get_certificate_request1_size,
+        &m_libspdm_get_certificate_request1, &response_size, response);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_certificate_response_t) +
+                     LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_CERTIFICATE);
+    assert_int_equal(spdm_response->header.param1, 0);
+    assert_int_equal(spdm_response->portion_length, LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
+    assert_int_equal(spdm_response->remainder_length,
+                     data_size - LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     arbitrary_size + m_libspdm_get_certificate_request1_size + response_size);
+    assert_memory_equal(spdm_context->transcript.message_b.buffer + arbitrary_size,
+                        &m_libspdm_get_certificate_request1,
+                        m_libspdm_get_certificate_request1_size);
+    assert_memory_equal(spdm_context->transcript.message_b.buffer + arbitrary_size +
+                        m_libspdm_get_certificate_request1_size,
+                        response, response_size);
+#endif
+
+    free(data);
+}
+
 libspdm_test_context_t m_libspdm_responder_certificate_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -1026,6 +1097,8 @@ int libspdm_responder_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_responder_certificate_case11),
         /* Requests byte by byte*/
         cmocka_unit_test(libspdm_test_responder_certificate_case12),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_certificate_case13),
 
     };
 

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -900,6 +900,96 @@ void libspdm_test_responder_challenge_auth_case14(void **state) {
     free(data1);
 }
 
+/**
+ * Test 15: receiving a correct CHALLENGE from the requester. Buffers A, B and
+ * C already have arbitrary data.
+ * Expected behavior: the responder accepts the request and produces a valid
+ * CHALLENGE_AUTH response message, and buffer C receives the exchanged CHALLENGE
+ * and CHALLENGE_AUTH (without signature) messages.
+ **/
+void libspdm_test_responder_challenge_auth_case15(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_challenge_auth_response_t *spdm_response;
+    void *data1;
+    size_t data_size1;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    size_t signature_size;
+#endif
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xF;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->local_context.slot_count = 1;
+    spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
+    libspdm_reset_message_c(spdm_context);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /*filling buffers with arbitrary data*/
+    libspdm_set_mem(spdm_context->transcript.message_a.buffer, 10, (uint8_t) 0xFF);
+    spdm_context->transcript.message_a.buffer_size = 10;
+    libspdm_set_mem(spdm_context->transcript.message_b.buffer, 8, (uint8_t) 0xEE);
+    spdm_context->transcript.message_b.buffer_size = 8;
+    libspdm_set_mem(spdm_context->transcript.message_c.buffer, 12, (uint8_t) 0xDD);
+    spdm_context->transcript.message_c.buffer_size = 12;
+
+    signature_size = libspdm_get_asym_signature_size(
+        spdm_context->connection_info.algorithm.base_asym_algo);
+#endif
+
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, m_libspdm_challenge_request1.nonce);
+    status = libspdm_get_response_challenge_auth(
+        spdm_context, m_libspdm_challenge_request1_size,
+        &m_libspdm_challenge_request1, &response_size, response);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(response_size,
+                     sizeof(spdm_challenge_auth_response_t) +
+                     libspdm_get_hash_size(m_libspdm_use_hash_algo) +
+                     SPDM_NONCE_SIZE + 0 + sizeof(uint16_t) + 0 +
+                     libspdm_get_asym_signature_size(m_libspdm_use_asym_algo));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_CHALLENGE_AUTH);
+    assert_int_equal(spdm_response->header.param1, 0);
+    assert_int_equal(spdm_response->header.param2, 1 << 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_a.buffer_size, 10);
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 8);
+    assert_int_equal(spdm_context->transcript.message_c.buffer_size, 12 +
+                     m_libspdm_challenge_request1_size + response_size - signature_size);
+
+    assert_memory_equal(spdm_context->transcript.message_c.buffer + 12,
+                        &m_libspdm_challenge_request1, m_libspdm_challenge_request1_size);
+    assert_memory_equal(spdm_context->transcript.message_c.buffer + 12 +
+                        m_libspdm_challenge_request1_size,
+                        response, response_size - signature_size);
+#endif
+    free(data1);
+}
+
 libspdm_test_context_t m_libspdm_responder_challenge_auth_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -928,6 +1018,8 @@ int libspdm_responder_challenge_auth_test_main(void)
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case12),
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case13),
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case14),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_challenge_auth_case15),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_challenge_auth_test_context);

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -2001,6 +2001,113 @@ void libspdm_test_responder_finish_case16(void **state)
     free(data2);
 }
 
+/**
+ * Test 17: receiving a correct FINISH from the requester.
+ * Expected behavior: the responder accepts the request and produces a valid FINISH
+ * response message, and buffer F receives the exchanged FINISH and FINISH_RSP messages.
+ **/
+void libspdm_test_responder_finish_case17(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_finish_response_t *spdm_response;
+    void *data1;
+    size_t data_size1;
+    uint8_t *ptr;
+    uint8_t *cert_buffer;
+    size_t cert_buffer_size;
+    uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+    libspdm_large_managed_buffer_t th_curr;
+    uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+    uint32_t hash_size;
+    uint32_t hmac_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x11;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+    spdm_context->local_context.slot_count = 1;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, false);
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_request_finished_key(
+        session_info->secured_message_context, m_dummy_buffer, hash_size);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context, LIBSPDM_SESSION_STATE_HANDSHAKING);
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    ptr = m_libspdm_finish_request1.signature;
+    libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+    cert_buffer = (uint8_t *)data1;
+    cert_buffer_size = data_size1;
+    libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size, cert_buffer_hash);
+    /* transcript.message_a size is 0*/
+    libspdm_append_managed_buffer(&th_curr, cert_buffer_hash, hash_size);
+    /* session_transcript.message_k is 0*/
+    libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
+                                  sizeof(spdm_finish_request_t));
+    libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
+    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
+                     hash_size, ptr);
+    m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
+    response_size = sizeof(response);
+    status = libspdm_get_response_finish(
+        spdm_context, m_libspdm_finish_request1_size, &m_libspdm_finish_request1,
+        &response_size, response);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_finish_response_t) + hmac_size);
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_FINISH_RSP);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_f.buffer_size,
+                     m_libspdm_finish_request1_size + response_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer,
+                        &m_libspdm_finish_request1, m_libspdm_finish_request1_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer +
+                        m_libspdm_finish_request1_size,
+                        response, response_size);
+#endif
+
+    free(data1);
+}
+
 libspdm_test_context_t m_libspdm_responder_finish_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -2038,6 +2145,8 @@ int libspdm_responder_finish_test_main(void)
         /* Incorrect signature*/
         cmocka_unit_test(libspdm_test_responder_finish_case15),
         cmocka_unit_test(libspdm_test_responder_finish_case16),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_finish_case17),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_finish_test_context);

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -1445,6 +1445,102 @@ void libspdm_test_responder_key_exchange_case15(void **state)
     free(data1);
 }
 
+void libspdm_test_responder_key_exchange_case16(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t current_request_size;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_key_exchange_response_t *spdm_response;
+    void *data1;
+    size_t data_size1;
+    uint8_t *ptr;
+    size_t dhe_key_size;
+    void *dhe_context;
+    size_t opaque_key_exchange_req_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x10;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->local_context.slot_count = 1;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+
+    libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE, m_libspdm_key_exchange_request1.random_data);
+    m_libspdm_key_exchange_request1.req_session_id = 0xFFFF;
+    m_libspdm_key_exchange_request1.reserved = 0;
+    ptr = m_libspdm_key_exchange_request1.exchange_data;
+    dhe_key_size = libspdm_get_dhe_pub_key_size(m_libspdm_use_dhe_algo);
+    dhe_context = libspdm_dhe_new(spdm_context->connection_info.version, m_libspdm_use_dhe_algo,
+                                  false);
+    libspdm_dhe_generate_key(m_libspdm_use_dhe_algo, dhe_context, ptr, &dhe_key_size);
+    ptr += dhe_key_size;
+    libspdm_dhe_free(m_libspdm_use_dhe_algo, dhe_context);
+    opaque_key_exchange_req_size =
+        libspdm_get_opaque_data_supported_version_data_size(spdm_context);
+    *(uint16_t *)ptr = (uint16_t)opaque_key_exchange_req_size;
+    ptr += sizeof(uint16_t);
+    libspdm_build_opaque_data_supported_version_data(
+        spdm_context, &opaque_key_exchange_req_size, ptr);
+    ptr += opaque_key_exchange_req_size;
+
+    current_request_size = sizeof(spdm_key_exchange_request_t) + dhe_key_size +
+                           sizeof(uint16_t) + opaque_key_exchange_req_size;
+    response_size = sizeof(response);
+    status = libspdm_get_response_key_exchange(
+        spdm_context, current_request_size, &m_libspdm_key_exchange_request1,
+        &response_size, response);
+
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_KEY_EXCHANGE_RSP);
+    assert_int_equal(spdm_response->rsp_session_id, 0xFFFF);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_k.buffer_size,
+                     current_request_size + response_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer,
+                        &m_libspdm_key_exchange_request1, current_request_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer +
+                        current_request_size,
+                        response, response_size);
+#endif
+    free(data1);
+}
+
 libspdm_test_context_t m_libspdm_responder_key_exchange_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -1483,6 +1579,8 @@ int libspdm_responder_key_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_responder_key_exchange_case14),
         /* HANDSHAKE_IN_THE_CLEAR set for requester and responder */
         cmocka_unit_test(libspdm_test_responder_key_exchange_case15),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_key_exchange_case16),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_key_exchange_test_context);

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -693,6 +693,104 @@ void libspdm_test_responder_psk_exchange_case7(void **state)
     free(data1);
 }
 
+void libspdm_test_responder_psk_exchange_case8(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t current_request_size;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_psk_exchange_response_t *spdm_response;
+    void *data1;
+    size_t data_size1;
+    uint8_t *ptr;
+    size_t opaque_psk_exchange_req_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x8;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+    spdm_context->local_context.slot_count = 1;
+    libspdm_reset_message_a(spdm_context);
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    m_libspdm_psk_exchange_request1.psk_hint_length =
+        (uint16_t)spdm_context->local_context.psk_hint_size;
+    m_libspdm_psk_exchange_request1.context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+    opaque_psk_exchange_req_size =
+        libspdm_get_opaque_data_supported_version_data_size(spdm_context);
+    m_libspdm_psk_exchange_request1.opaque_length =
+        (uint16_t)opaque_psk_exchange_req_size;
+    m_libspdm_psk_exchange_request1.req_session_id = 0xFFFF;
+    ptr = m_libspdm_psk_exchange_request1.psk_hint;
+    libspdm_copy_mem(ptr, sizeof(m_libspdm_psk_exchange_request1.psk_hint),
+                     spdm_context->local_context.psk_hint,
+                     spdm_context->local_context.psk_hint_size);
+    ptr += m_libspdm_psk_exchange_request1.psk_hint_length;
+    libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+    ptr += m_libspdm_psk_exchange_request1.context_length;
+    libspdm_build_opaque_data_supported_version_data(
+        spdm_context, &opaque_psk_exchange_req_size, ptr);
+    ptr += opaque_psk_exchange_req_size;
+
+    current_request_size = sizeof(spdm_psk_exchange_request_t) +
+                           m_libspdm_psk_exchange_request1.psk_hint_length +
+                           m_libspdm_psk_exchange_request1.context_length +
+                           opaque_psk_exchange_req_size;
+    response_size = sizeof(response);
+    status = libspdm_get_response_psk_exchange(
+        spdm_context, current_request_size, &m_libspdm_psk_exchange_request1,
+        &response_size, response);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(libspdm_secured_message_get_session_state(
+                         spdm_context->session_info[0].secured_message_context),
+                     LIBSPDM_SESSION_STATE_HANDSHAKING);
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_PSK_EXCHANGE_RSP);
+    assert_int_equal(spdm_response->rsp_session_id, 0xFFFF);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_k.buffer_size,
+                     current_request_size + response_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer,
+                        &m_libspdm_psk_exchange_request1, current_request_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_k.buffer +
+                        current_request_size, response, response_size);
+#endif
+    free(data1);
+}
+
 libspdm_test_context_t m_libspdm_responder_psk_exchange_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -715,6 +813,8 @@ int libspdm_responder_psk_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_responder_psk_exchange_case6),
         /* Buffer reset*/
         cmocka_unit_test(libspdm_test_responder_psk_exchange_case7),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_psk_exchange_case8),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_psk_exchange_test_context);

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -1498,6 +1498,108 @@ void libspdm_test_responder_psk_finish_case13(void **state)
     free(data1);
 }
 
+/**
+ * Test 14: receiving a correct PSK_FINISH from the requester.
+ * Expected behavior: the responder accepts the request and produces a valid PSK_FINISH
+ * response message, and buffer F receives the exchanged PSK_FINISH and PSK_FINISH_RSP messages.
+ **/
+void libspdm_test_responder_psk_finish_case14(void **state)
+{
+    return_status status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_psk_finish_response_t *spdm_response;
+    void *data1;
+    size_t data_size1;
+    uint8_t *ptr;
+    libspdm_large_managed_buffer_t th_curr;
+    uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+    uint32_t hash_size;
+    uint32_t hmac_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xE;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+    spdm_context->local_context.slot_count = 1;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    libspdm_set_mem(m_libspdm_dummy_buffer, hash_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_request_finished_key(
+        session_info->secured_message_context, m_libspdm_dummy_buffer, hash_size);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context, LIBSPDM_SESSION_STATE_HANDSHAKING);
+
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    ptr = m_libspdm_psk_finish_request1.verify_data;
+    libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+    /* transcript.message_a size is 0
+     * session_transcript.message_k is 0*/
+    libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
+                                  sizeof(spdm_psk_finish_request_t));
+    libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
+    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
+                     hash_size, ptr);
+    m_libspdm_psk_finish_request1_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
+    response_size = sizeof(response);
+    status = libspdm_get_response_psk_finish(
+        spdm_context, m_libspdm_psk_finish_request1_size, &m_libspdm_psk_finish_request1,
+        &response_size, response);
+    assert_int_equal(status, RETURN_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_psk_finish_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_PSK_FINISH_RSP);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->session_info[0].session_transcript.message_f.buffer_size,
+                     m_libspdm_psk_finish_request1_size + response_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer,
+                        &m_libspdm_psk_finish_request1, m_libspdm_psk_finish_request1_size);
+    assert_memory_equal(spdm_context->session_info[0].session_transcript.message_f.buffer +
+                        m_libspdm_psk_finish_request1_size, response, response_size);
+#endif
+
+    free(data1);
+}
+
 libspdm_test_context_t m_libspdm_responder_psk_finish_test_context = {
     LIBSPDM_TEST_CONTEXT_SIGNATURE,
     false,
@@ -1530,6 +1632,8 @@ int libspdm_responder_psk_finish_test_main(void)
         /* Incorrect MAC size*/
         cmocka_unit_test(libspdm_test_responder_psk_finish_case12),
         cmocka_unit_test(libspdm_test_responder_psk_finish_case13),
+        /* Buffer verification*/
+        cmocka_unit_test(libspdm_test_responder_psk_finish_case14),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_psk_finish_test_context);


### PR DESCRIPTION
This commit contains one new test case that verifies if the correct data was appended to the correct buffer regarding the message transcripts. It contains one test for each of the following messages:

- requester: get_version, get_capabilities, negotiate_algorithms, get_digests, get_certificate, get_measurements, challenge, key_exchange, finish, psk_exchange, psk_finish.
- responder: version, capabilities, algorithms, digests, certificate, measurements, challenge_auth, key_exchange, finish, psk_exchange, psk_finish.

Note that previous test cases only verified if the amount of data was correctly added to the buffers. Now, the test cases in this commit extend the test by also verifying if the correct data (message request and response) was appended to the correct buffer (A, B, C, M, K, or F) for posterior hash or signature.