### PR TITLE
Get digest coverage

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -73,8 +73,7 @@ static libspdm_return_t libspdm_try_get_digest(void *context, const uint32_t *se
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP)) {
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
     }
-    if (spdm_context->connection_info.connection_state <
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+    if (spdm_context->connection_info.connection_state < LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
         return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
     }
 
@@ -82,7 +81,6 @@ static libspdm_return_t libspdm_try_get_digest(void *context, const uint32_t *se
     if (session_id != NULL) {
         session_info = libspdm_get_session_info_via_session_id(spdm_context, *session_id);
         if (session_info == NULL) {
-            LIBSPDM_ASSERT(false);
             return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
         }
         session_state = libspdm_secured_message_get_session_state(

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(src_test_spdm_requester
     error_test/get_version_err.c
     error_test/get_capabilities_err.c
     error_test/negotiate_algorithms_err.c
+    error_test/get_digests_err.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -317,65 +317,38 @@ static libspdm_return_t libspdm_requester_get_digests_test_receive_message(
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0x9: {
-        static size_t sub_index2 = 0;
-        if (sub_index2 == 0) {
-            spdm_error_response_data_response_not_ready_t
-            *spdm_response;
-            size_t spdm_response_size;
-            size_t transport_header_size;
+        spdm_digest_response_t *spdm_response;
+        uint8_t *digest;
+        size_t spdm_response_size;
+        size_t transport_header_size;
 
-            spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
-            transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
-            spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
+            m_libspdm_use_hash_algo;
+        spdm_response_size = sizeof(spdm_digest_response_t) +
+                             libspdm_get_hash_size(m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT;
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
-            spdm_response->header.spdm_version =
-                SPDM_MESSAGE_VERSION_10;
-            spdm_response->header.request_response_code = SPDM_ERROR;
-            spdm_response->header.param1 =
-                SPDM_ERROR_CODE_RESPONSE_NOT_READY;
-            spdm_response->header.param2 = 0;
-            spdm_response->extend_error_data.rd_exponent = 1;
-            spdm_response->extend_error_data.rd_tm = 1;
-            spdm_response->extend_error_data.request_code =
-                SPDM_GET_DIGESTS;
-            spdm_response->extend_error_data.token = 1;
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.request_response_code = SPDM_DIGESTS;
+        spdm_response->header.param2 = 0;
+        libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                        (uint8_t)(0xFF));
 
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false,
-                spdm_response_size, spdm_response,
-                response_size, response);
-        } else if (sub_index2 == 1) {
-            spdm_digest_response_t *spdm_response;
-            uint8_t *digest;
-            size_t spdm_response_size;
-            size_t transport_header_size;
+        digest = (void *)(spdm_response + 1);
+        libspdm_zero_mem (digest,
+                          libspdm_get_hash_size(m_libspdm_use_hash_algo) *
+                          (SPDM_MAX_SLOT_COUNT - 1));
+        digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
+        libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
+                         LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, &digest[0]);
+        spdm_response->header.param2 |= (0xFF << 0);
 
-            ((libspdm_context_t *)spdm_context)
-            ->connection_info.algorithm.base_hash_algo =
-                m_libspdm_use_hash_algo;
-            spdm_response_size = sizeof(spdm_digest_response_t) +
-                                 libspdm_get_hash_size(m_libspdm_use_hash_algo);
-            transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
-            spdm_response = (void *)((uint8_t *)*response + transport_header_size);
-
-            spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
-            spdm_response->header.param1 = 0;
-            spdm_response->header.request_response_code = SPDM_DIGESTS;
-            spdm_response->header.param2 = 0;
-            libspdm_set_mem(m_libspdm_local_certificate_chain,
-                            LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, (uint8_t)(0xFF));
-
-            digest = (void *)(spdm_response + 1);
-            libspdm_hash_all(m_libspdm_use_hash_algo,
-                             m_libspdm_local_certificate_chain,
-                             LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, &digest[0]);
-            spdm_response->header.param2 |= (1 << 0);
-
-            libspdm_transport_test_encode_message(
-                spdm_context, NULL, false, false, spdm_response_size,
-                spdm_response, response_size, response);
-        }
-        sub_index2++;
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -630,8 +603,7 @@ static libspdm_return_t libspdm_requester_get_digests_test_receive_message(
         size_t spdm_response_size;
         size_t transport_header_size;
 
-        ((libspdm_context_t *)spdm_context)
-        ->connection_info.algorithm.base_hash_algo =
+        ((libspdm_context_t *)spdm_context)->connection_info.algorithm.base_hash_algo =
             m_libspdm_use_hash_algo;
         spdm_response_size = 5;
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -950,27 +922,50 @@ static libspdm_return_t libspdm_requester_get_digests_test_receive_message(
 }
 
 /**
- * Test 1:
- * Expected Behavior:
+ * Test 1: a failure occurs during the sending of the request message
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SEND_FAIL, with no DIGESTS message received
  **/
-static void libspdm_test_requester_get_digests_case1(void **state)
-{
-}
-
-/**
- * Test 2: a request message is successfully sent and a response message is successfully received
- * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is received
- **/
-static void libspdm_test_requester_get_digests_case2(void **state)
+static void libspdm_test_requester_get_digests_err_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint8_t slot_mask;
     uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t my_total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t *digest;
-    size_t data_return_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 2: Requester is unable to acquire the sender buffer.
+ * Expected Behavior: returns with error LIBSPDM_STATUS_ACQUIRE_FAIL.
+ **/
+static void libspdm_test_requester_get_digests_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -986,230 +981,65 @@ static void libspdm_test_requester_get_digests_case2(void **state)
                     (uint8_t)(0xFF));
     libspdm_reset_message_b(spdm_context);
 
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_m.buffer_size =
-        spdm_context->transcript.message_m.max_buffer_size;
-#endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+
+    libspdm_force_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
     status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    libspdm_release_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
 
-    assert_int_equal(slot_mask, 0xFF);
-    libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
-    digest = my_total_digest_buffer;
-    digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
-    libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, digest);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-
-    data_return_size = sizeof(uint8_t);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_SLOT_MASK,
-                              NULL, &slot_mask, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, sizeof(uint8_t));
-    assert_int_equal(slot_mask, 0xFF);
-
-    data_return_size = sizeof(total_digest_buffer);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_TOTAL_DIGEST_BUFFER,
-                              NULL, total_digest_buffer, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, libspdm_get_hash_size(
-                         m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(
-        spdm_context->transcript.message_b.buffer_size,
-        sizeof(spdm_get_digest_request_t) +
-        sizeof(spdm_digest_response_t) +
-        libspdm_get_hash_size(spdm_context->connection_info
-                              .algorithm.base_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
+    assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
 }
 
 /**
- * Test 3:
- * Expected Behavior:
+ * Test 3: connection_state equals to zero and makes the check fail, meaning that steps
+ * GET_CAPABILITIES-CAPABILITIES and NEGOTIATE_ALGORITHMS-ALGORITHMS of the protocol were not previously completed
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_INVALID_STATE_LOCAL, with no DIGESTS message received
  **/
-static void libspdm_test_requester_get_digests_case3(void **state)
-{
-}
-
-/**
- * Test 4:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case4(void **state)
-{
-}
-
-/**
- * Test 5:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case5(void **state)
-{
-}
-
-/**
- * Test 6:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case6(void **state)
-{
-}
-
-/**
- * Test 7:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case7(void **state)
-{
-}
-
-/**
- * Test 8:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case8(void **state)
-{
-}
-
-/**
- * Test 9:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case9(void **state)
-{
-}
-
-/**
- * Test 10:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case10(void **state)
-{
-}
-
-/**
- * Test 11:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case11(void **state)
-{
-}
-
-/**
- * Test 12:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case12(void **state)
-{
-}
-
-/**
- * Test 13:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case13(void **state)
-{
-}
-
-/**
- * Test 14:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case14(void **state)
-{
-}
-
-/**
- * Test 15:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case15(void **state)
-{
-}
-
-/**
- * Test 16:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case16(void **state)
-{
-}
-
-/**
- * Test 17:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case17(void **state)
-{
-}
-
-/**
- * Test 18:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case18(void **state)
-{
-}
-
-/**
- * Test 19:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case19(void **state)
-{
-}
-
-/**
- * Test 20:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case20(void **state)
-{
-}
-
-/**
- * Test 21:
- * Expected Behavior:
- **/
-static void libspdm_test_requester_get_digests_case21(void **state)
-{
-}
-
-/**
- * Test 22:
- * Expected behavior:.
- **/
-static void libspdm_test_requester_get_digests_case22(void **state)
-{
-}
-
-/**
- * Test 23: a request message is successfully sent and a response message is successfully received.
- * Buffer B already has arbitrary data.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is
- * received, buffer B appends the exchanged GET_DIGESTS and DIGESTS messages.
- **/
-static void libspdm_test_requester_get_digests_case23(void **state)
+static void libspdm_test_requester_get_digests_err_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint8_t slot_mask;
     uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    size_t arbitrary_size;
-#endif
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x17;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NOT_STARTED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 4: a request message is successfully sent and an ERROR response message with error code = InvalidRequest is received
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_ERROR_PEER, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
@@ -1223,268 +1053,672 @@ static void libspdm_test_requester_get_digests_case23(void **state)
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
     status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    arbitrary_size = 8;
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 5: request messages are successfully sent and ERROR response messages with error code = Busy are received in all attempts
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_BUSY_PEER, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 6: Requester is unable to acquire the receiver buffer.
+ * Expected Behavior: returns with error LIBSPDM_STATUS_ACQUIRE_FAIL.
+ **/
+static void libspdm_test_requester_get_digests_err_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+
+    libspdm_force_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    libspdm_release_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
+
+    assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
+}
+
+/**
+ * Test 7: a request message is successfully sent and an ERROR response message with error code = RequestResynch
+ * (Meaning Responder is requesting Requester to reissue GET_VERSION to resynchronize) is received
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case7(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x7;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_RESYNCH_PEER);
+    assert_int_equal(spdm_context->connection_info.connection_state,
+                     LIBSPDM_CONNECTION_STATE_NOT_STARTED);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 8: request messages are successfully sent and ERROR response messages with error code = ResponseNotReady
+ * are received in all attempts
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_ERROR_PEER
+ **/
+static void libspdm_test_requester_get_digests_err_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x8;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
+}
+
+/**
+ * Test 9: Invalid SPDM version in the DIGESTS response.
+ * Expected Behavior: returns with LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ **/
+static void libspdm_test_requester_get_digests_err_case9(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x9;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
+
+/**
+ * Test 10: flag cert_cap from CAPABILITIES is not setted meaning the Requester does not support DIGESTS and
+ * CERTIFICATE response messages
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_UNSUPPORTED_CAP, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case10(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xA;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 11: a request message is successfully sent but a failure occurs during the receiving of the response message
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_RECEIVE_FAIL, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case11(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xB;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-                     arbitrary_size + m_libspdm_local_buffer_size);
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
-                   m_libspdm_local_buffer_size));
-    libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-    assert_memory_equal(spdm_context->transcript.message_b.buffer + arbitrary_size,
-                        m_libspdm_local_buffer, m_libspdm_local_buffer_size);
+                     0);
 #endif
 }
 
 /**
- * Test 24: Test case for GetDigest, GetCert and GetDigest
- * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a second GetDigest can be sent.
+ * Test 12: a request message is successfully sent but the size of the response message is smaller than the size of the SPDM message header,
+ * meaning it is an invalid response message
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
  **/
-static void libspdm_test_requester_get_digests_case24(void **state)
+static void libspdm_test_requester_get_digests_err_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     uint8_t slot_mask;
     uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t my_total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t *digest;
-    size_t data_return_size;
-    void *data;
-    size_t data_size;
-    void *hash;
-    size_t hash_size;
-    const uint8_t *root_cert;
-    size_t root_cert_size;
-    size_t cert_chain_size;
-    uint8_t cert_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x18;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.req_base_asym_alg =
-        m_libspdm_use_req_asym_algo;
-
-    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
-    spdm_context->local_context.peer_cert_chain_provision_size =
-        LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                    (uint8_t)(0xFF));
-
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo, &data,
-                                                    &data_size, &hash, &hash_size);
-    libspdm_x509_get_cert_from_cert_chain(
-        (uint8_t *)data + sizeof(spdm_cert_chain_t) + hash_size,
-        data_size - sizeof(spdm_cert_chain_t) - hash_size, 0,
-        &root_cert, &root_cert_size);
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "root cert data :\n"));
-    libspdm_dump_hex(root_cert, root_cert_size);
-    spdm_context->local_context.peer_root_cert_provision_size[0] =
-        root_cert_size;
-    spdm_context->local_context.peer_root_cert_provision[0] = root_cert;
-
-    m_get_digest = true;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_m.buffer_size =
-        spdm_context->transcript.message_m.max_buffer_size;
-#endif
-    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    /* first GetDigest */
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(slot_mask, 0xFF);
-    libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
-    digest = my_total_digest_buffer;
-    digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
-    libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, digest);
-    assert_memory_equal(total_digest_buffer, my_total_digest_buffer,
-                        sizeof(my_total_digest_buffer));
-    data_return_size = sizeof(uint8_t);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_SLOT_MASK,
-                              NULL, &slot_mask, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, sizeof(uint8_t));
-    assert_int_equal(slot_mask, 0xFF);
-
-    data_return_size = sizeof(total_digest_buffer);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_TOTAL_DIGEST_BUFFER,
-                              NULL, total_digest_buffer, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, libspdm_get_hash_size(
-                         m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(
-        spdm_context->transcript.message_b.buffer_size,
-        sizeof(spdm_get_digest_request_t) +
-        sizeof(spdm_digest_response_t) +
-        libspdm_get_hash_size(spdm_context->connection_info
-                              .algorithm.base_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
-
-    m_get_digest = false;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_m.buffer_size =
-        spdm_context->transcript.message_m.max_buffer_size;
-#endif
-    cert_chain_size = sizeof(cert_chain);
-    libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
-                                     cert_chain);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
-    free(data);
-
-    m_get_digest = true;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_m.buffer_size =
-        spdm_context->transcript.message_m.max_buffer_size;
-#endif
-    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    /* second GetDigest */
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(slot_mask, 0xFF);
-    libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
-    digest = my_total_digest_buffer;
-    digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
-    libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, digest);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-    data_return_size = sizeof(uint8_t);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_SLOT_MASK,
-                              NULL, &slot_mask, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, sizeof(uint8_t));
-    assert_int_equal(slot_mask, 0xFF);
-    data_return_size = sizeof(total_digest_buffer);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_TOTAL_DIGEST_BUFFER,
-                              NULL, total_digest_buffer, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, libspdm_get_hash_size(
-                         m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(
-        spdm_context->transcript.message_b.buffer_size,
-        sizeof(spdm_get_digest_request_t) +
-        sizeof(spdm_digest_response_t) +
-        libspdm_get_hash_size(spdm_context->connection_info
-                              .algorithm.base_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
-}
-
-/**
- * Test 25: a request message is successfully sent and a response message is successfully received
- * in a session.
- * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is received
- **/
-static void libspdm_test_requester_get_digests_case25(void **state)
-{
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    uint8_t slot_mask;
-    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t my_total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-    uint8_t *digest;
-    size_t data_return_size;
-    uint32_t session_id;
-    libspdm_session_info_t *session_info;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x19;
+    spdm_test_context->case_id = 0xC;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
-    spdm_context->connection_info.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
-    spdm_context->connection_info.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
-    spdm_context->connection_info.algorithm.dhe_named_group =
-        m_libspdm_use_dhe_algo;
-    spdm_context->connection_info.algorithm.aead_cipher_suite =
-        m_libspdm_use_aead_algo;
-
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
     spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
     spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-
-    session_id = 0xFFFFFFFF;
-    session_info = &spdm_context->session_info[0];
-    libspdm_session_info_init(spdm_context, session_info, session_id, true);
-    libspdm_secured_message_set_session_state(session_info->secured_message_context,
-                                              LIBSPDM_SESSION_STATE_ESTABLISHED);
-
     libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
                     (uint8_t)(0xFF));
     libspdm_reset_message_b(spdm_context);
 
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    session_info->session_transcript.message_m.buffer_size =
-        session_info->session_transcript.message_m.max_buffer_size;
-#endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest_in_session(spdm_context, &session_id, &slot_mask,
-                                           &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-
-    assert_int_equal(slot_mask, 0xFF);
-    libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
-    digest = my_total_digest_buffer;
-    digest += libspdm_get_hash_size(m_libspdm_use_hash_algo) * (SPDM_MAX_SLOT_COUNT - 2);
-    libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_certificate_chain,
-                     LIBSPDM_MAX_MESSAGE_BUFFER_SIZE, digest);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-
-    data_return_size = sizeof(uint8_t);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_SLOT_MASK,
-                              NULL, &slot_mask, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, sizeof(uint8_t));
-    assert_int_equal(slot_mask, 0xFF);
-
-    data_return_size = sizeof(total_digest_buffer);
-    status = libspdm_get_data(spdm_context, LIBSPDM_DATA_PEER_TOTAL_DIGEST_BUFFER,
-                              NULL, total_digest_buffer, &data_return_size);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(data_return_size, libspdm_get_hash_size(
-                         m_libspdm_use_hash_algo) * SPDM_MAX_SLOT_COUNT);
-    assert_memory_equal (total_digest_buffer, my_total_digest_buffer,
-                         sizeof(my_total_digest_buffer));
-
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     sizeof(spdm_get_digest_request_t));
 #endif
