### PR TITLE
Code coverage 2

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -100,7 +100,7 @@ static bool validate_responder_capability(uint32_t capabilities_flag, uint8_t ve
                 return false;
             }
         } else {
-            /* If certificates or public keys are  not enabled then these capabilities
+            /* If certificates or public keys are not enabled then these capabilities
              * cannot be enabled. */
             if ((chal_cap == 1) || (key_ex_cap == 1) || (meas_cap == 2) || (mut_auth_cap == 1)) {
                 return false;
@@ -117,7 +117,7 @@ static bool validate_responder_capability(uint32_t capabilities_flag, uint8_t ve
 
     /* Checks specific to 1.2. */
     if (version == SPDM_MESSAGE_VERSION_12) {
-        if ((cert_cap == 0) && (alias_cert_cap == 1)) {
+        if ((cert_cap == 0) && ((alias_cert_cap == 1) || (set_cert_cap == 1))) {
             return false;
         }
         if ((csr_cap == 1) && (set_cert_cap == 0)) {

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -89,7 +89,6 @@ static bool validate_responder_capability(uint32_t capabilities_flag, uint8_t ve
             }
         }
 
-
         /* Checks that originate from certificate or public key capabilities. */
         if ((cert_cap == 1) || (pub_key_id_cap == 1)) {
             /* Certificate capabilities and public key capabilities cannot both be set. */

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(src_test_spdm_requester
     chunk_get.c
     chunk_send.c
     error_test/get_version_err.c
+    error_test/get_capabilities_err.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -366,12 +366,12 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
         libspdm_zero_mem(spdm_response, spdm_response_size);
-        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
         spdm_response->header.request_response_code = SPDM_CAPABILITIES;
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = 0xc00;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -489,7 +489,8 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP |
+                               SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -48,8 +48,8 @@
      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP | \
      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP)
 
-static size_t m_libspdm_local_buffer_size;
-static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_SMALL_BUFFER_SIZE];
+/* static size_t m_libspdm_local_buffer_size;
+ * static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_SMALL_BUFFER_SIZE]; */
 
 static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
     void *spdm_context, size_t request_size, const void *request,

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -340,7 +340,28 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
-    case 0x9:
+    case 0x9: {
+        spdm_capabilities_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(spdm_capabilities_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.request_response_code = SPDM_CAPABILITIES;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->ct_exponent = 0;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response,
+                                              response_size, response);
+    }
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0xa: {
@@ -416,8 +437,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP |
-                               SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -984,11 +1004,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
     }
 }
 
-static void libspdm_test_requester_get_capabilities_case1(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case2(void **state)
+static void libspdm_test_requester_get_capabilities_err_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -996,48 +1012,7 @@ static void libspdm_test_requester_get_capabilities_case2(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_m.buffer_size =
-        spdm_context->transcript.message_m.max_buffer_size;
-#endif
-
-    spdm_context->local_context.capability.ct_exponent = 0;
-    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
-    status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     LIBSPDM_DEFAULT_CAPABILITY_FLAG);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
-}
-
-static void libspdm_test_requester_get_capabilities_case3(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case4(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case5(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case6(void **state)
-{
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x6;
+    spdm_test_context->case_id = 0x1;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
@@ -1046,25 +1021,16 @@ static void libspdm_test_requester_get_capabilities_case6(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     LIBSPDM_DEFAULT_CAPABILITY_FLAG);
+    assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 }
 
-static void libspdm_test_requester_get_capabilities_case7(void **state)
-{
-}
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case2(void **state)
+ * {
+ * }
+ **/
 
-static void libspdm_test_requester_get_capabilities_case8(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case9(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case10(void **state)
+static void libspdm_test_requester_get_capabilities_err_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1072,7 +1038,26 @@ static void libspdm_test_requester_get_capabilities_case10(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xa;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NOT_STARTED;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
@@ -1081,17 +1066,10 @@ static void libspdm_test_requester_get_capabilities_case10(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP |
-                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |
-                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP |
-                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG |
-                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
-static void libspdm_test_requester_get_capabilities_case11(void **state)
+static void libspdm_test_requester_get_capabilities_err_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1099,7 +1077,55 @@ static void libspdm_test_requester_get_capabilities_case11(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xb;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
+}
+
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case6(void **state)
+ * {
+ * }
+ **/
+
+static void libspdm_test_requester_get_capabilities_err_case7(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x7;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_RESYNCH_PEER);
+    assert_int_equal(spdm_context->connection_info.connection_state,
+                     LIBSPDM_CONNECTION_STATE_NOT_STARTED);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x8;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
@@ -1107,18 +1133,14 @@ static void libspdm_test_requester_get_capabilities_case11(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(
-        spdm_context->connection_info.capability.flags,
-        !(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP |
-          SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |
-          SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP |
-          SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG |
-          SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
+    assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
 }
 
-static void libspdm_test_requester_get_capabilities_case12(void **state)
+/**
+ * Test 9: Responder returns a Reserved MEAS_CAP value.
+ * Expected behavior: returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ **/
+static void libspdm_test_requester_get_capabilities_err_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1126,7 +1148,7 @@ static void libspdm_test_requester_get_capabilities_case12(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xc;
+    spdm_test_context->case_id = 0x9;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
@@ -1134,26 +1156,28 @@ static void libspdm_test_requester_get_capabilities_case12(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG |
-                     SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-static void libspdm_test_requester_get_capabilities_case13(void **state)
-{
-}
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case10(void **state)
+ * {
+ * }
+ **/
 
-static void libspdm_test_requester_get_capabilities_case14(void **state)
-{
-}
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case11(void **state)
+ * {
+ * }
+ **/
 
-static void libspdm_test_requester_get_capabilities_case15(void **state)
-{
-}
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case12(void **state)
+ * {
+ * }
+ **/
 
-static void libspdm_test_requester_get_capabilities_case16(void **state)
+static void libspdm_test_requester_get_capabilities_err_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1161,7 +1185,70 @@ static void libspdm_test_requester_get_capabilities_case16(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x10;
+    spdm_test_context->case_id = 0xd;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case14(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xe;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case15(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xf;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case16(void **state)
+ * {
+ * }
+ **/
+
+static void libspdm_test_requester_get_capabilities_err_case17(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x11;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
@@ -1169,111 +1256,35 @@ static void libspdm_test_requester_get_capabilities_case16(void **state)
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-static void libspdm_test_requester_get_capabilities_case17(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case18(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case19(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case20(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case21(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case22(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case23(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case24(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case25(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case26(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case27(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case28(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case29(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case30(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case31(void **state)
-{
-}
-
-static void libspdm_test_requester_get_capabilities_case32(void **state)
+static void libspdm_test_requester_get_capabilities_err_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
-    size_t arbitrary_size;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x20;
+    spdm_test_context->case_id = 0x12;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
-    /*filling A with arbitrary data*/
-    arbitrary_size = 10;
-    libspdm_set_mem(spdm_context->transcript.message_a.buffer, arbitrary_size, (uint8_t) 0xFF);
-    spdm_context->transcript.message_a.buffer_size = arbitrary_size;
-
     spdm_context->local_context.capability.ct_exponent = 0;
-    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    spdm_context->local_context.capability.flags =
+        LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11);
-    libspdm_dump_hex(spdm_context->transcript.message_a.buffer,
-                     spdm_context->transcript.message_a.buffer_size);
-    assert_int_equal(spdm_context->transcript.message_a.buffer_size,
-                     arbitrary_size + m_libspdm_local_buffer_size);
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
-                   m_libspdm_local_buffer_size));
-    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-    assert_memory_equal(spdm_context->transcript.message_a.buffer + arbitrary_size,
-                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
 }
 
-static void libspdm_test_requester_get_capabilities_case33(void **state)
+static void libspdm_test_requester_get_capabilities_err_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1281,27 +1292,306 @@ static void libspdm_test_requester_get_capabilities_case33(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x21;
+    spdm_test_context->case_id = 0x13;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case20(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x14;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case21(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x15;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case22(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x16;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case23(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x17;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case24(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x18;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case25(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x19;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 & (0xFFFFFFFF^(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP)));*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case26(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1a;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    /*assert_int_equal (spdm_context->connection_info.capability.ct_exponent, 0);
+     * assert_int_equal (spdm_context->connection_info.capability.flags, LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11 | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP);*/
+}
+
+static void libspdm_test_requester_get_capabilities_err_case27(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1b;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case28(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1c;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
+
+static void libspdm_test_requester_get_capabilities_err_case29(void **state) {
+    libspdm_return_t status;
+    libspdm_test_context_t    *spdm_test_context;
+    libspdm_context_t  *spdm_context;
+    uint16_t error_code;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1d;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_11;
+
+    error_code = LIBSPDM_ERROR_CODE_RESERVED_00;
+    while(error_code <= 0xff) {
+        spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+        libspdm_reset_message_a(spdm_context);
+
+        status = libspdm_get_capabilities (spdm_context);
+        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
+
+        error_code++;
+        if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
+            error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+        }
+        if(error_code == LIBSPDM_ERROR_CODE_RESERVED_0D) { /*skip some reserved error codes (0d to 3e)*/
+            error_code = LIBSPDM_ERROR_CODE_RESERVED_3F;
+        }
+        if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) { /*skip response not ready, request resync, and some reserved codes (44 to fc)*/
+            error_code = LIBSPDM_ERROR_CODE_RESERVED_FD;
+        }
+    }
+}
+
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case30(void **state)
+ * {
+ * }
+ **/
+
+static void libspdm_test_requester_get_capabilities_err_case31(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1F;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
+}
+
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case32(void **state)
+ * {
+ * }
+ **/
+
+/**
+ * static void libspdm_test_requester_get_capabilities_err_case33(void **state)
+ * {
+ * }
+ **/
+
+static void libspdm_test_requester_get_capabilities_err_case34(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x22;
+
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
-
+    spdm_context->transcript.message_a.buffer_size =
+        spdm_context->transcript.message_a.max_buffer_size;
     spdm_context->local_context.capability.ct_exponent = 0;
-    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG_VERSION_12;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
     status = libspdm_get_capabilities(spdm_context);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(spdm_context->connection_info.capability.max_spdm_msg_size,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-    assert_int_equal(spdm_context->connection_info.capability.data_transfer_size,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-    assert_int_equal(spdm_context->connection_info.capability.ct_exponent, 0);
-    assert_int_equal(spdm_context->connection_info.capability.flags,
-                     LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_12);
-}
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_FULL);
 
-
-static void libspdm_test_requester_get_capabilities_case34(void **state)
-{
+    spdm_context->transcript.message_a.buffer_size = 0;
 }
 
 static libspdm_test_context_t m_libspdm_requester_get_capabilities_test_context = {
@@ -1311,47 +1601,46 @@ static libspdm_test_context_t m_libspdm_requester_get_capabilities_test_context 
     libspdm_requester_get_capabilities_test_receive_message,
 };
 
-int libspdm_requester_get_capabilities_test_main(void)
+int libspdm_requester_get_capabilities_error_test_main(void)
 {
     const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case1), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case2),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case3),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case4),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case5), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case6),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case7),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case8),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case9), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case10),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case11),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case12),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case13),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case14),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case15), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case16),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case17),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case18),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case19),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case20),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case21),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case22),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case23),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case24),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case25),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case26),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case27),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case28),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case29),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case30),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case31), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case32),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case33),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case34), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case1),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case2), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case3),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case4),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case5),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case6), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case7),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case8),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case9),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case10),
