### PR TITLE
Fix Building with no RSA Support

### DIFF
--- a/os_stub/cryptlib_mbedtls/pem/pem.c
+++ b/os_stub/cryptlib_mbedtls/pem/pem.c
@@ -31,6 +31,7 @@ static size_t ascii_str_len(const char *string)
     return length;
 }
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA Private key from the password-protected PEM key data.
  *
@@ -116,6 +117,7 @@ bool libspdm_rsa_get_private_key_from_pem(const uint8_t *pem_data,
     *rsa_context = rsa;
     return true;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC Private key from the password-protected PEM key data.

--- a/os_stub/cryptlib_mbedtls/pk/rsa_basic.c
+++ b/os_stub/cryptlib_mbedtls/pk/rsa_basic.c
@@ -20,6 +20,7 @@
 
 #include <mbedtls/rsa.h>
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Allocates and initializes one RSA context for subsequent use.
  *
@@ -131,7 +132,9 @@ bool libspdm_rsa_set_key(void *rsa_context, const libspdm_rsa_key_tag_t key_tag,
 
     return ret == 0;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
+#if LIBSPDM_RSA_SSA_SUPPORT
 /**
  * Verifies the RSA-SSA signature with EMSA-PKCS1-v1_5 encoding scheme defined in
  * RSA PKCS#1.
@@ -215,7 +218,9 @@ bool libspdm_rsa_pkcs1_verify_with_nid(void *rsa_context, size_t hash_nid,
     }
     return true;
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Verifies the RSA-SSA signature with EMSA-PSS encoding scheme defined in
  * RSA PKCS#1 v2.2.
@@ -300,3 +305,4 @@ bool libspdm_rsa_pss_verify(void *rsa_context, size_t hash_nid,
     }
     return true;
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_mbedtls/pk/rsa_ext.c
+++ b/os_stub/cryptlib_mbedtls/pk/rsa_ext.c
@@ -19,6 +19,7 @@
 #include "internal_crypt_lib.h"
 #include <mbedtls/rsa.h>
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Gets the tag-designated RSA key component from the established RSA context.
  *
@@ -226,7 +227,9 @@ bool libspdm_rsa_check_key(void *rsa_context)
     }
     return ret == 0;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
+#if LIBSPDM_RSA_SSA_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PKCS1-v1_5 encoding scheme.
  *
@@ -316,7 +319,9 @@ bool libspdm_rsa_pkcs1_sign_with_nid(void *rsa_context, size_t hash_nid,
     *sig_size = mbedtls_rsa_get_len(rsa_context);
     return true;
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PSS encoding scheme.
  *
@@ -409,3 +414,4 @@ bool libspdm_rsa_pss_sign(void *rsa_context, size_t hash_nid,
     *sig_size = ((mbedtls_rsa_context *)rsa_context)->len;
     return true;
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -411,6 +411,7 @@ libspdm_x509_get_organization_name(const uint8_t *cert, size_t cert_size,
         sizeof(m_libspdm_oid_organization_name), name_buffer, name_buffer_size);
 }
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA public key from one DER-encoded X509 certificate.
  *
@@ -461,6 +462,7 @@ bool libspdm_rsa_get_public_key_from_x509(const uint8_t *cert, size_t cert_size,
     *rsa_context = rsa;
     return true;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC public key from one DER-encoded X509 certificate.

--- a/os_stub/cryptlib_null/pem/pem.c
+++ b/os_stub/cryptlib_null/pem/pem.c
@@ -10,6 +10,7 @@
 
 #include "internal_crypt_lib.h"
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA Private key from the password-protected PEM key data.
  *
@@ -35,6 +36,7 @@ bool libspdm_rsa_get_private_key_from_pem(const uint8_t *pem_data,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC Private key from the password-protected PEM key data.

--- a/os_stub/cryptlib_null/pk/rsa_basic.c
+++ b/os_stub/cryptlib_null/pk/rsa_basic.c
@@ -18,6 +18,7 @@
 
 #include "internal_crypt_lib.h"
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Allocates and initializes one RSA context for subsequent use.
  *
@@ -70,6 +71,9 @@ bool libspdm_rsa_set_key(void *rsa_context, const libspdm_rsa_key_tag_t key_tag,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
+
+#if LIBSPDM_RSA_SSA_SUPPORT
 
 /**
  * Verifies the RSA-SSA signature with EMSA-PKCS1-v1_5 encoding scheme defined in
@@ -99,7 +103,9 @@ bool libspdm_rsa_pkcs1_verify_with_nid(void *rsa_context, size_t hash_nid,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Verifies the RSA-SSA signature with EMSA-PSS encoding scheme defined in
  * RSA PKCS#1 v2.2.
@@ -129,3 +135,4 @@ bool libspdm_rsa_pss_verify(void *rsa_context, size_t hash_nid,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_null/pk/rsa_ext.c
+++ b/os_stub/cryptlib_null/pk/rsa_ext.c
@@ -18,6 +18,7 @@
 
 #include "internal_crypt_lib.h"
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Gets the tag-designated RSA key component from the established RSA context.
  *
@@ -101,7 +102,9 @@ bool libspdm_rsa_check_key(void *rsa_context)
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
+#if LIBSPDM_RSA_SSA_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PKCS1-v1_5 encoding scheme.
  *
@@ -138,7 +141,9 @@ bool libspdm_rsa_pkcs1_sign_with_nid(void *rsa_context, size_t hash_nid,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PSS encoding scheme.
  *
@@ -175,3 +180,4 @@ bool libspdm_rsa_pss_sign(void *rsa_context, size_t hash_nid,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_null/pk/x509.c
+++ b/os_stub/cryptlib_null/pk/x509.c
@@ -191,6 +191,7 @@ libspdm_x509_get_organization_name(const uint8_t *cert, size_t cert_size,
     return false;
 }
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA public key from one DER-encoded X509 certificate.
  *
@@ -213,6 +214,7 @@ bool libspdm_rsa_get_public_key_from_x509(const uint8_t *cert, size_t cert_size,
     LIBSPDM_ASSERT(false);
     return false;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC public key from one DER-encoded X509 certificate.

--- a/os_stub/cryptlib_openssl/pem/pem.c
+++ b/os_stub/cryptlib_openssl/pem/pem.c
@@ -56,6 +56,7 @@ int PasswordCallback(char *buf, const int size, const int flag, const void *key)
     }
 }
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA Private key from the password-protected PEM key data.
  *
@@ -131,6 +132,7 @@ done:
 
     return status;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC Private key from the password-protected PEM key data.

--- a/os_stub/cryptlib_openssl/pk/rsa_basic.c
+++ b/os_stub/cryptlib_openssl/pk/rsa_basic.c
@@ -23,6 +23,7 @@
 #include <openssl/objects.h>
 #include <openssl/evp.h>
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Allocates and initializes one RSA context for subsequent use.
  *
@@ -260,7 +261,9 @@ err:
 
     return status;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
+#if LIBSPDM_RSA_SSA_SUPPORT
 /**
  * Verifies the RSA-SSA signature with EMSA-PKCS1-v1_5 encoding scheme defined in
  * RSA PKCS#1.
@@ -352,7 +355,9 @@ bool libspdm_rsa_pkcs1_verify_with_nid(void *rsa_context, size_t hash_nid,
                             sig_buf, (uint32_t)sig_size,
                             (RSA *)rsa_context);
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Verifies the RSA-SSA signature with EMSA-PSS encoding scheme defined in
  * RSA PKCS#1 v2.2.
@@ -464,3 +469,4 @@ bool libspdm_rsa_pss_verify(void *rsa_context, size_t hash_nid,
 
     return result;
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_openssl/pk/rsa_ext.c
+++ b/os_stub/cryptlib_openssl/pk/rsa_ext.c
@@ -24,6 +24,7 @@
 #include <openssl/objects.h>
 #include <openssl/evp.h>
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Gets the tag-designated RSA key component from the established RSA context.
  *
@@ -257,7 +258,9 @@ bool libspdm_rsa_check_key(void *rsa_context)
 
     return true;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
+#if LIBSPDM_RSA_SSA_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PKCS1-v1_5 encoding scheme.
  *
@@ -365,7 +368,9 @@ bool libspdm_rsa_pkcs1_sign_with_nid(void *rsa_context, size_t hash_nid,
                           signature, (uint32_t *)sig_size,
                           (RSA *)rsa_context);
 }
+#endif /* LIBSPDM_RSA_SSA_SUPPORT */
 
+#if LIBSPDM_RSA_PSS_SUPPORT
 /**
  * Carries out the RSA-SSA signature generation with EMSA-PSS encoding scheme.
  *
@@ -487,3 +492,4 @@ bool libspdm_rsa_pss_sign(void *rsa_context, size_t hash_nid,
         return true;
     }
 }
+#endif /* LIBSPDM_RSA_PSS_SUPPORT */

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1498,6 +1498,7 @@ bool libspdm_x509_get_extended_basic_constraints(const uint8_t *cert,
     return status;
 }
 
+#if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
 /**
  * Retrieve the RSA public key from one DER-encoded X509 certificate.
  *
@@ -1572,6 +1573,7 @@ done:
 
     return res;
 }
+#endif /* (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT) */
 
 /**
  * Retrieve the EC public key from one DER-encoded X509 certificate.


### PR DESCRIPTION
With both LIBSPDM_RSA_SSA_SUPPORT and LIBSPDM_RSA_PSS_SUPPORT switched off, any file which references the cryptlib_rsa.h header file will have an undefined reference.

Fix by switching out all functions which depend on RSA support
