### PR TITLE
Fix undefined behavior in GET_MEASUREMENTS unit test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           - GCC
           - VS2019
           - LIBFUZZER
-          #- CLANG
+          - CLANG
           - ARM_GNU
         configurations:
           - "-DLIBSPDM_ENABLE_CAPABILITY_CERT_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_CHAL_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_MEAS_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_SET_CERTIFICATE_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP=1 -DLIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP=1"
@@ -103,8 +103,8 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
-      - name:  Toolchain Setup - Clang 
-        if:  matrix.toolchain == 'CLANG' || matrix.toolchain == 'LIBFUZZER' && matrix.os == 'ubuntu-latest' 
+      - name:  Toolchain Setup - Clang
+        if:  matrix.toolchain == 'CLANG' || matrix.toolchain == 'LIBFUZZER' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install llvm

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -2699,41 +2699,42 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0x23: {
+
         spdm_measurements_response_t *spdm_response;
         spdm_measurement_block_dmtf_t *measurment_block;
-        uint8_t temp_buf[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-        size_t temp_buf_size;
-        uint8_t* temp_buf_ptr;
-
+        size_t spdm_response_size;
+        size_t transport_header_size;
         uint8_t *ptr;
         ((libspdm_context_t *)spdm_context)->connection_info.algorithm.measurement_hash_algo =
             m_libspdm_use_measurement_hash_algo;
-        temp_buf_size = sizeof(spdm_measurements_response_t) +
-                        sizeof(spdm_measurement_block_dmtf_t) +
-                        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo) +
-                        SPDM_NONCE_SIZE + sizeof(uint16_t);
-        temp_buf_ptr = temp_buf + sizeof(libspdm_test_message_header_t);
-        spdm_response = (void *)temp_buf_ptr;
+        spdm_response_size = sizeof(spdm_measurements_response_t) +
+                             sizeof(spdm_measurement_block_dmtf_t) +
+                             libspdm_get_measurement_hash_size(
+            m_libspdm_use_measurement_hash_algo) + SPDM_NONCE_SIZE + sizeof(uint16_t);
+        transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
 
         spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
         spdm_response->header.request_response_code = SPDM_MEASUREMENTS;
         spdm_response->header.param1 = 0;
         spdm_response->header.param2 = 0;
         spdm_response->number_of_blocks = 1;
-        libspdm_write_uint24(spdm_response->measurement_record_length,
-                             (uint32_t)(sizeof(spdm_measurement_block_dmtf_t) +
-                                        libspdm_get_measurement_hash_size(
-                                            m_libspdm_use_measurement_hash_algo)));
+        libspdm_write_uint24(
+            spdm_response->measurement_record_length,
+            (uint32_t)(sizeof(spdm_measurement_block_dmtf_t) +
+                       libspdm_get_measurement_hash_size(
+                           m_libspdm_use_measurement_hash_algo)));
         measurment_block = (void *)(spdm_response + 1);
         libspdm_set_mem(measurment_block,
                         sizeof(spdm_measurement_block_dmtf_t) +
-                        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo),
-                        1);
-        measurment_block->measurement_block_common_header.measurement_specification =
-            SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->measurement_block_common_header.measurement_size =
+                        libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo), 1);
+        measurment_block->measurement_block_common_header
+        .measurement_specification = SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+        measurment_block->measurement_block_common_header
+        .measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
-                       libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo));
+                       libspdm_get_measurement_hash_size(
+                           m_libspdm_use_measurement_hash_algo));
 
         ptr = (uint8_t *)spdm_response +
               sizeof(spdm_measurements_response_t) +
@@ -2742,14 +2743,10 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_get_random_number(SPDM_NONCE_SIZE,ptr);
         *(uint16_t *)(ptr + SPDM_NONCE_SIZE) = 0;
 
-        libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
-                         sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
-                         temp_buf_ptr, temp_buf_size);
-        m_libspdm_local_buffer_size += temp_buf_size;
-
-        libspdm_transport_test_encode_message(spdm_context, NULL, false, false,
-                                              temp_buf_size, temp_buf_ptr,
-                                              response_size, response);
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -402,13 +402,6 @@ static libspdm_return_t libspdm_requester_get_measurements_test_send_message(
         m_libspdm_local_buffer_size += app_message_size - 3;
         return LIBSPDM_STATUS_SUCCESS;
     case 0x23:
-        m_libspdm_local_buffer_size = 0;
-        message_size = libspdm_test_get_measurement_request_size(
-            spdm_context, (const uint8_t *)request + header_size,
-            request_size - header_size);
-        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
-                         (const uint8_t *)request + header_size, message_size);
-        m_libspdm_local_buffer_size += message_size;
         return LIBSPDM_STATUS_SUCCESS;
     case 0x24:
         m_libspdm_local_buffer_size = 0;
