### PR TITLE
Improve get_csr unit test

### DIFF
--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -1037,6 +1037,8 @@ typedef struct {
      * param2 == RSVD*/
     uint16_t requester_info_length;
     uint16_t opaque_data_length;
+    /* uint8_t RequesterInfo[requester_info_length];
+     * uint8_t opaque_data[opaque_data_length]; */
 } spdm_get_csr_request_t;
 
 /* SPDM CSR response*/

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -287,7 +287,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
             if (csr_buffer_size < *csr_len) {
                 free(cached_csr);
                 free(cached_req_info);
-                LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,"csr buffer is small to sotre cached csr! \n"));
+                LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                               "csr buffer is too small to sotre cached csr! \n"));
                 return false;
             } else {
                 libspdm_copy_mem(*csr_pointer, csr_buffer_size, cached_csr, *csr_len);
@@ -337,6 +338,11 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
                                   csr_len, csr_pointer);
     libspdm_asym_free(base_asym_algo, context);
     free(prikey);
+
+    if (csr_buffer_size < *csr_len) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,"csr buffer is too small to sotre generated csr! \n"));
+        result = false;
+    }
     return result;
 }
 

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -7,6 +7,68 @@
 #include "spdm_unit_test.h"
 #include "internal/libspdm_responder_lib.h"
 
