### PR TITLE
Enable cryptlib error injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,6 +799,7 @@ else()
         ADD_SUBDIRECTORY(unit_test/test_spdm_responder)
         ADD_SUBDIRECTORY(unit_test/test_crypt)
         ADD_SUBDIRECTORY(unit_test/test_spdm_crypt)
+        ADD_SUBDIRECTORY(unit_test/cryptlib_wrapper)
         endif()
 
         if(NOT TOOLCHAIN STREQUAL "ARM_DS2022")

--- a/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
+++ b/os_stub/cryptlib_mbedtls/internal_crypt_lib.h
@@ -25,4 +25,24 @@
 
 int libspdm_myrand(void *rng_state, unsigned char *output, size_t len);
 
-#endif
+#if LIBSPDM_UNIT_TEST
+#define libspdm_sha256_new libspdm_sha256_new_internal
+#define libspdm_sha256_init libspdm_sha256_init_internal
+#define libspdm_sha256_update libspdm_sha256_update_internal
+#define libspdm_sha256_final libspdm_sha256_final_internal
+#define libspdm_sha256_hash_all libspdm_sha256_hash_all_internal
+
+#define libspdm_sha384_new libspdm_sha384_new_internal
+#define libspdm_sha384_init libspdm_sha384_init_internal
+#define libspdm_sha384_update libspdm_sha384_update_internal
+#define libspdm_sha384_final libspdm_sha384_final_internal
+#define libspdm_sha384_hash_all libspdm_sha384_hash_all_internal
+
+#define libspdm_sha512_new libspdm_sha512_new_internal
+#define libspdm_sha512_init libspdm_sha512_init_internal
+#define libspdm_sha512_update libspdm_sha512_update_internal
+#define libspdm_sha512_final libspdm_sha512_final_internal
+#define libspdm_sha512_hash_all libspdm_sha512_hash_all_internal
+#endif /* LIBSPDM_UNIT_TEST */
+
+#endif /* __INTERNAL_CRYPT_LIB_H__ */

--- a/unit_test/cryptlib_wrapper/CMakeLists.txt
+++ b/unit_test/cryptlib_wrapper/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    ADD_COMPILE_OPTIONS(-Wno-incompatible-pointer-types -Wno-pointer-sign)
+endif()
+
+INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
+                    ${LIBSPDM_DIR}/include/hal
+                    ${LIBSPDM_DIR}/include/hal/${ARCH}
+                    ${LIBSPDM_DIR}/os_stub/include
+                    ${LIBSPDM_DIR}/os_stub
+                    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls
+                    ${LIBSPDM_DIR}/os_stub/mbedtlslib/include
+                    ${LIBSPDM_DIR}/os_stub/mbedtlslib/include/mbedtls
+                    ${LIBSPDM_DIR}/os_stub/mbedtlslib/mbedtls/include
+                    ${LIBSPDM_DIR}/os_stub/mbedtlslib/mbedtls/include/mbedtls
+)
+
+add_compile_definitions(LIBSPDM_UNIT_TEST=1)
+
+SET(src_cryptlib_wrapper
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/cipher/aead_aes_gcm.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/cipher/aead_chacha20_poly1305.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/cipher/aead_sm4_gcm.c
+    hash/sha.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hash/sha.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hash/sha3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hash/sm3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hmac/hmac_sha.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hmac/hmac_sha3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/hmac/hmac_sm3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/kdf/hkdf_sha.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/kdf/hkdf_sha3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/kdf/hkdf_sm3.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pem/pem.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/ec.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/ecd.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/dh.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/sm2.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/rsa_basic.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/rsa_ext.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/pk/x509.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/rand/rand.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/sys_call/mem_allocation.c
+    ${LIBSPDM_DIR}/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
+)
+
+ADD_LIBRARY(cryptlib_wrapper STATIC ${src_cryptlib_wrapper})
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    if((TOOLCHAIN STREQUAL "CBMC") OR (TOOLCHAIN STREQUAL "VS2015") OR (TOOLCHAIN STREQUAL "VS2019") OR (TOOLCHAIN STREQUAL "VS2022"))
+        TARGET_COMPILE_OPTIONS(cryptlib_wrapper PRIVATE /wd4090)
+    endif()
+endif()

