### PR TITLE
Begin to add error injection to unit tests

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -400,7 +400,8 @@ void libspdm_register_device_io_func(
  * @param  max_msg_size  Size in bytes of the maximum size of sender buffer.
  * @param  msg_buf_ptr   A pointer to a sender buffer.
  *
- * @retval RETURN_SUCCESS               The sender buffer is acquired.
+ * @retval LIBSPDM_STATUS_SUCCESS       The sender buffer has been acquired.
+ * @retval LIBSPDM_STATUS_ACQUIRE_FAIL  Unable to acquire sender buffer.
  **/
 typedef libspdm_return_t (*libspdm_device_acquire_sender_buffer_func)(
     void *spdm_context, size_t *max_msg_size, void **msg_buf_ptr);
@@ -451,7 +452,8 @@ typedef void (*libspdm_device_release_sender_buffer_func)(void *spdm_context,
  * @param  max_msg_size  Size in bytes of the maximum size of receiver buffer.
  * @param  msg_buf_pt    A pointer to a receiver buffer.
  *
- * @retval RETURN_SUCCESS  The receiver buffer is acquired.
+ * @retval LIBSPDM_STATUS_SUCCESS       The receiver buffer has been acquired.
+ * @retval LIBSPDM_STATUS_ACQUIRE_FAIL  Unable to acquire receiver buffer.
  **/
 typedef libspdm_return_t (*libspdm_device_acquire_receiver_buffer_func)(
     void *spdm_context, size_t *max_msg_size, void **msg_buf_ptr);

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -124,6 +124,10 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_STATUS_SESSION_MSG_ERROR \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x000f)
 
+/* Unable to acquire resource. */
+#define LIBSPDM_STATUS_ACQUIRE_FAIL \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0010)
+
 /* - Cryptography Errors - */
 
 /* Generic failure originating from the cryptography module. */

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1774,7 +1774,7 @@ void libspdm_register_device_buffer_func(
     spdm_context->release_sender_buffer = release_sender_buffer;
     spdm_context->acquire_receiver_buffer = acquire_receiver_buffer;
     spdm_context->release_receiver_buffer = release_receiver_buffer;
- }
+}
 
 /**
  * Register SPDM transport layer encode/decode functions for SPDM or APP messages.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1774,8 +1774,7 @@ void libspdm_register_device_buffer_func(
     spdm_context->release_sender_buffer = release_sender_buffer;
     spdm_context->acquire_receiver_buffer = acquire_receiver_buffer;
     spdm_context->release_receiver_buffer = release_receiver_buffer;
-    return;
-}
+ }
 
 /**
  * Register SPDM transport layer encode/decode functions for SPDM or APP messages.

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -28,8 +28,6 @@ void libspdm_register_get_encap_response_func(void *context,
 
     spdm_context = context;
     spdm_context->get_encap_response_func = (size_t)get_encap_response_func;
-
-    return;
 }
 
 /**

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -731,8 +731,6 @@ void libspdm_register_get_response_func(
 
     spdm_context = context;
     spdm_context->get_response_func = (size_t)get_response_func;
-
-    return;
 }
 
 /**

--- a/unit_test/spdm_unit_test_common/common.c
+++ b/unit_test/spdm_unit_test_common/common.c
@@ -10,7 +10,6 @@ static libspdm_test_context_t *m_spdm_test_context;
 
 static bool m_send_receive_buffer_acquired = false;
 static uint8_t m_send_receive_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-static size_t m_send_receive_buffer_size;
 
 static bool m_error_acquire_sender_buffer = false;
 static bool m_error_acquire_receiver_buffer = false;
@@ -131,23 +130,23 @@ int libspdm_unit_test_group_teardown(void **state)
 void libspdm_force_error (libspdm_error_target_t target)
 {
     switch (target) {
-        case LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER:
-            m_error_acquire_sender_buffer = true;
-            break;
-        case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
-            m_error_acquire_receiver_buffer = true;
-            break;
+    case LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER:
+        m_error_acquire_sender_buffer = true;
+        break;
+    case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
+        m_error_acquire_receiver_buffer = true;
+        break;
     }
 }
 
 void libspdm_release_error (libspdm_error_target_t target)
 {
     switch (target) {
-        case LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER:
-            m_error_acquire_sender_buffer = false;
-            break;
-        case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
-            m_error_acquire_receiver_buffer = false;
-            break;
+    case LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER:
+        m_error_acquire_sender_buffer = false;
+        break;
+    case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
+        m_error_acquire_receiver_buffer = false;
+        break;
     }
 }

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -66,20 +66,21 @@ typedef struct {
 } libspdm_test_context_t;
 
 int libspdm_unit_test_group_setup(void **state);
-
 int libspdm_unit_test_group_teardown(void **state);
-
 void libspdm_setup_test_context(libspdm_test_context_t *spdm_test_context);
-
 libspdm_test_context_t *libspdm_get_test_context(void);
-
 void libspdm_dump_hex_str(const uint8_t *buffer, size_t buffer_size);
-
 void libspdm_dump_data(const uint8_t *buffer, size_t buffer_size);
-
 void libspdm_dump_hex(const uint8_t *buffer, size_t buffer_size);
+bool libspdm_read_input_file(const char *file_name, void **file_data, size_t *file_size);
 
-bool libspdm_read_input_file(const char *file_name, void **file_data,
-                             size_t *file_size);
+typedef enum
+{
+    LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER,
+    LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER
+} libspdm_error_target_t;
+
+void libspdm_force_error (libspdm_error_target_t target);
+void libspdm_release_error (libspdm_error_target_t target);
 
 #endif

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(src_test_spdm_requester
     get_csr.c
     chunk_get.c
     chunk_send.c
+    error_test/get_version_err.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -661,19 +661,17 @@ static void libspdm_test_requester_get_version_err_case8(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
 }
 
+/*
+ * static void libspdm_test_requester_get_version_err_case9(void **state)
+ * {
+ * }
+ */
 
 /*
-void libspdm_test_requester_get_version_err_case9(void **state)
-{
-}
-*/
-
-
-/*
-void libspdm_test_requester_get_version_err_case10(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_err_case10(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 11: receiving a correct VERSION message with available version 1.0 and 1.1, but
@@ -771,16 +769,16 @@ static void libspdm_test_requester_get_version_err_case14(void **state) {
 }
 
 /*
-void libspdm_test_requester_get_version_err_case15(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_err_case15(void **state)
+ * {
+ * }
+ */
 
 /*
-void libspdm_test_requester_get_version_err_case16(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_err_case16(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 17: when no VERSION message is received, and the client returns a device error.

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -512,7 +512,7 @@ static libspdm_return_t receive_message(
  * Test 1: when no VERSION message is received, and the client returns a device error.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SEND_FAIL.
  **/
