### PR TITLE
Test size

### DIFF
--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_main.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_main.c
@@ -8,6 +8,8 @@
 
 #if defined(_MSC_EXTENSIONS)
 #pragma optimize("", off)
+#elif defined (__clang__)
+#pragma clang optimize off
 #endif
 
 void spdm_dispatch(void)

--- a/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -nostdlib -Wl,-n,-q,--gc-sections -Wl,--entry,ModuleEntryPoint")
+    SET(CMAKE_EXE_LINKER_FLAGS "-nostdlib -Wl,-n,-q,--gc-sections -Wl,--entry,ModuleEntryPoint")
 elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
     SET(CMAKE_EXE_LINKER_FLAGS "/DLL /ENTRY:ModuleEntryPoint /NOLOGO /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /NODEFAULTLIB /IGNORE:4086 /MAP /OPT:REF")
 endif()

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_main.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_main.c
@@ -11,6 +11,8 @@
 
 #if defined(_MSC_EXTENSIONS)
 #pragma optimize("", off)
+#elif defined (__clang__)
+#pragma clang optimize off
 #endif
 
 void spdm_dispatch(void)


### PR DESCRIPTION
Enable AARCH64 CLANG version test_size function.

It is based upon https://github.com/DMTF/libspdm/pull/1302

Initial result below:
```
-rw-r--r-- 1 jyao1 jyao1 43848 Oct 29 21:39 bin/test_size_of_spdm_requester.elf
-rw-r--r-- 1 jyao1 jyao1 54856 Oct 29 21:41 bin/test_size_of_spdm_responder.elf
```

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>