### PR TITLE
Improve fuzzy test coverage

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
@@ -176,6 +176,84 @@ void libspdm_test_requester_heartbeat_case1(void **State)
         ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number = 0;
+    session_info->heartbeat_period = 1;
+
+    libspdm_heartbeat(spdm_context, session_id);
+    free(data);
+}
+
+void libspdm_test_requester_heartbeat_case2(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+    libspdm_session_info_t *session_info;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11
+                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size,
+                                                    &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#endif
+    libspdm_zero_mem(m_libspdm_local_psk_hint, 32);
+    libspdm_copy_mem(&m_libspdm_local_psk_hint[0], sizeof(m_libspdm_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size = sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_libspdm_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(session_info->secured_message_context,
+                                              LIBSPDM_SESSION_STATE_ESTABLISHED);
+    libspdm_set_mem(
+        m_libspdm_dummy_key_buffer,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size,
+        (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_data_encryption_key(
+        session_info->secured_message_context, m_libspdm_dummy_key_buffer,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_key_size);
+    libspdm_set_mem(
+        m_libspdm_dummy_salt_buffer,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size,
+        (uint8_t)(0xFF));
+    libspdm_secured_message_set_response_data_salt(
+        session_info->secured_message_context, m_libspdm_dummy_salt_buffer,
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->aead_iv_size);
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
+    ->application_secret.response_data_sequence_number = 0;
+    session_info->heartbeat_period = 0;
 
     libspdm_heartbeat(spdm_context, session_id);
     free(data);
@@ -200,5 +278,9 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     /* Successful response*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_requester_heartbeat_case1(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_requester_heartbeat_case2(&State);
     libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -83,6 +83,7 @@ void libspdm_test_responder_heartbeat_case1(void **State)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 1;
 
     response_size = sizeof(response);
     libspdm_get_response_heartbeat(spdm_context,
@@ -144,6 +145,78 @@ void libspdm_test_responder_heartbeat_case3(void **State)
                                    &response_size, response);
 }
 
+void libspdm_test_responder_heartbeat_case4(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    void *data1;
+    size_t data_size1;
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+    uint8_t m_local_psk_hint[32];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data1,
+                                                    &data_size1, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] =
+        data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size =
+        data_size1;
+
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+    libspdm_zero_mem(m_local_psk_hint, 32);
+    libspdm_copy_mem(&m_local_psk_hint[0], sizeof(m_local_psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING, sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    spdm_context->local_context.psk_hint_size =
+        sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
+    spdm_context->local_context.psk_hint = m_local_psk_hint;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+    session_info->heartbeat_period = 0;
+
+    response_size = sizeof(response);
+    libspdm_get_response_heartbeat(spdm_context,
+                                   spdm_test_context->test_buffer_size,
+                                   spdm_test_context->test_buffer,
+                                   &response_size, response);
+    free(data1);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -167,6 +240,10 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     /* connection_state: LIBSPDM_RESPONSE_STATE_BUSY */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_heartbeat_case3(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_heartbeat_case4(&State);
     libspdm_unit_test_group_teardown(&State);
 }
 #else


### PR DESCRIPTION
Fix : #1420 
The coverage after improvement is:
AFL Every fuzzing test case run about 30 minutes.
      libspdm_rsp_heartbeat.c 94.9 %
      libspdm_req_heartbeat.c 90.0 %

Signed-off-by: Xiaohanjlll <hanx.xiao@intel.com>