+}
+
+/**
+ * Test 13: a request message is successfully sent but the request_response_code from the response message is different than the code of SPDM_DIGESTS
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_INVALID_MSG_FIELD, with no DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case13(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xD;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 14: a request message is successfully sent but the number of digests in the response message is equal to zero
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_INVALID_MSG_FIELD, with no successful DIGESTS message received
+ **/
+static void libspdm_test_requester_get_digests_err_case14(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xE;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     0);
+#endif
+}
+
+/**
+ * Test 15: a request message is successfully sent but it cannot be appended to the internal cache since the internal cache is full
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR
+ **/
+static void libspdm_test_requester_get_digests_err_case15(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xF;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->transcript.message_b.buffer_size =
+        spdm_context->transcript.message_b.max_buffer_size;
+#endif
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_FULL);
+}
+
+/**
+ * Test 16: a request message is successfully sent but the response message cannot be appended to the internal cache since the internal cache is full
+ * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION
+ **/
+static void libspdm_test_requester_get_digests_err_case16(void **state)
+{
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    libspdm_return_t status;
+    uint8_t slot_mask;
+#endif
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x10;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_FULL);
+#endif
+}
+
+/**
+ * Test 17: a request message is successfully sent but the single digest received in the response message is invalid
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_VERIF_FAIL, with error state LIBSPDM_STATUS_ERROR_CERTIFICATE_FAILURE
+ **/
+static void libspdm_test_requester_get_digests_err_case17(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x11;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
+}
+
+/**
+ * Test 18: a request message is successfully sent but the number of digests received in the response message is different than
+ * the number of bits set in param2 - Slot mask
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ **/
+static void libspdm_test_requester_get_digests_err_case18(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x12;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     0);
+#endif
+}
+
+/**
+ * Test 19: a request message is successfully sent but several digests (except the first) received in the response message are invalid
+ * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION, with error state LIBSPDM_STATUS_ERROR_CERTIFICATE_FAILURE
+ **/
+static void libspdm_test_requester_get_digests_err_case19(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x13;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
+}
+
+/**
+ * Test 20: a request message is successfully sent but the size of the response message is smaller than the minimum size of a SPDM DIGESTS response,
+ * meaning it is an invalid response message.
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ **/
+static void libspdm_test_requester_get_digests_err_case20(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x14;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     sizeof(spdm_get_digest_request_t));
+#endif
+}
+
+/**
+ * Test 21: a request message is successfully sent but the size of the response message is bigger than the maximum size of a SPDM DIGESTS response,
+ * meaning it is an invalid response message.
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ **/
+static void libspdm_test_requester_get_digests_err_case21(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x15;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                    (uint8_t)(0xFF));
+    libspdm_reset_message_b(spdm_context);
+
+    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
+    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
+                     sizeof(spdm_get_digest_request_t));
+#endif
+}
+
+/**
+ * Test 22: receiving an unexpected ERROR message from the responder.
+ * There are tests for all named codes, including some reserved ones
+ * (namely, 0x00, 0x0b, 0x0c, 0x3f, 0xfd, 0xfe).
+ * However, for having specific test cases, it is excluded from this case:
+ * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
+ * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
+ **/
+static void libspdm_test_requester_get_digests_err_case22(void **state) {
+    libspdm_return_t status;
+    libspdm_test_context_t    *spdm_test_context;
+    libspdm_context_t  *spdm_context;
+    uint8_t slot_mask;
+    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
+    uint16_t error_code;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x16;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
+    libspdm_set_mem (m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
+                     (uint8_t)(0xFF));
+
+    error_code = LIBSPDM_ERROR_CODE_RESERVED_00;
+    while(error_code <= 0xff) {
+        spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+        libspdm_reset_message_b(spdm_context);
+
+        libspdm_zero_mem (total_digest_buffer, sizeof(total_digest_buffer));
+        status = libspdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);
+        LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        LIBSPDM_ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0,
+                                       error_code);
+#endif
+
+        error_code++;
+        if(error_code == SPDM_ERROR_CODE_BUSY) { /*busy is treated in cases 5 and 6*/
+            error_code = SPDM_ERROR_CODE_UNEXPECTED_REQUEST;
+        }
+        if(error_code == LIBSPDM_ERROR_CODE_RESERVED_0D) { /*skip some reserved error codes (0d to 3e)*/
+            error_code = LIBSPDM_ERROR_CODE_RESERVED_3F;
+        }
+        if(error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) { /*skip response not ready, request resync, and some reserved codes (44 to fc)*/
+            error_code = LIBSPDM_ERROR_CODE_RESERVED_FD;
+        }
+    }
+}
+
+/**
+ * Test 23:
+ * Expected Behavior:
+ **/
+static void libspdm_test_requester_get_digests_err_case23(void **state)
+{
+}
+
+/**
+ * Test 24:
+ * Expected Behavior:
+ **/
+static void libspdm_test_requester_get_digests_err_case24(void **state)
+{
+}
+
+/**
+ * Test 25:
+ * Expected Behavior:
+ **/
+static void libspdm_test_requester_get_digests_err_case25(void **state)
+{
 }
 
 static libspdm_test_context_t m_libspdm_requester_get_digests_test_context = {
@@ -1494,35 +1728,32 @@ static libspdm_test_context_t m_libspdm_requester_get_digests_test_context = {
     libspdm_requester_get_digests_test_receive_message,
 };
 
-int libspdm_requester_get_digests_test_main(void)
+int libspdm_requester_get_digests_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_digests_tests[] = {
-        cmocka_unit_test(libspdm_test_requester_get_digests_case1),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case2),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case3),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case4),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case5),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case6),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case7),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case8),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case9),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case10),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case11),
-        /* size of response < spdm_message_header_t
-        * cmocka_unit_test(libspdm_test_requester_get_digests_case12),
-        * request_response_code wrong in response*/
-        cmocka_unit_test(libspdm_test_requester_get_digests_case13),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case14),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case16),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case17),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case18),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case1),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case2),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case3),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case4),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case5),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case6),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case7),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case8),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case9),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case10),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case11),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case13),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case14),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case16),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case17),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case18),
         /* cmocka_unit_test(libspdm_test_requester_get_digests_err_case19),
          * cmocka_unit_test(libspdm_test_requester_get_digests_err_case20),
          * cmocka_unit_test(libspdm_test_requester_get_digests_err_case21), */