@@ -2692,14 +2685,12 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             return LIBSPDM_STATUS_RECEIVE_FAIL;
         }
         /* WALKAROUND: If just use single context to encode message and then decode message */
-        ((libspdm_secured_message_context_t
-          *)(session_info->secured_message_context))
+        ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
     }
         return LIBSPDM_STATUS_SUCCESS;
 
     case 0x23: {
-
         spdm_measurements_response_t *spdm_response;
         spdm_measurement_block_dmtf_t *measurment_block;
         size_t spdm_response_size;
@@ -2722,26 +2713,27 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_write_uint24(
             spdm_response->measurement_record_length,
             (uint32_t)(sizeof(spdm_measurement_block_dmtf_t) +
-                       libspdm_get_measurement_hash_size(
-                           m_libspdm_use_measurement_hash_algo)));
+                       libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo)));
         measurment_block = (void *)(spdm_response + 1);
         libspdm_set_mem(measurment_block,
                         sizeof(spdm_measurement_block_dmtf_t) +
                         libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo), 1);
-        measurment_block->measurement_block_common_header
-        .measurement_specification = SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
-        measurment_block->measurement_block_common_header
-        .measurement_size =
+        measurment_block->measurement_block_common_header.measurement_specification =
+            SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF;
+        measurment_block->measurement_block_common_header.measurement_size =
             (uint16_t)(sizeof(spdm_measurement_block_dmtf_header_t) +
-                       libspdm_get_measurement_hash_size(
-                           m_libspdm_use_measurement_hash_algo));
+                       libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo));
 
         ptr = (uint8_t *)spdm_response +
               sizeof(spdm_measurements_response_t) +
               sizeof(spdm_measurement_block_dmtf_t) +
               libspdm_get_measurement_hash_size(m_libspdm_use_measurement_hash_algo);
-        libspdm_get_random_number(SPDM_NONCE_SIZE,ptr);
+        libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
         *(uint16_t *)(ptr + SPDM_NONCE_SIZE) = 0;
+
+        libspdm_copy_mem (m_libspdm_local_buffer, m_libspdm_local_buffer_size,
+                          spdm_response, spdm_response_size);
+        m_libspdm_local_buffer_size = spdm_response_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,
@@ -5362,8 +5354,7 @@ static void libspdm_test_requester_get_measurements_case35(void **state)
     spdm_test_context->case_id = 0x23;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
     libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
@@ -5376,8 +5367,7 @@ static void libspdm_test_requester_get_measurements_case35(void **state)
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
     spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
-        data_size;
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size = data_size;
     libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
                      sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
                      data, data_size);
@@ -5400,7 +5390,7 @@ static void libspdm_test_requester_get_measurements_case35(void **state)
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     /*filling M buffer with arbitrary data*/
     arbitrary_size = 18;
-    libspdm_set_mem(spdm_context->transcript.message_m.buffer, arbitrary_size, (uint8_t) 0xFF);
+    libspdm_set_mem(spdm_context->transcript.message_m.buffer, arbitrary_size, 0xFF);
     spdm_context->transcript.message_m.buffer_size = arbitrary_size;
 #endif
 
@@ -5412,12 +5402,13 @@ static void libspdm_test_requester_get_measurements_case35(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size,
+    /* Subtract the size of the request message. */
+    assert_int_equal(spdm_context->transcript.message_m.buffer_size - 0x4,
                      arbitrary_size + m_libspdm_local_buffer_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "m_libspdm_local_buffer (0x%x):\n",
                    m_libspdm_local_buffer_size));
     libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-    assert_memory_equal(spdm_context->transcript.message_m.buffer + arbitrary_size,
+    assert_memory_equal(spdm_context->transcript.message_m.buffer + arbitrary_size + 0x4,
                         m_libspdm_local_buffer, m_libspdm_local_buffer_size);
 #endif
     free(data);


### PR DESCRIPTION
and re-enable CLANG in CI/CD. The `temp_buf` array was being modified at an out-of-bounds index. GCC and Visual Studio didn't mind but CLANG 14, with -O1 or higher optimizations, did. 

Note that Valgrind is picking up additional issues in `test_spdm_requester`. I'll file a separate issue for those.

Fixes #1467.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>