### PR TITLE
Change function pointer type from size_t to void *

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -345,23 +345,23 @@ typedef struct {
     libspdm_error_struct_t last_spdm_error;
 
     /* Register GetResponse function (responder only) */
-    size_t get_response_func;
+    void *get_response_func;
 
     /* Register GetEncapResponse function (requester only) */
-    size_t get_encap_response_func;
+    void *get_encap_response_func;
     libspdm_encap_context_t encap_context;
 
     /* Register spdm_session_state_callback function (responder only)
     * Register can know the state after StartSession / EndSession. */
-    size_t spdm_session_state_callback[LIBSPDM_MAX_SESSION_STATE_CALLBACK_NUM];
+    void *spdm_session_state_callback[LIBSPDM_MAX_SESSION_STATE_CALLBACK_NUM];
 
     /* Register spdm_connection_state_callback function (responder only)
      * Register can know the connection state such as negotiated. */
-    size_t spdm_connection_state_callback[LIBSPDM_MAX_CONNECTION_STATE_CALLBACK_NUM];
+    void *spdm_connection_state_callback[LIBSPDM_MAX_CONNECTION_STATE_CALLBACK_NUM];
 
     /* Register libspdm_key_update_callback function (responder only)
      * Register can know when session keys are updated during KEY_UPDATE operations. */
-    size_t spdm_key_update_callback[LIBSPDM_MAX_KEY_UPDATE_CALLBACK_NUM];
+    void *spdm_key_update_callback[LIBSPDM_MAX_KEY_UPDATE_CALLBACK_NUM];
 
     libspdm_local_context_t local_context;
 

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -20,7 +20,7 @@ void libspdm_register_get_encap_response_func(void *context,
     libspdm_context_t *spdm_context;
 
     spdm_context = context;
-    spdm_context->get_encap_response_func = (size_t)get_encap_response_func;
+    spdm_context->get_encap_response_func = (void *)get_encap_response_func;
 }
 
 /**

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -827,7 +827,7 @@ void libspdm_register_get_response_func(void *context, libspdm_get_response_func
     libspdm_context_t *spdm_context;
 
     spdm_context = context;
-    spdm_context->get_response_func = (size_t)get_response_func;
+    spdm_context->get_response_func = (void *)get_response_func;
 }
 
 /**
@@ -850,9 +850,8 @@ libspdm_return_t libspdm_register_session_state_callback_func(
 
     spdm_context = context;
     for (index = 0; index < LIBSPDM_MAX_SESSION_STATE_CALLBACK_NUM; index++) {
-        if (spdm_context->spdm_session_state_callback[index] == 0) {
-            spdm_context->spdm_session_state_callback[index] =
-                (size_t)spdm_session_state_callback;
+        if (spdm_context->spdm_session_state_callback[index] == NULL) {
+            spdm_context->spdm_session_state_callback[index] = (void *)spdm_session_state_callback;
             return LIBSPDM_STATUS_SUCCESS;
         }
     }
@@ -880,11 +879,10 @@ libspdm_return_t libspdm_register_connection_state_callback_func(
     size_t index;
 
     spdm_context = context;
-    for (index = 0; index < LIBSPDM_MAX_CONNECTION_STATE_CALLBACK_NUM;
-         index++) {
-        if (spdm_context->spdm_connection_state_callback[index] == 0) {
+    for (index = 0; index < LIBSPDM_MAX_CONNECTION_STATE_CALLBACK_NUM; index++) {
+        if (spdm_context->spdm_connection_state_callback[index] == NULL) {
             spdm_context->spdm_connection_state_callback[index] =
-                (size_t)spdm_connection_state_callback;
+                (void *)spdm_connection_state_callback;
             return LIBSPDM_STATUS_SUCCESS;
         }
     }
@@ -912,9 +910,8 @@ libspdm_return_t libspdm_register_key_update_callback_func(
 
     spdm_context = context;
     for (index = 0; index < LIBSPDM_MAX_KEY_UPDATE_CALLBACK_NUM; index++) {
-        if (spdm_context->spdm_key_update_callback[index] == 0) {
-            spdm_context->spdm_key_update_callback[index] =
-                (size_t)spdm_key_update_callback;
+        if (spdm_context->spdm_key_update_callback[index] == NULL) {
+            spdm_context->spdm_key_update_callback[index] = (void *)spdm_key_update_callback;
             return LIBSPDM_STATUS_SUCCESS;
         }
     }


### PR DESCRIPTION
Fixes #1411.

These function pointers are declared as `void *` in the internal header, rather than declared as the function pointer typedef, because the function pointers are used by a Requester ^ Responder and we don't want to include the Requester / Responder's public headers.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>