-        cmocka_unit_test(libspdm_test_requester_get_digests_case22),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case23),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case24),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case25),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case22),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case23),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case24),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case25),
     };
 
     libspdm_setup_test_context(&m_libspdm_requester_get_digests_test_context);

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1540,6 +1540,7 @@ static void libspdm_test_requester_get_digests_err_case18(void **state)
 #endif
 }
 
+#if 0
 /**
  * Test 19: a request message is successfully sent but several digests (except the first) received in the response message are invalid
  * Expected Behavior: requester returns the status RETURN_SECURITY_VIOLATION, with error state LIBSPDM_STATUS_ERROR_CERTIFICATE_FAILURE
@@ -1642,6 +1643,7 @@ static void libspdm_test_requester_get_digests_err_case21(void **state)
                      sizeof(spdm_get_digest_request_t));
 #endif
 }
+#endif
 
 /**
  * Test 22: receiving an unexpected ERROR message from the responder.

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1300,39 +1300,11 @@ static void libspdm_test_requester_get_digests_err_case11(void **state)
 }
 
 /**
- * Test 12: a request message is successfully sent but the size of the response message is smaller than the size of the SPDM message header,
- * meaning it is an invalid response message
- * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ * Test 12:
+ * Expected Behavior:
  **/
 static void libspdm_test_requester_get_digests_err_case12(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    uint8_t slot_mask;
-    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xC;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
-    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
-    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                    (uint8_t)(0xFF));
-    libspdm_reset_message_b(spdm_context);
-
-    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_b.buffer_size,
-                     sizeof(spdm_get_digest_request_t));
-#endif
 }
 
 /**
@@ -1717,6 +1689,7 @@ int libspdm_requester_get_digests_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case9),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case10),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case11),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case12),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case13),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case14),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case15),

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1405,38 +1405,11 @@ static void libspdm_test_requester_get_digests_err_case14(void **state)
 }
 
 /**
- * Test 15: a request message is successfully sent but it cannot be appended to the internal cache since the internal cache is full
- * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR
+ * Test 15:
+ * Expected Behavior:
  **/
 static void libspdm_test_requester_get_digests_err_case15(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    uint8_t slot_mask;
-    uint8_t total_digest_buffer[LIBSPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_COUNT];
-
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xF;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
-    spdm_context->local_context.peer_cert_chain_provision = m_libspdm_local_certificate_chain;
-    spdm_context->local_context.peer_cert_chain_provision_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                    (uint8_t)(0xFF));
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->transcript.message_b.buffer_size =
-        spdm_context->transcript.message_b.max_buffer_size;
-#endif
-
-    libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
-    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_FULL);
 }
 
 /**
@@ -1746,6 +1719,7 @@ int libspdm_requester_get_digests_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case11),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case13),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case14),
+        cmocka_unit_test(libspdm_test_requester_get_digests_err_case15),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case16),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case17),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case18),

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1508,17 +1508,15 @@ int libspdm_requester_get_digests_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_case9),
         cmocka_unit_test(libspdm_test_requester_get_digests_case10),
         cmocka_unit_test(libspdm_test_requester_get_digests_case11),
-        /* size of response < spdm_message_header_t
-        * cmocka_unit_test(libspdm_test_requester_get_digests_case12),
-        * request_response_code wrong in response*/
+        cmocka_unit_test(libspdm_test_requester_get_digests_case12),
         cmocka_unit_test(libspdm_test_requester_get_digests_case13),
         cmocka_unit_test(libspdm_test_requester_get_digests_case14),
         cmocka_unit_test(libspdm_test_requester_get_digests_case16),
         cmocka_unit_test(libspdm_test_requester_get_digests_case17),
         cmocka_unit_test(libspdm_test_requester_get_digests_case18),
