### PR TITLE
Add macro for the data size in IO redefine.

### DIFF
--- a/include/industry_standard/spdm_secured_message.h
+++ b/include/industry_standard/spdm_secured_message.h
@@ -21,15 +21,16 @@
  * | ApplicationData |-----------------------------------------------------
  * +-----------------+                                                     |
  *                                                                         V
- * +---------------------------------+--------------------------=-------+-------+------+---+
- * |SPDM_SECURED_MESSAGE_ADATA_HEADER|spdm_secured_message_cipher_header_t|AppData|Random|MAC|
- * | session_id | SeqNum (O) | length |       application_data_length      |       |  (O) |   |
+ * +---------------------------------+----------------------------------+-------+------+---+
+ * |SPDM_SECURED_MESSAGE_ADATA_HEADER|SPDM_SECURED_MESSAGE_CIPHER_HEADER|AppData|Random|MAC|
+ * | SessionId | SeqNum (O) | Length |       ApplicationDataLength      |       |  (O) |   |
  * +---------------------------------+----------------------------------+-------+------+---+
  * |                                 |                                                 |   |
  *  --------------------------------- ------------------------------------------------- ---
  *                  |                                         |                          |
  *                  V                                         V                          V
- *            AssociatedData                            encrypted_data                 AeadTag*/
+ *            AssociatedData                            EncryptedData                 AeadTag
+ */
 
 /* (O) means Optional or Transport Layer Specific.*/
 
@@ -41,13 +42,14 @@
  *                                      V
  * +---------------------------------+-------+---+
  * |SPDM_SECURED_MESSAGE_ADATA_HEADER|AppData|MAC|
- * | session_id | SeqNum (T) | length |       |   |
+ * | SessionId | SeqNum (T) | length |       |   |
  * +---------------------------------+-------+---+
  * |                                         |   |
  *  ----------------------------------------- ---
  *                      |                     |
  *                      V                     V
- *                AssociatedData           AeadTag*/
+ *                AssociatedData           AeadTag
+ */
 
 
 typedef struct {

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -13,6 +13,10 @@
 
 #define INVALID_SESSION_ID 0
 
+/* Required scratch buffer size for libspdm internal usage.
+ * It maybe used to hold the encrypted/decrypted message and/or last sent/received message. */
+#define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SENDER_RECEIVE_BUFFER_SIZE)
+
 typedef struct {
     uint8_t spdm_version_count;
     spdm_version_number_t spdm_version[SPDM_MAX_VERSION_COUNT];

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2069,7 +2069,7 @@ void libspdm_register_transport_layer_func(
 size_t libspdm_get_sizeof_required_scratch_buffer (
     void *context)
 {
-    return LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    return LIBSPDM_SCRATCH_BUFFER_SIZE;
 }
 
 /**
@@ -2090,7 +2090,7 @@ void libspdm_set_scratch_buffer (
     libspdm_context_t *spdm_context;
 
     spdm_context = context;
-    LIBSPDM_ASSERT (scratch_buffer_size >= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+    LIBSPDM_ASSERT (scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
     spdm_context->scratch_buffer = scratch_buffer;
     spdm_context->scratch_buffer_size = scratch_buffer_size;
 }
@@ -2112,7 +2112,7 @@ void libspdm_get_scratch_buffer (
 
     spdm_context = context;
     LIBSPDM_ASSERT (spdm_context->scratch_buffer != NULL);
-    LIBSPDM_ASSERT (spdm_context->scratch_buffer_size >= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+    LIBSPDM_ASSERT (spdm_context->scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
     *scratch_buffer = spdm_context->scratch_buffer;
     *scratch_buffer_size = spdm_context->scratch_buffer_size;
 }
@@ -2332,8 +2332,8 @@ libspdm_return_t libspdm_init_context(void *context)
         sizeof(spdm_context->encap_context.certificate_chain_buffer.buffer);
 
     /* From the config.h, need different value for CHUNK - TBD*/
-    spdm_context->local_context.capability.data_transfer_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    spdm_context->local_context.capability.max_spdm_msg_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    spdm_context->local_context.capability.data_transfer_size = LIBSPDM_DATA_TRANSFER_SIZE;
+    spdm_context->local_context.capability.max_spdm_msg_size = LIBSPDM_MAX_SPDM_MSG_SIZE;
 
 #if !LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain_buffer_hash_size = 0;


### PR DESCRIPTION
The consumer need to know the required sender/receiver buffer size.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>