--- a/unit_test/cryptlib_wrapper/hash/sha.c
+++ b/unit_test/cryptlib_wrapper/hash/sha.c
@@ -1,0 +1,202 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+/** @file
+ * SHA-256/384/512 digest Wrapper Implementation.
+ **/
+
+#include "internal_crypt_lib.h"
+
+#undef libspdm_sha256_new
+#undef libspdm_sha256_init
+#undef libspdm_sha256_update
+#undef libspdm_sha256_final
+#undef libspdm_sha256_hash_all
+
+#undef libspdm_sha384_new
+#undef libspdm_sha384_init
+#undef libspdm_sha384_update
+#undef libspdm_sha384_final
+#undef libspdm_sha384_hash_all
+
+#undef libspdm_sha512_new
+#undef libspdm_sha512_init
+#undef libspdm_sha512_update
+#undef libspdm_sha512_final
+#undef libspdm_sha512_hash_all
+
+bool m_libspdm_sha256_new_error = false;
+bool m_libspdm_sha256_init_error = false;
+bool m_libspdm_sha256_update_error = false;
+bool m_libspdm_sha256_final_error = false;
+bool m_libspdm_sha256_hash_all_error = false;
+
+bool m_libspdm_sha384_new_error = false;
+bool m_libspdm_sha384_init_error = false;
+bool m_libspdm_sha384_update_error = false;
+bool m_libspdm_sha384_final_error = false;
+bool m_libspdm_sha384_hash_all_error = false;
+
+bool m_libspdm_sha512_new_error = false;
+bool m_libspdm_sha512_init_error = false;
+bool m_libspdm_sha512_update_error = false;
+bool m_libspdm_sha512_final_error = false;
+bool m_libspdm_sha512_hash_all_error = false;
+
+void *libspdm_sha256_new_internal(void);
+bool libspdm_sha256_init_internal(void *sha256_context);
+bool libspdm_sha256_update_internal(void *sha256_context, const void *data, size_t data_size);
+bool libspdm_sha256_final_internal(void *sha256_context, uint8_t *hash_value);
+bool libspdm_sha256_hash_all_internal(const void *data, size_t data_size, uint8_t *hash_value);
+
+void *libspdm_sha384_new_internal(void);
+bool libspdm_sha384_init_internal(void *sha384_context);
+bool libspdm_sha384_update_internal(void *sha384_context, const void *data, size_t data_size);
+bool libspdm_sha384_final_internal(void *sha384_context, uint8_t *hash_value);
+bool libspdm_sha384_hash_all_internal(const void *data, size_t data_size, uint8_t *hash_value);
+
+void *libspdm_sha512_new_internal(void);
+bool libspdm_sha512_init_internal(void *sha512_context);
+bool libspdm_sha512_update_internal(void *sha512_context, const void *data, size_t data_size);
+bool libspdm_sha512_final_internal(void *sha512_context, uint8_t *hash_value);
+bool libspdm_sha512_hash_all_internal(const void *data, size_t data_size, uint8_t *hash_value);
+
+void *libspdm_sha256_new(void)
+{
+    if (m_libspdm_sha256_new_error) {
+        return NULL;
+    } else {
+        return libspdm_sha256_new_internal();
+    }
+}
+
+bool libspdm_sha256_init(void *sha256_context)
+{
+    if (m_libspdm_sha256_init_error) {
+        return false;
+    } else {
+        return libspdm_sha256_init_internal(sha256_context);
+    }
+}
+
+bool libspdm_sha256_update(void *sha256_context, const void *data, size_t data_size)
+{
+    if (m_libspdm_sha256_update_error) {
+        return false;
+    } else {
+        return libspdm_sha256_update_internal(sha256_context, data, data_size);
+    }
+}
+
+bool libspdm_sha256_final(void *sha256_context, uint8_t *hash_value)
+{
+    if (m_libspdm_sha256_final_error) {
+        return false;
+    } else {
+        return libspdm_sha256_final_internal(sha256_context, hash_value);
+    }
+}
+
+bool libspdm_sha256_hash_all(const void *data, size_t data_size, uint8_t *hash_value)
+{
+    if (m_libspdm_sha256_hash_all_error) {
+        return false;
+    } else {
+        return libspdm_sha256_hash_all_internal(data, data_size, hash_value);
+    }
+}
+
+void *libspdm_sha384_new(void)
+{
+    if (m_libspdm_sha384_new_error) {
+        return NULL;
+    } else {
+        return libspdm_sha384_new_internal();
+    }
+}
+
+bool libspdm_sha384_init(void *sha384_context)
+{
+    if (m_libspdm_sha384_init_error) {
+        return false;
+    } else {
+        return libspdm_sha384_init_internal(sha384_context);
+    }
+}
+
+bool libspdm_sha384_update(void *sha384_context, const void *data,
+                           size_t data_size)
+{
+    if (m_libspdm_sha384_update_error) {
+        return false;
+    } else {
+        return libspdm_sha384_update_internal(sha384_context, data, data_size);
+    }
+}
+
+bool libspdm_sha384_final(void *sha384_context, uint8_t *hash_value)
+{
+    if (m_libspdm_sha384_final_error) {
+        return false;
+    } else {
+        return libspdm_sha384_final_internal(sha384_context, hash_value);
+    }
+}
+
+bool libspdm_sha384_hash_all(const void *data, size_t data_size, uint8_t *hash_value)
+{
+    if (m_libspdm_sha384_hash_all_error) {
+        return false;
+    } else {
+        return libspdm_sha384_hash_all_internal(data, data_size, hash_value);
+    }
+}
+
+void *libspdm_sha512_new(void)
+{
+    if (m_libspdm_sha512_new_error) {
+        return NULL;
+    } else {
+        return libspdm_sha512_new_internal();
+    }
+}
+
+bool libspdm_sha512_init(void *sha512_context)
+{
+    if (m_libspdm_sha512_init_error) {
+        return false;
+    } else {
+        return libspdm_sha512_init_internal(sha512_context);
+    }
+}
+
+bool libspdm_sha512_update(void *sha512_context, const void *data,
+                           size_t data_size)
+{
+    if (m_libspdm_sha512_update_error) {
+        return false;
+    } else {
+        return libspdm_sha512_update_internal(sha512_context, data, data_size);
+    }
+}
+
+bool libspdm_sha512_final(void *sha512_context, uint8_t *hash_value)
+{
+    if (m_libspdm_sha512_final_error) {
+        return false;
+    } else {
+        return libspdm_sha512_final_internal(sha512_context, hash_value);
+    }
+}
+
+bool libspdm_sha512_hash_all(const void *data, size_t data_size, uint8_t *hash_value)
+{
+    if (m_libspdm_sha512_hash_all_error) {
+        return false;
+    } else {
+        return libspdm_sha512_hash_all_internal(data, data_size, hash_value);
+    }
+}

