### PR TITLE
Use malloclib_simple for test_size.

### DIFF
--- a/unit_test/test_size/test_size_of_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_size/test_size_of_spdm_requester/CMakeLists.txt
@@ -44,7 +44,7 @@ SET(test_size_of_spdm_requester_LIBRARY
 #    cryptlib_${CRYPTO}
 #    rnglib_null
     cryptlib_null
-    malloclib_null
+    malloclib_simple
     spdm_crypt_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib

--- a/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_size/test_size_of_spdm_responder/CMakeLists.txt
@@ -42,7 +42,7 @@ SET(test_size_of_spdm_responder_LIBRARY
 #    cryptlib_${CRYPTO}
 #    rnglib_null
     cryptlib_null
-    malloclib_null
+    malloclib_simple
     spdm_crypt_lib
     spdm_secured_message_lib
     spdm_transport_mctp_lib


### PR DESCRIPTION
The reason is that it can better align to embed system config and avoid optimization caused by malloc failure.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>