### PR TITLE
New unit test cases for the psk_exchange messages

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -295,12 +295,14 @@ libspdm_return_t libspdm_try_send_receive_psk_exchange(
 
     ptr = (uint8_t *)spdm_response + sizeof(spdm_psk_exchange_response_t) +
           measurement_summary_hash_size + spdm_response->context_length;
-    status = libspdm_process_opaque_data_version_selection_data(
-        spdm_context, spdm_response->opaque_length, ptr);
-    if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        libspdm_free_session_id(spdm_context, *session_id);
-        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
-        goto receive_done;
+    if (spdm_response->opaque_length != 0) {
+        status = libspdm_process_opaque_data_version_selection_data(
+            spdm_context, spdm_response->opaque_length, ptr);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            libspdm_free_session_id(spdm_context, *session_id);
+            status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+            goto receive_done;
+        }
     }
 
     spdm_response_size = sizeof(spdm_psk_exchange_response_t) +

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -166,14 +166,16 @@ libspdm_return_t libspdm_get_response_psk_exchange(void *context,
                    spdm_request->context_length +
                    spdm_request->opaque_length;
 
-    cptr = (const uint8_t *)request + sizeof(spdm_psk_exchange_request_t) +
-           spdm_request->psk_hint_length + spdm_request->context_length;
-    status = libspdm_process_opaque_data_supported_version_data(
-        spdm_context, spdm_request->opaque_length, cptr);
-    if (LIBSPDM_STATUS_IS_ERROR(status)) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
-                                               response_size, response);
+    if (spdm_request->opaque_length != 0) {
+        cptr = (const uint8_t *)request + sizeof(spdm_psk_exchange_request_t) +
+               spdm_request->psk_hint_length + spdm_request->context_length;
+        status = libspdm_process_opaque_data_supported_version_data(
+            spdm_context, spdm_request->opaque_length, cptr);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                                   response_size, response);
+        }
     }
 
     opaque_psk_exchange_rsp_size =

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -3961,8 +3961,8 @@ void libspdm_test_requester_psk_exchange_case14(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4046,8 +4046,8 @@ void libspdm_test_requester_psk_exchange_case15(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4132,8 +4132,8 @@ void libspdm_test_requester_psk_exchange_case16(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4218,8 +4218,8 @@ void libspdm_test_requester_psk_exchange_case17(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4295,8 +4295,8 @@ void libspdm_test_requester_psk_exchange_case18(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4372,8 +4372,8 @@ void libspdm_test_requester_psk_exchange_case19(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4450,8 +4450,8 @@ void libspdm_test_requester_psk_exchange_case20(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4534,8 +4534,8 @@ void libspdm_test_requester_psk_exchange_case21(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4629,8 +4629,8 @@ void libspdm_test_requester_psk_exchange_case22(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 
 #endif
@@ -4711,8 +4711,8 @@ void libspdm_test_requester_psk_exchange_case23(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 #endif
     libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
@@ -4779,8 +4779,8 @@ void libspdm_test_requester_psk_exchange_case24(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 #endif
     libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
@@ -4852,8 +4852,8 @@ void libspdm_test_requester_psk_exchange_case25(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 #endif
     libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
@@ -4925,8 +4925,8 @@ void libspdm_test_requester_psk_exchange_case26(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
-    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
-                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
 #endif
     libspdm_zero_mem(m_libspdm_local_psk_hint, 32);

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -3959,7 +3959,7 @@ void libspdm_test_requester_psk_exchange_case14(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4044,7 +4044,7 @@ void libspdm_test_requester_psk_exchange_case15(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4130,7 +4130,7 @@ void libspdm_test_requester_psk_exchange_case16(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4216,7 +4216,7 @@ void libspdm_test_requester_psk_exchange_case17(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4293,7 +4293,7 @@ void libspdm_test_requester_psk_exchange_case18(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4370,7 +4370,7 @@ void libspdm_test_requester_psk_exchange_case19(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4448,7 +4448,7 @@ void libspdm_test_requester_psk_exchange_case20(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4532,7 +4532,7 @@ void libspdm_test_requester_psk_exchange_case21(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4627,7 +4627,7 @@ void libspdm_test_requester_psk_exchange_case22(void **state)
         m_libspdm_use_key_schedule_algo;
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4709,7 +4709,7 @@ void libspdm_test_requester_psk_exchange_case23(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4777,7 +4777,7 @@ void libspdm_test_requester_psk_exchange_case24(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4850,7 +4850,7 @@ void libspdm_test_requester_psk_exchange_case25(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
@@ -4923,7 +4923,7 @@ void libspdm_test_requester_psk_exchange_case26(void **state)
     spdm_context->connection_info.algorithm.key_schedule =
         m_libspdm_use_key_schedule_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
         data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -4162,7 +4162,7 @@ void libspdm_test_requester_psk_exchange_case16(void **state)
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     free(data);
 }
-//
+
 void libspdm_test_requester_psk_exchange_case17(void **state)
 {
     libspdm_return_t status;

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -16,6 +16,8 @@ static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static uint8_t m_libspdm_local_psk_hint[32];
 
+static LIBSPDM_GLOBAL_REMOVE_IF_UNREFERENCED uint8_t m_libspdm_zero_filled_buffer[64];
+
 size_t libspdm_test_get_psk_exchange_request_size(const void *spdm_context,
                                                   const void *buffer,
                                                   size_t buffer_size)
@@ -166,6 +168,123 @@ libspdm_return_t libspdm_requester_psk_exchange_test_send_message(
         m_libspdm_local_buffer_size += message_size;
         return LIBSPDM_STATUS_SUCCESS;
     case 0xD:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0xE:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0xF:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x10:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x11:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x12:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x13:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x14:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x15:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x16:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x17:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x18:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x19:
+        m_libspdm_local_buffer_size = 0;
+        message_size = libspdm_test_get_psk_exchange_request_size(
+            spdm_context, (const uint8_t *)request + header_size,
+            request_size - header_size);
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         (const uint8_t *)request + header_size, message_size);
+        m_libspdm_local_buffer_size += message_size;
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x1A:
         m_libspdm_local_buffer_size = 0;
         message_size = libspdm_test_get_psk_exchange_request_size(
             spdm_context, (const uint8_t *)request + header_size,
@@ -1247,6 +1366,1677 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
                                               response);
     }
         return LIBSPDM_STATUS_SUCCESS;
+    case 0xE: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint32_t measurement_hash_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t measurement_hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        measurement_hash_size = libspdm_get_measurement_hash_size(
+            m_libspdm_use_measurement_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) +
+                             measurement_hash_size + LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /*Mock measurement hash as TCB*/
+        libspdm_copy_mem(measurement_hash_data, sizeof(measurement_hash_data),
+                         m_libspdm_use_tcb_hash_value, measurement_hash_size);
+        libspdm_copy_mem(ptr, spdm_response_size - (ptr - (uint8_t *)spdm_response),
+                         measurement_hash_data, measurement_hash_size);
+        /*libspdm_zero_mem (ptr, measurement_hash_size);*/
+        ptr += measurement_hash_size;
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0xF: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint32_t measurement_hash_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t measurement_hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        measurement_hash_size = libspdm_get_measurement_hash_size(
+            m_libspdm_use_measurement_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) +
+                             measurement_hash_size + LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /*Mock measurement hash as 0x00 array*/
+        libspdm_zero_mem(measurement_hash_data, measurement_hash_size);
+        libspdm_copy_mem(ptr, spdm_response_size - (ptr - (uint8_t *)spdm_response),
+                         measurement_hash_data, measurement_hash_size);
+        /*libspdm_zero_mem (ptr, measurement_hash_size);*/
+        ptr += measurement_hash_size;
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x10: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint32_t measurement_hash_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t measurement_hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        measurement_hash_size = libspdm_get_measurement_hash_size(
+            m_libspdm_use_measurement_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) +
+                             measurement_hash_size + LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /*Mock measurement hash*/
+        libspdm_copy_mem(measurement_hash_data, sizeof(measurement_hash_data),
+                         m_libspdm_use_tcb_hash_value, measurement_hash_size);
+        libspdm_copy_mem(ptr, spdm_response_size - (ptr - (uint8_t *)spdm_response),
+                         measurement_hash_data, measurement_hash_size);
+        /*libspdm_zero_mem (ptr, measurement_hash_size);*/
+        ptr += measurement_hash_size;
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x11: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x12: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x13: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint32_t measurement_hash_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t measurement_hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        measurement_hash_size = libspdm_get_measurement_hash_size(
+            m_libspdm_use_measurement_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) +
+                             measurement_hash_size + LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response,spdm_response_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /*Mock measurement hash as TCB*/
+        libspdm_copy_mem(measurement_hash_data, sizeof(measurement_hash_data),
+                         m_libspdm_use_tcb_hash_value, measurement_hash_size);
+        libspdm_copy_mem(ptr, spdm_response_size - (ptr - (uint8_t *)spdm_response),
+                         measurement_hash_data, measurement_hash_size);
+        /*libspdm_zero_mem (ptr, measurement_hash_size);*/
+        ptr += measurement_hash_size;
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           SPDM_BIN_STR_7_LABEL, sizeof(SPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x14: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 5;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x15: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 5;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x16: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x17: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        /* Flip last byte of ResponderVerifyData*/
+        ptr += hmac_size-1;
+        *ptr ^= 0xFF;
+        ptr++;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x18: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size =
+            libspdm_get_opaque_data_version_selection_data_size(
+                spdm_context);
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             0 +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = 0;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        /* libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+         * ptr += LIBSPDM_PSK_CONTEXT_LENGTH;*/
+        libspdm_build_opaque_data_version_selection_data(
+            spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+        ptr += opaque_psk_exchange_rsp_size;
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x19: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size = 0;
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             LIBSPDM_PSK_CONTEXT_LENGTH +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = LIBSPDM_PSK_CONTEXT_LENGTH;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+        /* libspdm_build_opaque_data_version_selection_data(
+         *    spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+         * ptr += opaque_psk_exchange_rsp_size;*/
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    case 0x1A: {
+        spdm_psk_exchange_response_t *spdm_response;
+        uint32_t hash_size;
+        uint32_t hmac_size;
+        uint8_t *ptr;
+        size_t opaque_psk_exchange_rsp_size;
+        void *data;
+        size_t data_size;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t *cert_buffer;
+        size_t cert_buffer_size;
+        uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
+        libspdm_large_managed_buffer_t th_curr;
+        uint8_t bin_str2[128];
+        size_t bin_str2_size;
+        uint8_t bin_str7[128];
+        size_t bin_str7_size;
+        uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
+        uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        ((libspdm_context_t *)spdm_context)->connection_info.secured_message_version =
+            SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_asym_algo =
+            m_libspdm_use_asym_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.dhe_named_group =
+            m_libspdm_use_dhe_algo;
+        ((libspdm_context_t *)spdm_context)
+        ->connection_info.algorithm.measurement_hash_algo =
+            m_libspdm_use_measurement_hash_algo;
+        hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+        opaque_psk_exchange_rsp_size = 0;
+        spdm_response_size = sizeof(spdm_psk_exchange_response_t) + 0 +
+                             0 +
+                             opaque_psk_exchange_rsp_size + hmac_size;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code =
+            SPDM_PSK_EXCHANGE_RSP;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->rsp_session_id =
+            libspdm_allocate_rsp_session_id(spdm_context);
+        spdm_response->reserved = 0;
+        spdm_response->context_length = 0;
+        spdm_response->opaque_length =
+            (uint16_t)opaque_psk_exchange_rsp_size;
+        ptr = (void *)(spdm_response + 1);
+        /* libspdm_zero_mem (ptr, hash_size);
+         * ptr += hash_size;*/
+        /*libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+         * ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+         * libspdm_build_opaque_data_version_selection_data(
+         *  spdm_context, &opaque_psk_exchange_rsp_size, ptr);
+         * ptr += opaque_psk_exchange_rsp_size;*/
+        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
+                         sizeof(m_libspdm_local_buffer)
+                         - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
+                            m_libspdm_local_buffer),
+                         spdm_response, (size_t)ptr - (size_t)spdm_response);
+        m_libspdm_local_buffer_size += ((size_t)ptr - (size_t)spdm_response);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer_size (0x%x):\n",
+                       m_libspdm_local_buffer_size));
+        libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+        libspdm_init_managed_buffer(&th_curr, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                        m_libspdm_use_asym_algo, &data,
+                                                        &data_size, NULL, NULL);
+        cert_buffer =
+            (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size;
+        cert_buffer_size =
+            data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, cert_buffer, cert_buffer_size,
+                         cert_buffer_hash);
+        /* transcript.message_a size is 0*/
+        libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
+                                      m_libspdm_local_buffer_size);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        free(data);
+        bin_str2_size = sizeof(bin_str2);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_2_LABEL, sizeof(LIBSPDM_BIN_STR_2_LABEL) - 1,
+                           hash_data, (uint16_t)hash_size, hash_size,
+                           bin_str2, &bin_str2_size);
+        libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+        libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                         LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+        libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                m_libspdm_use_hash_algo, m_libspdm_local_psk_hint,
+                sizeof(LIBSPDM_TEST_PSK_HINT_STRING), bin_str2,
+                bin_str2_size,
+                response_handshake_secret, hash_size);
+        bin_str7_size = sizeof(bin_str7);
+        libspdm_bin_concat(((libspdm_context_t *)spdm_context)->connection_info.version,
+                           LIBSPDM_BIN_STR_7_LABEL, sizeof(LIBSPDM_BIN_STR_7_LABEL) - 1,
+                           NULL, (uint16_t)hash_size, hash_size, bin_str7,
+                           &bin_str7_size);
+        libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
+                            hash_size, bin_str7, bin_str7_size,
+                            response_finished_key, hash_size);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr),
+                         response_finished_key, hash_size, ptr);
+        ptr += hmac_size;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
     default:
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
@@ -2117,6 +3907,1050 @@ void libspdm_test_requester_psk_exchange_case13(void **state)
     free(data);
 }
 
+void libspdm_test_requester_psk_exchange_case14(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0xE;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_memory_equal(
+        measurement_hash,
+        m_libspdm_use_tcb_hash_value,
+        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo));
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case15(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0xF;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_memory_equal(
+        measurement_hash,
+        m_libspdm_zero_filled_buffer,
+        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo));
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case16(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x10;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_memory_equal(
+        measurement_hash,
+        m_libspdm_use_tcb_hash_value,
+        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo));
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+//
+void libspdm_test_requester_psk_exchange_case17(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x11;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case18(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x12;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_KEY_EXCHANGE_REQUEST_ALL_MEASUREMENTS_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case19(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x13;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case20(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x14;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case21(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x15;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    /* clear Heartbeat flags */
+    spdm_context->connection_info.capability.flags &=
+        !SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags &=
+        !SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    assert_int_equal(heartbeat_period,5);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case22(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x16;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+
+    spdm_context->connection_info.algorithm.measurement_spec =
+        SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+
+    /*clear Heartbeat flags*/
+    spdm_context->connection_info.capability.flags &=
+        !SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags &=
+        !SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    assert_int_equal(heartbeat_period,0);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case23(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x17;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case24(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x18;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case25(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x19;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+
+void libspdm_test_requester_psk_exchange_case26(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_test_context->case_id = 0x1A;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain_buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain_buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain_buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
+        &heartbeat_period, measurement_hash);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(
+        libspdm_secured_message_get_session_state(
+            spdm_context->session_info[0].secured_message_context),
+        LIBSPDM_SESSION_STATE_HANDSHAKING);
+    free(data);
+}
+
 
 libspdm_test_context_t m_libspdm_requester_psk_exchange_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
@@ -2152,6 +4986,32 @@ int libspdm_requester_psk_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case12),
         /* Successful response V1.2*/
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case13),
+        /* Measurement hash 1, returns a measurement hash*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case14),
+        /* Measurement hash 1, returns a 0x00 array (no TCB components)*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case15),
+        /* Measurement hash FF, returns a measurement_hash*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case16),
+        /* Measurement hash 1, returns no measurement_hash*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case17),
+        /* Measurement hash FF, returns no measurement_hash*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case18),
+        /* Measurement hash not requested, returns a measurement_hash*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case19),
+        /* Heartbeat not supported, heartbeat period different from 0 sent*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case20),
+        /* Heartbeat supported, heartbeat period different from 0 sent*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case21),
+        /* Heartbeat supported, heartbeat period 0 sent NOTE: This should disable heartbeat*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case22),
+        /* Wrong ResponderVerifyData*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case23),
+        /* No ResponderContext*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case24),
+        /* No OpaqueData*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case25),
+        /* No ResponderContext and OpaqueData*/
+        cmocka_unit_test(libspdm_test_requester_psk_exchange_case26),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_psk_exchange_test_context);

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -1415,11 +1415,6 @@ void libspdm_test_responder_psk_exchange_case13(void **state)
                      SPDM_ERROR);
     assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
 
-
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-                     0);
-#endif
     free(data1);
 }
 


### PR DESCRIPTION
We added unit test cases for the psk_exchange messages, expanding the existing tests for the message.

These tests verify the device behavior when receiving measurement hashes, heartbeat periods, responder context, and opaque data. There is also a test in which a wrong responder verify data is provided to check if the device deals correctly with failures in this validation.

Additionally, we corrected two minor errors in libspdm_req_psk_exchange.c and libspdm_rsp_psk_exchange.c: on line 298 and 169, respectively, the code always considered the presence of the OpaqueData field, when it is optional.

In this push request:

1) Additional unit test cases for psk_exchange requester (13 new tests)

- cases 14 to 19 are related to measurement hashes

- cases 20 to 22 are related to the heartbeat period

- case 23 is related to the ResponderVerifyData field

- cases 24 to 26 are related to optional data fields (ResponderContext and OpaqueData)

2) Additional unit test cases for psk_exchange responder (7 new tests)

- cases 10 to 13 are related to measurement hashes

- cases 14 to 16 are related to optional data fields (PSKHint and OpaqueData)

3) Modification to the psk_exchange (requester and responder) library:

- (line 298 - requester; line 169 - responder) Checks if opaque_length is different from 0 before processing the opaque data