### PR TITLE
Fix "reset message k " on fuzzing test case

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
@@ -52,6 +52,7 @@ void libspdm_test_requester_encap_certificate(void **State)
     libspdm_get_encap_response_certificate(spdm_context, request_size,
                                            (uint8_t *)spdm_test_context->test_buffer,
                                            &response_size, response);
+    libspdm_reset_message_mut_b(spdm_context);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/encap_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_digests/encap_digests.c
@@ -45,6 +45,7 @@ void libspdm_test_requester_encap_digests(void **State)
     libspdm_get_encap_response_digest(spdm_context, request_size,
                                       (uint8_t *)spdm_test_context->test_buffer,
                                       &response_size, response);
+    libspdm_reset_message_mut_b(spdm_context);
 }
 
 libspdm_test_context_t m_libspdm_requester_encap_digests_test_context = {

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_certificate/certificate.c
@@ -54,6 +54,7 @@ void libspdm_test_responder_certificate_case1(void **State)
                                      spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer,
                                      &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -91,6 +92,7 @@ void libspdm_test_responder_certificate_case2(void **State)
                                      spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer,
                                      &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -172,6 +174,7 @@ void libspdm_test_responder_certificate_case5(void **State)
                                      spdm_test_context->test_buffer_size,
                                      spdm_test_context->test_buffer,
                                      &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -57,6 +57,7 @@ void libspdm_test_responder_challenge_case1(void **State)
 
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -96,6 +97,7 @@ void libspdm_test_responder_challenge_case2(void **State)
 
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -136,6 +138,7 @@ void libspdm_test_responder_challenge_case3(void **State)
 
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -178,6 +181,7 @@ void libspdm_test_responder_challenge_case4(void **State)
     libspdm_reset_message_c(spdm_context);
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 
@@ -219,11 +223,8 @@ void libspdm_test_responder_challenge_case5(void **State)
 
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
-    #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    #else
-    free(spdm_context->transcript.digest_context_m1m2);
-    #endif
 }
 
 void libspdm_test_responder_challenge_case6(void **State)
@@ -266,6 +267,7 @@ void libspdm_test_responder_challenge_case6(void **State)
     libspdm_reset_message_c(spdm_context);
     libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
                                         spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_b(spdm_context);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
@@ -44,6 +44,7 @@ void libspdm_test_responder_digests_case1(void **State)
                                  spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer,
                                  &response_size, response);
+    libspdm_reset_message_b(spdm_context);
 }
 
 void libspdm_test_responder_digests_case2(void **State)
@@ -67,6 +68,7 @@ void libspdm_test_responder_digests_case2(void **State)
                                  spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer,
                                  &response_size, response);
+    libspdm_reset_message_b(spdm_context);
 }
 
 void libspdm_test_responder_digests_case3(void **State)
@@ -89,6 +91,7 @@ void libspdm_test_responder_digests_case3(void **State)
                                  spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer,
                                  &response_size, response);
+    libspdm_reset_message_b(spdm_context);
 }
 
 void libspdm_test_responder_digests_case4(void **State)
@@ -112,6 +115,7 @@ void libspdm_test_responder_digests_case4(void **State)
                                  spdm_test_context->test_buffer_size,
                                  spdm_test_context->test_buffer,
                                  &response_size, response);
+    libspdm_reset_message_b(spdm_context);
 }
 
 libspdm_test_context_t m_libspdm_responder_digests_test_context = {

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_certificate/encap_get_certificate.c
@@ -66,6 +66,7 @@ void libspdm_test_responder_encap_get_certificate_case1(void **State)
 
     libspdm_process_encap_response_certificate(spdm_context, spdm_response_size, spdm_response,
                                                &need_continue);
+    libspdm_reset_message_mut_b(spdm_context);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_get_digests/encap_get_digests.c
@@ -41,6 +41,7 @@ void libspdm_test_responder_encap_get_digests_case1(void **State)
 
     libspdm_process_encap_response_digest(spdm_context, spdm_test_context->test_buffer_size,
                                           spdm_test_context->test_buffer, &need_continue);
+    libspdm_reset_message_mut_c(spdm_context);
 }
 
 void libspdm_test_get_encap_request_get_digest_case2(void **State)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_encap_response/encap_response.c
@@ -232,6 +232,7 @@ void libspdm_test_get_response_encapsulated_response_ack_case1(void **State)
                                                    spdm_test_context->test_buffer_size,
                                                    spdm_test_context->test_buffer, &response_size,
                                                    response);
+    libspdm_reset_message_mut_b(spdm_context);
     free(data);
 }
 
@@ -305,6 +306,7 @@ void libspdm_test_get_response_encapsulated_response_ack_case3(void **State)
                                                    spdm_test_context->test_buffer_size,
                                                    spdm_test_context->test_buffer, &response_size,
                                                    response);
