### PR TITLE
Remove NULL definition

### DIFF
--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.h
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/toolchain_harness.h
@@ -16,7 +16,6 @@
 #define LIBSPDM_TEST_MESSAGE_TYPE_SPDM 0x01
 #define LIBSPDM_TEST_MESSAGE_TYPE_SECURED_TEST 0x02
 #define LIBSPDM_MAX_BUFFER_SIZE 64
-#define NULL ((void *)0)
 
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size);
 


### PR DESCRIPTION
`toolchain_harness.h` needlessly defines `NULL` when it already comes from `stdlib.h`. This has been causing warnings with CLANG.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>