### PR TITLE
Removing extraneous <stdio.h> in crypto

### DIFF
--- a/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
+++ b/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
@@ -17,7 +17,6 @@
 #include "library/debuglib.h"
 #include "library/cryptlib.h"
 #include "spdm_crypt_ext_lib/cryptlib_ext.h"
-#include <stdio.h>
 
 /* We should alwasy add mbedtls/config.h here
  * to ensure the config override takes effect.*/


### PR DESCRIPTION
Stdio.h is not required for compilation of the mbedtls hooks - the stdio.h might cause issues for build environments which don't have access to the headers.

Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>