### PR TITLE
Add macro checks to cryptlib

### DIFF
--- a/include/hal/library/cryptlib/cryptlib_dh.h
+++ b/include/hal/library/cryptlib/cryptlib_dh.h
@@ -32,53 +32,6 @@ extern void *libspdm_dh_new_by_nid(size_t nid);
 void libspdm_dh_free(void *dh_context);
 
 /**
- * Generates DH parameter.
- *
- * Given generator g, and length of prime number p in bits, this function generates p,
- * and sets DH context according to value of g and p.
- *
- * If dh_context is NULL, then return false.
- * If prime is NULL, then return false.
- * If this interface is not supported, then return false.
- *
- * @param[in, out]  dh_context    Pointer to the DH context.
- * @param[in]       generator     Value of generator.
- * @param[in]       prime_length  Length in bits of prime to be generated.
- * @param[out]      prime         Pointer to the buffer to receive the generated prime number.
- *
- * @retval true   DH parameter generation succeeded.
- * @retval false  Value of generator is not supported.
- * @retval false  Random number generator fails to generate random prime number with prime_length.
- * @retval false  This interface is not supported.
- **/
-extern bool libspdm_dh_generate_parameter(void *dh_context, size_t generator,
-                                          size_t prime_length, uint8_t *prime);
-
-/**
- * Sets generator and prime parameters for DH.
- *
- * Given generator g, and prime number p, this function and sets DH context accordingly.
- *
- * If dh_context is NULL, then return false.
- * If prime is NULL, then return false.
- * If this interface is not supported, then return false.
- *
- * @param[in, out]  dh_context    Pointer to the DH context.
- * @param[in]       generator     Value of generator.
- * @param[in]       prime_length  Length in bits of prime to be generated.
- * @param[in]       prime         Pointer to the prime number.
- *
- * @retval true   DH parameter setting succeeded.
- * @retval false  Value of generator is not supported.
- * @retval false  Value of generator is not suitable for the prime.
- * @retval false  Value of prime is not a prime number.
- * @retval false  Value of prime is not a safe prime number.
- * @retval false  This interface is not supported.
- **/
-extern bool libspdm_dh_set_parameter(void *dh_context, size_t generator,
-                                     size_t prime_length, const uint8_t *prime);
-
-/**
  * Generates DH public key.
  *
  * This function generates random secret exponent, and computes the public key, which is

--- a/include/hal/library/cryptlib/cryptlib_ec.h
+++ b/include/hal/library/cryptlib/cryptlib_ec.h
@@ -11,6 +11,7 @@
  *    Elliptic Curve Primitives
  *=====================================================================================*/
 
+#if (LIBSPDM_ECDHE_SUPPORT) || (LIBSPDM_ECDSA_SUPPORT)
 /**
  * Allocates and Initializes one Elliptic Curve context for subsequent use with the NID.
  *
@@ -27,73 +28,9 @@ extern void *libspdm_ec_new_by_nid(size_t nid);
  * @param[in]  ec_context  Pointer to the EC context to be released.
  **/
 extern void libspdm_ec_free(void *ec_context);
+#endif /* (LIBSPDM_ECDHE_SUPPORT) || (LIBSPDM_ECDSA_SUPPORT) */
 
-/**
- * Sets the public key component into the established EC context.
- *
- * For P-256, the public_size is 64. first 32-byte is X, second 32-byte is Y.
- * For P-384, the public_size is 96. first 48-byte is X, second 48-byte is Y.
- * For P-521, the public_size is 132. first 66-byte is X, second 66-byte is Y.
- *
- * @param[in, out]  ec_context   Pointer to EC context being set.
- * @param[in]       public       Pointer to the buffer to receive generated public X,Y.
- * @param[in]       public_size  The size of public buffer in bytes.
- *
- * @retval  true   EC public key component was set successfully.
- * @retval  false  Invalid EC public key component.
- **/
-extern bool libspdm_ec_set_pub_key(void *ec_context, const uint8_t *public_key,
-                                   size_t public_key_size);
-
-/**
- * Sets the private key component into the established EC context.
- *
- * For P-256, the private_key_size is 32 byte.
- * For P-384, the private_key_size is 48 byte.
- * For P-521, the private_key_size is 66 byte.
- *
- * @param[in, out]  ec_context       Pointer to EC context being set.
- * @param[in]       private_key      Pointer to the private key buffer.
- * @param[in]       private_key_size The size of private key buffer in bytes.
- *
- * @retval  true   EC private key component was set successfully.
- * @retval  false  Invalid EC private key component.
- *
- **/
-extern bool libspdm_ec_set_priv_key(void *ec_context, const uint8_t *private_key,
-                                    size_t private_key_size);
-
-/**
- * Gets the public key component from the established EC context.
- *
- * For P-256, the public_size is 64. first 32-byte is X, second 32-byte is Y.
- * For P-384, the public_size is 96. first 48-byte is X, second 48-byte is Y.
- * For P-521, the public_size is 132. first 66-byte is X, second 66-byte is Y.
- *
- * @param[in, out]  ec_context   Pointer to EC context being set.
- * @param[out]      public       Pointer to the buffer to receive generated public X,Y.
- * @param[in, out]  public_size  On input, the size of public buffer in bytes.
- *                               On output, the size of data returned in public buffer in bytes.
- *
- * @retval  true   EC key component was retrieved successfully.
- * @retval  false  Invalid EC key component.
- **/
-extern bool libspdm_ec_get_pub_key(void *ec_context, uint8_t *public_key, size_t *public_key_size);
-
-/**
- * Validates key components of EC context.
- * NOTE: This function performs integrity checks on all the EC key material, so
- *       the EC key structure must contain all the private key data.
- *
- * If ec_context is NULL, then return false.
- *
- * @param[in]  ec_context  Pointer to EC context to check.
- *
- * @retval  true   EC key components are valid.
- * @retval  false  EC key components are not valid.
- **/
-extern bool libspdm_ec_check_key(const void *ec_context);
-
+#if LIBSPDM_ECDHE_SUPPORT
 /**
  * Generates EC key and returns EC public key (X, Y).
  *
@@ -159,7 +96,9 @@ extern bool libspdm_ec_generate_key(void *ec_context, uint8_t *public_key, size_
 extern bool libspdm_ec_compute_key(void *ec_context, const uint8_t *peer_public,
                                    size_t peer_public_size, uint8_t *key,
                                    size_t *key_size);
+#endif /* LIBSPDM_ECDHE_SUPPORT */
 
