### PR TITLE
Allow user to specify the location of secured message context

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -46,12 +46,17 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
    ```
 
    The location of session keys can be separated from spdm_context if desired.
+   Each session holds keys in a secured context, and the location of each can be
+   directly specified.
 
    ```
-   spdm_secured_context_size = libspdm_secured_message_get_total_context_size();
-   spdm_secured_context = (void *)pointer_to_secured_memory;
+   spdm_secured_context_size = libspdm_secured_message_get_context_size();
+   spdm_secured_contexts[0] = (void *)pointer_to_secured_memory_0;
+   spdm_secured_contexts[1] = (void *)pointer_to_secured_memory_1;
+   [...]
+   spdm_secured_contexts[num_sessions] = (void *)pointer_to_secured_memory_num_sessions;
    spdm_context = (void *)malloc (libspdm_get_context_size_without_secured_context());
-   libspdm_init_context_with_secure_data_location(spdm_context, spdm_secured_context);
+   libspdm_init_context_with_secured_context(spdm_context, spdm_secured_contexts, num_sessions);
    ```
 
    1.2, register the device io functions, transport layer functions, and device buffer functions.
@@ -277,12 +282,17 @@ Refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF/spdm-e
    ```
   
    The location of session keys can be separated from spdm_context if desired.
