### PR TITLE
Fix potentially overflowing expression in libspdm_req_send_receive.c

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -153,7 +153,7 @@ libspdm_return_t libspdm_receive_response(void *context, const uint32_t *session
 
     if (spdm_context->crypto_request) {
         timeout = spdm_context->local_context.capability.rtt +
-                  (2 << spdm_context->local_context.capability.ct_exponent);
+                  ((uint64_t)2 << spdm_context->local_context.capability.ct_exponent);
     } else {
         timeout = spdm_context->local_context.capability.rtt +
                   spdm_context->local_context.capability.st1;


### PR DESCRIPTION
Cast 2 to type uint64_t

Fix #998

Signed-off-by: Wei Liu <wei3.liu@intel.com>