-static void libspdm_test_requester_get_version_case1(void **state)
+static void libspdm_test_requester_get_version_err_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -530,7 +530,7 @@ static void libspdm_test_requester_get_version_case1(void **state)
  * Test 2: Requester is unable to acquire the sender buffer.
  * Expected behavior: returns with status LIBSPDM_STATUS_ACQUIRE_FAIL.
  **/
-static void libspdm_test_requester_get_version_case2(void **state)
+static void libspdm_test_requester_get_version_err_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -551,7 +551,7 @@ static void libspdm_test_requester_get_version_case2(void **state)
  * Test 3: receiving a correct VERSION message header, but with 0 versions available.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_version_case3(void **state)
+static void libspdm_test_requester_get_version_err_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -569,7 +569,7 @@ static void libspdm_test_requester_get_version_case3(void **state)
  * Test 4: receiving an InvalidRequest ERROR message from the responder.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
-static void libspdm_test_requester_get_version_case4(void **state)
+static void libspdm_test_requester_get_version_err_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -587,7 +587,7 @@ static void libspdm_test_requester_get_version_case4(void **state)
  * Test 5: receiving a Busy ERROR message correct VERSION message from the responder.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_BUSY_PEER.
  **/
-static void libspdm_test_requester_get_version_case5(void **state)
+static void libspdm_test_requester_get_version_err_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -605,7 +605,7 @@ static void libspdm_test_requester_get_version_case5(void **state)
  * Test 6: Requester is unable to acquire the receiver buffer.
  * Expected behavior: returns with status LIBSPDM_STATUS_ACQUIRE_FAIL.
  **/