+   Each session holds keys in a secured context, and the location of each can be
+   directly specified.
 
    ```
-   spdm_secured_context_size = libspdm_secured_message_get_total_context_size();
-   spdm_secured_context = (void *)pointer_to_secured_memory;
+   spdm_secured_context_size = libspdm_secured_message_get_context_size();
+   spdm_secured_contexts[0] = (void *)pointer_to_secured_memory_0;
+   spdm_secured_contexts[1] = (void *)pointer_to_secured_memory_1;
+   [...]
+   spdm_secured_contexts[num_sessions] = (void *)pointer_to_secured_memory_num_sessions;
    spdm_context = (void *)malloc (libspdm_get_context_size_without_secured_context());
-   libspdm_init_context_with_secure_data_location(spdm_context, spdm_secured_context);
+   libspdm_init_context_with_secured_context(spdm_context, spdm_secured_contexts, num_sessions);
    ```
 
    1.2, register the device io functions, transport layer functions, and device buffer functions.

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -45,6 +45,15 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
    libspdm_set_scratch_buffer (spdm_context, m_scratch_buffer, scratch_buffer_size);
    ```
 
+   The location of session keys can be separated from spdm_context if desired.
+
+   ```
+   spdm_secured_context_size = libspdm_secured_message_get_total_context_size();
+   spdm_secured_context = (void *)pointer_to_secured_memory;
+   spdm_context = (void *)malloc (libspdm_get_context_size_without_secured_context());
+   libspdm_init_context_with_secure_data_location(spdm_context, spdm_secured_context);
+   ```
+
    1.2, register the device io functions, transport layer functions, and device buffer functions.
    The libspdm provides the default [spdm_transport_mctp_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_mctp_lib.h) and [spdm_transport_pcidoe_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_transport_pcidoe_lib.h).
    The SPDM device driver need provide device IO send/receive function.
@@ -265,6 +274,15 @@ Refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF/spdm-e
    scratch_buffer_size = libspdm_get_sizeof_required_scratch_buffer(m_spdm_context);
    LIBSPDM_ASSERT (scratch_buffer_size == LIBSPDM_SCRATCH_BUFFER_SIZE);
    libspdm_set_scratch_buffer (spdm_context, m_scratch_buffer, scratch_buffer_size);
+   ```
+  
+   The location of session keys can be separated from spdm_context if desired.
+
+   ```
+   spdm_secured_context_size = libspdm_secured_message_get_total_context_size();
+   spdm_secured_context = (void *)pointer_to_secured_memory;
+   spdm_context = (void *)malloc (libspdm_get_context_size_without_secured_context());
+   libspdm_init_context_with_secure_data_location(spdm_context, spdm_secured_context);
    ```
 
    1.2, register the device io functions, transport layer functions, and device buffer functions.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -246,11 +246,12 @@ void libspdm_set_last_spdm_error_struct(void *spdm_context,
  *                               the location of a secured message context.
  * @param  num_secured_contexts  Number of secured message contexts to initialize.
  *                               Currently, only LIBSPDM_MAX_SESSION_COUNT is supported.
+ *                               In future releases, lesser values may be supported.
  *
  * @retval RETURN_SUCCESS        Contexts are initialized.
  * @retval RETURN_DEVICE_ERROR   Context initialization failed.
  */
-libspdm_return_t libspdm_init_context_with_secured_context(void *context,
+libspdm_return_t libspdm_init_context_with_secured_context(void *spdm_context,
                                                            void **secured_contexts,
                                                            size_t num_secured_contexts);
 
@@ -266,7 +267,7 @@ libspdm_return_t libspdm_init_context_with_secured_context(void *context,
  * @retval RETURN_SUCCESS       context is initialized.
  * @retval RETURN_DEVICE_ERROR  context initialization failed.
  */
-libspdm_return_t libspdm_init_context(void *context);
+libspdm_return_t libspdm_init_context(void *spdm_context);
 
 /**
  * Reset an SPDM context.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -232,16 +232,38 @@ void libspdm_set_last_spdm_error_struct(void *spdm_context,
                                         libspdm_error_struct_t *last_spdm_error);
 
 /**
- * Initialize an SPDM context.
+ * Initialize an SPDM context, as well as all secured message contexts,
+ * in the specified locations.
  *
- * The size in bytes of the spdm_context can be returned by libspdm_get_context_size.
+ * The size in bytes of the spdm_context can be returned by
+ * libspdm_get_context_size_without_secured_context.
+ * 
+ * The size in bytes of the secured message context can be returned by
+ * libspdm_secured_message_get_total_context_size.
+ * 
+ * @param  spdm_context              A pointer to the SPDM context.
+ * @param  secured_message_contexts  A pointer to the secured message context buffer.
+ *                                   This will hold all secured message contexts.
  *
- * @param  spdm_context  A pointer to the SPDM context.
+ * @retval RETURN_SUCCESS       Contexts are initialized.
+ * @retval RETURN_DEVICE_ERROR  Context initialization failed.
+ */
+libspdm_return_t libspdm_init_context_with_secure_data_location(void *context,
+    void *secured_message_contexts);
+
+/**
+ * Initialize an SPDM context, as well as secured message contexts.
+ * The secured message contexts are appended to the context structure.
+ * 
+ * The total size in bytes of the spdm_context and all secured message
+ * contexts can be returned by libspdm_get_context_size().
+ *
+ * @param  spdm_context         A pointer to the SPDM context.
  *
  * @retval RETURN_SUCCESS       context is initialized.
  * @retval RETURN_DEVICE_ERROR  context initialization failed.
  */
-libspdm_return_t libspdm_init_context(void *spdm_context);
+libspdm_return_t libspdm_init_context(void *context);
 
 /**
  * Reset an SPDM context.
@@ -253,9 +275,21 @@ libspdm_return_t libspdm_init_context(void *spdm_context);
 void libspdm_reset_context(void *spdm_context);
 
 /**
- * Return the size in bytes of the SPDM context.
+ * Return the size in bytes of just the SPDM context, without secured message context.
+ * 
+ * For the complete context size, use libspdm_get_context_size.
  *
  * @return the size in bytes of the SPDM context.
+ **/
+size_t libspdm_get_context_size_without_secured_context(void);
+
+/**
+ * Return the size in bytes of the SPDM context. This includes all secured message
+ * context data as well.
+ * 
+ * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
+ *
+ * @return the size in bytes of the SPDM context and secured message contexts.
  **/
 size_t libspdm_get_context_size(void);
 

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -238,18 +238,21 @@ void libspdm_set_last_spdm_error_struct(void *spdm_context,
  * The size in bytes of the spdm_context can be returned by
  * libspdm_get_context_size_without_secured_context.
  *
- * The size in bytes of the secured message context can be returned by
- * libspdm_secured_message_get_total_context_size.
+ * The size in bytes of a single secured message context can be returned by
+ * libspdm_secured_message_get_context_size.
  *
- * @param  spdm_context              A pointer to the SPDM context.
- * @param  secured_message_contexts  A pointer to the secured message context buffer.
- *                                   This will hold all secured message contexts.
+ * @param  spdm_context          A pointer to the SPDM context.
+ * @param  secured_contexts      An array of pointers, with each entry containing
+ *                               the location of a secured message context.
+ * @param  num_secured_contexts  Number of secured message contexts to initialize.
+ *                               Currently, only LIBSPDM_MAX_SESSION_COUNT is supported.
  *
- * @retval RETURN_SUCCESS       Contexts are initialized.
- * @retval RETURN_DEVICE_ERROR  Context initialization failed.
+ * @retval RETURN_SUCCESS        Contexts are initialized.
+ * @retval RETURN_DEVICE_ERROR   Context initialization failed.
  */
-libspdm_return_t libspdm_init_context_with_secure_data_location(void *context,
-                                                                void *secured_message_contexts);
+libspdm_return_t libspdm_init_context_with_secured_context(void *context,
+                                                           void **secured_contexts,
+                                                           size_t num_secured_contexts);
 
 /**
  * Initialize an SPDM context, as well as secured message contexts.
@@ -275,6 +278,16 @@ libspdm_return_t libspdm_init_context(void *context);
 void libspdm_reset_context(void *spdm_context);
 
 /**
+ * Return the size in bytes of the SPDM context. This includes all
+ * secured message context data as well.
+ *
+ * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
+ *
+ * @return the size in bytes of the SPDM context and secured message contexts.
+ **/
+size_t libspdm_get_context_size(void);
+
+/**
  * Return the size in bytes of just the SPDM context, without secured message context.
  *
  * For the complete context size, use libspdm_get_context_size.
@@ -282,16 +295,6 @@ void libspdm_reset_context(void *spdm_context);
  * @return the size in bytes of the SPDM context.
  **/
 size_t libspdm_get_context_size_without_secured_context(void);
-
-/**
- * Return the size in bytes of the SPDM context. This includes all secured message
- * context data as well.
- *
- * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
- *
- * @return the size in bytes of the SPDM context and secured message contexts.
- **/
-size_t libspdm_get_context_size(void);
 
 /**
  * Send an SPDM transport layer message to a device.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -237,10 +237,10 @@ void libspdm_set_last_spdm_error_struct(void *spdm_context,
  *
  * The size in bytes of the spdm_context can be returned by
  * libspdm_get_context_size_without_secured_context.
- * 
+ *
  * The size in bytes of the secured message context can be returned by
  * libspdm_secured_message_get_total_context_size.
- * 
+ *
  * @param  spdm_context              A pointer to the SPDM context.
  * @param  secured_message_contexts  A pointer to the secured message context buffer.
  *                                   This will hold all secured message contexts.
@@ -249,12 +249,12 @@ void libspdm_set_last_spdm_error_struct(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR  Context initialization failed.
  */
 libspdm_return_t libspdm_init_context_with_secure_data_location(void *context,
-    void *secured_message_contexts);
+                                                                void *secured_message_contexts);
 
 /**
  * Initialize an SPDM context, as well as secured message contexts.
  * The secured message contexts are appended to the context structure.
- * 
+ *
  * The total size in bytes of the spdm_context and all secured message
  * contexts can be returned by libspdm_get_context_size().
  *
@@ -276,7 +276,7 @@ void libspdm_reset_context(void *spdm_context);
 
 /**
  * Return the size in bytes of just the SPDM context, without secured message context.
- * 
+ *
  * For the complete context size, use libspdm_get_context_size.
  *
  * @return the size in bytes of the SPDM context.
@@ -286,7 +286,7 @@ size_t libspdm_get_context_size_without_secured_context(void);
 /**
  * Return the size in bytes of the SPDM context. This includes all secured message
  * context data as well.
- * 
+ *
  * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
  *
  * @return the size in bytes of the SPDM context and secured message contexts.

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -34,11 +34,18 @@ typedef enum {
 } libspdm_session_state_t;
 
 /**
- * Return the size in bytes of the SPDM secured message context.
+ * Return the size in bytes of a single SPDM secured message context.
  *
- * @return the size in bytes of the SPDM secured message context.
+ * @return the size in bytes of a single SPDM secured message context.
  **/
 size_t libspdm_secured_message_get_context_size(void);
+
+/**
+ * Return the size in bytes of all SPDM secured message contexts.
+ *
+ * @return the size in bytes of all SPDM secured message contexts.
+ **/
+size_t libspdm_secured_message_get_total_context_size(void);
 
 /**
  * Initialize an SPDM secured message context.

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -41,13 +41,6 @@ typedef enum {
 size_t libspdm_secured_message_get_context_size(void);
 
 /**
- * Return the size in bytes of all SPDM secured message contexts.
- *
- * @return the size in bytes of all SPDM secured message contexts.
- **/
-size_t libspdm_secured_message_get_total_context_size(void);
-
-/**
  * Initialize an SPDM secured message context.
  *
  * The size in bytes of the spdm_secured_message_context can be returned by libspdm_secured_message_get_context_size.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2161,9 +2161,10 @@ libspdm_return_t libspdm_init_context(void *context)
     secured_context = (void *)((size_t)(spdm_context + 1));
     secured_context_size = libspdm_secured_message_get_context_size();
 
-    for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index ++)
+    for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++)
     {
-        secured_contexts[index] = secured_context + secured_context_size * index;
+        secured_contexts[index] =
+            (uint8_t *)secured_context + secured_context_size * index;
     }
 
     return libspdm_init_context_with_secured_context(context,
@@ -2235,7 +2236,7 @@ void libspdm_reset_context(void *context)
 size_t libspdm_get_context_size(void)
 {
     return sizeof(libspdm_context_t) +
-        libspdm_secured_message_get_context_size() * LIBSPDM_MAX_SESSION_COUNT;
+           libspdm_secured_message_get_context_size() * LIBSPDM_MAX_SESSION_COUNT;
 }
 
 /**

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2051,10 +2051,10 @@ void libspdm_set_last_spdm_error_struct(void *context, libspdm_error_struct_t *l
  *
  * The size in bytes of the spdm_context can be returned by
  * libspdm_get_context_size_without_secured_context.
- * 
+ *
  * The size in bytes of the secured message context can be returned by
  * libspdm_secured_message_get_total_context_size.
- * 
+ *
  * @param  spdm_context              A pointer to the SPDM context.
  * @param  secured_message_contexts  A pointer to the secured message context buffer.
  *                                   This will hold all secured message contexts.
@@ -2063,7 +2063,7 @@ void libspdm_set_last_spdm_error_struct(void *context, libspdm_error_struct_t *l
  * @retval RETURN_DEVICE_ERROR  Context initialization failed.
  */
 libspdm_return_t libspdm_init_context_with_secure_data_location(void *context,
-    void *secured_message_contexts)
+                                                                void *secured_message_contexts)
 {
     libspdm_context_t *spdm_context;
     void *secured_message_context;
@@ -2132,7 +2132,7 @@ libspdm_return_t libspdm_init_context_with_secure_data_location(void *context,
 /**
  * Initialize an SPDM context, as well as secured message contexts.
  * The secured message contexts are appended to the context structure.
- * 
+ *
  * The total size in bytes of the spdm_context and all secured message
  * contexts can be returned by libspdm_get_context_size().
  *
@@ -2153,7 +2153,7 @@ libspdm_return_t libspdm_init_context(void *context)
 
     /* libspdm_get_context_size() allocates space for all secured message context. */
     spdm_context = context;
-    secured_message_context = (void *)((size_t)(spdm_context + 1)); 
+    secured_message_context = (void *)((size_t)(spdm_context + 1));
 
     return libspdm_init_context_with_secure_data_location(context,
         secured_message_context);
@@ -2215,7 +2215,7 @@ void libspdm_reset_context(void *context)
 /**
  * Return the size in bytes of the SPDM context. This includes all secured message
  * context data as well.
- * 
+ *
  * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
  *
  * @return the size in bytes of the SPDM context and secured message contexts.
@@ -2227,7 +2227,7 @@ size_t libspdm_get_context_size(void)
 
 /**
  * Return the size in bytes of just the SPDM context, without secured message context.
- * 
+ *
  * For the complete context size, use libspdm_get_context_size.
  *
  * @return the size in bytes of the SPDM context.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2071,11 +2071,9 @@ libspdm_return_t libspdm_init_context_with_secured_context(void *context,
     libspdm_context_t *spdm_context;
     size_t index;
 
-    if (context == NULL || secured_contexts == NULL ||
-        num_secured_contexts != LIBSPDM_MAX_SESSION_COUNT)
-    {
-        return LIBSPDM_STATUS_INVALID_PARAMETER;
-    }
+    LIBSPDM_ASSERT(context != NULL);
+    LIBSPDM_ASSERT(secured_contexts != NULL);
+    LIBSPDM_ASSERT(num_secured_contexts == LIBSPDM_MAX_SESSION_COUNT);
 
     spdm_context = context;
     libspdm_zero_mem(spdm_context, sizeof(libspdm_context_t));
@@ -2150,10 +2148,7 @@ libspdm_return_t libspdm_init_context(void *context)
     size_t secured_context_size;
     size_t index;
 
-    if (context == NULL)
-    {
-        return LIBSPDM_STATUS_INVALID_PARAMETER;
-    }
+    LIBSPDM_ASSERT(context != NULL);
 
     /* libspdm_get_context_size() allocates space for all secured message
      * contexts. They are appended to the general SPDM context. */

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2156,7 +2156,7 @@ libspdm_return_t libspdm_init_context(void *context)
     secured_message_context = (void *)((size_t)(spdm_context + 1));
 
     return libspdm_init_context_with_secure_data_location(context,
-        secured_message_context);
+                                                          secured_message_context);
 }
 
 /**

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -7,13 +7,23 @@
 #include "internal/libspdm_secured_message_lib.h"
 
 /**
- * Return the size in bytes of the SPDM secured message context.
+ * Return the size in bytes of a single SPDM secured message context.
  *
- * @return the size in bytes of the SPDM secured message context.
+ * @return the size in bytes of a single SPDM secured message context.
  **/
 size_t libspdm_secured_message_get_context_size(void)
 {
     return sizeof(libspdm_secured_message_context_t);
+}
+
+/**
+ * Return the size in bytes of all SPDM secured message contexts.
+ *
+ * @return the size in bytes of all SPDM secured message contexts.
+ **/
+size_t libspdm_secured_message_get_total_context_size(void)
+{
+    return sizeof(libspdm_secured_message_context_t) * LIBSPDM_MAX_SESSION_COUNT;
 }
 
 /**

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -17,16 +17,6 @@ size_t libspdm_secured_message_get_context_size(void)
 }
 
 /**
- * Return the size in bytes of all SPDM secured message contexts.
- *
- * @return the size in bytes of all SPDM secured message contexts.
- **/
-size_t libspdm_secured_message_get_total_context_size(void)
-{
-    return sizeof(libspdm_secured_message_context_t) * LIBSPDM_MAX_SESSION_COUNT;
-}
-
-/**
  * Initialize an SPDM secured message context.
  *
  * The size in bytes of the spdm_secured_message_context can be returned by libspdm_secured_message_get_context_size.

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1246,7 +1246,7 @@ void libspdm_test_secured_message_context_location_selection_case18(void **state
     {
         /* Ensure the SPDM context points to the specified memory. */
         assert_int_equal(spdm_context->session_info[index].secured_message_context,
-            single_secured_context);
+                         single_secured_context);
         single_secured_context += libspdm_secured_message_get_context_size();
     }
 

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1229,7 +1229,7 @@ void libspdm_test_secured_message_context_location_selection_case18(void **state
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     void *secured_message_contexts;
-    void *single_secured_context;
+    uint8_t *single_secured_context;
     size_t index;
 
     spdm_test_context = *state;

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1238,7 +1238,8 @@ void libspdm_test_secured_message_context_location_selection_case18(void **state
 
     for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++)
     {
-        secured_message_contexts[index] = (void *)malloc(libspdm_secured_message_get_context_size());
+        secured_message_contexts[index] =
+            (void *)malloc(libspdm_secured_message_get_context_size());
     }
 
     status = libspdm_init_context_with_secured_context(spdm_context, secured_message_contexts,

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1223,6 +1223,37 @@ void libspdm_test_process_opaque_data_selection_version_data_case17(void **state
     free(opaque_data_ptr);
 }
 
+void libspdm_test_secured_message_context_location_selection_case18(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    void *secured_message_contexts;
+    void *single_secured_context;
+    size_t index;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x12;
+
+    spdm_context = (libspdm_context_t *)malloc(libspdm_get_context_size_without_secured_context());
+    secured_message_contexts = (void *)malloc(libspdm_secured_message_get_total_context_size());
+
+    status = libspdm_init_context_with_secure_data_location(spdm_context, secured_message_contexts);
+    assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);
+
+    single_secured_context = secured_message_contexts;
+    for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++)
+    {
+        /* Ensure the SPDM context points to the specified memory. */
+        assert_int_equal(spdm_context->session_info[index].secured_message_context,
+            single_secured_context);
+        single_secured_context += libspdm_secured_message_get_context_size();
+    }
+
+    free(spdm_context);
+    free(secured_message_contexts);
+}
+
 static libspdm_test_context_t m_libspdm_common_context_data_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     true,
