### PR TITLE
Fix the chunk issue.

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -397,6 +397,7 @@ libspdm_return_t libspdm_handle_large_request(
                     send_info->large_message, send_info->large_message_capacity,
                     spdm_response, response_size);
                 send_info->large_message_size = response_size;
+                break;
             }
             else {
                 status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
@@ -458,6 +459,7 @@ libspdm_return_t libspdm_handle_large_request(
                     chunk_ptr, response_size - sizeof(spdm_chunk_send_ack_response_t));
                 send_info->large_message_size =
                     (response_size - sizeof(spdm_chunk_send_ack_response_t));
+                break;
             }
         }
 


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/1237

When req trans size is 4096 and rsp trans size is 42, req fails.

The root cause is that send_info->large_message_size is override by response in chunk_send_ack. It is invalid to use send_info->chunk_bytes_transferred to check.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>