### PR TITLE
Make the mbedtls gen csr return right

### DIFF
--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -1819,16 +1819,18 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
     mbedtls_x509write_csr_set_key(&req, &key);
 
     /*data is written at the end of the buffer*/
-    *csr_len = mbedtls_x509write_csr_der(&req, *csr_pointer, csr_buffer_size, libspdm_myrand, NULL);
-    if (*csr_len <= 0) {
+    ret = mbedtls_x509write_csr_der(&req, *csr_pointer, csr_buffer_size, libspdm_myrand, NULL);
+    if (ret <= 0) {
         ret = 1;
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,"mbedtls_x509write_csr_der failed \n"));
         goto free_all;
     }
 
+    *csr_len = (size_t)ret;
     /*change csr_pointer to start location*/
     *csr_pointer = *csr_pointer + csr_buffer_size - *csr_len;
 
+    ret = 0;
 free_all:
     mbedtls_x509write_csr_free(&req);
     mbedtls_pk_free(&key);


### PR DESCRIPTION
`mbedtls_x509write_csr_der` return type is `int` not `size_t`.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>