### PR TITLE
Remove function pointers from symmetric cryptography functions in spdm_crypt_lib

### DIFF
--- a/library/spdm_crypt_lib/libspdm_crypt_aead.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_aead.c
@@ -6,56 +6,6 @@
 
 #include "internal/libspdm_crypt_lib.h"
 
-/**
- * Performs AEAD authenticated encryption on a data buffer and additional authenticated data (AAD).
- *
- * @param  key            Pointer to the encryption key.
- * @param  key_size       Size of the encryption key in bytes.
- * @param  iv             Pointer to the IV value.
- * @param  iv_size        Size of the IV value in bytes.
- * @param  a_data         Pointer to the additional authenticated data (AAD).
- * @param  a_data_size    Size of the additional authenticated data (AAD) in bytes.
- * @param  data_in        Pointer to the input data buffer to be encrypted.
- * @param  data_in_size   Size of the input data buffer in bytes.
- * @param  tag_out        Pointer to a buffer that receives the authentication tag output.
- * @param  tag_size       Size of the authentication tag in bytes.
- * @param  data_out       Pointer to a buffer that receives the encryption output.
- * @param  data_out_size  Size of the output data buffer in bytes.
- *
- * @retval true   AEAD authenticated encryption succeeded.
- * @retval false  AEAD authenticated encryption failed.
- **/
-typedef bool (*libspdm_aead_encrypt_func)(
-    const uint8_t *key, size_t key_size, const uint8_t *iv,
-    size_t iv_size, const uint8_t *a_data, size_t a_data_size,
-    const uint8_t *data_in, size_t data_in_size, uint8_t *tag_out,
-    size_t tag_size, uint8_t *data_out, size_t *data_out_size);
-
-/**
- * Performs AEAD authenticated decryption on a data buffer and additional authenticated data (AAD).
- *
- * @param  key            Pointer to the encryption key.
- * @param  key_size       Size of the encryption key in bytes.
- * @param  iv             Pointer to the IV value.
- * @param  iv_size        Size of the IV value in bytes.
- * @param  a_data         Pointer to the additional authenticated data (AAD).
- * @param  a_data_size    Size of the additional authenticated data (AAD) in bytes.
- * @param  data_in        Pointer to the input data buffer to be decrypted.
- * @param  data_in_size   Size of the input data buffer in bytes.
- * @param  tag            Pointer to a buffer that contains the authentication tag.
- * @param  tag_size       Size of the authentication tag in bytes.
- * @param  data_out       Pointer to a buffer that receives the decryption output.
- * @param  data_out_size  Size of the output data buffer in bytes.
- *
- * @retval true   AEAD authenticated decryption succeeded.
- * @retval false  AEAD authenticated decryption failed.
- **/
-typedef bool (*libspdm_aead_decrypt_func)(
-    const uint8_t *key, size_t key_size, const uint8_t *iv,
-    size_t iv_size, const uint8_t *a_data, size_t a_data_size,
-    const uint8_t *data_in, size_t data_in_size, const uint8_t *tag,
-    size_t tag_size, uint8_t *data_out, size_t *data_out_size);
-
 uint32_t libspdm_get_aead_key_size(uint16_t aead_cipher_suite)
 {
     switch (aead_cipher_suite) {
@@ -104,52 +54,6 @@ uint32_t libspdm_get_aead_tag_size(uint16_t aead_cipher_suite)
     }
 }
 
