### PR TITLE
Added start guide and script for fuzzing with AFLTurbo

### DIFF
--- a/doc/test.md
+++ b/doc/test.md
@@ -424,6 +424,80 @@ For riscv64: `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
    ```
    libspdm/unit_test/fuzzing/oss_fuzz.sh mbedtls ON 30
    ```
+6) fuzzing in Linux with [AFLTurbo](https://github.com/sleicasper/aflturbo)
+
+   #### Clone the repository and build the aflturbo code
+   ```
+   git clone https://github.com/sleicasper/aflturbo.git
+   cd aflturbo/
+   make
+   cp afl-fuzz afl-turbo-fuzz
+   export PATH=$PATH:$(pwd)
+   ```
+   > Build it with make & ensure AFLTurbo binary is in PATH environment variable.
+
+   Then run commands as root (every time reboot the OS):
+   ```
+   sudo bash -c 'echo core >/proc/sys/kernel/core_pattern'
+   cd /sys/devices/system/cpu/
+   sudo bash -c 'echo performance | tee cpu*/cpufreq/scaling_governor'
+   ```
+
+   Known issue: Above command cannot run in Windows Linux Subsystem.
+
+   Build cases with AFL toolchain `-DTOOLCHAIN=AFL`. For example:
+   ```
+   cd libspdm
+   mkdir build
+   cd build
+   cmake -DARCH=x64 -DTOOLCHAIN=AFL -DTARGET=Release -DCRYPTO=mbedtls ..
+   make copy_sample_key
+   make
+   ```
+
+   Run cases:
+   ```
+   mkdir testcase_dir
+   mkdir /dev/shm/findings_dir
+   cp <seed> testcase_dir
+   afl-turbo-fuzz -i testcase_dir -o /dev/shm/findings_dir <test_app> @@
+   ```
+   Note: /dev/shm is tmpfs.
+
+   Fuzzing Code Coverage in Linux with [AFLTurbo](https://github.com/sleicasper/aflturbo) and [lcov](http://ltp.sourceforge.net/coverage/lcov.php).
+   Install lcov `sudo apt-get install lcov`.
+
+   Build cases with AFL toolchain `-DTOOLCHAIN=AFL -DGCOV=ON`.
+   ```
+   cd libspdm
+   mkdir build
+   cd build
+   cmake -DARCH=x64 -DTOOLCHAIN=AFL -DTARGET=Release -DCRYPTO=mbedtls -DGCOV=ON ..
+   make copy_sample_key
+   make
+   ```
+   You can launch the script `fuzzing_AFLTurbo.sh` to run a duration for each fuzzing test case. If you want to run a specific case, please modify the cmd tuple in the script.
+
+   Firstly install [screen](https://www.gnu.org/software/screen/) `sudo apt install screen`.
+
+   The usage of the script `fuzzing_AFLTurbo.sh` is as following:
+   ```
+   libspdm/unit_test/fuzzing/fuzzing_AFLTurbo.sh <CRYPTO> <GCOV> <duration>
+   <CRYPTO> means selected Crypto library: mbedtls or openssl
+   <GCOV> means enable Code Coverage or not: ON or OFF
+   <duration> means the duration of every program keep fuzzing: NUMBER seconds
+   ```
+   For example: build with `mbedtls`, enable Code Coverage and every test case run 60 seconds.
+   ```
+   libspdm/unit_test/fuzzing/fuzzing_AFLTurbo.sh mbedtls ON 60
+   ```
+   Fuzzing output path and code coverage output path of the script `fuzzing_AFLTurbo.sh`:
+   ```
+   #libspdm/unit_test/fuzzing/out_<CRYPTO>_<GitLogHash>_<TIMESTAMP>/SummaryList.csv
+   libspdm/unit_test/fuzzing/out_mbedtls_ac992fd_2022-06-23_08-45-48/SummaryList.csv
+   #libspdm/unit_test/fuzzing/out_<CRYPTO>_<GitLogHash>_<TIMESTAMP>/coverage_log/index.html
+   libspdm/unit_test/fuzzing/out_mbedtls_ac992f_2022-06-23_08-45-48/coverage_log/index.html
+   ```
 
 ### Run Symbolic Execution
 

--- a/unit_test/fuzzing/fuzzing_AFLTurbo.sh
+++ b/unit_test/fuzzing/fuzzing_AFLTurbo.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# Before run this script, please Download and install AFLTurbo. Unzip and follow docs\QuickStartGuide.txt. Build it with make.
+# If command 'screen' not found, please install with: sudo apt install screen.
+# If you also want to collect Code Coverage in Linux with AFLTurbo and lcov, please Install lcov with: sudo apt-get install lcov.
+
+if [ "$#" -ne "3" ];then
+    echo "Usage: $0 <CRYPTO> <GCOV> <duration>"
+    echo "<CRYPTO> means selected Crypto library: mbedtls or openssl"
+    echo "<GCOV> means enable Code Coverage or not: ON or OFF"
+    echo "<duration> means the duration of every program keep fuzzing: NUMBER seconds"
+    #read -p "press enter to exit"
+    exit
+fi
+
+if [[ $1 = "mbedtls" || $1 = "openssl" ]]; then
+    echo "<CRYPTO> parameter is $1"
+else
+    echo "Usage: $0 <CRYPTO> <GCOV> <duration>"
+    echo "<CRYPTO> means selected Crypto library: mbedtls or openssl"
+    echo "<GCOV> means enable Code Coverage or not: ON or OFF"
+    echo "<duration> means the duration of every program keep fuzzing: NUMBER seconds"
+    exit
+fi
+
+if [[ $2 = "ON" || $2 = "OFF" ]]; then    
+    echo "<GCOV> parameter is $2"
+else
+    echo "Usage: $0 <CRYPTO> <GCOV> <duration>"
+    echo "<CRYPTO> means selected Crypto library: mbedtls or openssl"
+    echo "<GCOV> means enable Code Coverage or not: ON or OFF"
+    echo "<duration> means the duration of every program keep fuzzing: NUMBER seconds"
+    exit
+fi
+
+echo "<duration> parameter is $3"
+export duration=$3
+
+echo "start fuzzing in Linux with AFLTurbo"
+
+pkill screen
+
+export script_path="$(cd "$(dirname $0)";pwd)"
+export libspdm_path=$script_path/../..
+export fuzzing_path=$libspdm_path/unit_test/fuzzing
+export fuzzing_seeds=$libspdm_path/unit_test/fuzzing/seeds
+export TIMESTAMP=`date +%Y-%m-%d_%H-%M-%S`
+
+# Here '~/aflturbo/' is the AFLTurbo PATH, replace it with yours.
+# export AFL_PATH=~/aflturbo/
+# export PATH=$PATH:$AFL_PATH
+
+if [[ $PWD!=$libspdm_path ]];then
+    pushd $libspdm_path
+    latest_hash=`git log --pretty="%h" -1`
+    export fuzzing_out=$libspdm_path/unit_test/fuzzing/out_$1_$latest_hash_$TIMESTAMP
+    export build_fuzzing=build_fuzz_$1_$latest_hash_$TIMESTAMP
+fi
+
+if [ ! -d "$fuzzing_out" ];then
+    mkdir $fuzzing_out
+fi
+
+for i in $fuzzing_out/*;do
+    if [[ ! -d $i/crashes ]] && [[ ! -d $i/hangs ]];then
+        continue
+    fi
+
+    if [[ "`ls -A $i/crashes`" != "" ]];then
+        echo -e "\033[31m There are some crashes \033[0m"
+        echo -e "\033[31m Path in $i/crashes \033[0m"
+        exit
+    fi
+
+    if [[ "`ls -A $i/hangs`" != "" ]];then
+        echo -e "\033[31m There are some hangs \033[0m"
+        echo -e "\033[31m Path in $i/hangs \033[0m"
+        exit
+    fi
+done
+
+rm -rf $fuzzing_out/*
+
+if [[ "core" != `cat /proc/sys/kernel/core_pattern` ]];then
+    # Here 'test' is the sudo password, replace it with yours.
+    echo 'test' | sudo -S bash -c 'echo core >/proc/sys/kernel/core_pattern'
+    pushd /sys/devices/system/cpu/
+    echo 'test' | sudo -S bash -c 'echo performance | tee cpu*/cpufreq/scaling_governor'
+    popd
+fi
+
+if [ -d "$build_fuzzing" ];then
+    rm -rf $build_fuzzing
+fi
+
+mkdir $build_fuzzing
+pushd $build_fuzzing
+
+cmake -DARCH=x64 -DTOOLCHAIN=AFL -DTARGET=Release -DCRYPTO=$1 -DGCOV=$2 ..
+make copy_sample_key
+make
+pushd bin
+
+cmds=(
+test_spdm_transport_mctp_encode_message
+test_spdm_transport_mctp_decode_message
+test_spdm_transport_pci_doe_encode_message
+test_spdm_transport_pci_doe_decode_message
+test_spdm_decode_secured_message
+test_spdm_encode_secured_message
+test_spdm_requester_encap_digests
+test_spdm_requester_encap_certificate
+test_spdm_requester_encap_challenge_auth
+test_spdm_requester_encap_key_update
+test_spdm_requester_encap_request
+test_spdm_requester_get_version
+test_spdm_requester_get_capabilities
+test_spdm_requester_negotiate_algorithms
+test_spdm_requester_get_digests
+test_spdm_requester_get_certificate
+test_spdm_requester_challenge
+test_spdm_requester_get_measurements
+test_spdm_requester_key_exchange
+test_spdm_requester_finish
+test_spdm_requester_psk_exchange
+test_spdm_requester_psk_finish
+test_spdm_requester_heartbeat
+test_spdm_requester_key_update
+test_spdm_requester_end_session
+test_spdm_responder_encap_challenge
+test_spdm_responder_encap_get_certificate
+test_spdm_responder_encap_get_digests
+test_spdm_responder_encap_key_update
+test_spdm_responder_encap_response
+test_spdm_responder_version
+test_spdm_responder_capabilities
+test_spdm_responder_algorithms
+test_spdm_responder_digests
+test_spdm_responder_certificate
+test_spdm_responder_challenge_auth
+test_spdm_responder_measurements
+test_spdm_responder_key_exchange
+test_spdm_responder_finish_rsp
+test_spdm_responder_psk_exchange_rsp
+test_spdm_responder_psk_finish_rsp
+test_spdm_responder_heartbeat_ack
+test_spdm_responder_key_update
+test_spdm_responder_end_session
+test_spdm_responder_if_ready
+test_x509_certificate_check
+test_spdm_responder_set_certificate
+test_spdm_requester_set_certificate
+)
+
+export FUZZ_START_TIME=`date +%Y-%m-%d_%H:%M:%S`
+
+for ((i=0;i<${#cmds[*]};i++))
+do
+    echo ${cmds[$i]}
+    screen -ls | grep ${cmds[$i]}
+    if [[ $? -ne 0 ]]
+    then
+    screen -dmS ${cmds[$i]}
+    fi
+    screen -S ${cmds[$i]} -p 0 -X stuff "afl-turbo-fuzz -i $fuzzing_seeds/${cmds[$i]} -o $fuzzing_out/${cmds[$i]} ./${cmds[$i]} @@"
+    screen -S ${cmds[$i]} -p 0 -X stuff $'\n'
+    sleep $duration
+    screen -S ${cmds[$i]} -X quit
+    sleep 5
+done
+
+if [[ $2 = "ON" ]]; then
+    cd $fuzzing_out
+    mkdir coverage_log
+    cd coverage_log
+    lcov --capture --directory $libspdm_path --output-file coverage.info
+    genhtml coverage.info --output-directory . --title "Started at : $FUZZ_START_TIME | Crypto lib : $1 | AFL Turbo Fuzzing | Duration : $duration secs per testcase"
+fi
+
+function walk_dir(){
+    for file in `ls $1`
+    do
+        if [[ -d $1"/"$file ]]
+        then
+            walk_dir $1"/"$file
+        elif [[ $file = "fuzzer_stats" ]]
+        then
+            echo $1"/"$file
+            unique_crashes=''
+            unique_hangs=''
+            afl_banner=''
+            while read line
+                do
+                    if [[ $line =~ "unique_crashes" ]]
+                    then
+                        unique_crashes=${line##*:}
+                    elif [[ $line =~ "unique_hangs" ]]
+                    then
+                        unique_hangs=${line##*:}
+                    elif [[ $line =~ "afl_banner" ]]
+                    then
+                        afl_banner=${line##*:}
+                    fi
+                done < $1"/"$file
+            echo $afl_banner,$unique_crashes,$unique_hangs >> $fuzzing_out"/SummaryList.csv"
+        fi
+    done
+}
+
+echo afl_banner,unique_crashes,unique_hangs > $fuzzing_out"/SummaryList.csv"
+walk_dir $fuzzing_out


### PR DESCRIPTION
Changes:

1. Added guide for building and using AFLturbo for fuzzing.
2. script to run AFLTurbo for each fuzzing test case.

Signed-off-by: Jafar Sarif <jafar.sarif@intel.com>