### PR TITLE
move scratch buffer out of transport lib.

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -559,7 +559,7 @@ typedef libspdm_return_t (*libspdm_transport_encode_message_func)(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *

--- a/include/library/spdm_transport_mctp_lib.h
+++ b/include/library/spdm_transport_mctp_lib.h
@@ -65,7 +65,7 @@ libspdm_return_t libspdm_transport_mctp_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *

--- a/include/library/spdm_transport_pcidoe_lib.h
+++ b/include/library/spdm_transport_pcidoe_lib.h
@@ -65,7 +65,7 @@ libspdm_return_t libspdm_transport_pci_doe_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -104,6 +104,8 @@ libspdm_return_t libspdm_send_request(void *context, const uint32_t *session_id,
  * @param  response                     A pointer to a destination buffer to store the response.
  *                                     The caller is responsible for having
  *                                     either implicit or explicit ownership of the buffer.
+ *                                      For normal message, response pointer still point to original transport_message.
+ *                                      For secured message, response pointer will point to the scratch buffer in spdm_context.
  *
  * @retval RETURN_SUCCESS               The SPDM response is received successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when the SPDM response is received from the device.
@@ -144,6 +146,11 @@ libspdm_return_t libspdm_receive_response(void *context, const uint32_t *session
 
     message_session_id = NULL;
     is_message_app_message = false;
+
+    /* always use scratch buffer to response.
+     * if it is secured message, this scratch buffer will be used.
+     * if it is normal message, the response ptr will point to receiver buffer. */
+    libspdm_get_scratch_buffer (spdm_context, response, response_size);
     status = spdm_context->transport_decode_message(
         spdm_context, &message_session_id, &is_message_app_message,
         false, message_size, message, response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -145,6 +145,11 @@ libspdm_return_t libspdm_process_request(void *context, uint32_t **session_id,
     spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->last_spdm_request_size =
         sizeof(spdm_context->last_spdm_request);
+
+    /* always use scratch buffer to response.
+     * if it is secured message, this scratch buffer will be used.
+     * if it is normal message, the response ptr will point to receiver buffer. */
+    libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message_ptr, &decoded_message_size);
     status = spdm_context->transport_decode_message(
         spdm_context, &message_session_id, is_app_message, true,
         request_size, request, &decoded_message_size,

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -184,7 +184,7 @@ libspdm_return_t libspdm_transport_mctp_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *
@@ -248,7 +248,8 @@ libspdm_return_t libspdm_transport_mctp_decode_message(
         }
 
         /* Secured message to APP message*/
-        libspdm_get_scratch_buffer (spdm_context, (void **)&app_message, &app_message_size);
+        app_message = *message;
+        app_message_size = *message_size;
         status = libspdm_decode_secured_message(
             secured_message_context, *secured_message_session_id,
             is_requester, secured_message_size, secured_message,

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
@@ -166,7 +166,7 @@ libspdm_return_t libspdm_transport_pci_doe_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *
@@ -229,7 +229,6 @@ libspdm_return_t libspdm_transport_pci_doe_decode_message(
         }
 
         /* Secured message to message*/
-        libspdm_get_scratch_buffer (spdm_context, message, message_size);
         status = libspdm_decode_secured_message(
             secured_message_context, *secured_message_session_id,
             is_requester, secured_message_size, secured_message,

--- a/unit_test/include/library/spdm_transport_test_lib.h
+++ b/unit_test/include/library/spdm_transport_test_lib.h
@@ -72,7 +72,7 @@ libspdm_return_t libspdm_transport_test_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *

--- a/unit_test/spdm_transport_test_lib/common.c
+++ b/unit_test/spdm_transport_test_lib/common.c
@@ -184,7 +184,7 @@ libspdm_return_t libspdm_transport_test_encode_message(
  *                                      For normal message or secured message, it shall point to acquired receiver buffer.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall be msg_buf_ptr from receiver buffer.
+ *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
  *
@@ -248,7 +248,8 @@ libspdm_return_t libspdm_transport_test_decode_message(
         }
 
         /* Secured message to APP message*/
-        libspdm_get_scratch_buffer (spdm_context, (void **)&app_message, &app_message_size);
+        app_message = *message;
+        app_message_size = *message_size;
         status = libspdm_decode_secured_message(
             secured_message_context, *secured_message_session_id,
             is_requester, secured_message_size, secured_message,

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -385,6 +385,7 @@ libspdm_return_t libspdm_requester_get_measurements_test_send_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "Request (0x%x):\n",
                        request_size));
         libspdm_dump_hex(request, request_size);
+        libspdm_get_scratch_buffer (spdm_context, (void **)&app_message, &app_message_size);
         libspdm_transport_test_decode_message(
             spdm_context, &session_id, &is_app_message,
             false, request_size, (uint8_t *)request,

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -155,6 +155,7 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
                                                        request_size,
@@ -194,6 +195,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -237,6 +240,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -280,6 +285,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -323,6 +330,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -369,6 +378,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -421,6 +432,7 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
                                                        request_size,
@@ -460,6 +472,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -505,6 +519,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -549,6 +565,7 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
                                                        request_size,
@@ -585,6 +602,7 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
                                                        request_size,
@@ -624,6 +642,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -667,6 +687,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -710,6 +732,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,
@@ -756,6 +780,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
+                                        &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
                                                            &message_session_id, &is_app_message,
                                                            true,

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -115,6 +115,7 @@ libspdm_return_t libspdm_requester_psk_finish_test_send_message(void *spdm_conte
         ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
         ->handshake_secret.request_handshake_sequence_number--;
         m_libspdm_local_buffer_size = 0;
+        libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(
             spdm_context,
             &message_session_id, &is_app_message, true, request_size, request,


### PR DESCRIPTION
transport lib should be agnostic on the buffer management.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>