### PR TITLE
Add set cert new feature for libspdm 1.2

### DIFF
--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -46,6 +46,7 @@
 #define SPDM_ENCAPSULATED_REQUEST 0x6A
 #define SPDM_ENCAPSULATED_RESPONSE_ACK 0x6B
 #define SPDM_END_SESSION_ACK 0x6C
+#define SPDM_SET_CERTIFICATE_RSP 0x6E
 
 /* SPDM request code (1.0)*/
 
@@ -70,7 +71,7 @@
 #define SPDM_GET_ENCAPSULATED_REQUEST 0xEA
 #define SPDM_DELIVER_ENCAPSULATED_RESPONSE 0xEB
 #define SPDM_END_SESSION 0xEC
-
+#define SPDM_SET_CERTIFICATE 0xEE
 
 /* SPDM message header*/
 
@@ -980,6 +981,24 @@ typedef struct {
     /* param1 == RSVD
      * param2 == RSVD*/
 } spdm_end_session_response_t;
+
+
+/* SPDM SET_CERTIFICATE request*/
+
+typedef struct {
+    spdm_message_header_t header;
+    /* param1 == BIT[0:3]=slot_id, BIT[4:7]=RSVD
+     * param2 == RSVD
+     * void * cert_chain*/
+} spdm_set_certificate_request_t;
+
+/* SPDM SET_CERTIFICATE_RSP response*/
+
+typedef struct {
+    spdm_message_header_t header;
+    /* param1 == BIT[0:3]=slot_id, BIT[4:7]=RSVD
+     * param2 == RSVD*/
+} spdm_set_certificate_response_t;
 
 #pragma pack()
 

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -392,6 +392,10 @@ typedef struct {
     /* See LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY_*. */
 
     uint8_t handle_error_return_policy;
+
+    /* Control whether responder device requires a reset to complete the GET_CSR/SET_CERT request.*/
+
+    bool need_reset_to_set_cert;
 } libspdm_context_t;
 
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -654,3 +654,27 @@ void libspdm_set_connection_state(libspdm_context_t *spdm_context,
                                   libspdm_connection_state_t connection_state);
 
 #endif
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+/**
+ * Process the SPDM SET_CERTIFICATE request and return the response.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  request_size                  size in bytes of the request data.
+ * @param  request                      A pointer to the request data.
+ * @param  response_size                 size in bytes of the response data.
+ *                                     On input, it means the size in bytes of response data buffer.
+ *                                     On output, it means the size in bytes of copied response data buffer if RETURN_SUCCESS is returned,
+ *                                     and means the size in bytes of desired response data buffer if RETURN_BUFFER_TOO_SMALL is returned.
+ * @param  response                     A pointer to the response data.
+ *
+ * @retval RETURN_SUCCESS               The request is processed and the response is returned.
+ * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_get_response_set_certificate(void *context, size_t request_size,
+                                                      const void *request,
+                                                      size_t *response_size,
+                                                      void *response);
+#endif

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -111,6 +111,13 @@ typedef enum {
      **/
     LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY,
 
+    /**
+     * The LIBSPDM_DATA_NEED_RESET control whether responder device requires a reset to complete the GET_CSR/SET_CERT request.
+     * If the LIBSPDM_DATA_NEED_RESET is not set, the responder device doesn't need reset.
+     * If the LIBSPDM_DATA_NEED_RESET sets, the responder device needs reset.
+     **/
+    LIBSPDM_DATA_NEED_RESET,
+
     /* MAX*/
 
     LIBSPDM_DATA_MAX

--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -211,3 +211,18 @@ bool libspdm_psk_master_secret_hkdf_expand(
     size_t out_size);
 
 #endif
+
+/**
+ * This function sends SET_CERTIFICATE
+ * to set certificate from the device.
+ *
+ *
+ * @param[in]  slot_id                      The number of slot for the certificate chain.
+ * @param[in]  cert_chain                   The pointer for the certificate chain to set.
+ * @param[in]  cert_chain_size              The size of the certificate chain to set.
+ *
+ * @retval true                         Set certificate to NV successfully.
+ * @retval false                        Set certificate to NV unsuccessfully.
+ **/
+bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
+                                      size_t cert_chain_size);

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -167,6 +167,10 @@
 #define LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP 1
 #endif
 
