### PR TITLE
Fix build break in SPDM-Responder-Validator

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -460,4 +460,96 @@ libspdm_return_t libspdm_process_opaque_data_version_selection_data(libspdm_cont
                                                                     size_t data_in_size,
                                                                     void *data_in);
 
+/**
+ * This function generates the finish signature based upon TH.
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ * @param  session_info  The session info of an SPDM session.
+ * @param  signature     The buffer to store the finish signature.
+ *
+ * @retval true  finish signature is generated.
+ * @retval false finish signature is not generated.
+ **/
+bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
+                                           libspdm_session_info_t *session_info,
+                                           uint8_t *signature);
+
+/**
+ * This function generates the finish HMAC based upon TH.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_info                  The session info of an SPDM session.
+ * @param  hmac                         The buffer to store the finish HMAC.
+ *
+ * @retval true  finish HMAC is generated.
+ * @retval false finish HMAC is not generated.
+ **/
+bool libspdm_generate_finish_req_hmac(libspdm_context_t *spdm_context,
+                                      libspdm_session_info_t *session_info,
+                                      void *hmac);
+
+/**
+ * This function verifies the finish HMAC based upon TH.
+ *
+ * @param  spdm_context    A pointer to the SPDM context.
+ * @param  session_info    The session info of an SPDM session.
+ * @param  hmac_data       The HMAC data buffer.
+ * @param  hmac_data_size  Size in bytes of the HMAC data buffer.
+ *
+ * @retval true  HMAC verification pass.
+ * @retval false HMAC verification fail.
+ **/
+bool libspdm_verify_finish_rsp_hmac(libspdm_context_t *spdm_context,
+                                    libspdm_session_info_t *session_info,
+                                    const void *hmac_data, size_t hmac_data_size);
+
+/**
+ * This function verifies the key exchange HMAC based upon TH.
+ *
+ * @param  spdm_context    A pointer to the SPDM context.
+ * @param  session_info    The session info of an SPDM session.
+ * @param  hmac_data       The HMAC data buffer.
+ * @param  hmac_data_size  Size in bytes of the HMAC data buffer.
+ *
+ * @retval true  HMAC verification pass.
+ * @retval false HMAC verification fail.
+ **/
+bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
+                                          libspdm_session_info_t *session_info,
+                                          const void *hmac_data,
+                                          size_t hmac_data_size);
+
+/**
+ * This function verifies the key exchange signature based upon TH.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_info                  The session info of an SPDM session.
+ * @param  sign_data                     The signature data buffer.
+ * @param  sign_data_size                 size in bytes of the signature data buffer.
+ *
+ * @retval true  signature verification pass.
+ * @retval false signature verification fail.
+ **/
+bool libspdm_verify_key_exchange_rsp_signature(
+    libspdm_context_t *spdm_context, libspdm_session_info_t *session_info,
+    const void *sign_data, const size_t sign_data_size);
+
+/**
+ * This function verifies the measurement signature based upon l1l2.
+ * If session_info is NULL, this function will use M cache of SPDM context,
+ * else will use M cache of SPDM session context.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_info                  A pointer to the SPDM session context.
+ * @param  sign_data                     The signature data buffer.
+ * @param  sign_data_size                 size in bytes of the signature data buffer.
+ *
+ * @retval true  signature verification pass.
+ * @retval false signature verification fail.
+ **/
+bool libspdm_verify_measurement_signature(libspdm_context_t *spdm_context,
+                                          libspdm_session_info_t *session_info,
+                                          const void *sign_data,
+                                          size_t sign_data_size);
+
 #endif /* SPDM_REQUESTER_LIB_INTERNAL_H */

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -775,4 +775,93 @@ libspdm_process_opaque_data_supported_version_data(libspdm_context_t *spdm_conte
                                                    size_t data_in_size,
                                                    const void *data_in);
 
