### PR TITLE
Make unwanted HEARTBEAT request an error

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -244,6 +244,7 @@ typedef struct {
     uint8_t mut_auth_requested;
     uint8_t end_session_attributes;
     uint8_t session_policy;
+    uint8_t heartbeat_period;
     libspdm_session_transcript_t session_transcript;
     /* Register for the last KEY_UPDATE token and operation (responder only)*/
     spdm_key_update_request_t last_key_update_request;

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -55,6 +55,9 @@ static libspdm_return_t libspdm_try_heartbeat(void *context, uint32_t session_id
     if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
         return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
     }
+    if (session_info->heartbeat_period == 0) {
+        return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+    }
 
     /* -=[Construct Request Phase]=- */
     transport_header_size = spdm_context->transport_get_header_size(spdm_context);

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -706,6 +706,7 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
         libspdm_copy_mem(measurement_hash, measurement_summary_hash_size,
                          measurement_summary_hash, measurement_summary_hash_size);
     }
+    session_info->heartbeat_period = spdm_response->header.param1;
     session_info->mut_auth_requested = spdm_response->mut_auth_requested;
     session_info->session_policy = session_policy;
 

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -500,6 +500,8 @@ static libspdm_return_t libspdm_try_send_receive_psk_exchange(
             LIBSPDM_SESSION_STATE_ESTABLISHED);
     }
 
+    session_info->heartbeat_period = spdm_response->header.param1;
+
     status = LIBSPDM_STATUS_SUCCESS;
 
 receive_done:

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -419,8 +419,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
         /* No handshake in clear, then it must be in a session.*/
         if (!spdm_context->last_spdm_request_session_id_valid) {
             return libspdm_generate_error_response(
-                context, SPDM_ERROR_CODE_SESSION_REQUIRED, 0,
-                response_size, response);
+                context, SPDM_ERROR_CODE_SESSION_REQUIRED, 0, response_size, response);
         }
     } else {
         /* handshake in clear, then it must not be in a session.*/
@@ -435,8 +434,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
     } else {
         session_id = spdm_context->latest_session_id;
     }
-    session_info =
-        libspdm_get_session_info_via_session_id(spdm_context, session_id);
+    session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
     if (session_info == NULL) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_SESSION_REQUIRED, 0,
@@ -459,14 +457,12 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
                                                response_size, response);
     }
 
-    hmac_size = libspdm_get_hash_size(
-        spdm_context->connection_info.algorithm.base_hash_algo);
+    hmac_size = libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
     signature_size = 0;
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     if (session_info->mut_auth_requested) {
         signature_size = libspdm_get_req_asym_signature_size(
-            spdm_context->connection_info.algorithm
-            .req_base_asym_alg);
+            spdm_context->connection_info.algorithm.req_base_asym_alg);
     }
 #endif
 
@@ -507,8 +503,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
     if (session_info->mut_auth_requested) {
         result = libspdm_verify_finish_req_signature(
             spdm_context, session_info,
-            (const uint8_t *)request + sizeof(spdm_finish_request_t),
-            signature_size);
+            (const uint8_t *)request + sizeof(spdm_finish_request_t), signature_size);
         if (!result) {
             if((spdm_context->handle_error_return_policy &
                 LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY_DROP_ON_DECRYPT_ERROR) == 0) {
@@ -537,10 +532,8 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
 #endif
 
     result = libspdm_verify_finish_req_hmac(
-        spdm_context, session_info,
-        (const uint8_t *)request + signature_size +
-        sizeof(spdm_finish_request_t),
-        hmac_size);
+        spdm_context, session_info, (const uint8_t *)request + signature_size +
+        sizeof(spdm_finish_request_t), hmac_size);
     if (!result) {
         if((spdm_context->handle_error_return_policy &
             LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY_DROP_ON_DECRYPT_ERROR) == 0) {
@@ -618,8 +611,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
     }
 
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "libspdm_generate_session_data_key[%x]\n", session_id));
-    result = libspdm_calculate_th2_hash(spdm_context, session_info, false,
-                                        th2_hash_data);
+    result = libspdm_calculate_th2_hash(spdm_context, session_info, false, th2_hash_data);
     if (!result) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,
@@ -633,8 +625,7 @@ libspdm_return_t libspdm_get_response_finish(void *context, size_t request_size,
                                                response_size, response);
     }
 
-    result = libspdm_start_watchdog(session_id,
-                                    spdm_context->local_context.heartbeat_period * 2);
+    result = libspdm_start_watchdog(session_id, spdm_context->local_context.heartbeat_period * 2);
     if (!result) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -57,8 +57,7 @@ libspdm_return_t libspdm_get_response_heartbeat(void *context,
                                                SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
                                                0, response_size, response);
     }
