### PR TITLE
Buffer use after free

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_communication.c
+++ b/library/spdm_responder_lib/libspdm_rsp_communication.c
@@ -48,8 +48,8 @@ libspdm_return_t libspdm_responder_dispatch_message(void *context)
     }
     status = libspdm_process_request(spdm_context, &session_id, &is_app_message,
                                      request_size, request);
-    libspdm_release_receiver_buffer (spdm_context);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        libspdm_release_receiver_buffer (spdm_context);
         return status;
     }
 
@@ -70,12 +70,15 @@ libspdm_return_t libspdm_responder_dispatch_message(void *context)
     status = libspdm_build_response(spdm_context, session_id_ptr, is_app_message,
                                     &response_size, (void **)&response);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        libspdm_release_receiver_buffer (spdm_context);
         libspdm_release_sender_buffer (spdm_context);
         return status;
     }
 
     status = spdm_context->send_message(spdm_context, response_size,
                                         response, 0);
+
+    libspdm_release_receiver_buffer (spdm_context);
     libspdm_release_sender_buffer (spdm_context);
 
     return status;

--- a/library/spdm_responder_lib/libspdm_rsp_communication.c
+++ b/library/spdm_responder_lib/libspdm_rsp_communication.c
@@ -60,6 +60,8 @@ libspdm_return_t libspdm_responder_dispatch_message(void *context)
     } else {
         session_id_ptr = NULL;
     }
+    /* release buffer after use session_id, before acquire buffer */
+    libspdm_release_receiver_buffer (spdm_context);
 
     /* build and send response message */
     libspdm_acquire_sender_buffer (spdm_context, &message_size, (void **)&message);
@@ -70,7 +72,6 @@ libspdm_return_t libspdm_responder_dispatch_message(void *context)
     status = libspdm_build_response(spdm_context, session_id_ptr, is_app_message,
                                     &response_size, (void **)&response);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        libspdm_release_receiver_buffer (spdm_context);
         libspdm_release_sender_buffer (spdm_context);
         return status;
     }
@@ -78,7 +79,6 @@ libspdm_return_t libspdm_responder_dispatch_message(void *context)
     status = spdm_context->send_message(spdm_context, response_size,
                                         response, 0);
 
-    libspdm_release_receiver_buffer (spdm_context);
     libspdm_release_sender_buffer (spdm_context);
 
     return status;


### PR DESCRIPTION
Fixing #868

The session_id is a pointer point to receiver buffer, and it will be
dereferenced during construst response message. However, the buffer
is released after process the request message. So it may cause
use-after-free error.

Signed-off-by: Troy Lee <troy_lee@aspeedtech.com>