+#if LIBSPDM_ECDSA_SUPPORT
 /**
  * Carries out the EC-DSA signature.
  *
@@ -219,5 +158,5 @@ extern bool libspdm_ecdsa_sign(void *ec_context, size_t hash_nid,
 extern bool libspdm_ecdsa_verify(void *ec_context, size_t hash_nid,
                                  const uint8_t *message_hash, size_t hash_size,
                                  const uint8_t *signature, size_t sig_size);
-
+#endif /* LIBSPDM_ECDSA_SUPPORT */
 #endif /* CRYPTLIB_EC_H */

--- a/include/hal/library/cryptlib/cryptlib_ecd.h
+++ b/include/hal/library/cryptlib/cryptlib_ecd.h
@@ -11,6 +11,7 @@
  *    Edwards-Curve Primitives
  *=====================================================================================*/
 
+#if (LIBSPDM_EDDSA_ED25519_SUPPORT) || (LIBSPDM_EDDSA_ED448_SUPPORT)
 /**
  * Allocates and Initializes one Edwards-Curve context for subsequent use with the NID.
  *
@@ -27,75 +28,6 @@ extern void *libspdm_ecd_new_by_nid(size_t nid);
  * @param[in]  ecd_context  Pointer to the Ed context to be released.
  **/
 extern void libspdm_ecd_free(void *ecd_context);
-
-/**
- * Sets the public key component into the established Ed context.
- *
- * For ed25519, the public_size is 32.
- * For ed448, the public_size is 57.
- *
- * @param[in, out]  ecd_context    Pointer to Ed context being set.
- * @param[in]       public_key     Pointer to the buffer to receive generated public X,Y.
- * @param[in]       public_size    The size of public buffer in bytes.
- *
- * @retval  true   Ed public key component was set successfully.
- * @retval  false  Invalid EC public key component.
- **/
-extern bool libspdm_ecd_set_pub_key(void *ecd_context, const uint8_t *public_key,
-                                    size_t public_key_size);
-
-/**
- * Gets the public key component from the established Ed context.
- *
- * For ed25519, the public_size is 32.
- * For ed448, the public_size is 57.
- *
- * @param[in, out]  ecd_context    Pointer to Ed context being set.
- * @param[out]      public         Pointer to the buffer to receive generated public X,Y.
- * @param[in, out]  public_size    On input, the size of public buffer in bytes.
- *                                 On output, the size of data returned in public buffer in bytes.
- *
- * @retval  true   Ed key component was retrieved successfully.
- * @retval  false  Invalid EC public key component.
- **/
-extern bool libspdm_ecd_get_pub_key(void *ecd_context, uint8_t *public_key,
-                                    size_t *public_key_size);
-
-/**
- * Validates key components of Ed context.
- * NOTE: This function performs integrity checks on all the Ed key material, so
- *       the Ed key structure must contain all the private key data.
- *
- * If ecd_context is NULL, then return false.
- *
- * @param[in]  ecd_context  Pointer to Ed context to check.
- *
- * @retval  true   Ed key components are valid.
- * @retval  false  Ed key components are not valid.
- **/
-extern bool libspdm_ecd_check_key(const void *ecd_context);
-
-/**
- * Generates Ed key and returns Ed public key.
- *
- * For ed25519, the public_size is 32.
- * For ed448, the public_size is 57.
- *
- * If ecd_context is NULL, then return false.
- * If public_size is NULL, then return false.
- * If public_size is large enough but public is NULL, then return false.
- *
- * @param[in, out]  ecd_context      Pointer to the Ed context.
- * @param[out]      public_key       Pointer to the buffer to receive generated public key.
- * @param[in, out]  public_key_size  On input, the size of public buffer in bytes.
- *                                   On output, the size of data returned in public buffer in bytes.
- *
- * @retval true   Ed public key generation succeeded.
- * @retval false  Ed public key generation failed.
- * @retval false  public_size is not large enough.
- **/
-extern bool libspdm_ecd_generate_key(void *ecd_context, uint8_t *public_key,
-                                     size_t *public_key_size);
 
 /**
  * Carries out the Ed-DSA signature.
@@ -164,5 +96,5 @@ extern bool libspdm_eddsa_verify(const void *ecd_context, size_t hash_nid,
                                  const uint8_t *context, size_t context_size,
                                  const uint8_t *message, size_t size,
                                  const uint8_t *signature, size_t sig_size);
-
+#endif /* (LIBSPDM_EDDSA_ED25519_SUPPORT) || (LIBSPDM_EDDSA_ED448_SUPPORT) */
 #endif /* CRYPTLIB_ECD_H */