@@ -1261,6 +1292,9 @@ int libspdm_common_context_data_test_main(void)
         cmocka_unit_test(libspdm_test_process_opaque_data_selection_version_data_case16),
         /* Failed response V1.2 for multi element opaque data selecetion vesion, element number is wrong*/
         cmocka_unit_test(libspdm_test_process_opaque_data_selection_version_data_case17),
+
+        /* Successful initialization and setting of secured message context location. */
+        cmocka_unit_test(libspdm_test_secured_message_context_location_selection_case18),
     };
 
     libspdm_setup_test_context(&m_libspdm_common_context_data_test_context);

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1253,15 +1253,6 @@ void libspdm_test_secured_message_context_location_selection_case18(void **state
                          secured_message_contexts[index]);
     }
 
-    /* Check that only the expected number of sessions is supported. */
-    status = libspdm_init_context_with_secured_context(spdm_context, secured_message_contexts,
-                                                       LIBSPDM_MAX_SESSION_COUNT - 1);
-    assert_int_equal (status, LIBSPDM_STATUS_INVALID_PARAMETER);
-
-    status = libspdm_init_context_with_secured_context(spdm_context, secured_message_contexts,
-                                                       LIBSPDM_MAX_SESSION_COUNT + 1);
-    assert_int_equal (status, LIBSPDM_STATUS_INVALID_PARAMETER);
-
     free(spdm_context);
     for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++)
     {


### PR DESCRIPTION
Implements #1311. The motivation behind this is that the secured message context(s) hold key and key-related material, which some integrators may want to store separately in sensitive data storage. A split is desired, since this storage is often limited - we would like to avoid having to support the entire libspdm_context_t struct which can be quite large.

To do this, introduces new APIs which allows the user to allocated SPDM context and secured message contexts separately. Decided to add new APIs, rather than update the existing ones, to avoid extensive breaking change both internally and externally.

Existing APIs are now wrappers around the new APIs.

Updated documentation to alert users of this API.

Adds test as well, just to double check this code does what it says it does.

Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>