### PR TITLE
Don't erase export master secret

### DIFF
--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -23,7 +23,6 @@ typedef struct {
 typedef struct {
     uint8_t request_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
     uint8_t response_handshake_secret[LIBSPDM_MAX_HASH_SIZE];
-    uint8_t export_master_secret[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
     uint8_t response_finished_key[LIBSPDM_MAX_HASH_SIZE];
     uint8_t request_handshake_encryption_key[LIBSPDM_MAX_AEAD_KEY_SIZE];
@@ -68,6 +67,7 @@ typedef struct {
     bool responder_backup_valid;
     size_t psk_hint_size;
     uint8_t psk_hint[LIBSPDM_PSK_MAX_HINT_LENGTH];
+    uint8_t export_master_secret[LIBSPDM_MAX_HASH_SIZE];
 
     /* Cache the error in libspdm_decode_secured_message.
      * It is handled in libspdm_build_response. */

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -146,7 +146,7 @@ bool libspdm_secured_message_export_master_secret(
  * after libspdm_secured_message_export_master_secret().
  *
  * @param  spdm_secured_message_context  A pointer to the SPDM secured message context.
-  */
+ */
 void libspdm_secured_message_erase_export_master_secret(void *spdm_secured_message_context);
 
 #define LIBSPDM_SECURE_SESSION_KEYS_STRUCT_VERSION 1

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -141,6 +141,14 @@ bool libspdm_secured_message_export_master_secret(
     void *spdm_secured_message_context, void *export_master_secret,
     size_t *export_master_secret_size);
 
+/**
+ * Erase the export master secret from an SPDM secured message context. This is typically called
+ * after libspdm_secured_message_export_master_secret().
+ *
+ * @param  spdm_secured_message_context  A pointer to the SPDM secured message context.
+  */
+void libspdm_secured_message_erase_export_master_secret(void *spdm_secured_message_context);
+
 #define LIBSPDM_SECURE_SESSION_KEYS_STRUCT_VERSION 1
 
 #pragma pack(1)

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -221,7 +221,7 @@ void libspdm_secured_message_erase_export_master_secret(void *spdm_secured_messa
     secured_message_context = spdm_secured_message_context;
 
     libspdm_zero_mem(secured_message_context->export_master_secret,
-                     secured_message_context->hash_size);
+                     sizeof(secured_message_context->export_master_secret));
 }
 
 /**

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -218,6 +218,8 @@ void libspdm_secured_message_erase_export_master_secret(void *spdm_secured_messa
 
     LIBSPDM_ASSERT(spdm_secured_message_context != NULL);
 
+    secured_message_context = spdm_secured_message_context;
+
     libspdm_zero_mem(secured_message_context->export_master_secret,
                      secured_message_context->hash_size);
 }

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -206,10 +206,20 @@ bool libspdm_secured_message_export_master_secret(
         return false;
     }
     libspdm_copy_mem(export_master_secret, *export_master_secret_size,
-                     secured_message_context->handshake_secret.export_master_secret,
+                     secured_message_context->export_master_secret,
                      secured_message_context->hash_size);
     *export_master_secret_size = secured_message_context->hash_size;
     return true;
+}
+
+void libspdm_secured_message_erase_export_master_secret(void *spdm_secured_message_context)
+{
+    libspdm_secured_message_context_t *secured_message_context;
+
+    LIBSPDM_ASSERT(spdm_secured_message_context != NULL);
+
+    libspdm_zero_mem(secured_message_context->export_master_secret,
+                     secured_message_context->hash_size);
 }
 
 /**

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -519,7 +519,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             secured_message_context->psk_hint,
             secured_message_context->psk_hint_size, bin_str8,
             bin_str8_size,
-            secured_message_context->handshake_secret.export_master_secret,
+            secured_message_context->export_master_secret,
             hash_size);
 
         if (!status) {
@@ -532,7 +532,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             secured_message_context->base_hash_algo,
             secured_message_context->master_secret.master_secret,
             hash_size, bin_str8, bin_str8_size,
-            secured_message_context->handshake_secret.export_master_secret,
+            secured_message_context->export_master_secret,
             hash_size);
 
         if (!status) {
@@ -542,7 +542,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
 
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "export_master_secret (0x%x) - ", hash_size));
     libspdm_internal_dump_data(
-        secured_message_context->handshake_secret.export_master_secret, hash_size);
+        secured_message_context->export_master_secret, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
     status = libspdm_generate_aead_key_and_iv(


### PR DESCRIPTION
And allow integrator to erase it from the context. It looks like `spdm_secured_message_lib` needs its own unit testing framework to test this. I'll file a separate issue for that.

Fixes #1259.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>