-static void libspdm_test_requester_get_version_case6(void **state)
+static void libspdm_test_requester_get_version_err_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -627,7 +627,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
  * Expected behavior: client returns a status of LIBSPDM_STATUS_RESYNCH_PEER, and the
  * internal state should be reset.
  **/
-static void libspdm_test_requester_get_version_case7(void **state)
+static void libspdm_test_requester_get_version_err_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -647,7 +647,7 @@ static void libspdm_test_requester_get_version_case7(void **state)
  * Test 8: receiving a ResponseNotReady ERROR message from the responder.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
-static void libspdm_test_requester_get_version_case8(void **state)
+static void libspdm_test_requester_get_version_err_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -661,20 +661,26 @@ static void libspdm_test_requester_get_version_case8(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
 }
 
-static void libspdm_test_requester_get_version_case9(void **state)
-{
-}
 
-static void libspdm_test_requester_get_version_case10(void **state)
+/*
+void libspdm_test_requester_get_version_err_case9(void **state)
 {
 }
+*/
+
+
+/*
+void libspdm_test_requester_get_version_err_case10(void **state)
+{
+}
+*/
 
 /**
  * Test 11: receiving a correct VERSION message with available version 1.0 and 1.1, but
  * the requester do not have compatible versions with the responder.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_NEGOTIATION_FAIL.
  **/
-static void libspdm_test_requester_get_version_case11(void **state)
+static void libspdm_test_requester_get_version_err_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -693,7 +699,7 @@ static void libspdm_test_requester_get_version_case11(void **state)
  * 1.0-version format, with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_version_case12(void **state)
+static void libspdm_test_requester_get_version_err_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -713,7 +719,7 @@ static void libspdm_test_requester_get_version_case12(void **state)
  * VERSION message, with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_version_case13(void **state)
