### PR TITLE
Improve code coverage for KEY_EXCHANGE

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -529,12 +529,10 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
     rsp_session_id = spdm_response->rsp_session_id;
     *session_id = (req_session_id << 16) | rsp_session_id;
     session_info = libspdm_assign_session_id(spdm_context, *session_id, false);
-    if (session_info == NULL) {
-        libspdm_secured_message_dhe_free(
-            spdm_context->connection_info.algorithm.dhe_named_group, dhe_context);
-        status = LIBSPDM_STATUS_SESSION_NUMBER_EXCEED;
-        goto receive_done;
-    }
+
+    /* session_info cannot be null as the check after libspdm_allocate_req_session_id assures
+     * that there is space for a new session ID and its initialization. */
+    LIBSPDM_ASSERT(session_info != NULL);
 
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -46,6 +46,7 @@ SET(src_test_spdm_requester
     error_test/get_capabilities_err.c
     error_test/negotiate_algorithms_err.c
     error_test/get_digests_err.c
+    error_test/key_exchange_err.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
     ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -15,8 +15,8 @@ static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static uint8_t m_libspdm_zero_filled_buffer[64];
 
 static size_t libspdm_test_get_key_exchange_request_size(const void *spdm_context,
-                                                  const void *buffer,
-                                                  size_t buffer_size)
+                                                         const void *buffer,
+                                                         size_t buffer_size)
 {
     const spdm_key_exchange_request_t *spdm_request;
     size_t message_size;

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -15,8 +15,8 @@ static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
 static uint8_t m_libspdm_zero_filled_buffer[64];
 
 static size_t libspdm_test_get_key_exchange_request_size(const void *spdm_context,
-                                                  const void *buffer,
-                                                  size_t buffer_size)
+                                                         const void *buffer,
+                                                         size_t buffer_size)
 {
     const spdm_key_exchange_request_t *spdm_request;
     size_t message_size;
@@ -4583,7 +4583,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
-case 0x1F: {
+    case 0x1F: {
         spdm_key_exchange_response_t *spdm_response;
         size_t dhe_key_size;
         uint32_t hash_size;
@@ -4644,7 +4644,6 @@ case 0x1F: {
         spdm_response->rsp_session_id = libspdm_allocate_rsp_session_id(spdm_context);
         spdm_response->mut_auth_requested = 0;
         spdm_response->req_slot_id_param = 0;
-        //libspdm_get_random_number(SPDM_RANDOM_DATA_SIZE, spdm_response->random_data);
         memset(spdm_response->random_data, 0x5c, SPDM_RANDOM_DATA_SIZE);
         ptr = (void *)(spdm_response + 1);
         dhe_context = libspdm_dhe_new(

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -30,6 +30,7 @@ int libspdm_requester_get_measurements_test_main(void);
 
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 int libspdm_requester_key_exchange_test_main(void);
+int libspdm_requester_key_exchange_error_test_main(void);
 int libspdm_requester_finish_test_main(void);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
 
@@ -113,6 +114,9 @@ int main(void)
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
     if (libspdm_requester_key_exchange_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_key_exchange_error_test_main() != 0) {
         return_value = 1;
     }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/


### PR DESCRIPTION
And move error tests to its own file. There will be a follow-up pull request to expand the code coverage even more, and include error injection into the cryptography library.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>