### PR TITLE
Fix Condition for Base Hash and Base Asym Algorithm Selection

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -536,16 +536,47 @@ libspdm_return_t libspdm_get_response_algorithms(void *context,
                 0, response_size, response);
         }
     }
-    algo_size = libspdm_get_hash_size(
-        spdm_context->connection_info.algorithm.base_hash_algo);
-    if (algo_size == 0) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
-                                               response_size, response);
-    }
+
     if (libspdm_is_capabilities_flag_supported(
             spdm_context, false, 0,
-            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP)) {
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false, 0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false, 0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)) {
+        algo_size = libspdm_get_hash_size(
+            spdm_context->connection_info.algorithm.base_hash_algo);
+        if (algo_size == 0) {
+            return libspdm_generate_error_response(
+                spdm_context,
+                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                response_size, response);
+        }
+    }
+
+    if (libspdm_is_capabilities_flag_supported(
+            spdm_context, false, 0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false, 0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false, 0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG) ||
+        libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)) {
         algo_size = libspdm_get_asym_signature_size(
             spdm_context->connection_info.algorithm.base_asym_algo);
         if (algo_size == 0) {

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -2362,6 +2362,8 @@ int libspdm_responder_algorithms_test_main(void)
         SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
     m_libspdm_negotiate_algorithm_request17.spdm_request_version10.base_hash_algo =
         m_libspdm_use_hash_algo;
+    m_libspdm_negotiate_algorithm_request17.spdm_request_version10.base_asym_algo =
+        m_libspdm_use_asym_algo;
     m_libspdm_negotiate_algorithm_request18.spdm_request_version10.base_hash_algo =
         m_libspdm_use_hash_algo;
     libspdm_setup_test_context(&m_libspdm_responder_algorithms_test_context);

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -103,6 +103,8 @@ void libspdm_test_responder_chunk_send_ack_setup_algo_state(libspdm_context_t* s
     /* This state is copied form Algorithms test case 22 */
     m_libspdm_chunk_send_negotiate_algorithm_request1.spdm_request_version10.base_hash_algo =
         m_libspdm_use_hash_algo;
+    m_libspdm_chunk_send_negotiate_algorithm_request1.spdm_request_version10.base_asym_algo =
+        m_libspdm_use_asym_algo;
 
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     spdm_context->connection_info.connection_state =


### PR DESCRIPTION
The base hash algorithm selected is incorrectly mandated to be non-zero, given the case that the responder only supports unsigned measurements. The base asymmetric algorithm selected should also check for this case, however only the challenge capability is checked.

Fix by checking for capabilities which require these algorithms:
- CERT_CAP, CHAL_CAP, MEAS_CAP_SIG, KEY_EX_CAP, PSK_CAP, PUB_KEY_ID_CAP

This fixes issue #1189 