--- a/include/hal/library/cryptlib/cryptlib_sm2.h
+++ b/include/hal/library/cryptlib/cryptlib_sm2.h
@@ -11,6 +11,7 @@
  *    Shang-Mi2 Primitives
  *=====================================================================================*/
 
+#if LIBSPDM_SM2_DSA_SUPPORT
 /**
  * Allocates and Initializes one Shang-Mi2 context for subsequent use.
  *
@@ -29,79 +30,70 @@ extern void *libspdm_sm2_dsa_new_by_nid(size_t nid);
 extern void libspdm_sm2_dsa_free(void *sm2_context);
 
 /**
- * Sets the public key component into the established sm2 context.
+ * Carries out the SM2 signature, based upon GB/T 32918.2-2016: SM2 - Part2.
  *
- * The public_size is 64. first 32-byte is X, second 32-byte is Y.
- *
- * @param[in, out]  ec_context       Pointer to sm2 context being set.
- * @param[in]       public_key       Pointer to the buffer to receive generated public X,Y.
- * @param[in]       public_key_size  The size of public buffer in bytes.
- *
- * @retval  true   sm2 public key component was set successfully.
- * @retval  false  Invalid sm2 public key component.
- **/
-extern bool libspdm_sm2_dsa_set_pub_key(void *sm2_context, const uint8_t *public_key,
-                                        size_t public_key_size);
-
-/**
- * Gets the public key component from the established sm2 context.
- *
- * The public_size is 64. first 32-byte is X, second 32-byte is Y.
- *
- * @param[in, out]  sm2_context      Pointer to sm2 context being set.
- * @param[out]      public_key       Pointer to the buffer to receive generated public X,Y.
- * @param[in, out]  public_key_size  On input, the size of public buffer in bytes.
- *                                   On output, the size of data returned in public buffer in bytes.
- *
- * @retval  true   sm2 key component was retrieved successfully.
- * @retval  false  Invalid sm2 key component.
- **/
-extern bool libspdm_sm2_dsa_get_pub_key(void *sm2_context, uint8_t *public_key,
-                                        size_t *public_key_size);
-
-/**
- * Validates key components of sm2 context.
- * NOTE: This function performs integrity checks on all the sm2 key material, so
- *       the sm2 key structure must contain all the private key data.
+ * This function carries out the SM2 signature.
+ * If the signature buffer is too small to hold the contents of signature, false
+ * is returned and sig_size is set to the required buffer size to obtain the signature.
  *
  * If sm2_context is NULL, then return false.
+ * If message is NULL, then return false.
+ * hash_nid must be SM3_256.
+ * If sig_size is large enough but signature is NULL, then return false.
  *
- * @param[in]  sm2_context  Pointer to sm2 context to check.
+ * The id_a_size must be smaller than 2^16-1.
+ * The sig_size is 64. first 32-byte is R, second 32-byte is S.
  *
- * @retval  true   sm2 key components are valid.
- * @retval  false  sm2 key components are not valid.
+ * @param[in]       sm2_context  Pointer to sm2 context for signature generation.
+ * @param[in]       hash_nid     hash NID
+ * @param[in]       id_a         The ID-A of the signing context.
+ * @param[in]       id_a_size    Size of ID-A signing context.
+ * @param[in]       message      Pointer to octet message to be signed (before hash).
+ * @param[in]       size         Size of the message in bytes.
+ * @param[out]      signature    Pointer to buffer to receive SM2 signature.
+ * @param[in, out]  sig_size     On input, the size of signature buffer in bytes.
+ *                               On output, the size of data returned in signature buffer in bytes.
+ *
+ * @retval  true   signature successfully generated in SM2.
+ * @retval  false  signature generation failed.
+ * @retval  false  sig_size is too small.
  **/
