### PR TITLE
Update rnglib std variant to stdint

### DIFF
--- a/os_stub/rnglib/rng_std.c
+++ b/os_stub/rnglib/rng_std.c
@@ -19,21 +19,21 @@
  * @retval false        Failed to generate the random number.
  *
  **/
-bool libspdm_get_random_number_64(uint64 *rand_data)
+bool libspdm_get_random_number_64(uint64_t *rand_data)
 {
-    uint8 *ptr;
+    uint8_t *ptr;
 
     assert(rand_data != NULL);
 
-    ptr = (uint8 *)rand_data;
-    ptr[0] = (uint8)rand();
-    ptr[1] = (uint8)rand();
-    ptr[2] = (uint8)rand();
-    ptr[3] = (uint8)rand();
-    ptr[4] = (uint8)rand();
-    ptr[5] = (uint8)rand();
-    ptr[6] = (uint8)rand();
-    ptr[7] = (uint8)rand();
+    ptr = (uint8_t *)rand_data;
+    ptr[0] = (uint8_t)rand();
+    ptr[1] = (uint8_t)rand();
+    ptr[2] = (uint8_t)rand();
+    ptr[3] = (uint8_t)rand();
+    ptr[4] = (uint8_t)rand();
+    ptr[5] = (uint8_t)rand();
+    ptr[6] = (uint8_t)rand();
+    ptr[7] = (uint8_t)rand();
 
     return true;
 }


### PR DESCRIPTION
It appears since CI only builds linux and windows variants of the
rnglib, the std variant was left behind on the conversion to stdint
types.

Signed-off-by: Abe Kohandel <abe.kohandel@intel.com>