+static void libspdm_test_requester_get_version_err_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -735,7 +741,7 @@ static void libspdm_test_requester_get_version_case13(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
-static void libspdm_test_requester_get_version_case14(void **state) {
+static void libspdm_test_requester_get_version_err_case14(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -764,19 +770,23 @@ static void libspdm_test_requester_get_version_case14(void **state) {
     }
 }
 
-static void libspdm_test_requester_get_version_case15(void **state)
+/*
+void libspdm_test_requester_get_version_err_case15(void **state)
 {
 }
+*/
 
-static void libspdm_test_requester_get_version_case16(void **state)
+/*
+void libspdm_test_requester_get_version_err_case16(void **state)
 {
 }
+*/
 
 /**
  * Test 17: when no VERSION message is received, and the client returns a device error.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_version_case17(void **state)
+static void libspdm_test_requester_get_version_err_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -794,7 +804,7 @@ static void libspdm_test_requester_get_version_case17(void **state)
  * Test 18: when no VERSION message is received, and the client returns a device error.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_version_case18(void **state)
+static void libspdm_test_requester_get_version_err_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -818,24 +828,24 @@ static libspdm_test_context_t m_libspdm_requester_get_version_test_context = {
 int libspdm_requester_get_version_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_version_tests[] = {
-        cmocka_unit_test(libspdm_test_requester_get_version_case1),
-        cmocka_unit_test(libspdm_test_requester_get_version_case2),
-        cmocka_unit_test(libspdm_test_requester_get_version_case3),
-        cmocka_unit_test(libspdm_test_requester_get_version_case4),
-        cmocka_unit_test(libspdm_test_requester_get_version_case5),
-        cmocka_unit_test(libspdm_test_requester_get_version_case6),
-        cmocka_unit_test(libspdm_test_requester_get_version_case7),
-        cmocka_unit_test(libspdm_test_requester_get_version_case8),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case9), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case10), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case11),
-        cmocka_unit_test(libspdm_test_requester_get_version_case12),
-        cmocka_unit_test(libspdm_test_requester_get_version_case13),
-        cmocka_unit_test(libspdm_test_requester_get_version_case14),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case15), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case16), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case17),
-        cmocka_unit_test(libspdm_test_requester_get_version_case18),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case1),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case2),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case3),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case4),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case5),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case6),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case7),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case8),
+        /* cmocka_unit_test(libspdm_test_requester_get_version_err_case9),
+         * cmocka_unit_test(libspdm_test_requester_get_version_err_case10), */
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case11),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case12),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case13),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case14),
+        /* cmocka_unit_test(libspdm_test_requester_get_version_err_case15),
+         * cmocka_unit_test(libspdm_test_requester_get_version_err_case16), */
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case17),
+        cmocka_unit_test(libspdm_test_requester_get_version_err_case18),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_get_version_test_context);

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -563,30 +563,30 @@ static void libspdm_test_requester_get_version_case2(void **state)
  **/
 
 /*
-static void libspdm_test_requester_get_version_case3(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case3(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 4: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case4(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case4(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 5: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case5(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case5(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 6: on the first try, receiving a Busy ERROR message, and on retry, receiving
@@ -612,30 +612,30 @@ static void libspdm_test_requester_get_version_case6(void **state)
  **/
 
 /*
-static void libspdm_test_requester_get_version_case7(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case7(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 8: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case8(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case8(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 9: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case9(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case9(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 10: receiving a VERSION message with a larger list of available versions than indicated.
@@ -663,40 +663,40 @@ static void libspdm_test_requester_get_version_case10(void **state)
  **/
 
 /*
-static void libspdm_test_requester_get_version_case11(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case11(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 12: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case12(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case12(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 13: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case13(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case13(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 14: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case14(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case14(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 15: receiving a VERSION message with unordered vesion list.
@@ -772,20 +772,20 @@ static void libspdm_test_requester_get_version_case16(void **state)
  **/
 
 /*
-static void libspdm_test_requester_get_version_case17(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case17(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 18: Can be populated with new test.
  **/
 
 /*
-static void libspdm_test_requester_get_version_case18(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case18(void **state)
+ * {
+ * }
+ */
 
 libspdm_test_context_t m_libspdm_requester_get_version_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -535,10 +535,10 @@ static libspdm_return_t libspdm_requester_get_version_test_receive_message(
  **/
 
 /*
-static void libspdm_test_requester_get_version_case1(void **state)
-{
-}
-*/
+ * static void libspdm_test_requester_get_version_case1(void **state)
+ * {
+ * }
+ */
 
 /**
  * Test 2: receiving a correct VERSION message with available version 1.0 and 1.1.

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -19,7 +19,7 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_SMALL_BUFFER_SIZE];
 
-libspdm_return_t libspdm_requester_get_version_test_send_message(
+static libspdm_return_t libspdm_requester_get_version_test_send_message(
     void *spdm_context, size_t request_size, const void *request,
     uint64_t timeout)
 {
@@ -75,7 +75,7 @@ libspdm_return_t libspdm_requester_get_version_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_get_version_test_receive_message(
+static libspdm_return_t libspdm_requester_get_version_test_receive_message(
     void *spdm_context, size_t *response_size,
     void **response, uint64_t timeout)
 {
@@ -533,15 +533,18 @@ libspdm_return_t libspdm_requester_get_version_test_receive_message(
 /**
  * Test 1: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case1(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case1(void **state)
 {
 }
+*/
 
 /**
  * Test 2: receiving a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
-void libspdm_test_requester_get_version_case2(void **state)
+static void libspdm_test_requester_get_version_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -558,30 +561,39 @@ void libspdm_test_requester_get_version_case2(void **state)
 /**
  * Test 3: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case3(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case3(void **state)
 {
 }
+*/
 
 /**
  * Test 4: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case4(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case4(void **state)
 {
 }
+*/
 
 /**
  * Test 5: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case5(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case5(void **state)
 {
 }
+*/
 
 /**
  * Test 6: on the first try, receiving a Busy ERROR message, and on retry, receiving
  * a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
-void libspdm_test_requester_get_version_case6(void **state)
+static void libspdm_test_requester_get_version_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -598,23 +610,32 @@ void libspdm_test_requester_get_version_case6(void **state)
 /**
  * Test 7: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case7(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case7(void **state)
 {
 }
+*/
 
 /**
  * Test 8: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case8(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case8(void **state)
 {
 }
+*/
 
 /**
  * Test 9: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case9(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case9(void **state)
 {
 }
+*/
 
 /**
  * Test 10: receiving a VERSION message with a larger list of available versions than indicated.
@@ -623,7 +644,7 @@ void libspdm_test_requester_get_version_case9(void **state)
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS, but truncate the message
  * to consider only the two first versions, as indicated in the message.
  **/
-void libspdm_test_requester_get_version_case10(void **state)
+static void libspdm_test_requester_get_version_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -640,29 +661,42 @@ void libspdm_test_requester_get_version_case10(void **state)
 /**
  * Test 11: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case11(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case11(void **state)
 {
 }
+*/
 
 /**
  * Test 12: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case12(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case12(void **state)
 {
 }
+*/
 
 /**
  * Test 13: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case13(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case13(void **state)
 {
 }
+*/
 
 /**
  * Test 14: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case14(void **state) {
+
+/*
+static void libspdm_test_requester_get_version_case14(void **state)
+{
 }
+*/
 
 /**
  * Test 15: receiving a VERSION message with unordered vesion list.
@@ -670,7 +704,7 @@ void libspdm_test_requester_get_version_case14(void **state) {
  * Responder list:4.2, 5.2, 1.2, 1.1, 1.0
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and right negotiated version 1.1.
  **/
-void libspdm_test_requester_get_version_case15(void **state)
+static void libspdm_test_requester_get_version_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -698,7 +732,7 @@ void libspdm_test_requester_get_version_case15(void **state)
  * should be first reset, and then buffer A receives only the exchanged GET_VERSION
  * and VERSION messages.
  **/
-void libspdm_test_requester_get_version_case16(void **state)
+static void libspdm_test_requester_get_version_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -736,16 +770,22 @@ void libspdm_test_requester_get_version_case16(void **state)
 /**
  * Test 17: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case17(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case17(void **state)
 {
 }
+*/
 
 /**
  * Test 18: Can be populated with new test.
  **/
-void libspdm_test_requester_get_version_case18(void **state)
+
+/*
+static void libspdm_test_requester_get_version_case18(void **state)
 {
 }
+*/
 
 libspdm_test_context_t m_libspdm_requester_get_version_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
@@ -759,22 +799,22 @@ int libspdm_requester_get_version_test_main(void)
     const struct CMUnitTest spdm_requester_get_version_tests[] = {
         /* cmocka_unit_test(libspdm_test_requester_get_version_case1), */
         cmocka_unit_test(libspdm_test_requester_get_version_case2),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case3), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case4), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case5), */
