### PR TITLE
remove LIBSPDM_MAX_MEASUREMENT_BLOCK_COUNT.

### DIFF
--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -48,9 +48,6 @@
 #define LIBSPDM_MAX_ROOT_CERT_SUPPORT 10
 #endif
 
-#ifndef LIBSPDM_MAX_MEASUREMENT_BLOCK_COUNT
-#define LIBSPDM_MAX_MEASUREMENT_BLOCK_COUNT 8
-#endif
 /* If the Responder supports it a Requester is allowed to establish multiple secure sessions with
  * the Responder. This value specifies the maximum number of sessions libspdm can support.
  */

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -329,8 +329,6 @@ libspdm_return_t libspdm_get_response_measurements(void *context,
         }
     }
 
-    LIBSPDM_ASSERT(measurements_count <= LIBSPDM_MAX_MEASUREMENT_BLOCK_COUNT);
-
     switch (spdm_request->header.param2) {
     case SPDM_GET_MEASUREMENTS_REQUEST_MEASUREMENT_OPERATION_TOTAL_NUMBER_OF_MEASUREMENTS:
         spdm_response_size += 0; /* Just to match code pattern in other case blocks*/

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1582,9 +1582,6 @@ bool libspdm_generate_measurement_summary_hash(
             return false;
         }
 
-        LIBSPDM_ASSERT(device_measurement_count <=
-                       LIBSPDM_MAX_MEASUREMENT_BLOCK_COUNT);
-
         /* double confirm that MeasurmentData internal size is correct*/
         measurment_data_size = 0;
         cached_measurment_block = (void *)device_measurement;


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/1491

Since SPDM supports RAW data based measurement, having such MAX_BLOCK_COUNT is useless for size constrain.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>