### PR TITLE
Fix mbedtls entropy configuration.

### DIFF
--- a/os_stub/mbedtlslib/include/mbedtls/config.h
+++ b/os_stub/mbedtlslib/include/mbedtls/config.h
@@ -1239,7 +1239,8 @@ extern void my_free( void *ptr );
  *
  * Uncomment this macro to disable the built-in platform entropy functions.
  */
-#if defined(__clang__)
+#if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
+    !defined(_WIN32)
 #define MBEDTLS_NO_PLATFORM_ENTROPY
 #endif
 


### PR DESCRIPTION
Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>

This was added to enable ARM_DS2022 build, but in wrong way.

The entropy is not related to compiler, but related to platform.