### PR TITLE
Fixing potentially uninitialized warning in KEY_UPDATE callbacks.

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -172,6 +172,8 @@ libspdm_return_t libspdm_receive_response(void *context, const uint32_t *session
         false, message_size, message, response_size, response);
 
     reset_key_update = false;
+    temp_session_context = NULL;
+
     if (status == LIBSPDM_STATUS_SESSION_TRY_DISCARD_KEY_UPDATE) {
         /* Failed to decode, but have backup keys. Try rolling back before aborting.
          * message_session_id must be valid for us to have attempted decryption. */

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -184,6 +184,8 @@ libspdm_return_t libspdm_process_request(void *context, uint32_t **session_id,
         (void **)&decoded_message_ptr);
 
     reset_key_update = false;
+    temp_session_context = NULL;
+
     if (status == LIBSPDM_STATUS_SESSION_TRY_DISCARD_KEY_UPDATE) {
         /* Failed to decode, but have backup keys. Try rolling back before aborting.
          * message_session_id must be valid for us to have attempted decryption. */


### PR DESCRIPTION
Fixes #1489.

Although `temp_session_context` must necessarily be set when `reset_key_update` is true, the compiler does not catch this dependency, and we therefore get potentially uninitialized warnings in the code scanner.

Fixing this by ensuring `temp_session_context` is at least set to NULL - we check for this after `reset_key_update` to ensure we do not dereference a NULL pointer.

Signed-off-by: Timothy Prinz <tandrewprinz@nvidia.com>