-    if (spdm_context->connection_info.connection_state <
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+    if (spdm_context->connection_info.connection_state < LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
                                                0, response_size, response);
@@ -87,6 +86,12 @@ libspdm_return_t libspdm_get_response_heartbeat(void *context,
     if (request_size != sizeof(spdm_heartbeat_request_t)) {
         return libspdm_generate_error_response(context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    if (session_info->heartbeat_period == 0) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                                                response_size, response);
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -358,6 +358,8 @@ libspdm_return_t libspdm_get_response_key_exchange(void *context,
             response_size, response);
     }
 
+    session_info->heartbeat_period = spdm_context->local_context.heartbeat_period;
+
     spdm_response->rsp_session_id = rsp_session_id;
 
     spdm_response->mut_auth_requested = 0;

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -402,8 +402,7 @@ libspdm_return_t libspdm_get_response_psk_exchange(void *context,
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
         session_info->session_policy = spdm_request->header.param2;
     }
-    libspdm_set_session_state(spdm_context, session_id,
-                              LIBSPDM_SESSION_STATE_HANDSHAKING);
+    libspdm_set_session_state(spdm_context, session_id, LIBSPDM_SESSION_STATE_HANDSHAKING);
 
     if (!libspdm_is_capabilities_flag_supported(
             spdm_context, false, 0,
@@ -427,9 +426,10 @@ libspdm_return_t libspdm_get_response_psk_exchange(void *context,
                 0, response_size, response);
         }
 
-        libspdm_set_session_state(spdm_context, session_id,
-                                  LIBSPDM_SESSION_STATE_ESTABLISHED);
+        libspdm_set_session_state(spdm_context, session_id, LIBSPDM_SESSION_STATE_ESTABLISHED);
     }
+
+    session_info->heartbeat_period = spdm_context->local_context.heartbeat_period;
 
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -737,6 +737,7 @@ void libspdm_test_requester_heartbeat_case1(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
 
     status = libspdm_heartbeat(spdm_context, session_id);
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
@@ -806,6 +807,7 @@ void libspdm_test_requester_heartbeat_case2(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -990,6 +992,7 @@ void libspdm_test_requester_heartbeat_case4(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1082,6 +1085,7 @@ void libspdm_test_requester_heartbeat_case5(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1174,6 +1178,7 @@ void libspdm_test_requester_heartbeat_case6(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1266,6 +1271,7 @@ void libspdm_test_requester_heartbeat_case7(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1360,6 +1366,7 @@ void libspdm_test_requester_heartbeat_case8(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1452,6 +1459,7 @@ void libspdm_test_requester_heartbeat_case9(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1537,6 +1545,7 @@ void libspdm_test_requester_heartbeat_case10(void **state) {
         libspdm_session_info_init (spdm_context, session_info, session_id, true);
         libspdm_secured_message_set_session_state (session_info->secured_message_context,
                                                    LIBSPDM_SESSION_STATE_ESTABLISHED);
+        session_info->heartbeat_period = 1;
         libspdm_set_mem (m_libspdm_dummy_key_buffer,
                          ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->aead_key_size,
                          (uint8_t)(0xFF));
@@ -1640,6 +1649,7 @@ void libspdm_test_requester_heartbeat_case11(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1755,6 +1765,7 @@ void libspdm_test_requester_heartbeat_case12(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
     libspdm_set_mem(m_libspdm_dummy_key_buffer,
                     ((libspdm_secured_message_context_t
                       *)(session_info->secured_message_context))
@@ -1783,6 +1794,85 @@ void libspdm_test_requester_heartbeat_case12(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SESSION_MSG_ERROR);
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
 
+    free(data);
+}
+
+void libspdm_test_requester_heartbeat_case13(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+    libspdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+    libspdm_set_mem(m_libspdm_dummy_key_buffer,
+                    ((libspdm_secured_message_context_t
+                      *)(session_info->secured_message_context))
+                    ->aead_key_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_data_encryption_key(
+        session_info->secured_message_context, m_libspdm_dummy_key_buffer,
+        ((libspdm_secured_message_context_t
+          *)(session_info->secured_message_context))->aead_key_size);
+    libspdm_set_mem(m_libspdm_dummy_salt_buffer,
+                    ((libspdm_secured_message_context_t
+                      *)(session_info->secured_message_context))
+                    ->aead_iv_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_data_salt(
+        session_info->secured_message_context, m_libspdm_dummy_salt_buffer,
+        ((libspdm_secured_message_context_t
+          *)(session_info->secured_message_context))->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info
+                                           ->secured_message_context))
+    ->application_secret.response_data_sequence_number = 0;
+
+    session_info->heartbeat_period = 0;
+
+    status = libspdm_heartbeat(spdm_context, session_id);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
     free(data);
 }
 
@@ -1820,6 +1910,7 @@ int libspdm_requester_heartbeat_test_main(void)
         cmocka_unit_test(libspdm_test_requester_heartbeat_case11),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
         cmocka_unit_test(libspdm_test_requester_heartbeat_case12),
+        cmocka_unit_test(libspdm_test_requester_heartbeat_case13),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_heartbeat_test_context);

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -40,41 +40,30 @@ void libspdm_test_responder_heartbeat_case1(void **state)
     spdm_test_context->case_id = 0x1;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->connection_info.capability.flags |=
-        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.measurement_spec =
-        m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
     spdm_context->connection_info.algorithm.measurement_hash_algo =
         m_libspdm_use_measurement_hash_algo;
-    spdm_context->connection_info.algorithm.dhe_named_group =
-        m_libspdm_use_dhe_algo;
-    spdm_context->connection_info.algorithm.aead_cipher_suite =
-        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
     libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
                                                     m_libspdm_use_asym_algo, &data1,
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
     spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
     libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
     libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
                      LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
-    spdm_context->local_context.psk_hint_size =
-        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
     spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
 
     session_id = 0xFFFFFFFF;
@@ -86,6 +75,7 @@ void libspdm_test_responder_heartbeat_case1(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
 
     response_size = sizeof(response);
     status = libspdm_get_response_heartbeat(spdm_context,
@@ -95,8 +85,7 @@ void libspdm_test_responder_heartbeat_case1(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_heartbeat_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_HEARTBEAT_ACK);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_HEARTBEAT_ACK);
     free(data1);
 }
 
@@ -584,6 +573,7 @@ void libspdm_test_responder_heartbeat_case7(void **state)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
 
     response_size = sizeof(response);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -605,8 +595,7 @@ void libspdm_test_responder_heartbeat_case7(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(response_size, sizeof(spdm_heartbeat_response_t));
     spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_HEARTBEAT_ACK);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_HEARTBEAT_ACK);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -616,6 +605,82 @@ void libspdm_test_responder_heartbeat_case7(void **state)
 #endif
 
     free(data1);
+}
+/**
+ * Test 2: Responder has set HeartbeatPeriod to a value of 0 but Requester sends
+ *         HEARTBEAT request anyways.
+ * Expected behavior: Responder returns UnexpectedRequest ERROR message.
+ **/
+void libspdm_test_responder_heartbeat_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    spdm_heartbeat_response_t *spdm_response;
+    //void *data1;
+    //size_t data_size1;
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    #if 0
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+    #endif
+
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 0;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_heartbeat(spdm_context,
+                                            m_libspdm_heartbeat_request1_size,
+                                            &m_libspdm_heartbeat_request1,
+                                            &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    //free(data1);
 }
 
 libspdm_test_context_t m_libspdm_responder_heartbeat_test_context = {
@@ -640,6 +705,7 @@ int libspdm_responder_heartbeat_test_main(void)
         cmocka_unit_test(libspdm_test_responder_heartbeat_case6),
         /* Buffer reset*/
         cmocka_unit_test(libspdm_test_responder_heartbeat_case7),
+        cmocka_unit_test(libspdm_test_responder_heartbeat_case8),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_heartbeat_test_context);

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -619,8 +619,6 @@ void libspdm_test_responder_heartbeat_case8(void **state)
     size_t response_size;
     uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     spdm_heartbeat_response_t *spdm_response;
-    //void *data1;
-    //size_t data_size1;
     libspdm_session_info_t *session_info;
     uint32_t session_id;
 
@@ -639,15 +637,6 @@ void libspdm_test_responder_heartbeat_case8(void **state)
         m_libspdm_use_measurement_hash_algo;
     spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
     spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
-    #if 0
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo, &data1,
-                                                    &data_size1, NULL, NULL);
-    spdm_context->local_context.local_cert_chain_provision[0] = data1;
-    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
-    #endif
 
     libspdm_reset_message_a(spdm_context);
     spdm_context->local_context.mut_auth_requested = 0;
@@ -679,8 +668,6 @@ void libspdm_test_responder_heartbeat_case8(void **state)
     assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
     assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
     assert_int_equal(spdm_response->header.param2, 0);
-
-    //free(data1);
 }
 
 libspdm_test_context_t m_libspdm_responder_heartbeat_test_context = {


### PR DESCRIPTION
Fixes #549.
Fixes #1333.

This also saves the `HeartbeatPeriod` value to the `session_info` rather than the SPDM context.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>