### PR TITLE
fix memory leak for scratch_buffer

### DIFF
--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
@@ -106,6 +106,7 @@ size_t libspdm_unit_test_group_teardown(void **State)
 
     spdm_test_context = *State;
     free(spdm_test_context->spdm_context);
+    free(spdm_test_context->scratch_buffer);
     spdm_test_context->spdm_context = NULL;
     return 0;
 }


### PR DESCRIPTION

fix memory leak for scratch_buffer
fix: #813
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>