### PR TITLE
Fix libspdm_asn1_get_tag bug in cryptlib_openssl

### DIFF
--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -252,7 +252,7 @@ bool libspdm_asn1_get_tag(uint8_t **ptr, const uint8_t *end, size_t *length,
 
     ptr_old = *ptr;
 
-    /*when there is no object, retrun false*/
+    /*when there is no object, return false*/
     if ((*ptr) == end) {
         return false;
     }

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -252,6 +252,11 @@ bool libspdm_asn1_get_tag(uint8_t **ptr, const uint8_t *end, size_t *length,
 
     ptr_old = *ptr;
 
+    /*when there is no object, retrun false*/
+    if ((*ptr) == end) {
+        return false;
+    }
+
     ASN1_get_object((const uint8_t **)ptr, &obj_length, &obj_tag, &obj_class,
                     (int32_t)(end - (*ptr)));
     if (obj_tag == (int32_t)(tag & LIBSPDM_CRYPTO_ASN1_TAG_VALUE_MASK) &&


### PR DESCRIPTION
False should be returned, when no asn1 object is inputted.

When parse asn1 data cyclically, libspdm_asn1_get_tag will return the true in the end of the asn1 data for any tag type.

The follow example code  will be error with old libspdm_asn1_get_tag code logic :
```
    for (index = 0; index < 2; index++) {
        ret = libspdm_asn1_get_tag(&ptr, end, &obj_len,
                                   LIBSPDM_CRYPTO_ASN1_SEQUENCE |
                                   LIBSPDM_CRYPTO_ASN1_CONSTRUCTED);
        if (ret) {
            ptr += obj_len;
        } else {
            break;
        }
    }

```

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>