-extern bool libspdm_sm2_dsa_check_key(const void *sm2_context);
+extern bool libspdm_sm2_dsa_sign(const void *sm2_context, size_t hash_nid,
+                                 const uint8_t *id_a, size_t id_a_size,
+                                 const uint8_t *message, size_t size,
+                                 uint8_t *signature, size_t *sig_size);
 
 /**
- * Generates sm2 key and returns sm2 public key (X, Y), based upon GB/T 32918.3-2016: SM2 - Part3.
- *
- * This function generates random secret, and computes the public key (X, Y), which is
- * returned via parameter public, public_size.
- * X is the first half of public with size being public_size / 2,
- * Y is the second half of public with size being public_size / 2.
- * sm2 context is updated accordingly.
- * If the public buffer is too small to hold the public X, Y, false is returned and
- * public_size is set to the required buffer size to obtain the public X, Y.
- *
- * The public_size is 64. first 32-byte is X, second 32-byte is Y.
+ * Verifies the SM2 signature, based upon GB/T 32918.2-2016: SM2 - Part2.
  *
  * If sm2_context is NULL, then return false.
- * If public_size is NULL, then return false.
- * If public_size is large enough but public is NULL, then return false.
+ * If message is NULL, then return false.
+ * If signature is NULL, then return false.
+ * hash_nid must be SM3_256.
  *
- * @param[in, out]  sm2_context  Pointer to the sm2 context.
- * @param[out]      public_data  Pointer to the buffer to receive generated public X,Y.
- * @param[in, out]  public_size  On input, the size of public buffer in bytes.
- *                               On output, the size of data returned in public buffer in bytes.
+ * The id_a_size must be smaller than 2^16-1.
+ * The sig_size is 64. first 32-byte is R, second 32-byte is S.
  *
- * @retval true   sm2 public X,Y generation succeeded.
- * @retval false  sm2 public X,Y generation failed.
- * @retval false  public_size is not large enough.
+ * @param[in]  sm2_context  Pointer to SM2 context for signature verification.
+ * @param[in]  hash_nid     hash NID
+ * @param[in]  id_a         The ID-A of the signing context.
+ * @param[in]  id_a_size    Size of ID-A signing context.
+ * @param[in]  message      Pointer to octet message to be checked (before hash).
+ * @param[in]  size         Size of the message in bytes.
+ * @param[in]  signature    Pointer to SM2 signature to be verified.
+ * @param[in]  sig_size     Size of signature in bytes.
+ *
+ * @retval  true   Valid signature encoded in SM2.
+ * @retval  false  Invalid signature or invalid sm2 context.
+ *
  **/
-extern bool libspdm_sm2_dsa_generate_key(void *sm2_context, uint8_t *public_data,
-                                         size_t *public_size);
+extern bool libspdm_sm2_dsa_verify(const void *sm2_context, size_t hash_nid,
+                                   const uint8_t *id_a, size_t id_a_size,
+                                   const uint8_t *message, size_t size,
+                                   const uint8_t *signature, size_t sig_size);
+#endif /* LIBSPDM_SM2_DSA_SUPPORT */
 
+#if LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT
 /**
  * Allocates and Initializes one Shang-Mi2 context for subsequent use.
  *
@@ -198,67 +190,5 @@ extern bool libspdm_sm2_key_exchange_compute_key(void *sm2_context,
                                                  const uint8_t *peer_public,
                                                  size_t peer_public_size, uint8_t *key,
                                                  size_t *key_size);
-
-/**
- * Carries out the SM2 signature, based upon GB/T 32918.2-2016: SM2 - Part2.
- *
- * This function carries out the SM2 signature.
- * If the signature buffer is too small to hold the contents of signature, false
- * is returned and sig_size is set to the required buffer size to obtain the signature.
- *
- * If sm2_context is NULL, then return false.
- * If message is NULL, then return false.
- * hash_nid must be SM3_256.
- * If sig_size is large enough but signature is NULL, then return false.
- *
- * The id_a_size must be smaller than 2^16-1.
- * The sig_size is 64. first 32-byte is R, second 32-byte is S.
- *
- * @param[in]       sm2_context  Pointer to sm2 context for signature generation.
- * @param[in]       hash_nid     hash NID
- * @param[in]       id_a         The ID-A of the signing context.
- * @param[in]       id_a_size    Size of ID-A signing context.
- * @param[in]       message      Pointer to octet message to be signed (before hash).
- * @param[in]       size         Size of the message in bytes.
- * @param[out]      signature    Pointer to buffer to receive SM2 signature.
- * @param[in, out]  sig_size     On input, the size of signature buffer in bytes.
- *                               On output, the size of data returned in signature buffer in bytes.
- *
- * @retval  true   signature successfully generated in SM2.
- * @retval  false  signature generation failed.
- * @retval  false  sig_size is too small.
- **/
-extern bool libspdm_sm2_dsa_sign(const void *sm2_context, size_t hash_nid,
-                                 const uint8_t *id_a, size_t id_a_size,
-                                 const uint8_t *message, size_t size,
-                                 uint8_t *signature, size_t *sig_size);
-
-/**
- * Verifies the SM2 signature, based upon GB/T 32918.2-2016: SM2 - Part2.
- *
- * If sm2_context is NULL, then return false.
- * If message is NULL, then return false.
- * If signature is NULL, then return false.
- * hash_nid must be SM3_256.
- *
- * The id_a_size must be smaller than 2^16-1.
- * The sig_size is 64. first 32-byte is R, second 32-byte is S.
- *
- * @param[in]  sm2_context  Pointer to SM2 context for signature verification.
- * @param[in]  hash_nid     hash NID
- * @param[in]  id_a         The ID-A of the signing context.
- * @param[in]  id_a_size    Size of ID-A signing context.
- * @param[in]  message      Pointer to octet message to be checked (before hash).
- * @param[in]  size         Size of the message in bytes.
- * @param[in]  signature    Pointer to SM2 signature to be verified.
- * @param[in]  sig_size     Size of signature in bytes.
- *
- * @retval  true   Valid signature encoded in SM2.
- * @retval  false  Invalid signature or invalid sm2 context.
- *
- **/
-extern bool libspdm_sm2_dsa_verify(const void *sm2_context, size_t hash_nid,
-                                   const uint8_t *id_a, size_t id_a_size,
-                                   const uint8_t *message, size_t size,
-                                   const uint8_t *signature, size_t sig_size);
+#endif /* LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT */
 #endif /* CRYPTLIB_SM2_H */

