### PR TITLE
define libspdm_sleep_in_us to sleep microseconds.

### DIFF
--- a/include/hal/library/platform_lib.h
+++ b/include/hal/library/platform_lib.h
@@ -11,11 +11,20 @@
 
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
+ * This API is deprecated. Please use libspdm_sleep_in_us().
  *
  * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
 void libspdm_sleep(uint64_t milliseconds);
+
+/**
+ * Suspends the execution of the current thread until the time-out interval elapses.
+ *
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ *
+ **/
+void libspdm_sleep_in_us(uint64_t microseconds);
 
 #if LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP
 /**

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -173,7 +173,7 @@ static libspdm_return_t libspdm_handle_response_not_ready(libspdm_context_t *spd
     spdm_context->error_data.token = extend_error_data->token;
     spdm_context->error_data.rd_tm = extend_error_data->rd_tm;
 
-    libspdm_sleep((2 << extend_error_data->rd_exponent)/1000);
+    libspdm_sleep_in_us((2 << extend_error_data->rd_exponent));
     return libspdm_requester_respond_if_ready(spdm_context, session_id,
                                               response_size, response,
                                               expected_response_code,

--- a/os_stub/platform_lib/time_linux.c
+++ b/os_stub/platform_lib/time_linux.c
@@ -12,16 +12,16 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
-void libspdm_sleep(uint64_t milliseconds)
+void libspdm_sleep_in_us(uint64_t microseconds)
 {
     struct timeval tv;
     int err;
 
-    tv.tv_sec = milliseconds / 1000;
-    tv.tv_usec = (milliseconds % 1000) * 1000;
+    tv.tv_sec = microseconds / 1000000;
+    tv.tv_usec = (microseconds % 1000000);
 
     do {
         err=select(0, NULL, NULL, NULL, &tv);

--- a/os_stub/platform_lib/time_sample.c
+++ b/os_stub/platform_lib/time_sample.c
@@ -17,11 +17,11 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
 
-void libspdm_sleep(uint64_t milliseconds)
+void libspdm_sleep_in_us(uint64_t microseconds)
 {
     /*the feature for armclang build is TBD*/
     LIBSPDM_ASSERT(false);

--- a/os_stub/platform_lib/time_win.c
+++ b/os_stub/platform_lib/time_win.c
@@ -12,10 +12,13 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
-void libspdm_sleep(uint64_t milliseconds)
+void libspdm_sleep_in_us(uint64_t microseconds)
 {
+    uint64_t milliseconds;
+
+    milliseconds = (microseconds + 1000 - 1) / 1000;
     Sleep((DWORD)milliseconds);
 }

--- a/os_stub/platform_lib_null/time_linux.c
+++ b/os_stub/platform_lib_null/time_linux.c
@@ -9,9 +9,9 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
-void libspdm_sleep(uint64_t milliseconds)
+void libspdm_sleep_in_us(uint64_t microseconds)
 {
 }

--- a/os_stub/platform_lib_null/time_win.c
+++ b/os_stub/platform_lib_null/time_win.c
@@ -9,9 +9,9 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
  *
  **/
-void libspdm_sleep(uint64_t milliseconds)
+void libspdm_sleep_in_us(uint64_t microseconds)
 {
 }


### PR DESCRIPTION
Deprecate libspdm_sleep which sleeps milliseconds.

Fix: https://github.com/DMTF/libspdm/issues/1555

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>