-        /* cmocka_unit_test(libspdm_test_requester_get_digests_err_case19),
-         * cmocka_unit_test(libspdm_test_requester_get_digests_err_case20),
-         * cmocka_unit_test(libspdm_test_requester_get_digests_err_case21), */
+        cmocka_unit_test(libspdm_test_requester_get_digests_case19),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case20),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case21),
         cmocka_unit_test(libspdm_test_requester_get_digests_case22),
         cmocka_unit_test(libspdm_test_requester_get_digests_case23),
         cmocka_unit_test(libspdm_test_requester_get_digests_case24),

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1511,6 +1511,7 @@ int libspdm_requester_get_digests_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_case12),
         cmocka_unit_test(libspdm_test_requester_get_digests_case13),
         cmocka_unit_test(libspdm_test_requester_get_digests_case14),
+        cmocka_unit_test(libspdm_test_requester_get_digests_case15),
         cmocka_unit_test(libspdm_test_requester_get_digests_case16),
         cmocka_unit_test(libspdm_test_requester_get_digests_case17),
         cmocka_unit_test(libspdm_test_requester_get_digests_case18),

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -16,6 +16,7 @@ int libspdm_requester_negotiate_algorithms_error_test_main(void);
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 int libspdm_requester_get_digests_test_main(void);
+int libspdm_requester_get_digests_error_test_main(void);
 int libspdm_requester_get_certificate_test_main(void);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
@@ -88,6 +89,9 @@ int main(void)
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
     if (libspdm_requester_get_digests_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_get_digests_error_test_main() != 0) {
         return_value = 1;
     }
     if (libspdm_requester_get_certificate_test_main() != 0) {


### PR DESCRIPTION
Move error tests to their own file. This brings line coverage up to 90.1 %.