--- a/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
+++ b/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
@@ -409,4 +409,260 @@ extern bool libspdm_hkdf_sm3_256_extract_and_expand(const uint8_t *key, size_t k
                                                     const uint8_t *info, size_t info_size,
                                                     uint8_t *out, size_t out_size);
 
+/**
+ * Sets the public key component into the established EC context.
+ *
+ * For P-256, the public_size is 64. first 32-byte is X, second 32-byte is Y.
+ * For P-384, the public_size is 96. first 48-byte is X, second 48-byte is Y.
+ * For P-521, the public_size is 132. first 66-byte is X, second 66-byte is Y.
+ *
+ * @param[in, out]  ec_context   Pointer to EC context being set.
+ * @param[in]       public       Pointer to the buffer to receive generated public X,Y.
+ * @param[in]       public_size  The size of public buffer in bytes.
+ *
+ * @retval  true   EC public key component was set successfully.
+ * @retval  false  Invalid EC public key component.
+ **/
+extern bool libspdm_ec_set_pub_key(void *ec_context, const uint8_t *public_key,
+                                   size_t public_key_size);
+
+/**
+ * Sets the private key component into the established EC context.
+ *
+ * For P-256, the private_key_size is 32 byte.
+ * For P-384, the private_key_size is 48 byte.
+ * For P-521, the private_key_size is 66 byte.
+ *
+ * @param[in, out]  ec_context       Pointer to EC context being set.
+ * @param[in]       private_key      Pointer to the private key buffer.
+ * @param[in]       private_key_size The size of private key buffer in bytes.
+ *
+ * @retval  true   EC private key component was set successfully.
+ * @retval  false  Invalid EC private key component.
+ *
+ **/
+extern bool libspdm_ec_set_priv_key(void *ec_context, const uint8_t *private_key,
+                                    size_t private_key_size);
+
+/**
+ * Gets the public key component from the established EC context.
+ *
+ * For P-256, the public_size is 64. first 32-byte is X, second 32-byte is Y.
+ * For P-384, the public_size is 96. first 48-byte is X, second 48-byte is Y.
+ * For P-521, the public_size is 132. first 66-byte is X, second 66-byte is Y.
+ *
+ * @param[in, out]  ec_context   Pointer to EC context being set.
+ * @param[out]      public       Pointer to the buffer to receive generated public X,Y.
+ * @param[in, out]  public_size  On input, the size of public buffer in bytes.
+ *                               On output, the size of data returned in public buffer in bytes.
+ *
+ * @retval  true   EC key component was retrieved successfully.
+ * @retval  false  Invalid EC key component.
+ **/
+extern bool libspdm_ec_get_pub_key(void *ec_context, uint8_t *public_key, size_t *public_key_size);
+
+/**
+ * Validates key components of EC context.
+ * NOTE: This function performs integrity checks on all the EC key material, so
+ *       the EC key structure must contain all the private key data.
+ *
+ * If ec_context is NULL, then return false.
+ *
+ * @param[in]  ec_context  Pointer to EC context to check.
+ *
+ * @retval  true   EC key components are valid.
+ * @retval  false  EC key components are not valid.
+ **/
+extern bool libspdm_ec_check_key(const void *ec_context);
+
+/**
+ * Sets the public key component into the established Ed context.
+ *
+ * For ed25519, the public_size is 32.
+ * For ed448, the public_size is 57.
+ *
+ * @param[in, out]  ecd_context    Pointer to Ed context being set.
+ * @param[in]       public_key     Pointer to the buffer to receive generated public X,Y.
+ * @param[in]       public_size    The size of public buffer in bytes.
+ *
+ * @retval  true   Ed public key component was set successfully.
+ * @retval  false  Invalid EC public key component.
+ **/
+extern bool libspdm_ecd_set_pub_key(void *ecd_context, const uint8_t *public_key,
+                                    size_t public_key_size);
+
+/**
+ * Gets the public key component from the established Ed context.
+ *
+ * For ed25519, the public_size is 32.
+ * For ed448, the public_size is 57.
+ *
+ * @param[in, out]  ecd_context    Pointer to Ed context being set.
+ * @param[out]      public         Pointer to the buffer to receive generated public X,Y.
+ * @param[in, out]  public_size    On input, the size of public buffer in bytes.
+ *                                 On output, the size of data returned in public buffer in bytes.
+ *
+ * @retval  true   Ed key component was retrieved successfully.
+ * @retval  false  Invalid EC public key component.
+ **/
+extern bool libspdm_ecd_get_pub_key(void *ecd_context, uint8_t *public_key,
+                                    size_t *public_key_size);
+
+/**
+ * Validates key components of Ed context.
+ * NOTE: This function performs integrity checks on all the Ed key material, so
+ *       the Ed key structure must contain all the private key data.
+ *
+ * If ecd_context is NULL, then return false.
+ *
+ * @param[in]  ecd_context  Pointer to Ed context to check.
+ *
+ * @retval  true   Ed key components are valid.
+ * @retval  false  Ed key components are not valid.
+ **/
+extern bool libspdm_ecd_check_key(const void *ecd_context);
+
+/**
+ * Generates Ed key and returns Ed public key.
+ *
+ * For ed25519, the public_size is 32.
+ * For ed448, the public_size is 57.
+ *
+ * If ecd_context is NULL, then return false.
+ * If public_size is NULL, then return false.
+ * If public_size is large enough but public is NULL, then return false.
+ *
+ * @param[in, out]  ecd_context      Pointer to the Ed context.
+ * @param[out]      public_key       Pointer to the buffer to receive generated public key.
+ * @param[in, out]  public_key_size  On input, the size of public buffer in bytes.
+ *                                   On output, the size of data returned in public buffer in bytes.
+ *
+ * @retval true   Ed public key generation succeeded.
+ * @retval false  Ed public key generation failed.
+ * @retval false  public_size is not large enough.
+ **/
+extern bool libspdm_ecd_generate_key(void *ecd_context, uint8_t *public_key,
+                                     size_t *public_key_size);
+
+/**
+ * Generates DH parameter.
+ *
+ * Given generator g, and length of prime number p in bits, this function generates p,
+ * and sets DH context according to value of g and p.
+ *
+ * If dh_context is NULL, then return false.
+ * If prime is NULL, then return false.
+ * If this interface is not supported, then return false.
+ *
+ * @param[in, out]  dh_context    Pointer to the DH context.
+ * @param[in]       generator     Value of generator.
+ * @param[in]       prime_length  Length in bits of prime to be generated.
+ * @param[out]      prime         Pointer to the buffer to receive the generated prime number.
+ *
+ * @retval true   DH parameter generation succeeded.
+ * @retval false  Value of generator is not supported.
+ * @retval false  Random number generator fails to generate random prime number with prime_length.
+ * @retval false  This interface is not supported.
+ **/
+extern bool libspdm_dh_generate_parameter(void *dh_context, size_t generator,
+                                          size_t prime_length, uint8_t *prime);
+
+/**
+ * Sets generator and prime parameters for DH.
+ *
+ * Given generator g, and prime number p, this function and sets DH context accordingly.
+ *
+ * If dh_context is NULL, then return false.
+ * If prime is NULL, then return false.
+ * If this interface is not supported, then return false.
+ *
+ * @param[in, out]  dh_context    Pointer to the DH context.
+ * @param[in]       generator     Value of generator.
+ * @param[in]       prime_length  Length in bits of prime to be generated.
+ * @param[in]       prime         Pointer to the prime number.
+ *
+ * @retval true   DH parameter setting succeeded.
+ * @retval false  Value of generator is not supported.
+ * @retval false  Value of generator is not suitable for the prime.
+ * @retval false  Value of prime is not a prime number.
+ * @retval false  Value of prime is not a safe prime number.
+ * @retval false  This interface is not supported.
+ **/
+extern bool libspdm_dh_set_parameter(void *dh_context, size_t generator,
+                                     size_t prime_length, const uint8_t *prime);
+
+/**
+ * Sets the public key component into the established sm2 context.
+ *
+ * The public_size is 64. first 32-byte is X, second 32-byte is Y.
+ *
+ * @param[in, out]  ec_context       Pointer to sm2 context being set.
+ * @param[in]       public_key       Pointer to the buffer to receive generated public X,Y.
+ * @param[in]       public_key_size  The size of public buffer in bytes.
+ *
+ * @retval  true   sm2 public key component was set successfully.
+ * @retval  false  Invalid sm2 public key component.
+ **/
+extern bool libspdm_sm2_dsa_set_pub_key(void *sm2_context, const uint8_t *public_key,
+                                        size_t public_key_size);
+
+/**
+ * Gets the public key component from the established sm2 context.
+ *
+ * The public_size is 64. first 32-byte is X, second 32-byte is Y.
+ *
+ * @param[in, out]  sm2_context      Pointer to sm2 context being set.
+ * @param[out]      public_key       Pointer to the buffer to receive generated public X,Y.
+ * @param[in, out]  public_key_size  On input, the size of public buffer in bytes.
+ *                                   On output, the size of data returned in public buffer in bytes.
+ *
+ * @retval  true   sm2 key component was retrieved successfully.
+ * @retval  false  Invalid sm2 key component.
+ **/
+extern bool libspdm_sm2_dsa_get_pub_key(void *sm2_context, uint8_t *public_key,
+                                        size_t *public_key_size);
+
+/**
+ * Validates key components of sm2 context.
+ * NOTE: This function performs integrity checks on all the sm2 key material, so
+ *       the sm2 key structure must contain all the private key data.
+ *
+ * If sm2_context is NULL, then return false.
+ *
+ * @param[in]  sm2_context  Pointer to sm2 context to check.
+ *
+ * @retval  true   sm2 key components are valid.
+ * @retval  false  sm2 key components are not valid.
+ **/
+extern bool libspdm_sm2_dsa_check_key(const void *sm2_context);
+
+/**
+ * Generates sm2 key and returns sm2 public key (X, Y), based upon GB/T 32918.3-2016: SM2 - Part3.
+ *
+ * This function generates random secret, and computes the public key (X, Y), which is
+ * returned via parameter public, public_size.
+ * X is the first half of public with size being public_size / 2,
+ * Y is the second half of public with size being public_size / 2.
+ * sm2 context is updated accordingly.
+ * If the public buffer is too small to hold the public X, Y, false is returned and
+ * public_size is set to the required buffer size to obtain the public X, Y.
+ *
+ * The public_size is 64. first 32-byte is X, second 32-byte is Y.
+ *
+ * If sm2_context is NULL, then return false.
+ * If public_size is NULL, then return false.
+ * If public_size is large enough but public is NULL, then return false.
+ *
+ * @param[in, out]  sm2_context  Pointer to the sm2 context.
+ * @param[out]      public_data  Pointer to the buffer to receive generated public X,Y.
+ * @param[in, out]  public_size  On input, the size of public buffer in bytes.
+ *                               On output, the size of data returned in public buffer in bytes.
+ *
+ * @retval true   sm2 public X,Y generation succeeded.
+ * @retval false  sm2 public X,Y generation failed.
+ * @retval false  public_size is not large enough.
+ **/
+extern bool libspdm_sm2_dsa_generate_key(void *sm2_context, uint8_t *public_data,
+                                         size_t *public_size);
+
 #endif /* CRYPTLIB_EXT_H */

