### PR TITLE
Add unit_test:test_spdm_common to CI test and fix the test_spdm_common error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,10 @@ jobs:
         run: |
           cd build/bin
           ./test_spdm_responder
+      - name: Test_spdm_common
+        run: |
+          cd build/bin
+          ./test_spdm_common
       - name: Test with initial seed
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
         run: |

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -223,6 +223,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case5(void **state)
     spdm_context->local_context.peer_cert_chain_provision = NULL;
     spdm_context->local_context.peer_cert_chain_provision_size = 0;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo= m_libspdm_use_asym_algo;
 
     /*clear root cert array*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT; root_cert_index++) {
@@ -294,6 +295,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case6(void **state)
     spdm_context->local_context.peer_cert_chain_provision = NULL;
     spdm_context->local_context.peer_cert_chain_provision_size = 0;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo= m_libspdm_use_asym_algo;
 
     /*clear root cert array*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT; root_cert_index++) {
@@ -379,6 +381,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case7(void **state)
     spdm_context->local_context.peer_cert_chain_provision = NULL;
     spdm_context->local_context.peer_cert_chain_provision_size = 0;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo= m_libspdm_use_asym_algo;
 
     /*clear root cert array*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT; root_cert_index++) {
@@ -481,6 +484,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case8(void **state)
     spdm_context->local_context.peer_cert_chain_provision = NULL;
     spdm_context->local_context.peer_cert_chain_provision_size = 0;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo= m_libspdm_use_asym_algo;
 
     /*case: there is no match root cert*/
     for (root_cert_index = 0; root_cert_index < LIBSPDM_MAX_ROOT_CERT_SUPPORT; root_cert_index++) {


### PR DESCRIPTION
Fix: #775 

Add unit_test: test_spdm_common to CI test.
Fit the unit_test: test_spdm_common error.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>