### PR TITLE
Add LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP check for FINISH

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -458,6 +458,7 @@ libspdm_return_t libspdm_process_opaque_data_version_selection_data(libspdm_cont
                                                                     size_t data_in_size,
                                                                     void *data_in);
 
+#if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 /**
  * This function generates the finish signature based upon TH.
  *
@@ -471,6 +472,7 @@ libspdm_return_t libspdm_process_opaque_data_version_selection_data(libspdm_cont
 bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
                                            libspdm_session_info_t *session_info,
                                            uint8_t *signature);
+#endif
 
 /**
  * This function generates the finish HMAC based upon TH.

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -791,6 +791,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
                                     libspdm_session_info_t *session_info,
                                     const uint8_t *hmac, size_t hmac_size);
 
+#if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 /**
  * This function verifies the finish signature based upon TH.
  *
@@ -806,6 +807,7 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
                                          libspdm_session_info_t *session_info,
                                          const void *sign_data,
                                          const size_t sign_data_size);
+#endif
 
 /**
  * This function generates the finish HMAC based upon TH.

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -485,6 +485,12 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
     }
     *req_slot_id_param = spdm_response->req_slot_id_param;
     if (spdm_response->mut_auth_requested != 0) {
+        if (!libspdm_is_capabilities_flag_supported(
+                spdm_context, true,
+                SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP,
+                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP)) {
+            return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        }
         if ((spdm_response->mut_auth_requested != SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED) &&
             (spdm_response->mut_auth_requested !=
              SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST) &&

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -99,6 +99,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
     return true;
 }
 
+#if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 /**
  * This function verifies the finish signature based upon TH.
  *
@@ -261,6 +262,7 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
 
     return true;
 }
+#endif
 
 /**
  * This function generates the finish HMAC based upon TH.
@@ -459,13 +461,14 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
 
     hmac_size = libspdm_get_hash_size(
         spdm_context->connection_info.algorithm.base_hash_algo);
+    signature_size = 0;
+#if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     if (session_info->mut_auth_requested) {
         signature_size = libspdm_get_req_asym_signature_size(
             spdm_context->connection_info.algorithm
             .req_base_asym_alg);
-    } else {
-        signature_size = 0;
     }
+#endif
 
     if (request_size !=
         sizeof(spdm_finish_request_t) + signature_size + hmac_size) {
@@ -500,6 +503,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,
                                                response_size, response);
     }
+#if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     if (session_info->mut_auth_requested) {
         result = libspdm_verify_finish_req_signature(
             spdm_context, session_info,
@@ -530,6 +534,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
                 0, response_size, response);
         }
     }
+#endif
 
     result = libspdm_verify_finish_req_hmac(
         spdm_context, session_info,


### PR DESCRIPTION
That can save ~5K space for the device, to remove X.509 process.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>

Size before: (X64, VS2019, release, mbedtls, 
cap: disable CHAL_CAP/PSK_EX_CAP/GET_CSR_CAP/SET_CERTIFICATE_CAP/CHUNK_CAP/MUT_AUTH_CAP/ENCAP_CAP,
algo: only enable SHA384/ECDSA/ECDH/AES-GCM

```
10/30/2022  10:44 AM            94,208 test_size_of_spdm_requester.exe
10/30/2022  10:44 AM            65,536 test_size_of_spdm_responder.exe
```

After fix mut_auth

```
10/30/2022  11:23 AM            94,208 test_size_of_spdm_requester.exe
10/30/2022  11:23 AM            59,392 test_size_of_spdm_responder.exe
```