--- a/os_stub/spdm_device_secret_lib_sample/spdm_device_secret_lib_internal.h
+++ b/os_stub/spdm_device_secret_lib_sample/spdm_device_secret_lib_internal.h
@@ -14,6 +14,7 @@
 
 #include "library/spdm_crypt_lib.h"
 #include "spdm_crypt_ext_lib/spdm_crypt_ext_lib.h"
+#include "spdm_crypt_ext_lib/cryptlib_ext.h"
 #include "library/spdm_device_secret_lib.h"
 #include "hal/library/debuglib.h"
 

--- a/unit_test/test_crypt/ec_verify.c
+++ b/unit_test/test_crypt/ec_verify.c
@@ -6,6 +6,8 @@
 
 #include "test_crypt.h"
 
+#if (LIBSPDM_ECDHE_SUPPORT_TEST) && (LIBSPDM_ECDSA_SUPPORT_TEST)
+
 /*ecp256 key: https://lapo.it/asn1js/#MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjqRWI_stNQKCZwHIIL9pQLqos_cTSZ2Q3L5XaPaE-hGhRANCAAR-X9hTLdaMSJxS9gNglcAxjLCocVJ5I6msv8D7iLloQfRC_RsnQFl5UkTDAKfkavduNdy0AM2VR4XMmD6I9E1D*/
 uint8_t m_libspdm_ec_public_key[] = {
     0x7E, 0x5F, 0xD8, 0x53, 0x2D, 0xD6, 0x8C, 0x48, 0x9C, 0x52, 0xF6, 0x03, 0x60, 0x95, 0xC0, 0x31,
@@ -68,9 +70,7 @@ bool libspdm_validate_crypt_ec(void)
         return false;
     }
 