+         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case11),
+         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case12), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case13),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case14),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case15),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case16), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case17),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case18),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case19),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case20),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case21),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case22),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case23),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case24),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case25),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case26),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case27),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case28),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case29),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case30), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case31),
+        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case32),
+         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case33), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case34),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_get_capabilities_test_context);
+    libspdm_setup_test_context(&m_libspdm_requester_get_capabilities_test_context);
 
     return cmocka_run_group_tests(m_spdm_requester_get_capabilities_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -121,14 +121,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
         return LIBSPDM_STATUS_SUCCESS;
     case 0x1F:
         return LIBSPDM_STATUS_SUCCESS;
-    case 0x20: {
-        const uint8_t *ptr = (const uint8_t *)request;
-
-        m_libspdm_local_buffer_size = 0;
-        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer), &ptr[1],
-                         request_size - 1);
-        m_libspdm_local_buffer_size += (request_size - 1);
-    }
+    case 0x20:
         return LIBSPDM_STATUS_SUCCESS;
     case 0x21:
         return LIBSPDM_STATUS_SUCCESS;
@@ -165,7 +158,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -243,52 +236,27 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0x6: {
-        static size_t sub_index1 = 0;
-        if (sub_index1 == 0) {
-            spdm_error_response_t *spdm_response;
-            size_t spdm_response_size;
-            size_t transport_header_size;
+        spdm_capabilities_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
 
-            spdm_response_size = sizeof(spdm_error_response_t);
-            transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
-            spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+        spdm_response_size = sizeof(spdm_capabilities_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
-            libspdm_zero_mem(spdm_response, spdm_response_size);
-            spdm_response->header.spdm_version =
-                SPDM_MESSAGE_VERSION_10;
-            spdm_response->header.request_response_code = SPDM_ERROR;
-            spdm_response->header.param1 = SPDM_ERROR_CODE_BUSY;
-            spdm_response->header.param2 = 0;
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.request_response_code = SPDM_CAPABILITIES;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->ct_exponent = 0;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG |
+                               SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP;
 
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false,
-                spdm_response_size, spdm_response,
-                response_size, response);
-        } else if (sub_index1 == 1) {
-            spdm_capabilities_response_t *spdm_response;
-            size_t spdm_response_size;
-            size_t transport_header_size;
-
-            spdm_response_size = sizeof(spdm_capabilities_response_t);
-            transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
-            spdm_response = (void *)((uint8_t *)*response + transport_header_size);
-
-            libspdm_zero_mem(spdm_response, spdm_response_size);
-            spdm_response->header.spdm_version =
-                SPDM_MESSAGE_VERSION_10;
-            spdm_response->header.request_response_code =
-                SPDM_CAPABILITIES;
-            spdm_response->header.param1 = 0;
-            spdm_response->header.param2 = 0;
-            spdm_response->ct_exponent = 0;
-            spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
-
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false,
-                spdm_response_size, spdm_response,
-                response_size, response);
-        }
-        sub_index1++;
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response,
+                                              response_size, response);
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -379,12 +347,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags =
-            (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP |
-             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |
-             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP |
-             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG |
-             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP);
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -408,12 +371,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags =
-            !(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP |
-              SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP |
-              SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP |
-              SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG |
-              SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP);
+        spdm_response->flags = 0xc00;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -432,12 +390,12 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
         libspdm_zero_mem(spdm_response, spdm_response_size);
