### PR TITLE
Fix and add fuzzy test cases to improve code coverage

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -239,6 +239,10 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(
                              &th_curr), response_finished_key, hash_size, ptr);
+        libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                         libspdm_get_managed_buffer_size(&th_curr), hash_data);
+        libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                         response_finished_key, hash_size, ptr);
         break;
     }
     case 0x02: {

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -163,9 +163,10 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
                        (uint16_t)hash_size, hash_size, bin_str7, &bin_str7_size);
     libspdm_hkdf_expand(m_libspdm_use_hash_algo, response_handshake_secret, hash_size, bin_str7,
                         bin_str7_size, response_finished_key, hash_size);
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(
-                         &th_curr), response_finished_key, hash_size, ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     response_finished_key, hash_size, ptr);
     ptr += hmac_size;
 
     libspdm_transport_test_encode_message(spdm_context, NULL, false, false,

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -60,6 +60,7 @@ void libspdm_test_responder_finish_case1(void **State)
     uint32_t hmac_size;
     libspdm_finish_request_mine_t *spdm_test_finish_request;
     size_t spdm_test_finish_request_size;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
 
     spdm_test_context = *State;
@@ -122,9 +123,10 @@ void libspdm_test_responder_finish_case1(void **State)
     libspdm_append_managed_buffer(&th_curr, spdm_test_finish_request,
                                   sizeof(spdm_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key, hash_size,
-                     ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     spdm_test_finish_request_size = sizeof(spdm_finish_request_t) + hmac_size;
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_finish_request_size,
@@ -149,7 +151,7 @@ void libspdm_test_responder_finish_case2(void **State)
 
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NOT_READY;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
 
     response_size = sizeof(response);
     libspdm_get_response_finish(spdm_context, spdm_test_context->test_buffer_size,
@@ -362,6 +364,7 @@ void libspdm_test_responder_finish_case8(void **State)
     uint32_t hash_size;
     uint32_t hmac_size;
     size_t req_asym_signature_size;
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
     libspdm_finish_request_mine_t *spdm_test_finish_request;
     size_t spdm_test_finish_request_size;
@@ -426,6 +429,7 @@ void libspdm_test_responder_finish_case8(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     req_asym_signature_size = libspdm_get_req_asym_signature_size(m_libspdm_use_req_asym_algo);
@@ -457,9 +461,10 @@ void libspdm_test_responder_finish_case8(void **State)
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key, hash_size,
-                     ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     spdm_test_finish_request_size =
         sizeof(spdm_finish_request_t) + req_asym_signature_size + hmac_size;
     response_size = sizeof(response);
@@ -488,7 +493,7 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_finish_case1(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /*response_state: LIBSPDM_RESPONSE_STATE_NOT_READY */
+    /*response_state: LIBSPDM_RESPONSE_STATE_BUSY */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_finish_case2(&State);
     libspdm_unit_test_group_teardown(&State);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -19,7 +19,7 @@ libspdm_test_context_t m_libspdm_responder_heartbeat_test_context = {
     false,
 };
 
-void libspdm_test_responder_heartbeat(void **State)
+void libspdm_test_responder_heartbeat_case1(void **State)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -33,6 +33,8 @@ void libspdm_test_responder_heartbeat(void **State)
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |=
@@ -88,6 +90,58 @@ void libspdm_test_responder_heartbeat(void **State)
     free(data1);
 }
 
+void libspdm_test_responder_heartbeat_case2(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+
+    response_size = sizeof(response);
+    libspdm_get_response_heartbeat(spdm_context,
+                                   spdm_test_context->test_buffer_size,
+                                   spdm_test_context->test_buffer,
+                                   &response_size, response);
+}
+
+void libspdm_test_responder_heartbeat_case3(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NOT_STARTED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+
+    response_size = sizeof(response);
+    libspdm_get_response_heartbeat(spdm_context,
+                                   spdm_test_context->test_buffer_size,
+                                   spdm_test_context->test_buffer,
+                                   &response_size, response);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -98,10 +152,18 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     m_libspdm_responder_heartbeat_test_context.test_buffer_size =
         test_buffer_size;
 
-    libspdm_unit_test_group_setup(&State);
-
     /* Success Case*/
-    libspdm_test_responder_heartbeat(&State);
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_heartbeat_case1(&State);
+    libspdm_unit_test_group_teardown(&State);
 
+    /* response_state: LIBSPDM_RESPONSE_STATE_BUSY */
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_heartbeat_case2(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /* connection_state: LIBSPDM_RESPONSE_STATE_BUSY */
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_heartbeat_case3(&State);
     libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/key_update.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_update/key_update.c
@@ -126,24 +126,26 @@ void libspdm_test_responder_key_update(void **State)
     libspdm_secured_message_context_t *secured_message_context;
     size_t response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
-    uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
 
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_set_standard_key_update_test_state(spdm_context, &session_id);
 
     session_info = &spdm_context->session_info[0];
     secured_message_context = session_info->secured_message_context;
 
     libspdm_set_standard_key_update_test_secrets(
-        session_info->secured_message_context, m_rsp_secret_buffer,
-        (uint8_t)(0xFF), m_req_secret_buffer, (uint8_t)(0xEE));
+        session_info->secured_message_context, rsp_secret_buffer,
+        (uint8_t)(0xFF), req_secret_buffer, (uint8_t)(0xEE));
 
     libspdm_compute_secret_update(spdm_context->connection_info.version,
                                   secured_message_context->hash_size,
-                                  m_req_secret_buffer, m_req_secret_buffer,
+                                  req_secret_buffer, req_secret_buffer,
                                   secured_message_context->hash_size);
 
     response_size = sizeof(response);
@@ -163,10 +165,8 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     m_libspdm_responder_key_update_test_context.test_buffer_size =
         test_buffer_size;
 
-    libspdm_unit_test_group_setup(&State);
-
     /* Success Case*/
+    libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_key_update(&State);
-
     libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -53,6 +53,9 @@ void libspdm_test_responder_psk_finish_rsp_case1(void **State)
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
@@ -115,6 +118,7 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
     size_t data_size1;
     libspdm_large_managed_buffer_t th_curr;
     static uint8_t m_dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     uint8_t m_local_psk_hint[32];
     uint8_t *ptr;
@@ -128,6 +132,9 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
     spdm_test_psk_finish_request =
         (libspdm_psk_finish_request_mine_t *)spdm_test_context->test_buffer;
     spdm_test_psk_finish_request_size = spdm_test_context->test_buffer_size;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
@@ -176,11 +183,11 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)spdm_test_psk_finish_request,
                                   sizeof(spdm_psk_finish_request_t));
     libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
-    libspdm_hmac_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
-                     libspdm_get_managed_buffer_size(&th_curr), request_finished_key, hash_size,
-                     ptr);
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
     spdm_test_psk_finish_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
-
     response_size = sizeof(response);
     libspdm_get_response_psk_finish(spdm_context, spdm_test_psk_finish_request_size,
                                     spdm_test_psk_finish_request, &response_size, response);


### PR DESCRIPTION
Fix: #1215 
Improve the reduced coverage to more than 75%.

libspdm_req_finish.c : 79.2 %
libspdm_req_key_exchange.c :80. 9%
libspdm_req_psk_exchange.c : 79.6 %
libspdm_req_psk_finish.c : 83.2 %
libspdm_rsp_finish.c : 83.3 %
libspdm_rsp_psk_finish.c : 80.4 %

Signed-off-by: Xiaohanjlll <hanx.xiao@intel.com>