-
-    /* Verify EC-DH*/
-
+    /* Verify EC-DH */
     libspdm_my_print("Generate key1 ... ");
     status = libspdm_ec_generate_key(ec1, public1, &public1_length);
     if (!status || public1_length != 48 * 2) {
@@ -248,9 +248,7 @@ bool libspdm_validate_crypt_ec(void)
         return false;
     }
 
-
-    /* Verify EC-DSA*/
-
+    /* Verify EC-DSA */
     hash_size = sizeof(hash_value);
     sig_size = sizeof(signature);
     libspdm_my_print("\n- EC-DSA Signing ... ");
@@ -430,3 +428,4 @@ bool libspdm_validate_crypt_ec(void)
 
     return true;
 }
+#endif /* (LIBSPDM_ECDHE_SUPPORT_TEST) && (LIBSPDM_ECDSA_SUPPORT_TEST) */

--- a/unit_test/test_crypt/sm2_verify.c
+++ b/unit_test/test_crypt/sm2_verify.c
@@ -6,6 +6,8 @@
 
 #include "test_crypt.h"
 
+#if (LIBSPDM_SM2_DSA_SUPPORT_TEST) || (LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST)
+
 #define DEFAULT_SM2_ID "1234567812345678"
 
 /**
@@ -23,15 +25,20 @@ bool libspdm_validate_crypt_sm2(void)
     size_t public1_length;
     uint8_t public2[66 * 2];
     size_t public2_length;
+    #if LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST
     uint8_t key1[66];
     size_t key1_length;
     uint8_t key2[66];
     size_t key2_length;
+    #endif /* LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST */
+    #if LIBSPDM_SM2_DSA_SUPPORT
     uint8_t message[] = "Sm2Test";
     uint8_t signature[66 * 2];
     size_t sig_size;
