### PR TITLE
Change mbedtls_rsa_complete function location to setup RSA key

### DIFF
--- a/os_stub/cryptlib_mbedtls/pk/rsa_basic.c
+++ b/os_stub/cryptlib_mbedtls/pk/rsa_basic.c
@@ -128,7 +128,7 @@ bool libspdm_rsa_set_key(void *rsa_context, const libspdm_rsa_key_tag_t key_tag,
         ret = -1;
         break;
     }
-    mbedtls_rsa_complete(rsa_key);
+
     return ret == 0;
 }
 
@@ -159,12 +159,18 @@ bool libspdm_rsa_pkcs1_verify_with_nid(void *rsa_context, size_t hash_nid,
 {
     int32_t ret;
     mbedtls_md_type_t md_alg;
+    mbedtls_rsa_context *rsa_key;
 
     if (rsa_context == NULL || message_hash == NULL || signature == NULL) {
         return false;
     }
 
     if (sig_size > INT_MAX || sig_size == 0) {
+        return false;
+    }
+
+    rsa_key = (mbedtls_rsa_context *)rsa_context;
+    if (mbedtls_rsa_complete(rsa_key) != 0) {
         return false;
     }
 
@@ -238,12 +244,18 @@ bool libspdm_rsa_pss_verify(void *rsa_context, size_t hash_nid,
 {
     int32_t ret;
     mbedtls_md_type_t md_alg;
+    mbedtls_rsa_context *rsa_key;
 
     if (rsa_context == NULL || message_hash == NULL || signature == NULL) {
         return false;
     }
 
     if (sig_size > INT_MAX || sig_size == 0) {
+        return false;
+    }
+
+    rsa_key = (mbedtls_rsa_context *)rsa_context;
+    if (mbedtls_rsa_complete(rsa_key) != 0) {
         return false;
     }
 

--- a/os_stub/cryptlib_mbedtls/pk/rsa_ext.c
+++ b/os_stub/cryptlib_mbedtls/pk/rsa_ext.c
@@ -265,8 +265,14 @@ bool libspdm_rsa_pkcs1_sign_with_nid(void *rsa_context, size_t hash_nid,
 {
     int32_t ret;
     mbedtls_md_type_t md_alg;
+    mbedtls_rsa_context *rsa_key;
 
     if (rsa_context == NULL || message_hash == NULL) {
+        return false;
+    }
+
+    rsa_key = (mbedtls_rsa_context *)rsa_context;
+    if (mbedtls_rsa_complete(rsa_key) != 0) {
         return false;
     }
 
@@ -349,8 +355,14 @@ bool libspdm_rsa_pss_sign(void *rsa_context, size_t hash_nid,
 {
     int32_t ret;
     mbedtls_md_type_t md_alg;
+    mbedtls_rsa_context *rsa_key;
 
     if (rsa_context == NULL || message_hash == NULL) {
+        return false;
+    }
+
+    rsa_key = (mbedtls_rsa_context *)rsa_context;
+    if (mbedtls_rsa_complete(rsa_key) != 0) {
         return false;
     }
 


### PR DESCRIPTION
Fix: #1079 

The `mbedtls_rsa_complete` function completes an RSA context from a set of imported core parameters.
To setup an RSA public key, precisely N and E must have been imported.
To setup an RSA private key, sufficient information must be present for the other parameters to be derivable.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>