--- a/unit_test/spdm_unit_test_common/common.c
+++ b/unit_test/spdm_unit_test_common/common.c
@@ -14,6 +14,26 @@ static uint8_t m_send_receive_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static bool m_error_acquire_sender_buffer = false;
 static bool m_error_acquire_receiver_buffer = false;
 
+#if LIBSPDM_UNIT_TEST
+extern bool m_libspdm_sha256_new_error;
+extern bool m_libspdm_sha256_init_error;
+extern bool m_libspdm_sha256_update_error;
+extern bool m_libspdm_sha256_final_error;
+extern bool m_libspdm_sha256_hash_all_error;
+
+extern bool m_libspdm_sha384_new_error;
+extern bool m_libspdm_sha384_init_error;
+extern bool m_libspdm_sha384_update_error;
+extern bool m_libspdm_sha384_final_error;
+extern bool m_libspdm_sha384_hash_all_error;
+
+extern bool m_libspdm_sha512_new_error;
+extern bool m_libspdm_sha512_init_error;
+extern bool m_libspdm_sha512_update_error;
+extern bool m_libspdm_sha512_final_error;
+extern bool m_libspdm_sha512_hash_all_error;
+#endif
+
 libspdm_return_t spdm_device_acquire_sender_buffer (
     void *context, size_t *max_msg_size, void **msg_buf_ptr)
 {
@@ -127,6 +147,7 @@ int libspdm_unit_test_group_teardown(void **state)
     return 0;
 }
 
+#if LIBSPDM_UNIT_TEST
 void libspdm_force_error (libspdm_error_target_t target)
 {
     switch (target) {
@@ -135,6 +156,9 @@ void libspdm_force_error (libspdm_error_target_t target)
         break;
     case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
         m_error_acquire_receiver_buffer = true;
+        break;
+    case LIBSPDM_ERR_SHA256_HASH_ALL:
+        m_libspdm_sha256_hash_all_error = true;
         break;
     }
 }
@@ -148,5 +172,9 @@ void libspdm_release_error (libspdm_error_target_t target)
     case LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER:
         m_error_acquire_receiver_buffer = false;
         break;
+    case LIBSPDM_ERR_SHA256_HASH_ALL:
+        m_libspdm_sha256_hash_all_error = false;
+        break;
     }
 }
+#endif

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -77,7 +77,8 @@ bool libspdm_read_input_file(const char *file_name, void **file_data, size_t *fi
 typedef enum
 {
     LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER,
-    LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER
+    LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER,
+    LIBSPDM_ERR_SHA256_HASH_ALL,
 } libspdm_error_target_t;
 
 void libspdm_force_error (libspdm_error_target_t target);

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -17,6 +17,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     endif()
 endif()
 
+add_compile_definitions(LIBSPDM_UNIT_TEST=1)
+
 SET(src_test_spdm_requester
     test_spdm_requester.c
     get_version.c
@@ -59,7 +61,7 @@ SET(test_spdm_requester_LIBRARY
     spdm_common_lib
     ${CRYPTO_LIB_PATHS}
     rnglib
-    cryptlib_${CRYPTO}
+    cryptlib_wrapper
     malloclib
     spdm_crypt_lib
     spdm_crypt_ext_lib

--- a/unit_test/test_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_spdm_responder/CMakeLists.txt
@@ -17,6 +17,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     endif()
 endif()
 
+add_compile_definitions(LIBSPDM_UNIT_TEST=1)
+
 SET(src_test_spdm_responder
     test_spdm_responder.c
     version.c
@@ -57,7 +59,7 @@ SET(test_spdm_responder_LIBRARY
     spdm_common_lib
     ${CRYPTO_LIB_PATHS}
     rnglib
-    cryptlib_${CRYPTO}
+    cryptlib_wrapper
     malloclib
     spdm_crypt_lib
     spdm_crypt_ext_lib


### PR DESCRIPTION
This pull request is to get feedback on enabling error injection in the cryptography library. It creates a new library, `cryptlib_wrapper`, that includes both the underlying cryptography library as well as a wrapper that can be used to inject errors. The only modification to the files in `os_stub` is in `os_stub/cryptlib_mbedtls/internal_crypt_lib.h` and this may be able to be moved to `unit_test`.

This pull request is not intended to be merged.