### PR TITLE
challenge_auth param2 slot mask should return all populated slots

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1132,4 +1132,14 @@ void libspdm_get_receiver_buffer (
     void **receiver_buffer,
     size_t *receiver_buffer_size);
 
+/**
+ * Get the certificate slot mask
+ *
+ * @param[in]   context              A pointer to the SPDM context.
+ *
+ * @retval slot_mask                 get slot mask
+ **/
+uint8_t libspdm_get_cert_slot_mask (
+    libspdm_context_t *spdm_context);
+
 #endif /* SPDM_COMMON_LIB_INTERNAL_H */

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -493,6 +493,29 @@ bool libspdm_generate_cert_chain_hash(libspdm_context_t *spdm_context,
 }
 
 /**
+ * Get the certificate slot mask
+ *
+ * @param[in]   context              A pointer to the SPDM context.
+ *
+ * @retval slot_mask                 get slot mask
+ **/
+uint8_t libspdm_get_cert_slot_mask(libspdm_context_t *spdm_context)
+{
+    size_t index;
+    uint8_t slot_mask;
+
+    slot_mask = 0;
+    for (index = 0; index < SPDM_MAX_SLOT_COUNT; index++) {
+        if (spdm_context->local_context
+            .local_cert_chain_provision[index] != NULL) {
+            slot_mask |= (1 << index);
+        }
+    }
+
+    return slot_mask;
+}
+
+/**
  * This function verifies the digest.
  *
  * @param  spdm_context                  A pointer to the SPDM context.

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -45,6 +45,7 @@ libspdm_return_t libspdm_get_response_challenge_auth(void *context,
     uint8_t auth_attribute;
     libspdm_return_t status;
     size_t response_capacity;
+    uint8_t slot_mask;
 
     spdm_context = context;
     spdm_request = request;
@@ -165,13 +166,20 @@ libspdm_return_t libspdm_get_response_challenge_auth(void *context,
     }
 
     spdm_response->header.param1 = auth_attribute;
+
     if (slot_id == 0xFF) {
         spdm_response->header.param2 = 0;
 
         slot_id = spdm_context->local_context.provisioned_slot_id;
-    }
-    else {
-        spdm_response->header.param2 = (1 << slot_id);
+    } else {
+        slot_mask = libspdm_get_cert_slot_mask(spdm_context);
+        if (slot_mask != 0) {
+            spdm_response->header.param2 = slot_mask;
+        } else {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
     }
 
     ptr = (void *)(spdm_response + 1);

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -574,6 +574,8 @@ void libspdm_test_responder_challenge_auth_case9(void **state) {
     spdm_challenge_auth_response_t *spdm_response;
     void                 *data1;
     size_t data_size1;
+    size_t index;
+    uint8_t slot_mask;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -611,7 +613,15 @@ void libspdm_test_responder_challenge_auth_case9(void **state) {
     spdm_response = (void *)response;
     assert_int_equal (spdm_response->header.request_response_code, SPDM_CHALLENGE_AUTH);
     assert_int_equal (spdm_response->header.param1, 1);
-    assert_int_equal (spdm_response->header.param2, 1 << 1);
+
+    slot_mask = 0;
+    for (index = 0; index < SPDM_MAX_SLOT_COUNT; index++) {
+        if (spdm_context->local_context
+            .local_cert_chain_provision[index] != NULL) {
+            slot_mask |= (1 << index);
+        }
+    }
+    assert_int_equal (spdm_response->header.param2, slot_mask);
     free(data1);
 }
 
@@ -630,6 +640,7 @@ void libspdm_test_responder_challenge_auth_case10(void **state) {
     spdm_challenge_auth_response_t *spdm_response;
     void                 *data1;
     size_t data_size1;
+    size_t index;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -649,6 +660,12 @@ void libspdm_test_responder_challenge_auth_case10(void **state) {
                                                      m_libspdm_use_asym_algo,
                                                      &data1, &data_size1,
                                                      NULL, NULL);
+    /*clear local_cert_chain_provision*/
+    for (index = 0; index <SPDM_MAX_SLOT_COUNT; index++) {
+        spdm_context->local_context.local_cert_chain_provision[index] = NULL;
+        spdm_context->local_context.local_cert_chain_provision_size[index] = 0;
+    }
+
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
     spdm_context->local_context.slot_count = 1;


### PR DESCRIPTION
Fix: #1013 

Because the populated slot store cert_chain may be not continuous, the get slot number logic is changed.

And the PR has passed unit test and emu test.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>