+    #endif /* LIBSPDM_SM2_DSA_SUPPORT_TEST */
     bool status;
 
+    #if LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST
     libspdm_my_print("\nCrypto SM2 key Exchange Testing:\n");
 
     /* Initialize key length*/
@@ -130,7 +137,9 @@ bool libspdm_validate_crypt_sm2(void)
 
     libspdm_sm2_key_exchange_free(Sm2_1);
     libspdm_sm2_key_exchange_free(Sm2_2);
+    #endif /* LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST */
 
+    #if LIBSPDM_SM2_DSA_SUPPORT_TEST
     libspdm_my_print("\nCrypto sm2 Signing Verification Testing:\n");
 
     public1_length = sizeof(public1);
@@ -258,6 +267,8 @@ bool libspdm_validate_crypt_sm2(void)
 
     libspdm_sm2_dsa_free(Sm2_1);
     libspdm_sm2_dsa_free(Sm2_2);
+    #endif /* LIBSPDM_SM2_DSA_SUPPORT_TEST */
 
     return true;
 }
+#endif /* (LIBSPDM_SM2_DSA_SUPPORT_TEST) || (LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST) */

--- a/unit_test/test_crypt/test_crypt.c
+++ b/unit_test/test_crypt/test_crypt.c
@@ -90,14 +90,14 @@ bool libspdm_cryptest_main(void)
         return status;
     }
 
-    #if LIBSPDM_FFDHE_SUPPORT
+    #if LIBSPDM_FFDHE_SUPPORT_TEST
     status = libspdm_validate_crypt_dh();
     if (!status) {
         return status;
     }
-    #endif /* LIBSPDM_FFDHE_SUPPORT */
+    #endif /* LIBSPDM_FFDHE_SUPPORT_TEST */
 
-    #if LIBSPDM_ECDSA_SUPPORT_TEST
+    #if (LIBSPDM_ECDHE_SUPPORT_TEST) && (LIBSPDM_ECDSA_SUPPORT_TEST)
     status = libspdm_validate_crypt_ec();
     if (!status) {
         return status;
@@ -107,7 +107,7 @@ bool libspdm_cryptest_main(void)
     if (!status) {
         return status;
     }
-    #endif /* LIBSPDM_ECDSA_SUPPORT_TEST */
+    #endif /* (LIBSPDM_ECDHE_SUPPORT_TEST) && (LIBSPDM_ECDSA_SUPPORT_TEST) */
 
     #if (LIBSPDM_EDDSA_ED25519_SUPPORT_TEST) || (LIBSPDM_EDDSA_ED448_SUPPORT_TEST)
     status = libspdm_validate_crypt_ecd();
@@ -121,12 +121,12 @@ bool libspdm_cryptest_main(void)
     }
     #endif /* (LIBSPDM_EDDSA_ED25519_SUPPORT_TEST) || (LIBSPDM_EDDSA_ED448_SUPPORT_TEST) */
 
-    #if LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST
+    #if (LIBSPDM_SM2_DSA_SUPPORT_TEST) || (LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST)
     status = libspdm_validate_crypt_sm2();
     if (!status) {
         return status;
     }
-    #endif /*LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST*/
+    #endif /* (LIBSPDM_SM2_DSA_SUPPORT_TEST) || (LIBSPDM_SM2_KEY_EXCHANGE_SUPPORT_TEST) */
 
     #if LIBSPDM_SM2_DSA_SUPPORT_TEST
     status = libspdm_validate_crypt_sm2_2();


### PR DESCRIPTION
and move unused functions to `os_stub`.

Fixes #1535.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>