### PR TITLE
ResponderVerifyData / RequesterVerifyData should use hash of transcript

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -183,9 +183,9 @@ typedef struct {
     libspdm_small_managed_buffer_t message_mut_c;
     libspdm_large_managed_buffer_t message_m;
 #else
-    void                   *digest_context_m1m2;
-    void                   *digest_context_mut_m1m2;
-    void                   *digest_context_l1l2;
+    void *digest_context_m1m2;
+    void *digest_context_mut_m1m2;
+    void *digest_context_l1l2;
 #endif
 } libspdm_transcript_t;
 
@@ -249,14 +249,10 @@ typedef struct {
     libspdm_large_managed_buffer_t temp_message_k;
     bool message_f_initialized;
     bool finished_key_ready;
-    void                   *digest_context_th;
-    void                   *digest_context_l1l2;
-    void                   *hmac_rsp_context_th;
-    void                   *hmac_req_context_th;
+    void *digest_context_th;
+    void *digest_context_l1l2;
     /* this is back up for message F reset.*/
-    void                   *digest_context_th_backup;
-    void                   *hmac_rsp_context_th_backup;
-    void                   *hmac_req_context_th_backup;
+    void *digest_context_th_backup;
 #endif
 } libspdm_session_transcript_t;
 

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -245,10 +245,7 @@ typedef struct {
     libspdm_large_managed_buffer_t message_f;
     libspdm_large_managed_buffer_t message_m;
 #else
-    /* the message_k must be plan text because we do not know the finished_key yet.*/
-    libspdm_large_managed_buffer_t temp_message_k;
     bool message_f_initialized;
-    bool finished_key_ready;
     void *digest_context_th;
     void *digest_context_l1l2;
     /* this is back up for message F reset.*/

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -59,7 +59,6 @@ typedef struct {
     size_t aead_iv_size;
     size_t aead_tag_size;
     bool use_psk;
-    bool finished_key_ready;
     libspdm_session_state_t session_state;
     libspdm_session_info_struct_master_secret_t master_secret;
     libspdm_session_info_struct_handshake_secret_t handshake_secret;

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -65,17 +65,6 @@ void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context,
                                          bool use_psk);
 
 /**
- * Return if finished_key is ready.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true  finished_key is ready.
- * @retval false finished_key is not ready.
- */
-bool
-libspdm_secured_message_is_finished_key_ready(void *spdm_secured_message_context);
-
-/**
  * Set session_state to an SPDM secured message context.
  *
  * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -910,8 +910,6 @@ void libspdm_reset_message_k(void *context, void *session_info)
 
         spdm_context = context;
 
-        libspdm_reset_managed_buffer(&spdm_session_info->session_transcript.temp_message_k);
-
         if (spdm_session_info->session_transcript.digest_context_th != NULL) {
             libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                spdm_session_info->session_transcript.digest_context_th);
@@ -922,7 +920,6 @@ void libspdm_reset_message_k(void *context, void *session_info)
                                spdm_session_info->session_transcript.digest_context_th_backup);
             spdm_session_info->session_transcript.digest_context_th_backup = NULL;
         }
-        spdm_session_info->session_transcript.finished_key_ready = false;
     }
 #endif
 }
@@ -1445,19 +1442,14 @@ libspdm_return_t libspdm_append_message_k(void *context, void *session_info,
 #else
     {
         libspdm_context_t *spdm_context;
-        void *secured_message_context;
         uint8_t *cert_chain_buffer;
         size_t cert_chain_buffer_size;
         bool result;
         uint8_t cert_chain_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint32_t hash_size;
-        bool finished_key_ready;
-        libspdm_return_t status;
         uint8_t slot_id;
 
         spdm_context = context;
-        secured_message_context = spdm_session_info->secured_message_context;
-        finished_key_ready = libspdm_secured_message_is_finished_key_ready(secured_message_context);
         slot_id = spdm_context->connection_info.peer_used_cert_chain_slot_id;
 
         if (spdm_session_info->session_transcript.digest_context_th == NULL) {
@@ -1537,13 +1529,6 @@ libspdm_return_t libspdm_append_message_k(void *context, void *session_info,
                                    spdm_session_info->session_transcript.digest_context_th);
                 return LIBSPDM_STATUS_CRYPTO_ERROR;
             }
-            status = libspdm_append_managed_buffer(
-                &spdm_session_info->session_transcript.temp_message_k,
-                libspdm_get_managed_buffer(&spdm_context->transcript.message_a),
-                libspdm_get_managed_buffer_size(&spdm_context->transcript.message_a));
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                return status;
-            }
             if (!spdm_session_info->use_psk) {
                 result = libspdm_hash_update (
                     spdm_context->connection_info.algorithm.base_hash_algo,
@@ -1553,12 +1538,6 @@ libspdm_return_t libspdm_append_message_k(void *context, void *session_info,
                     libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                        spdm_session_info->session_transcript.digest_context_th);
                     return LIBSPDM_STATUS_CRYPTO_ERROR;
-                }
-                status = libspdm_append_managed_buffer(
-                    &spdm_session_info->session_transcript.temp_message_k,
-                    cert_chain_buffer_hash, hash_size);
-                if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                    return status;
                 }
             }
         }
@@ -1570,16 +1549,6 @@ libspdm_return_t libspdm_append_message_k(void *context, void *session_info,
             libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                spdm_session_info->session_transcript.digest_context_th);
             return LIBSPDM_STATUS_CRYPTO_ERROR;
-        }
-        if (!finished_key_ready) {
-
-            /* append message only if finished_key is NOT ready.*/
-
-            status = libspdm_append_managed_buffer(
-                &spdm_session_info->session_transcript.temp_message_k, message, message_size);
-            if (LIBSPDM_STATUS_IS_ERROR(status)) {
-                return status;
-            }
         }
         return LIBSPDM_STATUS_SUCCESS;
     }