+#ifndef LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+#define LIBSPDM_ENABLE_SET_CERTIFICATE_CAP 1
+#endif
+
 /*
  * MinDataTransferSize = 42
  *

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -582,3 +582,27 @@ libspdm_return_t libspdm_generate_encap_extended_error_response(
     size_t *spdm_response_size, void *spdm_response);
 
 #endif
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+/**
+ * This function try to send SET_CERTIFICATE
+ * to set certificate from the device.
+ *
+ * @param  context                      A pointer to the SPDM context.
+ * @param  slot_id                      The number of slot for the certificate chain.
+ * @param  cert_chain                   The pointer for the certificate chain to set.
+ *                                      The cert chain is a full SPDM certificate chain, including Length and Root Cert Hash.
+ * @param  cert_chain_size              The size of the certificate chain to set.
+ * @param  session_id                   Indicates if it is a secured message protected via SPDM session.
+ *                                      If session_id is NULL, it is a normal message.
+ *                                      If session_id is NOT NULL, it is a secured message.
+ *
+ * @retval RETURN_SUCCESS               The measurement is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_set_certificate(void * context, uint8_t slot_id,
+                                         void * cert_chain, size_t cert_chain_size,
+                                         const uint32_t *session_id);
+
+#endif

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -490,6 +490,12 @@ libspdm_return_t libspdm_set_data(void *context, libspdm_data_type_t data_type,
         }
         spdm_context->handle_error_return_policy = *(uint8_t *)data;
         break;
+    case LIBSPDM_DATA_NEED_RESET:
+        if (data_size != sizeof(bool)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        spdm_context->need_reset_to_set_cert = *(bool *)data;
+        break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;
@@ -728,6 +734,10 @@ libspdm_return_t libspdm_get_data(void *context, libspdm_data_type_t data_type,
     case LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY:
         target_data_size = sizeof(uint8_t);
         target_data = &spdm_context->handle_error_return_policy;
+        break;
+    case LIBSPDM_DATA_NEED_RESET:
+        target_data_size = sizeof(bool);
+        target_data = &spdm_context->need_reset_to_set_cert;
         break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;

--- a/library/spdm_requester_lib/CMakeLists.txt
+++ b/library/spdm_requester_lib/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(src_spdm_requester_lib
     libspdm_req_psk_exchange.c
     libspdm_req_psk_finish.c
     libspdm_req_send_receive.c
+    libspdm_req_set_certificate.c
 )
 
 ADD_LIBRARY(spdm_requester_lib STATIC ${src_spdm_requester_lib})

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -1,0 +1,189 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_requester_lib.h"
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+
+/**
+ * This function sends SET_CERTIFICATE
+ * to set certificate from the device.
+ *
+ * @param  context                      A pointer to the SPDM context.
+ * @param  slot_id                      The number of slot for the certificate chain.
+ * @param  cert_chain                   The pointer for the certificate chain to set.
+ *                                      The cert chain is a full SPDM certificate chain, including Length and Root Cert Hash.
+ * @param  cert_chain_size              The size of the certificate chain to set.
+ * @param  session_id                   Indicates if it is a secured message protected via SPDM session.
+ *                                      If session_id is NULL, it is a normal message.
+ *                                      If session_id is NOT NULL, it is a secured message.
+ *
+ * @retval RETURN_SUCCESS               The measurement is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_try_set_certificate(void *context, uint8_t slot_id,
+                                             void * cert_chain, size_t cert_chain_size,
+                                             const uint32_t *session_id)
+{
+    libspdm_return_t status;
+    spdm_set_certificate_request_t *spdm_request;
+    size_t spdm_request_size;
+    libspdm_context_t *spdm_context;
+    spdm_set_certificate_response_t *spdm_response;
+    size_t spdm_response_size;
+    size_t transport_header_size;
+    uint8_t *message;
+    size_t message_size;
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+
+    spdm_context = context;
+
+    LIBSPDM_ASSERT(slot_id < SPDM_MAX_SLOT_COUNT);
+
+    if ((cert_chain == NULL) || (cert_chain_size == 0)) {
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
+    /*The Requester shall issue SET_CERTIFICATE inside a secure session
+     * for slot 1-7 provisioning*/
+    if ((slot_id != 0) && (session_id == NULL)) {
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
+    if (spdm_context->connection_info.connection_state <
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+        return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+    }
+
+    if (session_id != NULL) {
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context, *session_id);
+        if (session_info == NULL) {
+            LIBSPDM_ASSERT(false);
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        session_state = libspdm_secured_message_get_session_state(
+            session_info->secured_message_context);
+        if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+    }
+
+    transport_header_size = spdm_context->transport_get_header_size(spdm_context);
+    libspdm_acquire_sender_buffer (spdm_context, &message_size, (void **)&message);
+    LIBSPDM_ASSERT (message_size >= transport_header_size);
+    spdm_request = (void *)(message + transport_header_size);
+    spdm_request_size = message_size - transport_header_size;
+
+    spdm_request->header.spdm_version = libspdm_get_connection_version (spdm_context);
+    spdm_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    spdm_request->header.param1 = slot_id;
+    spdm_request->header.param2 = 0;
+
+    LIBSPDM_ASSERT(spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12);
+
+    libspdm_copy_mem(spdm_request + 1,
+                     spdm_request_size - sizeof(spdm_set_certificate_request_t),
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    spdm_request_size = sizeof(spdm_set_certificate_request_t) + cert_chain_size;
+
+    status = libspdm_send_spdm_request(spdm_context, session_id, spdm_request_size, spdm_request);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        libspdm_release_sender_buffer (spdm_context);
+        return status;
+    }
+    libspdm_release_sender_buffer (spdm_context);
+    spdm_request = (void *)spdm_context->last_spdm_request;
+
+    /* receive */
+    libspdm_acquire_receiver_buffer (spdm_context, &message_size, (void **)&message);
+    LIBSPDM_ASSERT (message_size >= transport_header_size);
+    spdm_response = (void *)(message);
+    spdm_response_size = message_size;
+
+    libspdm_zero_mem(spdm_response, spdm_response_size);
+    status = libspdm_receive_spdm_response(spdm_context, session_id,
+                                           &spdm_response_size, (void **)&spdm_response);
+
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        goto receive_done;
+    }
+    if (spdm_response_size < sizeof(spdm_message_header_t)) {
+        status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        goto receive_done;
+    }
+    if (spdm_response->header.spdm_version != spdm_request->header.spdm_version) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto receive_done;
+    }
+    if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        status = libspdm_handle_error_response_main(
+            spdm_context, NULL,
+            &spdm_response_size,
+            (void **)&spdm_response, SPDM_SET_CERTIFICATE, SPDM_SET_CERTIFICATE_RSP,
+            sizeof(spdm_set_certificate_response_t));
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            goto receive_done;
+        }
+    } else if (spdm_response->header.request_response_code != SPDM_SET_CERTIFICATE_RSP) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto receive_done;
+    }
+    if ((spdm_response->header.param1 & SPDM_CERTIFICATE_RESPONSE_SLOT_ID_MASK) != slot_id) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto receive_done;
+    }
+
+    status = LIBSPDM_STATUS_SUCCESS;
+
+receive_done:
+    libspdm_release_receiver_buffer (spdm_context);
+    return status;
+}
+
+/**
+ * This function try to send SET_CERTIFICATE
+ * to set certificate from the device.
+ *
+ * @param  context                      A pointer to the SPDM context.
+ * @param  slot_id                      The number of slot for the certificate chain.
+ * @param  cert_chain                   The pointer for the certificate chain to set.
+ *                                      The cert chain is a full SPDM certificate chain, including Length and Root Cert Hash.
+ * @param  cert_chain_size              The size of the certificate chain to set.
+ * @param  session_id                   Indicates if it is a secured message protected via SPDM session.
+ *                                      If session_id is NULL, it is a normal message.
+ *                                      If session_id is NOT NULL, it is a secured message.
+ *
+ * @retval RETURN_SUCCESS               The measurement is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_set_certificate(void * context, uint8_t slot_id,
+                                         void * cert_chain, size_t cert_chain_size,
+                                         const uint32_t *session_id)
+{
+    libspdm_context_t *spdm_context;
+    size_t retry;
+    libspdm_return_t status;
+
+    spdm_context = context;
+    spdm_context->crypto_request = true;
+    retry = spdm_context->retry_times;
+    do {
+        status = libspdm_try_set_certificate(spdm_context, slot_id,
+                                             cert_chain, cert_chain_size, session_id);
+        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+            return status;
+        }
+    } while (retry-- != 0);
+
+    return status;
+}
+
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/

--- a/library/spdm_responder_lib/CMakeLists.txt
+++ b/library/spdm_responder_lib/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(src_spdm_responder_lib
     libspdm_rsp_receive_send.c
     libspdm_rsp_respond_if_ready.c
     libspdm_rsp_version.c
+    libspdm_rsp_set_certificate.c
 )
 
 ADD_LIBRARY(spdm_responder_lib STATIC ${src_spdm_responder_lib})

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -60,6 +60,11 @@ libspdm_get_response_struct_t m_libspdm_get_response_struct[] = {
     { SPDM_HEARTBEAT, libspdm_get_response_heartbeat },
     { SPDM_KEY_UPDATE, libspdm_get_response_key_update },
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP || LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP*/
+
+
+    #if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+    { SPDM_SET_CERTIFICATE, libspdm_get_response_set_certificate },
+    #endif
 };
 
 /**

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
@@ -1,0 +1,152 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_responder_lib.h"
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+
+/**
+ * Process the SPDM SET_CERTIFICATE request and return the response.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  request_size                  size in bytes of the request data.
+ * @param  request                      A pointer to the request data.
+ * @param  response_size                 size in bytes of the response data.
+ *                                     On input, it means the size in bytes of response data buffer.
+ *                                     On output, it means the size in bytes of copied response data buffer if RETURN_SUCCESS is returned,
+ *                                     and means the size in bytes of desired response data buffer if RETURN_BUFFER_TOO_SMALL is returned.
+ * @param  response                     A pointer to the response data.
+ *
+ * @retval RETURN_SUCCESS               The request is processed and the response is returned.
+ * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_get_response_set_certificate(void *context, size_t request_size,
+                                                      const void *request,
+                                                      size_t *response_size,
+                                                      void *response)
+{
+    const spdm_set_certificate_request_t *spdm_request;
+    spdm_set_certificate_response_t *spdm_response;
+
+    libspdm_context_t *spdm_context;
+    bool result;
+    uint8_t slot_id;
+
+    size_t root_cert_hash_size;
+    const spdm_cert_chain_t *cert_chain_header;
+    size_t cert_chain_size;
+    const void * cert_chain;
+
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+
+    spdm_context = context;
+    spdm_request = request;
+
+    if (spdm_request->header.spdm_version != libspdm_get_connection_version(spdm_context)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_VERSION_MISMATCH, 0,
+                                               response_size, response);
+    }
+
+    if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
+        return libspdm_responder_handle_response_state(spdm_context,
+                                                       spdm_request->header.request_response_code,
+                                                       response_size, response);
+    }
+
+    if (request_size <= sizeof(spdm_set_certificate_request_t)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    if (spdm_context->connection_info.connection_state <
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+        return libspdm_generate_error_response(
+            spdm_context,
+            SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+            response_size, response);
+    }
+
+    if (spdm_context->last_spdm_request_session_id_valid) {
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context,
+            spdm_context->last_spdm_request_session_id);
+        if (session_info == NULL) {
+            return libspdm_generate_error_response(
+                spdm_context,
+                SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+                response_size, response);
+        }
+        session_state = libspdm_secured_message_get_session_state(
+            session_info->secured_message_context);
+        if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+            return libspdm_generate_error_response(
+                spdm_context,
+                SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+                response_size, response);
+        }
+    }
+
+    slot_id = spdm_request->header.param1 & SPDM_GET_CERTIFICATE_REQUEST_SLOT_ID_MASK;
+    if (slot_id >= spdm_context->local_context.slot_count) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    root_cert_hash_size = libspdm_get_hash_size(
+        spdm_context->connection_info.algorithm.base_hash_algo);
+
+    /*point to full SPDM certificate chain*/
+    cert_chain = (const void*)(spdm_request + 1);
+    cert_chain_header = cert_chain;
+
+    /*get actual cert_chain size*/
+    cert_chain_size = cert_chain_header->length - sizeof(spdm_cert_chain_t) - root_cert_hash_size;
+
+    /*point to actual cert_chain*/
+    cert_chain = (const void*)((const uint8_t *)cert_chain
+                               + sizeof(spdm_cert_chain_t) + root_cert_hash_size);
+
+    if ((request_size - sizeof(spdm_set_certificate_request_t)) < cert_chain_header->length) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    /* set certificate to NV*/
+    result = libspdm_write_certificate_to_nvm(slot_id, cert_chain,
+                                              cert_chain_size);
+    if (!result) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                                               response_size, response);
+    }
+
+    LIBSPDM_ASSERT(*response_size >= sizeof(spdm_set_certificate_response_t));
+    *response_size = sizeof(spdm_set_certificate_response_t);
+    libspdm_zero_mem(response, *response_size);
+    spdm_response = response;
+
+    if (spdm_context->need_reset_to_set_cert) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_RESET_REQUIRED, 0,
+                                               response_size, response);
+    } else {
+        spdm_response->header.spdm_version = spdm_request->header.spdm_version;
+        spdm_response->header.request_response_code = SPDM_SET_CERTIFICATE_RSP;
+        spdm_response->header.param1 = slot_id;
+        spdm_response->header.param2 = 0;
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+#endif /*LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -173,3 +173,21 @@ bool libspdm_psk_master_secret_hkdf_expand(
 {
     return false;
 }
+
+/**
+ * This function sends SET_CERTIFICATE
+ * to set certificate from the device.
+ *
+ *
+ * @param[in]  slot_id                      The number of slot for the certificate chain.
+ * @param[in]  cert_chain                   The pointer for the certificate chain to set.
+ * @param[in]  cert_chain_size              The size of the certificate chain to set.
+ *
+ * @retval true                         Set certificate to NV successfully.
+ * @retval false                        Set certificate to NV unsuccessfully.
+ **/
+bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
+                                      size_t cert_chain_size)
+{
+    return false;
+}

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(src_test_spdm_requester
     encap_digests.c
     encap_key_update.c
     encap_request.c
+    set_certificate.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -1,0 +1,401 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+
+
+libspdm_return_t libspdm_requester_set_certificate_test_send_message(
+    void *spdm_context, size_t request_size, const void *request,
+    uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+    uint32_t *session_id;
+    libspdm_session_info_t *session_info;
+    bool is_app_message;
+    uint8_t *app_message;
+    size_t app_message_size;
+    uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
+    memcpy(message_buffer, request, request_size);
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    case 0x2:
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x3:
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x4:
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x5:
+
+        session_id = NULL;
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context, 0xFFFFFFFF);
+        if (session_info == NULL) {
+            return LIBSPDM_STATUS_SEND_FAIL;
+        }
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "Request (0x%x):\n",
+                       request_size));
+        libspdm_dump_hex(request, request_size);
+
+        libspdm_get_scratch_buffer (spdm_context, (void **)&app_message, &app_message_size);
+        libspdm_transport_test_decode_message(
+            spdm_context, &session_id, &is_app_message,
+            false, request_size, message_buffer,
+            &app_message_size, (void **)&app_message);
+
+        /* WALKAROUND: If just use single context to encode
+         * message and then decode message */
+        ((libspdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->application_secret.request_data_sequence_number--;
+
+        return LIBSPDM_STATUS_SUCCESS;
+
+    default:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
+}
+
+libspdm_return_t libspdm_requester_set_certificate_test_receive_message(
+    void *spdm_context, size_t *response_size,
+    void **response, uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1:
+        return LIBSPDM_STATUS_RECEIVE_FAIL;
+
+    case 0x2: {
+        spdm_set_certificate_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(spdm_set_certificate_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+        spdm_response->header.request_response_code = SPDM_SET_CERTIFICATE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x3: {
+        spdm_set_certificate_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(spdm_set_certificate_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+        spdm_response->header.request_response_code = SPDM_SET_CERTIFICATE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x4: {
+        spdm_set_certificate_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(spdm_set_certificate_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+        spdm_response->header.request_response_code = SPDM_SET_CERTIFICATE_RSP;
+        spdm_response->header.param1 = 1;
+        spdm_response->header.param2 = 0;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x05: {
+        spdm_set_certificate_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+        uint32_t session_id;
+        libspdm_session_info_t *session_info;
+        uint8_t *scratch_buffer;
+        size_t scratch_buffer_size;
+
+        session_id = 0xFFFFFFFF;
+
+        spdm_response_size = sizeof(spdm_set_certificate_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+        spdm_response->header.request_response_code = SPDM_SET_CERTIFICATE_RSP;
+        /*slot id is 1*/
+        spdm_response->header.param1 = 1;
+        spdm_response->header.param2 = 0;
+
+        /* For secure message, message is in sender buffer, we need copy it to scratch buffer.
+         * transport_message is always in sender buffer. */
+        libspdm_get_scratch_buffer (spdm_context, (void **)&scratch_buffer, &scratch_buffer_size);
+        libspdm_copy_mem (scratch_buffer + transport_header_size,
+                          scratch_buffer_size - transport_header_size,
+                          spdm_response, spdm_response_size);
+        spdm_response = (void *)(scratch_buffer + transport_header_size);
+        libspdm_transport_test_encode_message(spdm_context, &session_id, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+        session_info = libspdm_get_session_info_via_session_id(
+            spdm_context, session_id);
+        if (session_info == NULL) {
+            return LIBSPDM_STATUS_RECEIVE_FAIL;
+        }
+        /* WALKAROUND: If just use single context to encode message and then decode message */
+        ((libspdm_secured_message_context_t
+          *)(session_info->secured_message_context))
+        ->application_secret.response_data_sequence_number--;
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    default:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
+}
+
+
+/**
+ * Test 1: message could not be sent
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code
+ **/
+void libspdm_test_requester_set_certificate_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo,
+                                                    &data, &data_size, NULL, NULL);
+
+    status = libspdm_set_certificate(spdm_context, 0, data, data_size, NULL);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
+    free(data);
+}
+
+/**
+ * Test 2: Successful response to set certificate for slot 0
+ * Expected Behavior: get a RETURN_SUCCESS return code
+ **/
+void libspdm_test_requester_set_certificate_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo,
+                                                    &data, &data_size, NULL, NULL);
+
+    status = libspdm_set_certificate(spdm_context, 0, data, data_size, NULL);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    free(data);
+}
+
+/**
+ * Test 3: Unsuccessful response to set certificate for slot 0, because cert_chain is NULL.
+ * Expected Behavior: get a LIBSPDM_STATUS_INVALID_PARAMETER return code
+ **/
+void libspdm_test_requester_set_certificate_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    status = libspdm_set_certificate(spdm_context, 0, NULL, 0, NULL);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+}
+
+/**
+ * Test 4: Unsuccessful response to set certificate for slot 1, because the session id is null
+ * Expected Behavior: get a LIBSPDM_STATUS_INVALID_PARAMETER return code
+ **/
+void libspdm_test_requester_set_certificate_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo,
+                                                    &data, &data_size, NULL, NULL);
+
+    /* slot id is 1*/
+    status = libspdm_set_certificate(spdm_context, 1, data, data_size, NULL);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+    free(data);
+}
+
+/**
+ * Test 5: Successful response to set certificate for slot 1 in secure session
+ * Expected Behavior: get a RETURN_SUCCESS return code
+ **/
+void libspdm_test_requester_set_certificate_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    libspdm_session_info_t *session_info;
+
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x05;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(session_info->secured_message_context,
+                                              LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    /* slot id is 1*/
+    status = libspdm_set_certificate(spdm_context, 1, data, data_size, &session_id);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    free(data);
+}
+
+libspdm_test_context_t m_libspdm_requester_set_certificate_test_context = {
+    LIBSPDM_TEST_CONTEXT_VERSION,
+    true,
+    libspdm_requester_set_certificate_test_send_message,
+    libspdm_requester_set_certificate_test_receive_message,
+};
+
+int libspdm_requester_set_certificate_test_main(void)
+{
+    const struct CMUnitTest spdm_requester_set_certificate_tests[] = {
+        /* SendRequest failed*/
+        cmocka_unit_test(libspdm_test_requester_set_certificate_case1),
+        /* Successful response to set certificate*/
+        cmocka_unit_test(libspdm_test_requester_set_certificate_case2),
+        /* Set null cert_chain for slot 0*/
+        cmocka_unit_test(libspdm_test_requester_set_certificate_case3),
+        /* Set certificate for slot 1,but the session id is null*/
+        cmocka_unit_test(libspdm_test_requester_set_certificate_case4),
+        /* Successful response to set certificate for slot 1 in secure session*/
+        cmocka_unit_test(libspdm_test_requester_set_certificate_case5),
+    };
+
+    libspdm_setup_test_context(
+        &m_libspdm_requester_set_certificate_test_context);
+
+    return cmocka_run_group_tests(spdm_requester_set_certificate_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -43,6 +43,8 @@ int libspdm_requester_encap_key_update_test_main(void);
 int libspdm_requester_end_session_test_main(void);
 int libspdm_requester_encap_request_test_main(void);
 
+int libspdm_requester_set_certificate_test_main(void);
+
 int main(void)
 {
     int return_value = 0;
@@ -129,5 +131,10 @@ int main(void)
     if (libspdm_requester_encap_request_test_main() != 0) {
         return_value = 1;
     }
+
+    if (libspdm_requester_set_certificate_test_main() != 0) {
+        return_value = 1;
+    }
+
     return return_value;
 }

--- a/unit_test/test_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_spdm_responder/CMakeLists.txt
@@ -32,6 +32,7 @@ SET(src_test_spdm_responder
     encap_key_update.c
     encap_challenge.c
     encap_response.c
+    set_certificate_rsp.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1,0 +1,390 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_responder_lib.h"
+
+#if LIBSPDM_ENABLE_SET_CERTIFICATE_CAP
+
+/**
+ * Test 1: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:0
+ * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
+ **/
+void libspdm_test_responder_set_cetificate_rsp_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_set_certificate_response_t *spdm_response;
+    void *cert_chain;
+    size_t cert_chain_size;
+    spdm_set_certificate_request_t *m_libspdm_set_certificate_request;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &cert_chain,
+                                                    &cert_chain_size, NULL, NULL);
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_set_certificate_request_t) +
+                                               cert_chain_size);
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1,
+                     LIBSPDM_MAX_CERT_CHAIN_SIZE,
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_set_certificate_request_t) +
+                                                    cert_chain_size;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_certificate(spdm_context,
+                                                  m_libspdm_set_certificate_request_size,
+                                                  m_libspdm_set_certificate_request,
+                                                  &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_set_certificate_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_SET_CERTIFICATE_RSP);
+
+    free(cert_chain);
+    free(m_libspdm_set_certificate_request);
+}
+
+/**
+ * Test 2: Wrong SET_CERTIFICATE message size (larger than expected)
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_responder_set_cetificate_rsp_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_set_certificate_response_t *spdm_response;
+    void *cert_chain;
+    size_t cert_chain_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &cert_chain,
+                                                    &cert_chain_size, NULL, NULL);
+
+    spdm_set_certificate_request_t *m_libspdm_set_certificate_request;
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_set_certificate_request_t) +
+                                               cert_chain_size);
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1,
+                     LIBSPDM_MAX_CERT_CHAIN_SIZE,
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    /* Bad request size: only have header size*/
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_set_certificate_request_t);
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_certificate(spdm_context,
+                                                  m_libspdm_set_certificate_request_size,
+                                                  m_libspdm_set_certificate_request,
+                                                  &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    free(cert_chain);
+    free(m_libspdm_set_certificate_request);
+}
+
+
+/**
+ * Test 3: Force response_state = LIBSPDM_RESPONSE_STATE_BUSY when asked SET_CERTIFICATE
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
+ **/
+void libspdm_test_responder_set_cetificate_rsp_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_set_certificate_response_t *spdm_response;
+    void *cert_chain;
+    size_t cert_chain_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &cert_chain,
+                                                    &cert_chain_size, NULL, NULL);
+
+    spdm_set_certificate_request_t *m_libspdm_set_certificate_request;
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_set_certificate_request_t) +
+                                               cert_chain_size);
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1,
+                     LIBSPDM_MAX_CERT_CHAIN_SIZE,
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    /* Bad request size: right request size + 1*/
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_set_certificate_request_t) +
+                                                    cert_chain_size + 1;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_certificate(spdm_context,
+                                                  m_libspdm_set_certificate_request_size,
+                                                  m_libspdm_set_certificate_request,
+                                                  &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_BUSY);
+    assert_int_equal(spdm_response->header.param2, 0);
+    assert_int_equal(spdm_context->response_state,
+                     LIBSPDM_RESPONSE_STATE_BUSY);
+
+    free(cert_chain);
+    free(m_libspdm_set_certificate_request);
+}
+
+
+/**
+ * Test 4: Force response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC when asked SET_CERTIFICATE
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
+ **/
+void libspdm_test_responder_set_cetificate_rsp_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_set_certificate_response_t *spdm_response;
+    void *cert_chain;
+    size_t cert_chain_size;
+    spdm_set_certificate_request_t *m_libspdm_set_certificate_request;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &cert_chain,
+                                                    &cert_chain_size, NULL, NULL);
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_set_certificate_request_t) +
+                                               cert_chain_size);
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1,
+                     LIBSPDM_MAX_CERT_CHAIN_SIZE,
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_set_certificate_request_t) +
+                                                    cert_chain_size;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_certificate(spdm_context,
+                                                  m_libspdm_set_certificate_request_size,
+                                                  m_libspdm_set_certificate_request,
+                                                  &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_REQUEST_RESYNCH);
+    assert_int_equal(spdm_response->header.param2, 0);
+    assert_int_equal(spdm_context->response_state,
+                     LIBSPDM_RESPONSE_STATE_NEED_RESYNC);
+
+    free(cert_chain);
+    free(m_libspdm_set_certificate_request);
+}
+
+/**
+ * Test 5: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:1
+ * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
+ **/
+void libspdm_test_responder_set_cetificate_rsp_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_set_certificate_response_t *spdm_response;
+    void *cert_chain;
+    size_t cert_chain_size;
+    spdm_set_certificate_request_t *m_libspdm_set_certificate_request;
+
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    /*responset_state need to set normal*/
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    /*slot_count = 2(slot_id:0  slot_id:1)*/
+    spdm_context->local_context.slot_count = 2;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &cert_chain,
+                                                    &cert_chain_size, NULL, NULL);
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_set_certificate_request_t) +
+                                               cert_chain_size);
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_SET_CERTIFICATE;
+    m_libspdm_set_certificate_request->header.param1 = 1;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1,
+                     LIBSPDM_MAX_CERT_CHAIN_SIZE,
+                     (uint8_t *)cert_chain, cert_chain_size);
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_set_certificate_request_t) +
+                                                    cert_chain_size;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_certificate(spdm_context,
+                                                  m_libspdm_set_certificate_request_size,
+                                                  m_libspdm_set_certificate_request,
+                                                  &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_set_certificate_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_SET_CERTIFICATE_RSP);
+
+    free(cert_chain);
+    free(m_libspdm_set_certificate_request);
+}
+
+libspdm_test_context_t m_libspdm_responder_set_certificate_rsp_test_context = {
+    LIBSPDM_TEST_CONTEXT_VERSION,
+    false,
+};
+
+int libspdm_responder_set_certificate_rsp_test_main(void)
+{
+    const struct CMUnitTest spdm_responder_set_cetificate_tests[] = {
+        /* Success Case for set_certificate to slot_id:0 */
+        cmocka_unit_test(libspdm_test_responder_set_cetificate_rsp_case1),
+        /* Bad request size*/
+        cmocka_unit_test(libspdm_test_responder_set_cetificate_rsp_case2),
+        /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
+        cmocka_unit_test(libspdm_test_responder_set_cetificate_rsp_case3),
+        /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
+        cmocka_unit_test(libspdm_test_responder_set_cetificate_rsp_case4),
+        /* Success Case for set_certificate to slot_id:1 */
+        cmocka_unit_test(libspdm_test_responder_set_cetificate_rsp_case5),
+    };
+
+    libspdm_setup_test_context(&m_libspdm_responder_set_certificate_rsp_test_context);
+
+    return cmocka_run_group_tests(spdm_responder_set_cetificate_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* LIBSPDM_ENABLE_SET_CERTIFICATE_CAP*/

--- a/unit_test/test_spdm_responder/test_spdm_responder.c
+++ b/unit_test/test_spdm_responder/test_spdm_responder.c
@@ -52,6 +52,8 @@ int libspdm_responder_end_session_test_main(void);
 int libspdm_responder_encap_key_update_test_main(void);
 int libspdm_responder_encapsulated_response_test_main(void);
 
+int libspdm_responder_set_certificate_rsp_test_main(void);
+
 int main(void)
 {
     int return_value = 0;
@@ -152,6 +154,10 @@ int main(void)
     }
 
     if (libspdm_responder_encapsulated_response_test_main() != 0) {
+        return_value = 1;
+    }
+
+    if (libspdm_responder_set_certificate_rsp_test_main() != 0) {
         return_value = 1;
     }
 


### PR DESCRIPTION
Fix: #506 


- Add SET_CERTIFICATE new feature for libspdm 1.2.
- Add unit_test for new libspdm 1.2 feature: set_certificate.
- Add set_certificate new feature support for emu test.
 
Set cert for slot_id 0 and 1 in emu/unit test suceessfully: 
1. Set cert for slot_id 0 in secure environment;
2. Set cert for slot_id 1 in secure session.


Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>