+    libspdm_reset_message_mut_b(spdm_context);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -131,6 +131,10 @@ void libspdm_test_responder_finish_case1(void **State)
     libspdm_get_response_finish(spdm_context, spdm_test_finish_request_size,
                                 spdm_test_finish_request,
                                 &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data1);
 }
 
@@ -151,6 +155,10 @@ void libspdm_test_responder_finish_case2(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
 }
 
 void libspdm_test_responder_finish_case3(void **State)
@@ -172,6 +180,10 @@ void libspdm_test_responder_finish_case3(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
 }
 
 void libspdm_test_responder_finish_case4(void **State)
@@ -194,6 +206,10 @@ void libspdm_test_responder_finish_case4(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
 }
 
 void libspdm_test_responder_finish_case5(void **State)
@@ -218,6 +234,10 @@ void libspdm_test_responder_finish_case5(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
 }
 
 void libspdm_test_responder_finish_case6(void **State)
@@ -246,6 +266,10 @@ void libspdm_test_responder_finish_case6(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
 }
 
 void libspdm_test_responder_finish_case7(void **State)
@@ -310,6 +334,10 @@ void libspdm_test_responder_finish_case7(void **State)
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
                                 spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data1);
 }
 
@@ -439,8 +467,10 @@ void libspdm_test_responder_finish_case8(void **State)
     libspdm_get_response_finish(spdm_context, spdm_test_finish_request_size,
                                 spdm_test_finish_request,
                                 &response_size, response);
-
-    libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data1);
     free(data2);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
@@ -92,6 +92,9 @@ void libspdm_test_responder_key_exchange_case1(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -155,6 +158,9 @@ void libspdm_test_responder_key_exchange_case2(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -201,6 +207,9 @@ void libspdm_test_responder_key_exchange_case3(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -271,6 +280,9 @@ void libspdm_test_responder_key_exchange_case4(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -339,6 +351,9 @@ void libspdm_test_responder_key_exchange_case5(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -401,6 +416,9 @@ void libspdm_test_responder_key_exchange_case6(void **State)
 
     libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
                                       spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_measurements/measurements.c
@@ -43,6 +43,7 @@ void libspdm_test_responder_measurements_case1(void **State)
     response_size = sizeof(response);
     libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                       spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_m(spdm_context, NULL);
 }
 
 void libspdm_test_responder_measurements_case2(void **State)
@@ -89,6 +90,7 @@ void libspdm_test_responder_measurements_case2(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                       spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_m(spdm_context, NULL);
 }
 
 void libspdm_test_responder_measurements_case3(void **State)
@@ -130,6 +132,7 @@ void libspdm_test_responder_measurements_case3(void **State)
 
     libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                       spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_m(spdm_context, NULL);
     free(data);
 }
 
@@ -191,6 +194,7 @@ void libspdm_test_responder_measurements_case4(void **State)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
     libspdm_get_response_measurements(spdm_context, spdm_test_context->test_buffer_size,
                                       spdm_test_context->test_buffer, &response_size, response);
+    libspdm_reset_message_m(spdm_context, NULL);
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -108,8 +108,9 @@ void libspdm_test_responder_psk_exchange_case1(void **State)
     libspdm_get_response_psk_exchange(
         spdm_context, spdm_test_psk_exchange_request_size,
         spdm_test_psk_exchange_request, &response_size, response);
-
-    libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -160,7 +161,9 @@ void libspdm_test_responder_psk_exchange_case2(void **State)
         spdm_context,  spdm_test_context->test_buffer_size,
         spdm_test_context->test_buffer, &response_size, response);
 
-    libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -321,7 +324,9 @@ void libspdm_test_responder_psk_exchange_case4(void **State)
                                       spdm_test_psk_exchange_request, &response_size,
                                       response);
 
-    libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 
@@ -405,7 +410,9 @@ void libspdm_test_responder_psk_exchange_case5(void **State)
                                       spdm_test_psk_exchange_request, &response_size,
                                       response);
 
-    libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data);
 }
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -97,6 +97,10 @@ void libspdm_test_responder_psk_finish_rsp_case1(void **State)
     response_size = sizeof(response);
     libspdm_get_response_psk_finish(spdm_context, spdm_test_context->test_buffer_size,
                                     spdm_test_context->test_buffer, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data1);
 }
 
@@ -181,6 +185,10 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
     response_size = sizeof(response);
     libspdm_get_response_psk_finish(spdm_context, spdm_test_psk_finish_request_size,
                                     spdm_test_psk_finish_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
     free(data1);
 }
 


### PR DESCRIPTION
Fix : #871
Fix "reset message k " on test_spdm_responder_psk_exchange_rsp,and fix similar problems about "reset message cache in spdm context"
Signed-off-by: yaohuixguo <yaohuix.guo@intel.com>