### PR TITLE
Enable manual trigger for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
       - '**/*.md'
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This will allow developers to manually trigger the build and test process in their forked repositories.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>