### PR TITLE
Move the LIBSPDM_CONFIG logic

### DIFF
--- a/include/hal/library/cryptlib.h
+++ b/include/hal/library/cryptlib.h
@@ -14,11 +14,7 @@
 #ifndef CRYPTLIB_H
 #define CRYPTLIB_H
 
-#ifndef LIBSPDM_CONFIG
-#include "library/spdm_lib_config.h"
-#else
-#include LIBSPDM_CONFIG
-#endif
+#include "internal/libspdm_lib_config.h"
 
 #define LIBSPDM_CRYPTO_NID_NULL 0x0000
 

--- a/include/internal/libspdm_lib_config.h
+++ b/include/internal/libspdm_lib_config.h
@@ -1,0 +1,16 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#ifndef LIBSPDM_LIB_CONFIG_H
+#define LIBSPDM_LIB_CONFIG_H
+
+#ifndef LIBSPDM_CONFIG
+#include "library/spdm_lib_config.h"
+#else
+#include LIBSPDM_CONFIG
+#endif
+
+#endif /* LIBSPDM_LIB_CONFIG_H */

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -7,11 +7,7 @@
 #ifndef SPDM_COMMON_LIB_H
 #define SPDM_COMMON_LIB_H
 
-#ifndef LIBSPDM_CONFIG
-#include "library/spdm_lib_config.h"
-#else
-#include LIBSPDM_CONFIG
-#endif
+#include "internal/libspdm_lib_config.h"
 
 #if defined(LIBSPDM_ENABLE_SET_CERTIFICATE_CAP) && \
     !defined(LIBSPDM_ENABLE_CAPABILITY_SET_CERTIFICATE_CAP)

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -7,11 +7,7 @@
 #ifndef SPDM_CRYPT_LIB_H
 #define SPDM_CRYPT_LIB_H
 
-#ifndef LIBSPDM_CONFIG
-#include "library/spdm_lib_config.h"
-#else
-#include LIBSPDM_CONFIG
-#endif
+#include "internal/libspdm_lib_config.h"
 
 #include "hal/base.h"
 #include "industry_standard/spdm.h"

--- a/include/library/spdm_device_secret_lib.h
+++ b/include/library/spdm_device_secret_lib.h
@@ -7,11 +7,7 @@
 #ifndef SPDM_DEVICE_SECRET_LIB_H
 #define SPDM_DEVICE_SECRET_LIB_H
 
-#ifndef LIBSPDM_CONFIG
-#include "library/spdm_lib_config.h"
-#else
-#include LIBSPDM_CONFIG
-#endif
+#include "internal/libspdm_lib_config.h"
 
 #include "hal/base.h"
 #include "industry_standard/spdm.h"


### PR DESCRIPTION
Move the `LIBSPDM_CONFIG` logic to a common internal header. This has the benefit that if `LIBSPDM_CONFIG` is defined then it's always within #include guards.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>