### PR TITLE
Work around build failure when GCOV is on

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -23,9 +23,9 @@ jobs:
           mkdir build
           cd build
           cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=mbedtls -DGCOV=ON ..
-          make copy_sample_key
-          make copy_seed
-          make -j`nproc`
+          make copy_sample_key copy_seed lib cmockalib cryptlib_mbedtls debuglib intrinsiclib malloclib mbedcrypto mbedtls mbedx509 memlib platform_lib
+            rnglib spdm_common_lib spdm_crypt_ext_lib spdm_crypt_lib spdm_device_secret_lib_sample spdm_requester_lib spdm_responder_lib
+            spdm_secured_message_lib spdm_transport_mctp_lib spdm_transport_pcidoe_lib test_spdm_common test_spdm_crypt test_spdm_responder test_spdm_requester -j`nproc`
       - name: Test Requester
         run: |
           cd build/bin


### PR DESCRIPTION
Currently the `make all` build fails when GCOV is on. This works around it by only building the targets that are needed for code coverage. When #1334 is fixed this can go back to `make all`.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>