-/**
- * Return AEAD encryption function, based upon the negotiated AEAD algorithm.
- *
- * @param  aead_cipher_suite              SPDM aead_cipher_suite
- *
- * @return AEAD encryption function
- **/
-static libspdm_aead_encrypt_func libspdm_get_aead_enc_func(uint16_t aead_cipher_suite)
-{
-    switch (aead_cipher_suite) {
-    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM:
-#if LIBSPDM_AEAD_GCM_SUPPORT
-        return libspdm_aead_aes_gcm_encrypt;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM:
-#if LIBSPDM_AEAD_GCM_SUPPORT
-        return libspdm_aead_aes_gcm_encrypt;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_CHACHA20_POLY1305:
-#if LIBSPDM_AEAD_CHACHA20_POLY1305_SUPPORT
-        return libspdm_aead_chacha20_poly1305_encrypt;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AEAD_SM4_GCM:
-#if LIBSPDM_AEAD_SM4_SUPPORT
-        return libspdm_aead_sm4_gcm_encrypt;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
 bool libspdm_aead_encryption(const spdm_version_number_t secured_message_version,
                              uint16_t aead_cipher_suite, const uint8_t *key,
                              size_t key_size, const uint8_t *iv,
@@ -159,60 +63,47 @@ bool libspdm_aead_encryption(const spdm_version_number_t secured_message_version
                              size_t tag_size, uint8_t *data_out,
                              size_t *data_out_size)
 {
-    libspdm_aead_encrypt_func aead_enc_function;
-    aead_enc_function = libspdm_get_aead_enc_func(aead_cipher_suite);
-    if (aead_enc_function == NULL) {
-        return false;
-    }
-    return aead_enc_function(key, key_size, iv, iv_size, a_data,
-                             a_data_size, data_in, data_in_size, tag_out,
-                             tag_size, data_out, data_out_size);
-}
-
-/**
- * Return AEAD decryption function, based upon the negotiated AEAD algorithm.
- *
- * @param  aead_cipher_suite              SPDM aead_cipher_suite
- *
- * @return AEAD decryption function
- **/
-static libspdm_aead_decrypt_func libspdm_get_aead_dec_func(uint16_t aead_cipher_suite)
-{
     switch (aead_cipher_suite) {
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM:
 #if LIBSPDM_AEAD_GCM_SUPPORT
-        return libspdm_aead_aes_gcm_decrypt;
+        return libspdm_aead_aes_gcm_encrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag_out,
+                                            tag_size, data_out, data_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM:
 #if LIBSPDM_AEAD_GCM_SUPPORT
-        return libspdm_aead_aes_gcm_decrypt;
+        return libspdm_aead_aes_gcm_encrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag_out,
+                                            tag_size, data_out, data_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_CHACHA20_POLY1305:
 #if LIBSPDM_AEAD_CHACHA20_POLY1305_SUPPORT
-        return libspdm_aead_chacha20_poly1305_decrypt;
+        return libspdm_aead_chacha20_poly1305_encrypt(key, key_size, iv, iv_size, a_data,
+                                                      a_data_size, data_in, data_in_size, tag_out,
+                                                      tag_size, data_out, data_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AEAD_SM4_GCM:
 #if LIBSPDM_AEAD_SM4_SUPPORT
-        return libspdm_aead_sm4_gcm_decrypt;
+        return libspdm_aead_sm4_gcm_encrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag_out,
+                                            tag_size, data_out, data_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     default:
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
     }
-
-    return NULL;
 }
 
 bool libspdm_aead_decryption(const spdm_version_number_t secured_message_version,
@@ -224,12 +115,45 @@ bool libspdm_aead_decryption(const spdm_version_number_t secured_message_version
                              size_t tag_size, uint8_t *data_out,
                              size_t *data_out_size)
 {
-    libspdm_aead_decrypt_func aead_dec_function;
-    aead_dec_function = libspdm_get_aead_dec_func(aead_cipher_suite);
-    if (aead_dec_function == NULL) {
+    switch (aead_cipher_suite) {
+    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_128_GCM:
+#if LIBSPDM_AEAD_GCM_SUPPORT
+        return libspdm_aead_aes_gcm_decrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag,
+                                            tag_size, data_out, data_out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM:
+#if LIBSPDM_AEAD_GCM_SUPPORT
+        return libspdm_aead_aes_gcm_decrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag,
+                                            tag_size, data_out, data_out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_CHACHA20_POLY1305:
+#if LIBSPDM_AEAD_CHACHA20_POLY1305_SUPPORT
+        return libspdm_aead_chacha20_poly1305_decrypt(key, key_size, iv, iv_size, a_data,
+                                                      a_data_size, data_in, data_in_size, tag,
+                                                      tag_size, data_out, data_out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AEAD_SM4_GCM:
+#if LIBSPDM_AEAD_SM4_SUPPORT
+        return libspdm_aead_sm4_gcm_decrypt(key, key_size, iv, iv_size, a_data,
+                                            a_data_size, data_in, data_in_size, tag,
+                                            tag_size, data_out, data_out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return aead_dec_function(key, key_size, iv, iv_size, a_data,
-                             a_data_size, data_in, data_in_size, tag,
-                             tag_size, data_out, data_out_size);
 }

--- a/library/spdm_crypt_lib/libspdm_crypt_hash.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hash.c
@@ -6,101 +6,6 @@
 
 #include "internal/libspdm_crypt_lib.h"
 
-/**
- * Allocates and initializes one HASH_CTX context for subsequent hash use.
- *
- * @return  Pointer to the HASH_CTX context that has been initialized.
- *          If the allocations fails, libspdm_hash_new_func() returns NULL.
- **/
-typedef void *(*libspdm_hash_new_func)(void);
-
-/**
- * Release the specified HASH_CTX context.
- *
- * @param  hash_context Pointer to the HASH_CTX context to be released.
- **/
-typedef void (*libspdm_hash_free_func)(void *hash_context);
-
-/**
- * Initializes user-supplied memory pointed by hash_context as hash context for
- * subsequent use.
- *
- * @param  base_hash_algo  SPDM base_hash_algo
- * @param  hash_context    Pointer to hash context being initialized.
- *
- * @retval true   Hash context initialization succeeded.
- * @retval false  Hash context initialization failed.
- **/
-typedef bool (*libspdm_hash_init_func)(void *hash_context);
-
-/**
- * Makes a copy of an existing hash context.
- *
- * If hash_ctx is NULL, then return false.
- * If new_hash_ctx is NULL, then return false.
- *
- * @param[in]  hash_ctx      Pointer to hash context being copied.
- * @param[out] new_hash_ctx  Pointer to new hash context.
- *
- * @retval true   Hash context copy succeeded.
- * @retval false  Hash context copy failed.
- *
- **/
-typedef bool (*libspdm_hash_duplicate_func)(const void *hash_ctx, void *new_hash_ctx);
-
-/**
- * Digests the input data and updates hash context.
- *
- * This function performs hash digest on a data buffer of the specified size.
- * It can be called multiple times to compute the digest of long or discontinuous data streams.
- * Hash context should be already correctly initialized by hash_init(), and should not be finalized
- * by hash_final(). Behavior with invalid context is undefined.
- *
- * If hash_context is NULL, then return false.
- *
- * @param[in, out]  hash_context   Pointer to the MD context.
- * @param[in]       data           Pointer to the buffer containing the data to be hashed.
- * @param[in]       data_size      Size of data buffer in bytes.
- *
- * @retval true   hash data digest succeeded.
- * @retval false  hash data digest failed.
- **/
-typedef bool (*libspdm_hash_update_func)(void *hash_context, const void *data, size_t data_size);
-
-/**
- * Completes computation of the hash digest value.
- *
- * This function completes hash computation and retrieves the digest value into
- * the specified memory. After this function has been called, the hash context cannot
- * be used again.
- * hash context should be already correctly initialized by hash_init(), and should not be
- * finalized by hash_final(). Behavior with invalid hash context is undefined.
- *
- * If hash_context is NULL, then return false.
- * If hash_value is NULL, then return false.
- *
- * @param[in, out]  hash_context    Pointer to the hash context.
- * @param[out]      hash_value      Pointer to a buffer that receives the hash digest value.
- *
- * @retval true   hash digest computation succeeded.
- * @retval false  hash digest computation failed.
- **/
-typedef bool (*libspdm_hash_final_func)(void *hash_context, uint8_t *hash_value);
-
-/**
- * Computes the hash of a input data buffer.
- *
- * This function performs the hash of a given data buffer, and return the hash value.
- *
- * @param  data        Pointer to the buffer containing the data to be hashed.
- * @param  data_size   Size of data buffer in bytes.
- * @param  hash_value  Pointer to a buffer that receives the hash value.
- *
- * @retval true   hash computation succeeded.
- * @retval false  hash computation failed.
- **/
-typedef bool (*libspdm_hash_all_func)(const void *data, size_t data_size, uint8_t *hash_value);
-
 uint32_t libspdm_get_hash_size(uint32_t base_hash_algo)
 {
     switch (base_hash_algo) {
@@ -142,545 +47,412 @@ size_t libspdm_get_hash_nid(uint32_t base_hash_algo)
     }
 }
 
-/**
- * Return hash new function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash new function
- **/
-static libspdm_hash_new_func libspdm_get_hash_new_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash free function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash free function
- **/
-static libspdm_hash_free_func libspdm_get_hash_free_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash init function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash init function
- **/
-static libspdm_hash_init_func libspdm_get_hash_init_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_init;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash duplicate function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash duplicate function
- **/
-static libspdm_hash_duplicate_func libspdm_get_hash_duplicate_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash update function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash update function
- **/
-static libspdm_hash_update_func libspdm_get_hash_update_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash final function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash final function
- **/
-static libspdm_hash_final_func libspdm_get_hash_final_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return hash function, based upon the negotiated hash algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return hash function
- **/
-static libspdm_hash_all_func libspdm_get_hash_all_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_sha256_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_sha384_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_sha512_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_sha3_256_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_sha3_384_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_sha3_512_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_sm3_256_hash_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
 void *libspdm_hash_new(uint32_t base_hash_algo)
 {
-    libspdm_hash_new_func hash_function;
-    hash_function = libspdm_get_hash_new_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return NULL;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return NULL;
     }
-    return hash_function();
 }
 
 void libspdm_hash_free(uint32_t base_hash_algo, void *hash_context)
 {
-    libspdm_hash_free_func hash_function;
-    hash_function = libspdm_get_hash_free_func(base_hash_algo);
-    if (hash_function == NULL) {
-        return;
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        libspdm_sha256_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        libspdm_sha384_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        libspdm_sha512_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        libspdm_sha3_256_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        libspdm_sha3_384_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        libspdm_sha3_512_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        libspdm_sm3_256_free(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
+        break;
     }
-    hash_function(hash_context);
 }
 
 bool libspdm_hash_init(uint32_t base_hash_algo, void *hash_context)
 {
-    libspdm_hash_init_func hash_function;
-    hash_function = libspdm_get_hash_init_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_init(hash_context);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hash_function(hash_context);
 }
 
 bool libspdm_hash_duplicate(uint32_t base_hash_algo, const void *hash_ctx, void *new_hash_ctx)
 {
-    libspdm_hash_duplicate_func hash_function;
-    hash_function = libspdm_get_hash_duplicate_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_duplicate(hash_ctx, new_hash_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hash_function(hash_ctx, new_hash_ctx);
 }
 
 bool libspdm_hash_update(uint32_t base_hash_algo, void *hash_context,
                          const void *data, size_t data_size)
 {
-    libspdm_hash_update_func hash_function;
-    hash_function = libspdm_get_hash_update_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_update(hash_context, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hash_function(hash_context, data, data_size);
 }
 
 bool libspdm_hash_final(uint32_t base_hash_algo, void *hash_context, uint8_t *hash_value)
 {
-    libspdm_hash_final_func hash_function;
-    hash_function = libspdm_get_hash_final_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_final(hash_context, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hash_function(hash_context, hash_value);
 }
 
 bool libspdm_hash_all(uint32_t base_hash_algo, const void *data,
                       size_t data_size, uint8_t *hash_value)
 {
-    libspdm_hash_all_func hash_function;
-    hash_function = libspdm_get_hash_all_func(base_hash_algo);
-    if (hash_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_sha256_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_sha384_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_sha512_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_sha3_256_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_sha3_384_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_sha3_512_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_sm3_256_hash_all(data, data_size, hash_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hash_function(data, data_size, hash_value);
 }
 
 uint32_t libspdm_get_measurement_hash_size(uint32_t measurement_hash_algo)

--- a/library/spdm_crypt_lib/libspdm_crypt_hash.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hash.c
@@ -113,50 +113,50 @@ void libspdm_hash_free(uint32_t base_hash_algo, void *hash_context)
         libspdm_sha256_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
 #if LIBSPDM_SHA384_SUPPORT
         libspdm_sha384_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
 #if LIBSPDM_SHA512_SUPPORT
         libspdm_sha512_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
 #if LIBSPDM_SHA3_256_SUPPORT
         libspdm_sha3_256_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
 #if LIBSPDM_SHA3_384_SUPPORT
         libspdm_sha3_384_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
 #if LIBSPDM_SHA3_512_SUPPORT
         libspdm_sha3_512_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
 #if LIBSPDM_SM3_256_SUPPORT
         libspdm_sm3_256_free(hash_context);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     default:
         LIBSPDM_ASSERT(false);
         break;

--- a/library/spdm_crypt_lib/libspdm_crypt_hkdf.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hkdf.c
@@ -6,194 +6,122 @@
 
 #include "internal/libspdm_crypt_lib.h"
 
-/**
- * Derive HMAC-based Extract key Derivation Function (HKDF) Extract.
- *
- * @param  ikm           Pointer to the input key material.
- * @param  ikm_size      Key size in bytes.
- * @param  salt          Pointer to the salt value.
- * @param  salt_size     Salt size in bytes.
- * @param  prk_out       Pointer to buffer to receive hkdf value.
- * @param  prk_out_size  Size of hkdf bytes to generate.
- *
- * @retval true   Hkdf generated successfully.
- * @retval false  Hkdf generation failed.
- **/
-typedef bool (*libspdm_hkdf_extract_func)(const uint8_t *ikm, size_t ikm_size,
-                                          const uint8_t *salt, size_t salt_size,
-                                          uint8_t *prk_out, size_t prk_out_size);
-
-/**
- * Derive HMAC-based Expand key Derivation Function (HKDF) Expand.
- *
- * @param  prk        Pointer to the user-supplied key.
- * @param  prk_size   Key size in bytes.
- * @param  info       Pointer to the application specific info.
- * @param  info_size  Info size in bytes.
- * @param  out        Pointer to buffer to receive hkdf value.
- * @param  out_size   Size of hkdf bytes to generate.
- *
- * @retval true   Hkdf generated successfully.
- * @retval false  Hkdf generation failed.
- **/
-typedef bool (*libspdm_hkdf_expand_func)(const uint8_t *prk, size_t prk_size,
-                                         const uint8_t *info, size_t info_size,
-                                         uint8_t *out, size_t out_size);
-
-/**
- * Return HKDF extract function, based upon the negotiated HKDF algorithm.
- *
- * @param  base_hash_algo                 SPDM base_hash_algo
- *
- * @return HKDF extract function
- **/
-static libspdm_hkdf_extract_func get_spdm_hkdf_extract_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hkdf_sha256_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hkdf_sha384_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hkdf_sha512_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hkdf_sha3_256_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hkdf_sha3_384_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hkdf_sha3_512_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hkdf_sm3_256_extract;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
 bool libspdm_hkdf_extract(uint32_t base_hash_algo, const uint8_t *ikm, size_t ikm_size,
                           const uint8_t *salt, size_t salt_size,
                           uint8_t *prk_out, size_t prk_out_size)
 {
-    libspdm_hkdf_extract_func hkdf_extract_function;
-    hkdf_extract_function = get_spdm_hkdf_extract_func(base_hash_algo);
-    if (hkdf_extract_function == NULL) {
-        return false;
-    }
-    return hkdf_extract_function(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
-}
-
-/**
- * Return HKDF expand function, based upon the negotiated HKDF algorithm.
- *
- * @param  base_hash_algo                 SPDM base_hash_algo
- *
- * @return HKDF expand function
- **/
-static libspdm_hkdf_expand_func get_spdm_hkdf_expand_func(uint32_t base_hash_algo)
-{
     switch (base_hash_algo) {
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
 #if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hkdf_sha256_expand;
+        return libspdm_hkdf_sha256_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
 #if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hkdf_sha384_expand;
+        return libspdm_hkdf_sha384_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
 #if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hkdf_sha512_expand;
+        return libspdm_hkdf_sha512_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
 #if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hkdf_sha3_256_expand;
+        return libspdm_hkdf_sha3_256_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
 #if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hkdf_sha3_384_expand;
+        return libspdm_hkdf_sha3_384_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
 #if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hkdf_sha3_512_expand;
+        return libspdm_hkdf_sha3_512_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
 #if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hkdf_sm3_256_expand;
+        return libspdm_hkdf_sm3_256_extract(ikm, ikm_size, salt, salt_size, prk_out, prk_out_size);
 #else
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
 #endif
     default:
         LIBSPDM_ASSERT(false);
-        break;
+        return false;
     }
-
-    return NULL;
 }
 
 bool libspdm_hkdf_expand(uint32_t base_hash_algo, const uint8_t *prk,
                          size_t prk_size, const uint8_t *info,
                          size_t info_size, uint8_t *out, size_t out_size)
 {
-    libspdm_hkdf_expand_func hkdf_expand_function;
-    hkdf_expand_function = get_spdm_hkdf_expand_func(base_hash_algo);
-    if (hkdf_expand_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hkdf_sha256_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hkdf_sha384_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hkdf_sha512_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hkdf_sha3_256_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hkdf_sha3_384_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hkdf_sha3_512_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hkdf_sm3_256_expand(prk, prk_size, info, info_size, out, out_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hkdf_expand_function(prk, prk_size, info, info_size, out, out_size);
 }

--- a/library/spdm_crypt_lib/libspdm_crypt_hmac.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hmac.c
@@ -6,650 +6,414 @@
 
 #include "internal/libspdm_crypt_lib.h"
 
-/**
- * Allocates and initializes one HMAC context for subsequent hash use.
- *
- * @return  Pointer to the HMAC context that has been initialized.
- *          If the allocations fails, libspdm_hmac_new_func() returns NULL.
- **/
-typedef void *(*libspdm_hmac_new_func)(void);
-
-/**
- * Release the specified HMAC context.
- *
- * @param  hmac_ctx  Pointer to the HMAC context to be released.
- **/
-typedef void (*libspdm_hmac_free_func)(void *hmac_ctx);
-
-/**
- * Set user-supplied key for subsequent use. It must be done before any
- * calling to hmac_update().
- *
- * If hmac_ctx is NULL, then return false.
- *
- * @param[out]  hmac_ctx  Pointer to HMAC context.
- * @param[in]   key       Pointer to the user-supplied key.
- * @param[in]   key_size  Key size in bytes.
- *
- * @retval true   The key is set successfully.
- * @retval false  The key is set unsuccessfully.
- *
- **/
-typedef bool (*libspdm_hmac_set_key_func)(void *hmac_ctx, const uint8_t *key, size_t key_size);
-
-/**
- * Makes a copy of an existing HMAC context.
- *
- * If hmac_ctx is NULL, then return false.
- * If new_hmac_ctx is NULL, then return false.
- *
- * @param[in]  hmac_ctx      Pointer to HMAC context being copied.
- * @param[out] new_hmac_ctx  Pointer to new HMAC context.
- *
- * @retval true   HMAC context copy succeeded.
- * @retval false  HMAC context copy failed.
- *
- **/
-typedef bool (*libspdm_hmac_duplicate_func)(const void *hmac_ctx, void *new_hmac_ctx);
-
-/**
- * Digests the input data and updates HMAC context.
- *
- * This function performs HMAC digest on a data buffer of the specified size.
- * It can be called multiple times to compute the digest of long or discontinuous data streams.
- * HMAC context should be initialized by hmac_new(), and should not be finalized
- * by hmac_final(). Behavior with invalid context is undefined.
- *
- * If hmac_ctx is NULL, then return false.
- *
- * @param[in, out]  hmac_ctx   Pointer to the HMAC context.
- * @param[in]       data       Pointer to the buffer containing the data to be digested.
- * @param[in]       data_size  Size of data buffer in bytes.
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- *
- **/
-typedef bool (*libspdm_hmac_update_func)(void *hmac_ctx, const void *data, size_t data_size);
-
-/**
- * Completes computation of the HMAC digest value.
- *
- * This function completes HMAC hash computation and retrieves the digest value into
- * the specified memory. After this function has been called, the HMAC context cannot
- * be used again.
- *
- * If hmac_ctx is NULL, then return false.
- * If hmac_value is NULL, then return false.
- *
- * @param[in, out]  hmac_ctx    Pointer to the HMAC context.
- * @param[out]      hmac_value  Pointer to a buffer that receives the HMAC digest value.
- *
- * @retval true   HMAC digest computation succeeded.
- * @retval false  HMAC digest computation failed.
- *
- **/
-typedef bool (*libspdm_hmac_final_func)(void *hmac_ctx, uint8_t *hmac_value);
-
-/**
- * Computes the HMAC of a input data buffer.
- *
- * This function performs the HMAC of a given data buffer, and return the hash value.
- *
- * @param  data        Pointer to the buffer containing the data to be HMACed.
- * @param  data_size   Size of data buffer in bytes.
- * @param  key         Pointer to the user-supplied key.
- * @param  key_size    Key size in bytes.
- * @param  hash_value  Pointer to a buffer that receives the HMAC value.
- *
- * @retval true   HMAC computation succeeded.
- * @retval false  HMAC computation failed.
- **/
-typedef bool (*libspdm_hmac_all_func)(const void *data, size_t data_size,
-                                      const uint8_t *key, size_t key_size,
-                                      uint8_t *hmac_value);
-
-/**
- * Return HMAC new function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC new function
- **/
-static libspdm_hmac_new_func libspdm_get_hmac_new_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_new;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC free function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC free function
- **/
-static libspdm_hmac_free_func libspdm_get_hmac_free_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_free;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC init function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC init function
- **/
-static libspdm_hmac_set_key_func libspdm_get_hmac_init_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_set_key;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC duplicate function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC duplicate function
- **/
-static libspdm_hmac_duplicate_func libspdm_get_hmac_duplicate_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_duplicate;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC update function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC update function
- **/
-static libspdm_hmac_update_func libspdm_get_hmac_update_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_update;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC final function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                  SPDM base_hash_algo
- *
- * @return HMAC final function
- **/
-static libspdm_hmac_final_func libspdm_get_hmac_final_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_final;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
-/**
- * Return HMAC all function, based upon the negotiated HMAC algorithm.
- *
- * @param  base_hash_algo                 SPDM base_hash_algo
- *
- * @return HMAC function
- **/
-static libspdm_hmac_all_func libspdm_get_hmac_all_func(uint32_t base_hash_algo)
-{
-    switch (base_hash_algo) {
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
-#if LIBSPDM_SHA256_SUPPORT
-        return libspdm_hmac_sha256_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
-#if LIBSPDM_SHA384_SUPPORT
-        return libspdm_hmac_sha384_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
-#if LIBSPDM_SHA512_SUPPORT
-        return libspdm_hmac_sha512_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
-#if LIBSPDM_SHA3_256_SUPPORT
-        return libspdm_hmac_sha3_256_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
-#if LIBSPDM_SHA3_384_SUPPORT
-        return libspdm_hmac_sha3_384_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
-#if LIBSPDM_SHA3_512_SUPPORT
-        return libspdm_hmac_sha3_512_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
-#if LIBSPDM_SM3_256_SUPPORT
-        return libspdm_hmac_sm3_256_all;
-#else
-        LIBSPDM_ASSERT(false);
-        break;
-#endif
-    default:
-        LIBSPDM_ASSERT(false);
-        break;
-    }
-
-    return NULL;
-}
-
 void *libspdm_hmac_new(uint32_t base_hash_algo)
 {
-    libspdm_hmac_new_func hmac_function;
-    hmac_function = libspdm_get_hmac_new_func(base_hash_algo);
-    if (hmac_function == NULL) {
-        return NULL;
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_new();
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
+        return false;
     }
-    return hmac_function();
 }
 
 void libspdm_hmac_free(uint32_t base_hash_algo, void *hmac_ctx)
 {
-    libspdm_hmac_free_func hmac_function;
-    hmac_function = libspdm_get_hmac_free_func(base_hash_algo);
-    if (hmac_function == NULL) {
-        return;
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        libspdm_hmac_sha256_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        libspdm_hmac_sha384_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        libspdm_hmac_sha512_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        libspdm_hmac_sha3_256_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        libspdm_hmac_sha3_384_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        libspdm_hmac_sha3_512_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        libspdm_hmac_sm3_256_free(hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        break;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
+        break;
     }
-    hmac_function(hmac_ctx);
 }
 
 bool libspdm_hmac_init(uint32_t base_hash_algo,
                        void *hmac_ctx, const uint8_t *key,
                        size_t key_size)
 {
-    libspdm_hmac_set_key_func hmac_function;
-    hmac_function = libspdm_get_hmac_init_func(base_hash_algo);
-    if (hmac_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_set_key(hmac_ctx, key, key_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hmac_function(hmac_ctx, key, key_size);
 }
 
 bool libspdm_hmac_duplicate(uint32_t base_hash_algo, const void *hmac_ctx, void *new_hmac_ctx)
 {
-    libspdm_hmac_duplicate_func hmac_function;
-    hmac_function = libspdm_get_hmac_duplicate_func(base_hash_algo);
-    if (hmac_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_duplicate(hmac_ctx, new_hmac_ctx);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hmac_function(hmac_ctx, new_hmac_ctx);
 }
 
 bool libspdm_hmac_update(uint32_t base_hash_algo,
                          void *hmac_ctx, const void *data,
                          size_t data_size)
 {
-    libspdm_hmac_update_func hmac_function;
-    hmac_function = libspdm_get_hmac_update_func(base_hash_algo);
-    if (hmac_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_update(hmac_ctx, data, data_size);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hmac_function(hmac_ctx, data, data_size);
 }
 
 bool libspdm_hmac_final(uint32_t base_hash_algo, void *hmac_ctx,  uint8_t *hmac_value)
 {
-    libspdm_hmac_final_func hmac_function;
-    hmac_function = libspdm_get_hmac_final_func(base_hash_algo);
-    if (hmac_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_final(hmac_ctx, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hmac_function(hmac_ctx, hmac_value);
 }
 
 bool libspdm_hmac_all(uint32_t base_hash_algo, const void *data,
                       size_t data_size, const uint8_t *key,
                       size_t key_size, uint8_t *hmac_value)
 {
-    libspdm_hmac_all_func hmac_function;
-    hmac_function = libspdm_get_hmac_all_func(base_hash_algo);
-    if (hmac_function == NULL) {
+    switch (base_hash_algo) {
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256:
+#if LIBSPDM_SHA256_SUPPORT
+        return libspdm_hmac_sha256_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
+#if LIBSPDM_SHA384_SUPPORT
+        return libspdm_hmac_sha384_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
+#if LIBSPDM_SHA512_SUPPORT
+        return libspdm_hmac_sha512_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
+#if LIBSPDM_SHA3_256_SUPPORT
+        return libspdm_hmac_sha3_256_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
+#if LIBSPDM_SHA3_384_SUPPORT
+        return libspdm_hmac_sha3_384_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
+#if LIBSPDM_SHA3_512_SUPPORT
+        return libspdm_hmac_sha3_512_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
+#if LIBSPDM_SM3_256_SUPPORT
+        return libspdm_hmac_sm3_256_all(data, data_size, key, key_size, hmac_value);
+#else
+        LIBSPDM_ASSERT(false);
+        return false;
+#endif
+    default:
+        LIBSPDM_ASSERT(false);
         return false;
     }
-    return hmac_function(data, data_size, key, key_size, hmac_value);
 }

--- a/library/spdm_crypt_lib/libspdm_crypt_hmac.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hmac.c
@@ -72,50 +72,50 @@ void libspdm_hmac_free(uint32_t base_hash_algo, void *hmac_ctx)
         libspdm_hmac_sha256_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384:
 #if LIBSPDM_SHA384_SUPPORT
         libspdm_hmac_sha384_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_512:
 #if LIBSPDM_SHA512_SUPPORT
         libspdm_hmac_sha512_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_256:
 #if LIBSPDM_SHA3_256_SUPPORT
         libspdm_hmac_sha3_256_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_384:
 #if LIBSPDM_SHA3_384_SUPPORT
         libspdm_hmac_sha3_384_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA3_512:
 #if LIBSPDM_SHA3_512_SUPPORT
         libspdm_hmac_sha3_512_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     case SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SM3_256:
 #if LIBSPDM_SM3_256_SUPPORT
         libspdm_hmac_sm3_256_free(hmac_ctx);
 #else
         LIBSPDM_ASSERT(false);
-        break;
 #endif
+        break;
     default:
         LIBSPDM_ASSERT(false);
         break;

--- a/unit_test/test_crypt/rsa_verify.c
+++ b/unit_test/test_crypt/rsa_verify.c
@@ -353,7 +353,7 @@ bool libspdm_validate_crypt_rsa(void)
 
     free_pool(KeyBuffer);
 
-    #ifdef LIBSPDM_SHA256_SUPPORT_TEST
+    #if LIBSPDM_SHA256_SUPPORT_TEST
     /* SHA-256 digest message for PKCS#1 signature*/
     libspdm_my_print("hash Original message ... ");
     hash_size = LIBSPDM_SHA256_DIGEST_SIZE;

--- a/unit_test/test_crypt/rsa_verify.c
+++ b/unit_test/test_crypt/rsa_verify.c
@@ -353,7 +353,7 @@ bool libspdm_validate_crypt_rsa(void)
 
     free_pool(KeyBuffer);
 
-    #if LIBSPDM_SHA256_SUPPORT_TEST
+    #ifdef LIBSPDM_SHA256_SUPPORT_TEST
     /* SHA-256 digest message for PKCS#1 signature*/
     libspdm_my_print("hash Original message ... ");
     hash_size = LIBSPDM_SHA256_DIGEST_SIZE;


### PR DESCRIPTION
Function pointers for asymmetric cryptography functions will be removed in a subsequent pull request.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>