+/**
+ * This function verifies the finish HMAC based upon TH.
+ *
+ * @param  spdm_context    A pointer to the SPDM context.
+ * @param  session_info    The session info of an SPDM session.
+ * @param  hmac_data       The HMAC data buffer.
+ * @param  hmac_data_size  Size in bytes of the HMAC data buffer.
+ *
+ * @retval true  HMAC verification pass.
+ * @retval false HMAC verification fail.
+ **/
+bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
+                                    libspdm_session_info_t *session_info,
+                                    const uint8_t *hmac, size_t hmac_size);
+
+/**
+ * This function verifies the finish signature based upon TH.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_info                  The session info of an SPDM session.
+ * @param  sign_data                     The signature data buffer.
+ * @param  sign_data_size                 size in bytes of the signature data buffer.
+ *
+ * @retval true  signature verification pass.
+ * @retval false signature verification fail.
+ **/
+bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
+                                         libspdm_session_info_t *session_info,
+                                         const void *sign_data,
+                                         const size_t sign_data_size);
+
+/**
+ * This function generates the finish HMAC based upon TH.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  session_info                  The session info of an SPDM session.
+ * @param  hmac                         The buffer to store the finish HMAC.
+ *
+ * @retval true  finish HMAC is generated.
+ * @retval false finish HMAC is not generated.
+ **/
+bool libspdm_generate_finish_rsp_hmac(libspdm_context_t *spdm_context,
+                                      libspdm_session_info_t *session_info,
+                                      uint8_t *hmac);
+
+/**
+ * This function generates the key exchange HMAC based upon TH.
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ * @param  session_info  The session info of an SPDM session.
+ * @param  hmac          The buffer to store the key exchange HMAC.
+ *
+ * @retval true  key exchange HMAC is generated.
+ * @retval false key exchange HMAC is not generated.
+ **/
+bool libspdm_generate_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
+                                            libspdm_session_info_t *session_info,
+                                            uint8_t *hmac);
+
+/**
+ * This function generates the key exchange signature based upon TH.
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ * @param  session_info  The session info of an SPDM session.
+ * @param  signature     The buffer to store the key exchange signature.
+ *
+ * @retval true  key exchange signature is generated.
+ * @retval false key exchange signature is not generated.
+ **/
+bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context,
+                                                 libspdm_session_info_t *session_info,
+                                                 uint8_t *signature);
+
+/**
+ * This function generates the measurement signature to response message based upon l1l2.
+ * If session_info is NULL, this function will use M cache of SPDM context,
+ * else will use M cache of SPDM session context.
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ * @param  session_info  A pointer to the SPDM session context.
+ * @param  signature     The buffer to store the signature.
+ *
+ * @retval true  measurement signature is generated.
+ * @retval false measurement signature is not generated.
+ **/
+bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
+                                            libspdm_session_info_t *session_info,
+                                            uint8_t *signature);
+
 #endif /* SPDM_RESPONDER_LIB_INTERNAL_H */

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -121,9 +121,9 @@ bool libspdm_verify_finish_rsp_hmac(libspdm_context_t *spdm_context,
  * @retval true  finish HMAC is generated.
  * @retval false finish HMAC is not generated.
  **/
-static bool libspdm_generate_finish_req_hmac(libspdm_context_t *spdm_context,
-                                             libspdm_session_info_t *session_info,
-                                             void *hmac)
+bool libspdm_generate_finish_req_hmac(libspdm_context_t *spdm_context,
+                                      libspdm_session_info_t *session_info,
+                                      void *hmac)
 {
     size_t hash_size;
     uint8_t calc_hmac_data[LIBSPDM_MAX_HASH_SIZE];
@@ -206,9 +206,9 @@ static bool libspdm_generate_finish_req_hmac(libspdm_context_t *spdm_context,
  * @retval true  finish signature is generated.
  * @retval false finish signature is not generated.
  **/
-static bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
-                                                  libspdm_session_info_t *session_info,
-                                                  uint8_t *signature)
+bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
+                                           libspdm_session_info_t *session_info,
+                                           uint8_t *signature)
 {
     uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     bool result;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -36,10 +36,10 @@ typedef struct {
  * @retval true  signature verification pass.
  * @retval false signature verification fail.
  **/
-static bool libspdm_verify_measurement_signature(libspdm_context_t *spdm_context,
-                                                 libspdm_session_info_t *session_info,
-                                                 const void *sign_data,
-                                                 size_t sign_data_size)
+bool libspdm_verify_measurement_signature(libspdm_context_t *spdm_context,
+                                          libspdm_session_info_t *session_info,
+                                          const void *sign_data,
+                                          size_t sign_data_size)
 {
     bool result;
     const uint8_t *cert_buffer;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -123,7 +123,7 @@ bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
  * @retval true  signature verification pass.
  * @retval false signature verification fail.
  **/
-static bool libspdm_verify_key_exchange_rsp_signature(
+bool libspdm_verify_key_exchange_rsp_signature(
     libspdm_context_t *spdm_context, libspdm_session_info_t *session_info,
     const void *sign_data, const size_t sign_data_size)
 {

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -272,9 +272,9 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
  * @retval true  finish HMAC is generated.
  * @retval false finish HMAC is not generated.
  **/
-static bool libspdm_generate_finish_rsp_hmac(libspdm_context_t *spdm_context,
-                                             libspdm_session_info_t *session_info,
-                                             uint8_t *hmac)
+bool libspdm_generate_finish_rsp_hmac(libspdm_context_t *spdm_context,
+                                      libspdm_session_info_t *session_info,
+                                      uint8_t *hmac)
 {
     uint8_t hmac_data[LIBSPDM_MAX_HASH_SIZE];
     size_t hash_size;

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -18,9 +18,9 @@
  * @retval true  key exchange HMAC is generated.
  * @retval false key exchange HMAC is not generated.
  **/
-static bool libspdm_generate_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
-                                                   libspdm_session_info_t *session_info,
-                                                   uint8_t *hmac)
+bool libspdm_generate_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
+                                            libspdm_session_info_t *session_info,
+                                            uint8_t *hmac)
 {
     uint8_t hmac_data[LIBSPDM_MAX_HASH_SIZE];
     size_t hash_size;
@@ -87,9 +87,9 @@ static bool libspdm_generate_key_exchange_rsp_hmac(libspdm_context_t *spdm_conte
  * @retval true  key exchange signature is generated.
  * @retval false key exchange signature is not generated.
  **/
-static bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context,
-                                                        libspdm_session_info_t *session_info,
-                                                        uint8_t *signature)
+bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context,
+                                                 libspdm_session_info_t *session_info,
+                                                 uint8_t *signature)
 {
     uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
     const uint8_t *cert_chain_buffer;

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -20,9 +20,9 @@
  * @retval true  measurement signature is generated.
  * @retval false measurement signature is not generated.
  **/
-static bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
-                                                   libspdm_session_info_t *session_info,
-                                                   uint8_t *signature)
+bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
+                                            libspdm_session_info_t *session_info,
+                                            uint8_t *signature)
 {
     size_t signature_size;
     bool result;


### PR DESCRIPTION
#1281 moved functions from internal common_lib to the Requester / Responder .c files and made them static. However the SPDM-Responder-Validator needs to access some of those functions and #1281 caused a build break.

This pull request moves function declarations that are needed by SPDM-Responder-Validator to the internal requester_lib and responder_lib libraries. The function definitions remain in the requester_lib and responder_lib .c files.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>