### PR TITLE
Fix potential unaligned access for rand.

### DIFF
--- a/os_stub/openssllib/rand_pool.c
+++ b/os_stub/openssllib/rand_pool.c
@@ -45,7 +45,7 @@ static bool rand_get_bytes(size_t length, uint8_t *rand_buffer)
             return ret;
         }
         if (length >= sizeof(temp_rand)) {
-            *((uint64_t *)rand_buffer) = temp_rand;
+            libspdm_copy_mem(rand_buffer, length, &temp_rand, sizeof(uint64_t));
             rand_buffer += sizeof(uint64_t);
             length -= sizeof(temp_rand);
         } else {


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/195

copy_mem is used here to align solution between mbedtls and openssl.
we may change to other solution later and together.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>