### PR TITLE
Fixing potential maybe-uninitialized warning with hash_size

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1453,12 +1453,8 @@ libspdm_return_t libspdm_append_message_k(void *context, void *session_info,
                     }
                 }
             }
-        }
 
-
-        /* prepare digest_context_th*/
-
-        if (spdm_session_info->session_transcript.digest_context_th == NULL) {
+            /* prepare digest_context_th*/
             spdm_session_info->session_transcript.digest_context_th = libspdm_hash_new (
                 spdm_context->connection_info.algorithm.base_hash_algo);
             if (spdm_session_info->session_transcript.digest_context_th == NULL) {
@@ -1623,13 +1619,9 @@ libspdm_return_t libspdm_append_message_f(void *context, void *session_info,
                 spdm_session_info->session_transcript.digest_context_th_backup = NULL;
                 return LIBSPDM_STATUS_CRYPTO_ERROR;
             }
-        }
 
-
-        /* prepare digest_context_th*/
-
-        LIBSPDM_ASSERT (spdm_session_info->session_transcript.digest_context_th != NULL);
-        if (!spdm_session_info->session_transcript.message_f_initialized) {
+            /* prepare digest_context_th*/
+            LIBSPDM_ASSERT (spdm_session_info->session_transcript.digest_context_th != NULL);
             if (!spdm_session_info->use_psk && spdm_session_info->mut_auth_requested) {
                 result = libspdm_hash_update (
                     spdm_context->connection_info.algorithm.base_hash_algo,


### PR DESCRIPTION
Fixing a "maybe-uninitialized" usage warning of my compiler was throwing about `hash_size` in the funcitons `libspdm_append_message_k` and `libspdm_append_message_f`.

Both functions use two checks for the same condition, which has no possibility of changing between the two checks. Removing this second check extra check also improves readability.

Ran unit tests locally with `LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT ` set to 1.

Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>