+uint8_t m_csr_opaque_data[8] = "libspdm";
+
+/*ECC 256 req_info(include right req_info attribute)*/
+static uint8_t right_req_info[] = {
+    0x30, 0x81, 0xBF, 0x02, 0x01, 0x00, 0x30, 0x45, 0x31, 0x0B, 0x30, 0x09,
+    0x06, 0x03, 0x55, 0x04, 0x06, 0x13, 0x02, 0x41, 0x55, 0x31, 0x13, 0x30, 0x11, 0x06, 0x03, 0x55,
+    0x04, 0x08, 0x0C, 0x0A, 0x53, 0x6F, 0x6D, 0x65, 0x2D, 0x53, 0x74, 0x61, 0x74, 0x65, 0x31, 0x21,
+    0x30, 0x1F, 0x06, 0x03, 0x55, 0x04, 0x0A, 0x0C, 0x18, 0x49, 0x6E, 0x74, 0x65, 0x72, 0x6E, 0x65,
+    0x74, 0x20, 0x57, 0x69, 0x64, 0x67, 0x69, 0x74, 0x73, 0x20, 0x50, 0x74, 0x79, 0x20, 0x4C, 0x74,
+    0x64, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01, 0x06, 0x08,
+    0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0xDB, 0xC2, 0xB2, 0xB7,
+    0x83, 0x3C, 0xC8, 0x85, 0xE4, 0x3D, 0xE1, 0xF3, 0xBA, 0xE2, 0xF2, 0x90, 0x8E, 0x30, 0x25, 0x14,
+    0xE1, 0xF7, 0xA9, 0x82, 0x29, 0xDB, 0x9D, 0x76, 0x2F, 0x80, 0x11, 0x32, 0xEE, 0xAB, 0xE2, 0x68,
+    0xD1, 0x22, 0xE7, 0xBD, 0xB4, 0x71, 0x27, 0xC8, 0x79, 0xFB, 0xDC, 0x7C, 0x9E, 0x33, 0xA6, 0x67,
+    0xC2, 0x10, 0x47, 0x36, 0x32, 0xC5, 0xA1, 0xAA, 0x6B, 0x2B, 0xAA, 0xC9, 0xA0, 0x18, 0x30, 0x16,
+    0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x09, 0x07, 0x31, 0x09, 0x0C, 0x07, 0x74,
+    0x65, 0x73, 0x74, 0x31, 0x32, 0x33
+};
+
+/*ECC 256 req_info(include wrong req_info attribute, oid is wrong)*/
+static uint8_t wrong_req_info[] = {
+    0x30, 0x81, 0xBF, 0x02, 0x01, 0x00, 0x30, 0x45, 0x31, 0x0B, 0x30, 0x09,
+    0x06, 0x03, 0x55, 0x04, 0x06, 0x13, 0x02, 0x41, 0x55, 0x31, 0x13, 0x30, 0x11, 0x06, 0x03, 0x55,
+    0x04, 0x08, 0x0C, 0x0A, 0x53, 0x6F, 0x6D, 0x65, 0x2D, 0x53, 0x74, 0x61, 0x74, 0x65, 0x31, 0x21,
+    0x30, 0x1F, 0x06, 0x03, 0x55, 0x04, 0x0A, 0x0C, 0x18, 0x49, 0x6E, 0x74, 0x65, 0x72, 0x6E, 0x65,
+    0x74, 0x20, 0x57, 0x69, 0x64, 0x67, 0x69, 0x74, 0x73, 0x20, 0x50, 0x74, 0x79, 0x20, 0x4C, 0x74,
+    0x64, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01, 0x06, 0x08,
+    0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0xDB, 0xC2, 0xB2, 0xB7,
+    0x83, 0x3C, 0xC8, 0x85, 0xE4, 0x3D, 0xE1, 0xF3, 0xBA, 0xE2, 0xF2, 0x90, 0x8E, 0x30, 0x25, 0x14,
+    0xE1, 0xF7, 0xA9, 0x82, 0x29, 0xDB, 0x9D, 0x76, 0x2F, 0x80, 0x11, 0x32, 0xEE, 0xAB, 0xE2, 0x68,
+    0xD1, 0x22, 0xE7, 0xBD, 0xB4, 0x71, 0x27, 0xC8, 0x79, 0xFB, 0xDC, 0x7C, 0x9E, 0x33, 0xA6, 0x67,
+    0xC2, 0x10, 0x47, 0x36, 0x32, 0xC5, 0xA1, 0xAA, 0x6B, 0x2B, 0xAA, 0xC9, 0xA0, 0x18, 0x30, 0x16,
+    0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D,       0x09, 0x07, 0x31, 0x09, 0x0C, 0x07, 0x74,
+    0x65, 0x73, 0x74, 0x31, 0x32, 0x33
+};
+
+/*req_info attribute*/
+char right_req_info_string[] = {0x74, 0x65, 0x73, 0x74, 0x31, 0x32, 0x33};
+
+/*find destination buffer from source buffer*/
+bool libspdm_find_buffer(char *src, size_t src_len, char *dst, size_t dst_len)
+{
+    size_t index;
+
+    if ((src == NULL) || (dst == NULL)) {
+        return false;
+    }
+
+    if (src_len < dst_len) {
+        return false;
+    }
+
+    for (index = 0; index < src_len - dst_len; index++) {
+        if ((*(src + index) == *dst) &&
+            (libspdm_const_compare_mem(src + index, dst, dst_len) == 0)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /**
  * Test 1: receives a valid GET_CSR request message from Requester to set cert in slot_id:0
  * Expected Behavior: produces a valid CSR response message
@@ -20,6 +82,8 @@ void libspdm_test_responder_csr_case1(void **state)
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     spdm_csr_response_t *spdm_response;
     spdm_get_csr_request_t *m_libspdm_set_certificate_request;
+    uint8_t wrong_csr[LIBSPDM_MAX_CSR_SIZE];
+    libspdm_zero_mem(wrong_csr, LIBSPDM_MAX_CSR_SIZE);
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -61,6 +125,9 @@ void libspdm_test_responder_csr_case1(void **state)
     assert_int_equal(response_size, sizeof(spdm_csr_response_t) + spdm_response->csr_length);
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_CSR);
+
+    /*check returned CSR not zero */
+    assert_memory_not_equal(spdm_response + 1, wrong_csr, spdm_response->csr_length);
 
     free(m_libspdm_set_certificate_request);
 }
@@ -127,6 +194,214 @@ void libspdm_test_responder_csr_case2(void **state)
     free(m_libspdm_set_certificate_request);
 }
 
+/**
+ * Test 3: receives a valid GET_CSR request message from Requester with non-null right req_info to set cert in slot_id:0
+ * Expected Behavior: produces a valid CSR response message
+ **/
+void libspdm_test_responder_csr_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_csr_response_t *spdm_response;
+    spdm_get_csr_request_t *m_libspdm_set_certificate_request;
+    uint8_t wrong_csr[LIBSPDM_MAX_CSR_SIZE];
+    libspdm_zero_mem(wrong_csr, LIBSPDM_MAX_CSR_SIZE);
+    char *csr;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_get_csr_request_t) +
+                                               sizeof(right_req_info));
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_GET_CSR;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    m_libspdm_set_certificate_request->opaque_data_length = 0;
+    m_libspdm_set_certificate_request->requester_info_length = sizeof(right_req_info);
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1, sizeof(right_req_info),
+                     right_req_info, sizeof(right_req_info));
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_get_csr_request_t) +
+                                                    sizeof(right_req_info);
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_csr(spdm_context,
+                                      m_libspdm_set_certificate_request_size,
+                                      m_libspdm_set_certificate_request,
+                                      &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    spdm_response = (void *)response;
+    assert_int_equal(response_size, sizeof(spdm_csr_response_t) + spdm_response->csr_length);
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_CSR);
+
+    /*check returned CSR not zero */
+    assert_memory_not_equal(spdm_response + 1, wrong_csr, spdm_response->csr_length);
+
+    csr = (char *)(spdm_response + 1);
+    assert_true(libspdm_find_buffer(csr, spdm_response->csr_length,
+                                    right_req_info_string, sizeof(right_req_info_string)));
+
+    free(m_libspdm_set_certificate_request);
+}
+
+/**
+ * Test 4: receives a valid GET_CSR request message from Requester with non-null opaque_data to set cert in slot_id:0
+ * Expected Behavior: produces a valid CSR response message
+ **/
+void libspdm_test_responder_csr_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_csr_response_t *spdm_response;
+    spdm_get_csr_request_t *m_libspdm_set_certificate_request;
+    uint8_t wrong_csr[LIBSPDM_MAX_CSR_SIZE];
+    libspdm_zero_mem(wrong_csr, LIBSPDM_MAX_CSR_SIZE);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_get_csr_request_t) +
+                                               sizeof(m_csr_opaque_data));
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_GET_CSR;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    m_libspdm_set_certificate_request->opaque_data_length = sizeof(m_csr_opaque_data);
+    m_libspdm_set_certificate_request->requester_info_length = 0;
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1, sizeof(m_csr_opaque_data),
+                     m_csr_opaque_data, sizeof(m_csr_opaque_data));
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_get_csr_request_t) +
+                                                    sizeof(m_csr_opaque_data);
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_csr(spdm_context,
+                                      m_libspdm_set_certificate_request_size,
+                                      m_libspdm_set_certificate_request,
+                                      &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    spdm_response = (void *)response;
+    assert_int_equal(response_size, sizeof(spdm_csr_response_t) + spdm_response->csr_length);
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_CSR);
+
+    /*check returned CSR not zero */
+    assert_memory_not_equal(spdm_response + 1, wrong_csr, spdm_response->csr_length);
+
+    free(m_libspdm_set_certificate_request);
+}
+
+/**
+ * Test 5: receives a valid GET_CSR request message from Requester with non-null wrong req_info to set cert in slot_id:0
+ * Expected Behavior: produces a valid CSR response message
+ **/
+void libspdm_test_responder_csr_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_csr_response_t *spdm_response;
+    spdm_get_csr_request_t *m_libspdm_set_certificate_request;
+    uint8_t wrong_csr[LIBSPDM_MAX_CSR_SIZE];
+    libspdm_zero_mem(wrong_csr, LIBSPDM_MAX_CSR_SIZE);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+
+    spdm_context->local_context.slot_count = 1;
+
+    m_libspdm_set_certificate_request = malloc(sizeof(spdm_get_csr_request_t) +
+                                               sizeof(wrong_req_info));
+
+    m_libspdm_set_certificate_request->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    m_libspdm_set_certificate_request->header.request_response_code = SPDM_GET_CSR;
+    m_libspdm_set_certificate_request->header.param1 = 0;
+    m_libspdm_set_certificate_request->header.param2 = 0;
+
+    m_libspdm_set_certificate_request->opaque_data_length = 0;
+    m_libspdm_set_certificate_request->requester_info_length = sizeof(wrong_req_info);
+
+    libspdm_copy_mem(m_libspdm_set_certificate_request + 1, sizeof(wrong_req_info),
+                     wrong_req_info, sizeof(wrong_req_info));
+
+    size_t m_libspdm_set_certificate_request_size = sizeof(spdm_get_csr_request_t) +
+                                                    sizeof(wrong_req_info);
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_csr(spdm_context,
+                                      m_libspdm_set_certificate_request_size,
+                                      m_libspdm_set_certificate_request,
+                                      &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    free(m_libspdm_set_certificate_request);
+}
 
 libspdm_test_context_t m_libspdm_responder_csr_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
@@ -140,6 +415,12 @@ int libspdm_responder_csr_test_main(void)
         cmocka_unit_test(libspdm_test_responder_csr_case1),
         /* Bad request size*/
         cmocka_unit_test(libspdm_test_responder_csr_case2),
+        /* Success Case for csr response with non-null right req_info */
+        cmocka_unit_test(libspdm_test_responder_csr_case3),
+        /* Success Case for csr response with non-null opaque_data */
+        cmocka_unit_test(libspdm_test_responder_csr_case4),
+        /* Failed Case for csr response with non-null wrong req_info */
+        cmocka_unit_test(libspdm_test_responder_csr_case5),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_csr_test_context);


### PR DESCRIPTION
Fix: #993 

- Add gen CSR with non-null right and wrong req_info unit test;
- Add gen CSR with non-null opaque_data unit test;
- Add returned CSR not zero check ;
- Add  returned CSR match req_info check;

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>