### PR TITLE
Remove debug code in libspdm_calculate_m1m2 & libspdm_calculate_l1l2

### DIFF
--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -165,15 +165,10 @@ static bool libspdm_calculate_m1m2(void *context, bool is_mut,
 {
     libspdm_context_t *spdm_context;
     libspdm_return_t status;
-    uint32_t hash_size;
-    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
 
     spdm_context = context;
 
     libspdm_init_managed_buffer(m1m2, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-
-    hash_size = libspdm_get_hash_size(
-        spdm_context->connection_info.algorithm.base_hash_algo);
 
     if (is_mut) {
         if ((spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT) >
@@ -224,20 +219,6 @@ static bool libspdm_calculate_m1m2(void *context, bool is_mut,
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             return false;
         }
-
-        /* Debug code only - calculate and print value of m1m2 mut hash*/
-        LIBSPDM_DEBUG_CODE(
-            if (!libspdm_hash_all(
-                    spdm_context->connection_info.algorithm.base_hash_algo,
-                    libspdm_get_managed_buffer(m1m2),
-                    libspdm_get_managed_buffer_size(m1m2), hash_data)) {
-            return false;
-        }
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m1m2 Mut hash - "));
-            libspdm_internal_dump_data(hash_data, hash_size);
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
-            );
-
     } else {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "message_a data :\n"));
         libspdm_internal_dump_hex(
@@ -280,19 +261,6 @@ static bool libspdm_calculate_m1m2(void *context, bool is_mut,
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             return false;
         }
-
-        /* Debug code only - calculate and print value of m1m2 hash*/
-        LIBSPDM_DEBUG_CODE(
-            if (!libspdm_hash_all(
-                    spdm_context->connection_info.algorithm.base_hash_algo,
-                    libspdm_get_managed_buffer(m1m2),
-                    libspdm_get_managed_buffer_size(m1m2), hash_data)) {
-            return false;
-        }
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m1m2 hash - "));
-            libspdm_internal_dump_data(hash_data, hash_size);
-            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
-            );
     }
 
     return true;
@@ -366,16 +334,11 @@ static bool libspdm_calculate_l1l2(void *context, void *session_info,
     libspdm_context_t *spdm_context;
     libspdm_return_t status;
     libspdm_session_info_t *spdm_session_info;
-    uint32_t hash_size;
-    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
 
     spdm_context = context;
     spdm_session_info = session_info;
 
     libspdm_init_managed_buffer(l1l2, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-
-    hash_size = libspdm_get_hash_size(
-        spdm_context->connection_info.algorithm.base_hash_algo);
 
     if ((spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT) >
         SPDM_MESSAGE_VERSION_11) {
@@ -421,19 +384,6 @@ static bool libspdm_calculate_l1l2(void *context, void *session_info,
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
-
-    /* Debug code only - calculate and print value of l1l2 hash*/
-    LIBSPDM_DEBUG_CODE(
-        if (!libspdm_hash_all(
-                spdm_context->connection_info.algorithm.base_hash_algo,
-                libspdm_get_managed_buffer(l1l2),
-                libspdm_get_managed_buffer_size(l1l2), hash_data)) {
-        return false;
-    }
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "l1l2 hash - "));
-        libspdm_internal_dump_data(hash_data, hash_size);
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
-        );
 
     return true;
 }


### PR DESCRIPTION
Remove the debug code in these two functions since they update the
m1m2 or l1l2 content thus affect the actual code logic once enabled
in the case when LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT is set.

Signed-off-by: Liming Sun <limings@nvidia.com>