### PR TITLE
Run CodeQL daily

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,18 +12,9 @@
 name: "CodeQL"
 
 on:
-  push:
-    paths-ignore:
-      - '**/*.md'
-      - 'doc/**'
-    branches: [ "main" ]
-  pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'doc/**'
-    branches: [ "main" ]
   schedule:
-    - cron: '0 0 * * 6'
+    - cron:  '00 8 * * *'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
Or it can be manually triggered. This will remove the running of CodeQL with each pull request, which did not seem to have much value, and there was considerable overlap with certain GCC and CLANG warnings.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>