-        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
         spdm_response->header.request_response_code = SPDM_CAPABILITIES;
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -531,7 +489,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -877,8 +835,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
-    case 0x1d:
-    {
+    case 0x1d: {
         static uint16_t error_code = LIBSPDM_ERROR_CODE_RESERVED_00;
 
         spdm_error_response_t *spdm_response;
@@ -914,6 +871,30 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
+    case 0x1e: {
+        spdm_capabilities_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(spdm_capabilities_response_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+        spdm_response->header.request_response_code = SPDM_CAPABILITIES;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        spdm_response->ct_exponent = 0;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response,
+                                              response_size, response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
     case 0x1F:
         return LIBSPDM_STATUS_RECEIVE_FAIL;
 
@@ -927,21 +908,12 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
         libspdm_zero_mem(spdm_response, spdm_response_size);
-        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
         spdm_response->header.request_response_code = SPDM_CAPABILITIES;
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11;
-
-        spdm_response_size = sizeof(spdm_capabilities_response_t) -
-                             sizeof(spdm_response->data_transfer_size) -
-                             sizeof(spdm_response->max_spdm_msg_size);
-
-        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
-                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
-                         (uint8_t *)spdm_response, spdm_response_size);
-        m_libspdm_local_buffer_size += spdm_response_size;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -965,7 +937,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->ct_exponent = 0;
-        spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_12;
+        spdm_response->flags = SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_INSTALL_RESET_CAP;
         spdm_response->data_transfer_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
         spdm_response->max_spdm_msg_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1015,8 +987,7 @@ static void libspdm_test_requester_get_capabilities_err_case1(void **state)
     spdm_test_context->case_id = 0x1;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
 
     spdm_context->local_context.capability.ct_exponent = 0;
     spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
@@ -1025,10 +996,27 @@ static void libspdm_test_requester_get_capabilities_err_case1(void **state)
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case2(void **state)
- * {
- * }
+ * Test 2: Responder sets MEAS_FRESH_CAP but does not set MEAS_CAP.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case3(void **state)
 {
@@ -1090,10 +1078,28 @@ static void libspdm_test_requester_get_capabilities_err_case5(void **state)
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case6(void **state)
- * {
- * }
+ * Test 6: Responder sets illegal SPDM 1.0 combination of MEAS_CAP (no signature), CERT_CAP,
+ *         and CHAL_CAP.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x6;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case7(void **state)
 {
@@ -1160,22 +1166,77 @@ static void libspdm_test_requester_get_capabilities_err_case9(void **state)
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case10(void **state)
- * {
- * }
+ * Test 10: Responder sets illegal SPDM 1.0 combination of MEAS_CAP (with signature), CERT_CAP,
+ *         and CHAL_CAP.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case10(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xa;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case11(void **state)
- * {
- * }
+ * Test 11: Responder sets illegal 1.1/1.2 PSK_CAP value (3).
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case11(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xb;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case12(void **state)
- * {
- * }
+ * Test 11: Responder sets illegal 1.1/1.2 combination of values.
+ *          CERT_CAP enabled.
+ *          CHAL_CAP and KEY_EX_CAP disabled.
+ *          MEAS_CAP with signature is disabled.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case12(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xc;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case13(void **state)
 {
@@ -1235,10 +1296,30 @@ static void libspdm_test_requester_get_capabilities_err_case15(void **state)
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case16(void **state)
- * {
- * }
+ * Test 16: Responder sets illegal 1.1/1.2 combination of values.
+ *          CERT_CAP and PUB_KEY_ID_CAP disabled.
+ *          At least one of CHAL_CAP, KEY_EX_CAP, MEAS_CAP (with signature), or MUT_AUTH_CAP
+ *          is enabled.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case16(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x10;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case17(void **state)
 {
@@ -1536,10 +1617,29 @@ static void libspdm_test_requester_get_capabilities_err_case29(void **state) {
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case30(void **state)
- * {
- * }
+ * Test 30: Responder sets illegal 1.2 combination of values.
+ *          CERT_CAP is disabled.
+ *          ALIAS_CERT_CAP is enabled.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case30(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1E;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case31(void **state)
 {
@@ -1560,16 +1660,54 @@ static void libspdm_test_requester_get_capabilities_err_case31(void **state)
 }
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case32(void **state)
- * {
- * }
+ * Test 32: Responder sets illegal 1.2 combination of values.
+ *          CSR_CAP is enabled.
+ *          SET_CERT_CAP is disabled.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case32(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x20;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 /**
- * static void libspdm_test_requester_get_capabilities_err_case33(void **state)
- * {
- * }
+ * Test 33: Responder sets illegal 1.2 combination of values.
+ *          CERT_INSTALL_RESET_CAP is enabled.
+ *          CSR_CAP and SET_CERT_CAP are disabled.
+ * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
+static void libspdm_test_requester_get_capabilities_err_case33(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x21;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+
+    spdm_context->local_context.capability.ct_exponent = 0;
+    spdm_context->local_context.capability.flags = LIBSPDM_DEFAULT_CAPABILITY_FLAG;
+    status = libspdm_get_capabilities(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
 
 static void libspdm_test_requester_get_capabilities_err_case34(void **state)
 {
@@ -1605,21 +1743,21 @@ int libspdm_requester_get_capabilities_error_test_main(void)
 {
     const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case1),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case2), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case3),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case4),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case5),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case6), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case6),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case7),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case8),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case9),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case10),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case11),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case12), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case10),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case11),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case12),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case13),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case14),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case15),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case16), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case16),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case17),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case18),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case19),
@@ -1633,10 +1771,10 @@ int libspdm_requester_get_capabilities_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case27),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case28),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case29),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case30), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case30),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case31),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case32),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case33), */
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case32),
+        cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case33),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case34),
     };
 

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -984,9 +984,11 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
     }
 }
 
-static void libspdm_test_requester_get_capabilities_case1(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case1(void **state)
+ * {
+ * }
+ */
 
 static void libspdm_test_requester_get_capabilities_case2(void **state)
 {
@@ -1017,17 +1019,23 @@ static void libspdm_test_requester_get_capabilities_case2(void **state)
 #endif
 }
 
-static void libspdm_test_requester_get_capabilities_case3(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case3(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case4(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case4(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case5(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case5(void **state)
+ * {
+ * }
+ */
 
 static void libspdm_test_requester_get_capabilities_case6(void **state)
 {
@@ -1052,17 +1060,23 @@ static void libspdm_test_requester_get_capabilities_case6(void **state)
                      LIBSPDM_DEFAULT_CAPABILITY_FLAG);
 }
 
-static void libspdm_test_requester_get_capabilities_case7(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case7(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case8(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case8(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case9(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case9(void **state)
+ * {
+ * }
+ */
 
 static void libspdm_test_requester_get_capabilities_case10(void **state)
 {
@@ -1141,17 +1155,23 @@ static void libspdm_test_requester_get_capabilities_case12(void **state)
                      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP);
 }
 
-static void libspdm_test_requester_get_capabilities_case13(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case13(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case14(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case14(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case15(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case15(void **state)
+ * {
+ * }
+ */
 
 static void libspdm_test_requester_get_capabilities_case16(void **state)
 {
@@ -1175,65 +1195,95 @@ static void libspdm_test_requester_get_capabilities_case16(void **state)
                      LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_11);
 }
 
-static void libspdm_test_requester_get_capabilities_case17(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case17(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case18(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case18(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case19(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case19(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case20(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case20(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case21(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case21(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case22(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case22(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case23(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case23(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case24(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case24(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case25(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case25(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case26(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case26(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case27(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case27(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case28(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case28(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case29(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case29(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case30(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case30(void **state)
+ * {
+ * }
+ */
 
-static void libspdm_test_requester_get_capabilities_case31(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case31(void **state)
+ * {
+ * }
+ */
 
 static void libspdm_test_requester_get_capabilities_case32(void **state)
 {
@@ -1300,9 +1350,11 @@ static void libspdm_test_requester_get_capabilities_case33(void **state)
 }
 
 
-static void libspdm_test_requester_get_capabilities_case34(void **state)
-{
-}
+/*
+ * static void libspdm_test_requester_get_capabilities_case34(void **state)
+ * {
+ * }
+ */
 
 static libspdm_test_context_t m_libspdm_requester_get_capabilities_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -10,6 +10,7 @@
 int libspdm_requester_get_version_test_main(void);
 int libspdm_requester_get_version_error_test_main(void);
 int libspdm_requester_get_capabilities_test_main(void);
+int libspdm_requester_get_capabilities_error_test_main(void);
 int libspdm_requester_negotiate_algorithms_test_main(void);
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
@@ -71,6 +72,9 @@ int main(void)
     }
 
     if (libspdm_requester_get_capabilities_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_get_capabilities_error_test_main() != 0) {
         return_value = 1;
     }
 


### PR DESCRIPTION
Increase `GET_VERSION` code coverage. Put `GET_CAPABILITIES` error tests in its own file. Expand and refactor capability flag checking. Will complete 100 % code coverage of `GET_CAPABILITIES` in a subsequent pull request.

Fixes https://github.com/DMTF/libspdm/issues/1343.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>