@@ -1612,29 +1581,20 @@ libspdm_return_t libspdm_append_message_f(void *context, void *session_info,
 #else
     {
         libspdm_context_t *spdm_context;
-        void *secured_message_context;
         const uint8_t *mut_cert_chain_buffer;
         size_t mut_cert_chain_buffer_size;
         bool result;
         uint8_t mut_cert_chain_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint32_t hash_size;
-        bool finished_key_ready;
         libspdm_return_t status;
         uint8_t slot_id;
 
         spdm_context = context;
-        secured_message_context = spdm_session_info->secured_message_context;
-        finished_key_ready = libspdm_secured_message_is_finished_key_ready(secured_message_context);
-        LIBSPDM_ASSERT (finished_key_ready);
         slot_id = spdm_context->connection_info.peer_used_cert_chain_slot_id;
 
         if (!spdm_session_info->session_transcript.message_f_initialized) {
 
-            /* digest_context_th might be NULL in unit test, where message_k is hardcoded.
-             * hmac_{rsp,req}_context_th might be NULL in real case, because
-             *   after finished_key_ready is generated, no one trigger libspdm_append_message_k.
-             * trigger message_k to initialize by using zero length message_k, no impact to hash or HMAC.
-             *   only temp_message_k is appended.*/
+            /* digest_context_th might be NULL in unit test, where message_k is hardcoded.*/
 
             if (spdm_session_info->session_transcript.digest_context_th == NULL) {
                 status = libspdm_append_message_k (context, session_info, is_requester, NULL, 0);

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -18,10 +18,6 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
 {
     libspdm_session_type_t session_type;
     uint32_t capabilities_flag;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-#else
-    void *secured_message_context;
-#endif
 
     capabilities_flag = spdm_context->connection_info.capability.flags &
                         spdm_context->local_context.capability.flags;
@@ -46,36 +42,15 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 #else
-    secured_message_context = session_info->secured_message_context;
     if (session_info->session_transcript.digest_context_th != NULL) {
         libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                            session_info->session_transcript.digest_context_th);
         session_info->session_transcript.digest_context_th = NULL;
     }
-    if (session_info->session_transcript.hmac_rsp_context_th != NULL) {
-        libspdm_hmac_free_with_response_finished_key (secured_message_context,
-                                                      session_info->session_transcript.hmac_rsp_context_th);
-        session_info->session_transcript.hmac_rsp_context_th = NULL;
-    }
-    if (session_info->session_transcript.hmac_req_context_th != NULL) {
-        libspdm_hmac_free_with_request_finished_key (secured_message_context,
-                                                     session_info->session_transcript.hmac_req_context_th);
-        session_info->session_transcript.hmac_req_context_th = NULL;
-    }
     if (session_info->session_transcript.digest_context_th_backup != NULL) {
         libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                            session_info->session_transcript.digest_context_th_backup);
         session_info->session_transcript.digest_context_th_backup = NULL;
-    }
-    if (session_info->session_transcript.hmac_rsp_context_th_backup != NULL) {
-        libspdm_hmac_free_with_response_finished_key (secured_message_context,
-                                                      session_info->session_transcript.hmac_rsp_context_th_backup);
-        session_info->session_transcript.hmac_rsp_context_th_backup = NULL;
-    }
-    if (session_info->session_transcript.hmac_req_context_th_backup != NULL) {
-        libspdm_hmac_free_with_request_finished_key (secured_message_context,
-                                                     session_info->session_transcript.hmac_req_context_th_backup);
-        session_info->session_transcript.hmac_req_context_th_backup = NULL;
     }
 #endif
 

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -79,9 +79,6 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
         sizeof(session_info->session_transcript.message_f.buffer);
     session_info->session_transcript.message_m.max_buffer_size =
         sizeof(session_info->session_transcript.message_m.buffer);
-#else
-    session_info->session_transcript.temp_message_k.max_buffer_size =
-        sizeof(session_info->session_transcript.temp_message_k.buffer);
 #endif
 }
 

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -167,7 +167,6 @@ bool libspdm_calculate_th_hmac_for_exchange_rsp(
     uint32_t hash_size;
     void *hash_context_th;
     uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
-    libspdm_return_t status;
     bool result;
 
     spdm_context = context;
@@ -178,15 +177,6 @@ bool libspdm_calculate_th_hmac_for_exchange_rsp(
         spdm_context->connection_info.algorithm.base_hash_algo);
 
     LIBSPDM_ASSERT(*th_hmac_buffer_size >= hash_size);
-
-    if (session_info->session_transcript.digest_context_th == NULL) {
-        /* trigger message_k to initialize context after finished_key is ready.*/
-        status = libspdm_append_message_k (context, spdm_session_info, is_requester, NULL, 0);
-        if (LIBSPDM_STATUS_IS_ERROR(status)) {
-            return false;
-        }
-        LIBSPDM_ASSERT(session_info->session_transcript.digest_context_th != NULL);
-    }
 
     /* duplicate the th context, because we still need use original context to continue.*/
     hash_context_th = libspdm_hash_new (spdm_context->connection_info.algorithm.base_hash_algo);

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -47,22 +47,6 @@ void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context, boo
 }
 
 /**
- * Return if finished_key is ready.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true  finished_key is ready.
- * @retval false finished_key is not ready.
- */
-bool libspdm_secured_message_is_finished_key_ready(void *spdm_secured_message_context)
-{
-    libspdm_secured_message_context_t *secured_message_context;
-
-    secured_message_context = spdm_secured_message_context;
-    return secured_message_context->finished_key_ready;
-}
-
-/**
  * Set session_state to an SPDM secured message context.
  *
  * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -350,7 +350,6 @@ bool libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
     libspdm_zero_mem(secured_message_context->master_secret.dhe_secret,
                      LIBSPDM_MAX_DHE_KEY_SIZE);
 
-    secured_message_context->finished_key_ready = true;
     return true;
 }
 

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
@@ -23,7 +23,6 @@ void libspdm_secured_message_set_response_finished_key(void *spdm_secured_messag
     libspdm_copy_mem(secured_message_context->handshake_secret.response_finished_key,
                      sizeof(secured_message_context->handshake_secret.response_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 size_t libspdm_get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
@@ -18,10 +18,6 @@ static uint8_t m_libspdm_dummy_salt_buffer[LIBSPDM_MAX_AEAD_IV_SIZE];
 
 static void libspdm_secured_message_set_dummy_finished_key(void *spdm_secured_message_context)
 {
-    libspdm_secured_message_context_t *secured_message_context;
-
-    secured_message_context = spdm_secured_message_context;
-    secured_message_context->finished_key_ready = true;
 }
 
 void libspdm_secured_message_set_response_handshake_encryption_key(

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -31,7 +31,6 @@ void libspdm_secured_message_set_request_finished_key(void *spdm_secured_message
     libspdm_copy_mem(secured_message_context->handshake_secret.request_finished_key,
                      sizeof(secured_message_context->handshake_secret.request_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 typedef struct

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -34,7 +34,6 @@ static void libspdm_secured_message_set_request_finished_key(void *spdm_secured_
     libspdm_copy_mem(secured_message_context->handshake_secret.request_finished_key,
                      sizeof(secured_message_context->handshake_secret.request_finished_key),
                      key,  secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 void libspdm_test_responder_psk_finish_rsp_case1(void **State)

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -199,6 +199,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -246,8 +247,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -270,6 +272,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -317,8 +320,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -405,6 +409,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
             size_t cert_buffer_size;
             uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
             libspdm_large_managed_buffer_t th_curr;
+            uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
             uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
             size_t spdm_response_size;
             size_t transport_header_size;
@@ -459,9 +464,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
                                           m_libspdm_local_buffer_size);
             libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE,
                             (uint8_t)(0xFF));
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
             free(data);
@@ -560,6 +565,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
             size_t cert_buffer_size;
             uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
             libspdm_large_managed_buffer_t th_curr;
+            uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
             uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
             size_t spdm_response_size;
             size_t transport_header_size;
@@ -614,9 +620,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
                                           m_libspdm_local_buffer_size);
             libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE,
                             (uint8_t)(0xFF));
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
             free(data);
@@ -676,6 +682,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -723,8 +730,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -747,6 +755,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -794,8 +803,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -818,6 +828,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -865,8 +876,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -889,6 +901,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -937,8 +950,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -961,6 +975,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         size_t cert_buffer_size;
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -1008,8 +1023,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -1033,6 +1049,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -1092,8 +1109,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
         free(data);
@@ -1208,6 +1226,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -1268,8 +1287,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         libspdm_copy_mem(ptr, spdm_response_size - (ptr - (uint8_t *)spdm_response),
                          ptr + hmac_size, hmac_size); /* 2x HMAC size*/
@@ -1295,6 +1315,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -1355,8 +1376,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size/2; /* half HMAC size*/
         libspdm_set_mem(ptr, hmac_size/2, (uint8_t) 0x00);
@@ -1402,6 +1424,7 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
         libspdm_large_managed_buffer_t th_curr;
+        uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
         uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -1452,8 +1475,9 @@ libspdm_return_t libspdm_requester_finish_test_receive_message(
         libspdm_append_managed_buffer(&th_curr, m_libspdm_local_buffer,
                                       m_libspdm_local_buffer_size);
         libspdm_set_mem(response_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -25,7 +25,6 @@ void libspdm_secured_message_set_response_finished_key(
     libspdm_copy_mem(secured_message_context->handshake_secret.response_finished_key,
                      sizeof(secured_message_context->handshake_secret.response_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 libspdm_return_t libspdm_requester_finish_test_send_message(void *spdm_context,

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -506,8 +506,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -672,8 +673,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -916,9 +918,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                                 response_handshake_secret, hash_size,
                                 bin_str7, bin_str7_size,
                                 response_finished_key, hash_size);
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
 
@@ -1174,9 +1176,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                                 response_handshake_secret, hash_size,
                                 bin_str7, bin_str7_size,
                                 response_finished_key, hash_size);
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
 
@@ -1377,8 +1379,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1552,8 +1555,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1727,8 +1731,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1903,8 +1908,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2070,8 +2076,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2237,8 +2244,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2413,8 +2421,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2583,8 +2592,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2877,8 +2887,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3044,8 +3055,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3211,8 +3223,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3379,8 +3392,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3547,8 +3561,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3715,8 +3730,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3884,8 +3900,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -4053,8 +4070,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -4222,8 +4240,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -4369,8 +4388,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
@@ -4540,8 +4560,9 @@ libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -421,8 +421,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -544,8 +545,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -743,9 +745,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
                                 response_handshake_secret, hash_size,
                                 bin_str7, bin_str7_size,
                                 response_finished_key, hash_size);
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
 
@@ -956,9 +958,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
                                 response_handshake_secret, hash_size,
                                 bin_str7, bin_str7_size,
                                 response_finished_key, hash_size);
-            libspdm_hmac_all(m_libspdm_use_hash_algo,
-                             libspdm_get_managed_buffer(&th_curr),
-                             libspdm_get_managed_buffer_size(&th_curr),
+            libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                             libspdm_get_managed_buffer_size(&th_curr), hash_data);
+            libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                              response_finished_key, hash_size, ptr);
             ptr += hmac_size;
 
@@ -1117,8 +1119,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1226,8 +1229,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
@@ -1354,8 +1358,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1489,8 +1494,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1624,8 +1630,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1760,8 +1767,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -1887,8 +1895,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2014,8 +2023,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2150,8 +2160,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2275,8 +2286,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2400,8 +2412,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2525,8 +2538,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2650,8 +2664,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         /* Flip last byte of ResponderVerifyData*/
         ptr += hmac_size-1;
@@ -2778,8 +2793,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -2901,8 +2917,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 
@@ -3024,8 +3041,9 @@ libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
         libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret,
                             hash_size, bin_str7, bin_str7_size,
                             response_finished_key, hash_size);
-        libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                         libspdm_get_managed_buffer_size(&th_curr),
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
                          response_finished_key, hash_size, ptr);
         ptr += hmac_size;
 

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -20,10 +20,6 @@ static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static void libspdm_secured_message_set_dummy_finished_key(
     void *spdm_secured_message_context)
 {
-    libspdm_secured_message_context_t *secured_message_context;
-
-    secured_message_context = spdm_secured_message_context;
-    secured_message_context->finished_key_ready = true;
 }
 
 void libspdm_secured_message_set_response_handshake_encryption_key(

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -72,6 +72,7 @@ void libspdm_test_responder_finish_case1(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -145,9 +146,10 @@ void libspdm_test_responder_finish_case1(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -183,6 +185,7 @@ void libspdm_test_responder_finish_case2(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -254,9 +257,10 @@ void libspdm_test_responder_finish_case2(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request2,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
                                          m_libspdm_finish_request2_size,
@@ -294,6 +298,7 @@ void libspdm_test_responder_finish_case3(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -368,9 +373,10 @@ void libspdm_test_responder_finish_case3(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -410,6 +416,7 @@ void libspdm_test_responder_finish_case4(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -484,9 +491,10 @@ void libspdm_test_responder_finish_case4(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -527,6 +535,7 @@ void libspdm_test_responder_finish_case5(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -602,9 +611,10 @@ void libspdm_test_responder_finish_case5(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -652,6 +662,7 @@ void libspdm_test_responder_finish_case6(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -726,9 +737,10 @@ void libspdm_test_responder_finish_case6(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -761,6 +773,7 @@ void libspdm_test_responder_finish_case7(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -847,9 +860,10 @@ void libspdm_test_responder_finish_case7(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -898,6 +912,7 @@ void libspdm_test_responder_finish_case8(void **state)
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1017,9 +1032,10 @@ void libspdm_test_responder_finish_case8(void **state)
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request3_size = sizeof(spdm_finish_request_t) +
                                      req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
@@ -1058,6 +1074,7 @@ void libspdm_test_responder_finish_case9(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1132,9 +1149,10 @@ void libspdm_test_responder_finish_case9(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -1174,6 +1192,7 @@ void libspdm_test_responder_finish_case10(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1247,9 +1266,10 @@ void libspdm_test_responder_finish_case10(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(spdm_context,
@@ -1486,6 +1506,7 @@ void libspdm_test_responder_finish_case13(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1559,9 +1580,10 @@ void libspdm_test_responder_finish_case13(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     libspdm_copy_mem(ptr, sizeof(m_libspdm_finish_request1.signature),
                      ptr + hmac_size, hmac_size); /* 2x HMAC size*/
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + 2*hmac_size;
@@ -1602,6 +1624,7 @@ void libspdm_test_responder_finish_case14(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1675,9 +1698,10 @@ void libspdm_test_responder_finish_case14(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     libspdm_set_mem(ptr + hmac_size/2, hmac_size/2, (uint8_t) 0x00); /* half HMAC size*/
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size/2;
     response_size = sizeof(response);
@@ -1720,6 +1744,7 @@ void libspdm_test_responder_finish_case15(void **state)
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1825,9 +1850,10 @@ void libspdm_test_responder_finish_case15(void **state)
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     libspdm_set_mem(m_libspdm_finish_request3.signature,
                     req_asym_signature_size, (uint8_t) 0x00); /*zero signature*/
     m_libspdm_finish_request3_size = sizeof(spdm_finish_request_t) +
@@ -1874,6 +1900,7 @@ void libspdm_test_responder_finish_case16(void **state)
     uint8_t req_cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     uint8_t random_buffer[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1980,9 +2007,10 @@ void libspdm_test_responder_finish_case16(void **state)
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request3_size = sizeof(spdm_finish_request_t) +
                                      req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
@@ -2022,6 +2050,7 @@ void libspdm_test_responder_finish_case17(void **state)
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -2083,9 +2112,10 @@ void libspdm_test_responder_finish_case17(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request1,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_finish_request1_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_finish(

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -47,7 +47,6 @@ void libspdm_secured_message_set_request_finished_key(
     libspdm_copy_mem(secured_message_context->handshake_secret.request_finished_key,
                      sizeof(secured_message_context->handshake_secret.request_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 /**

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -61,6 +61,7 @@ void libspdm_test_responder_psk_finish_case1(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -136,9 +137,10 @@ void libspdm_test_responder_psk_finish_case1(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -171,6 +173,7 @@ void libspdm_test_responder_psk_finish_case2(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -244,9 +247,10 @@ void libspdm_test_responder_psk_finish_case2(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request2,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     response_size = sizeof(response);
     status = libspdm_get_response_psk_finish(spdm_context,
                                              m_libspdm_psk_finish_request2_size,
@@ -281,6 +285,7 @@ void libspdm_test_responder_psk_finish_case3(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -357,9 +362,10 @@ void libspdm_test_responder_psk_finish_case3(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -397,6 +403,7 @@ void libspdm_test_responder_psk_finish_case4(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -473,9 +480,10 @@ void libspdm_test_responder_psk_finish_case4(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -514,6 +522,7 @@ void libspdm_test_responder_psk_finish_case5(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -591,9 +600,10 @@ void libspdm_test_responder_psk_finish_case5(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -639,6 +649,7 @@ void libspdm_test_responder_psk_finish_case6(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -715,9 +726,10 @@ void libspdm_test_responder_psk_finish_case6(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -748,6 +760,7 @@ void libspdm_test_responder_psk_finish_case7(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -837,9 +850,10 @@ void libspdm_test_responder_psk_finish_case7(void **state)
 #endif
 
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -881,6 +895,7 @@ void libspdm_test_responder_psk_finish_case8(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -956,9 +971,10 @@ void libspdm_test_responder_psk_finish_case8(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -996,6 +1012,7 @@ void libspdm_test_responder_psk_finish_case9(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1071,9 +1088,10 @@ void libspdm_test_responder_psk_finish_case9(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
@@ -1324,6 +1342,7 @@ void libspdm_test_responder_psk_finish_case12(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1399,9 +1418,10 @@ void libspdm_test_responder_psk_finish_case12(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     libspdm_copy_mem(ptr, sizeof(m_libspdm_psk_finish_request1.verify_data),
                      ptr + hmac_size, hmac_size); /* 2x HMAC size*/
     m_libspdm_psk_finish_request1_size =
@@ -1440,6 +1460,7 @@ void libspdm_test_responder_psk_finish_case13(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1515,9 +1536,10 @@ void libspdm_test_responder_psk_finish_case13(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     libspdm_set_mem(ptr + hmac_size/2, hmac_size/2, (uint8_t) 0x00); /* half HMAC size*/
     m_libspdm_psk_finish_request1_size =
         sizeof(spdm_psk_finish_request_t) + hmac_size/2;
@@ -1554,6 +1576,7 @@ void libspdm_test_responder_psk_finish_case14(void **state)
     size_t data_size1;
     uint8_t *ptr;
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t *session_info;
     uint32_t session_id;
@@ -1617,9 +1640,10 @@ void libspdm_test_responder_psk_finish_case14(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_psk_finish_request1,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key,
-                     hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     m_libspdm_psk_finish_request1_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     status = libspdm_get_response_psk_finish(

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -40,7 +40,6 @@ static void libspdm_secured_message_set_request_finished_key(
     libspdm_copy_mem(secured_message_context->handshake_secret.request_finished_key,
                      sizeof(secured_message_context->handshake_secret.request_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 /**

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -695,6 +695,7 @@ void libspdm_test_responder_respond_if_ready_case6(void **state) {
     size_t cert_buffer_size;
     uint8_t cert_buffer_hash[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t    *session_info;
     uint32_t session_id;
@@ -761,9 +762,10 @@ void libspdm_test_responder_respond_if_ready_case6(void **state) {
     libspdm_append_managed_buffer (&th_curr, (uint8_t *)&m_libspdm_finish_request,
                                    sizeof(spdm_finish_request_t));
     libspdm_set_mem (request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all (m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                      libspdm_get_managed_buffer_size(
-                          &th_curr), request_finished_key, hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
 
     spdm_context->last_spdm_request_size = sizeof(spdm_finish_request_t) + hmac_size;
     libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
@@ -923,6 +925,7 @@ void libspdm_test_responder_respond_if_ready_case8(void **state) {
     uint8_t local_psk_hint[32];
     uint8_t dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
     libspdm_large_managed_buffer_t th_curr;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     libspdm_session_info_t    *session_info;
     uint32_t session_id;
@@ -993,9 +996,10 @@ void libspdm_test_responder_respond_if_ready_case8(void **state) {
     libspdm_append_managed_buffer (&th_curr, (uint8_t *)&m_libspdm_psk_finish_request,
                                    sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem (request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all (m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                      libspdm_get_managed_buffer_size(
-                          &th_curr), request_finished_key, hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
 
     spdm_context->last_spdm_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
     libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -277,7 +277,6 @@ static void libspdm_secured_message_set_request_finished_key(
     libspdm_copy_mem(secured_message_context->handshake_secret.request_finished_key,
                      sizeof(secured_message_context->handshake_secret.request_finished_key),
                      key, secured_message_context->hash_size);
-    secured_message_context->finished_key_ready = true;
 }
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP


### PR DESCRIPTION
Fix https://github.com/DMTF/libspdm/issues/1136.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>