+        /* cmocka_unit_test(libspdm_test_requester_get_version_case3),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case4),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case5), */
         cmocka_unit_test(libspdm_test_requester_get_version_case6),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case7), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case8), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case9), */
+        /* cmocka_unit_test(libspdm_test_requester_get_version_case7),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case8),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case9), */
         cmocka_unit_test(libspdm_test_requester_get_version_case10),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case11), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case12), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case13), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case14), */
+        /* cmocka_unit_test(libspdm_test_requester_get_version_case11),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case12),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case13),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case14), */
         cmocka_unit_test(libspdm_test_requester_get_version_case15),
         cmocka_unit_test(libspdm_test_requester_get_version_case16),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case17), */
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case18), */
+        /* cmocka_unit_test(libspdm_test_requester_get_version_case17),
+         * cmocka_unit_test(libspdm_test_requester_get_version_case18), */
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_get_version_test_context);

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -8,6 +8,7 @@
 #include "internal/libspdm_requester_lib.h"
 
 int libspdm_requester_get_version_test_main(void);
+int libspdm_requester_get_version_error_test_main(void);
 int libspdm_requester_get_capabilities_test_main(void);
 int libspdm_requester_negotiate_algorithms_test_main(void);
 
@@ -58,6 +59,9 @@ int main(void)
 {
     int return_value = 0;
     if (libspdm_requester_get_version_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_get_version_error_test_main() != 0) {
         return_value = 1;
     }
 


### PR DESCRIPTION
This pull request adds the new `libspdm_force_error` and `libspdm_release_error` functions through which unit tests can manipulate errors to improve code coverage. It also begins to split the error / negative tests from the functional / positive tests.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>