### PR TITLE
Zero key for FIPS

### DIFF
--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -407,7 +407,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             zero_filled_buffer, hash_size, salt1, hash_size,
             secured_message_context->master_secret.master_secret, hash_size);
         if (!status) {
-            return false;
+            goto cleanup;
         }
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "master_secret (0x%x) - ", hash_size));
         LIBSPDM_INTERNAL_DUMP_DATA(
@@ -437,7 +437,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP */
@@ -450,7 +450,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
 
@@ -480,7 +480,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP */
@@ -493,7 +493,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
 
@@ -524,7 +524,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP */
@@ -537,7 +537,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
             hash_size);
 
         if (!status) {
-            return false;
+            goto cleanup;
         }
     }
 
@@ -552,7 +552,7 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
         secured_message_context->application_secret.request_data_encryption_key,
         secured_message_context->application_secret.request_data_salt);
     if (!status) {
-        return status;
+        goto cleanup;
     }
     secured_message_context->application_secret.request_data_sequence_number = 0;
 
@@ -562,11 +562,14 @@ bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
         secured_message_context->application_secret.response_data_encryption_key,
         secured_message_context->application_secret.response_data_salt);
     if (!status) {
-        return status;
+        goto cleanup;
     }
     secured_message_context->application_secret.response_data_sequence_number = 0;
 
-    return true;
+cleanup:
+    /*zero salt1 for security*/
+    libspdm_zero_mem(salt1, hash_size);
+    return status;
 }
 
 /**

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_request/encap_request.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_request/encap_request.c
@@ -36,6 +36,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     size_t aead_tag_max_size;
     uint8_t *scratch_buffer;
     size_t scratch_buffer_size;
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     session_id = 0xFFFFFFFF;
     spdm_test_context = libspdm_get_test_context();
@@ -114,6 +116,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     /* WALKAROUND: If just use single context to encode message and then decode message */
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
+    salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+           ->application_secret.response_data_salt;
+    sequence_number = ((libspdm_secured_message_context_t
+                        *)(session_info->secured_message_context))
+                      ->application_secret.response_data_sequence_number;
+    if (sequence_number > 0) {
+        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+    }
 
     sub_index++;
     return LIBSPDM_STATUS_SUCCESS;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/end_session.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_end_session/end_session.c
@@ -60,6 +60,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     size_t aead_tag_max_size;
     uint8_t *scratch_buffer;
     size_t scratch_buffer_size;
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     session_id = 0xFFFFFFFF;
     spdm_test_context = libspdm_get_test_context();
@@ -101,6 +103,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     /* WALKAROUND: If just use single context to encode message and then decode message */
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
+    salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+           ->application_secret.response_data_salt;
+    sequence_number = ((libspdm_secured_message_context_t
+                        *)(session_info->secured_message_context))
+                      ->application_secret.response_data_sequence_number;
+    if (sequence_number > 0) {
+        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+    }
 
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
@@ -28,6 +28,8 @@ libspdm_return_t libspdm_device_send_message(void *spdm_context,
     uint8_t *app_message;
     size_t app_message_size;
     uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     memcpy(message_buffer, request, request_size);
     if (!m_secured_on_off)
@@ -57,6 +59,14 @@ libspdm_return_t libspdm_device_send_message(void *spdm_context,
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         return LIBSPDM_STATUS_SUCCESS;
     }
@@ -104,6 +114,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
         size_t aead_tag_max_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_test_context = libspdm_get_test_context();
@@ -150,6 +162,15 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
+
     }
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
@@ -62,6 +62,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
         size_t aead_tag_max_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = spdm_test_context->test_buffer_size;
@@ -103,6 +105,15 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
+
     }
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
@@ -113,6 +113,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
         size_t aead_tag_max_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = spdm_test_context->test_buffer_size;
@@ -154,6 +156,15 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
+
     }
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_heartbeat/heartbeat.c
@@ -60,6 +60,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     size_t aead_tag_max_size;
     uint8_t *scratch_buffer;
     size_t scratch_buffer_size;
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     session_id = 0xFFFFFFFF;
     spdm_test_context = libspdm_get_test_context();
@@ -101,6 +103,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     /* WALKAROUND: If just use single context to encode message and then decode message */
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
+    salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+           ->application_secret.response_data_salt;
+    sequence_number = ((libspdm_secured_message_context_t
+                        *)(session_info->secured_message_context))
+                      ->application_secret.response_data_sequence_number;
+    if (sequence_number > 0) {
+        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+    }
 
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
@@ -126,6 +126,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     size_t scratch_buffer_size;
     size_t aead_tag_max_size;
     static uint8_t sub_index = 0;
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     session_id = 0xFFFFFFFF;
     session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
@@ -182,6 +184,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     /* WALKAROUND: If just use single context to encode message and then decode message */
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->application_secret.response_data_sequence_number--;
+    salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+           ->application_secret.response_data_salt;
+    sequence_number = ((libspdm_secured_message_context_t
+                        *)(session_info->secured_message_context))
+                      ->application_secret.response_data_sequence_number;
+    if (sequence_number > 0) {
+        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+    }
 
     if (sub_index != 0) {
         sub_index = 0;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_finish/psk_finish.c
@@ -68,6 +68,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     size_t aead_tag_max_size;
     uint8_t *scratch_buffer;
     size_t scratch_buffer_size;
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     session_id = 0xFFFFFFFF;
     spdm_test_context = libspdm_get_test_context();
@@ -109,6 +111,15 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     /* WALKAROUND: If just use single context to encode message and then decode message */
     ((libspdm_secured_message_context_t *)(session_info->secured_message_context))
     ->handshake_secret.response_handshake_sequence_number--;
+
+    salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+           ->handshake_secret.response_handshake_salt;
+    sequence_number = ((libspdm_secured_message_context_t
+                        *)(session_info->secured_message_context))
+                      ->handshake_secret.response_handshake_sequence_number;
+    if (sequence_number > 0) {
+        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+    }
 
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
@@ -28,6 +28,8 @@ libspdm_return_t libspdm_device_send_message(void *spdm_context,
     uint8_t *app_message;
     size_t app_message_size;
     uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+    uint64_t sequence_number;
+    uint8_t *salt;
 
     memcpy(message_buffer, request, request_size);
     if (!m_secured_on_off)
@@ -57,6 +59,14 @@ libspdm_return_t libspdm_device_send_message(void *spdm_context,
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         return LIBSPDM_STATUS_SUCCESS;
     }
@@ -104,6 +114,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
         size_t aead_tag_max_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_test_context = libspdm_get_test_context();
@@ -148,6 +160,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
     return LIBSPDM_STATUS_SUCCESS;
 }

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -95,6 +95,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_end_session_response_t);
@@ -127,6 +129,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -138,6 +148,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_end_session_response_t);
@@ -169,6 +181,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -180,6 +200,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -211,6 +233,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -222,6 +252,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -253,6 +285,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -266,6 +306,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -300,6 +342,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index1 == 1) {
             spdm_end_session_response_t *spdm_response;
             size_t spdm_response_size;
@@ -308,6 +358,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_end_session_response_t);
@@ -342,6 +394,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -354,6 +414,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -385,6 +447,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -396,6 +466,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -432,6 +504,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -446,6 +526,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -486,6 +568,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index2 == 1) {
             spdm_end_session_response_t *spdm_response;
             size_t spdm_response_size;
@@ -494,6 +584,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_end_session_response_t);
@@ -528,6 +620,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -543,6 +643,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t      *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -571,6 +673,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
             session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
             ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
             application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         error_code++;
@@ -593,6 +703,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_end_session_response_t);
@@ -625,6 +737,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
     case 0xC: {
@@ -635,6 +755,8 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -666,6 +788,14 @@ libspdm_return_t libspdm_requester_end_session_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1880,6 +1880,8 @@ libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
 
@@ -1955,6 +1957,16 @@ libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
+
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -94,6 +94,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_heartbeat_response_t);
@@ -126,6 +128,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -137,6 +147,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_heartbeat_response_t);
@@ -168,6 +180,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -179,6 +199,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -210,6 +232,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -221,6 +251,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -252,6 +284,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -265,6 +305,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -299,6 +341,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index1 == 1) {
             spdm_heartbeat_response_t *spdm_response;
             size_t spdm_response_size;
@@ -307,6 +357,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_heartbeat_response_t);
@@ -341,6 +393,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -353,6 +413,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -384,6 +446,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -395,6 +465,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -431,6 +503,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -445,6 +525,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -485,6 +567,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index2 == 1) {
             spdm_heartbeat_response_t *spdm_response;
             size_t spdm_response_size;
@@ -493,6 +583,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_heartbeat_response_t);
@@ -527,6 +619,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
               *)(session_info->secured_message_context))
             ->application_secret
             .response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -592,6 +692,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_heartbeat_response_t);
@@ -624,6 +726,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -635,6 +745,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -666,6 +778,14 @@ libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -141,6 +141,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         bool is_app_message;
         libspdm_session_info_t *session_info;
         uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         message_session_id = NULL;
         session_id = 0xFFFFFFFF;
@@ -156,6 +158,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
         libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
@@ -182,6 +192,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -197,6 +209,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -228,6 +248,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -243,6 +265,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -274,6 +304,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -289,6 +321,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -320,6 +360,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -335,6 +377,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -369,6 +419,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t    *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -384,6 +436,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -424,6 +484,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         bool is_app_message;
         libspdm_session_info_t *session_info;
         uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         message_session_id = NULL;
         session_id = 0xFFFFFFFF;
@@ -439,6 +501,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
         libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
@@ -465,6 +535,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t    *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -480,6 +552,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -513,6 +593,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t    *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -528,6 +610,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -560,6 +650,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         bool is_app_message;
         libspdm_session_info_t *session_info;
         uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         message_session_id = NULL;
         session_id = 0xFFFFFFFF;
@@ -575,6 +667,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
         libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
@@ -598,6 +698,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         bool is_app_message;
         libspdm_session_info_t *session_info;
         uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         message_session_id = NULL;
         session_id = 0xFFFFFFFF;
@@ -613,6 +715,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.request_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.request_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.request_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
         libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message, &decoded_message_size);
         status = libspdm_transport_test_decode_message(spdm_context,
                                                        &message_session_id, &is_app_message, true,
@@ -639,6 +749,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -654,6 +766,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -685,6 +805,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -700,6 +822,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -731,6 +861,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -746,6 +878,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -780,6 +920,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             bool is_app_message;
             libspdm_session_info_t    *session_info;
             uint8_t message_buffer[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             message_session_id = NULL;
             session_id = 0xFFFFFFFF;
@@ -795,6 +937,14 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.request_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.request_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.request_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
             libspdm_get_scratch_buffer (spdm_context, (void **)&decoded_message,
                                         &decoded_message_size);
             status = libspdm_transport_test_decode_message(spdm_context,
@@ -844,6 +994,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -885,6 +1037,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -900,6 +1060,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -941,6 +1103,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -954,6 +1124,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t    *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -986,6 +1158,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -997,6 +1177,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t    *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1029,6 +1211,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -1051,6 +1241,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1079,12 +1271,22 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 1) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1114,12 +1316,22 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1149,6 +1361,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -1163,6 +1383,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t    *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1195,6 +1417,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -1206,6 +1436,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t    *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1243,6 +1475,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -1266,6 +1506,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1300,12 +1542,22 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 1) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1335,12 +1587,22 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1370,6 +1632,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -1387,6 +1657,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         size_t transport_header_size;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1427,6 +1699,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         error_code++;
@@ -1455,6 +1735,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1496,6 +1778,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1511,6 +1801,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1553,6 +1845,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1568,6 +1868,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1609,6 +1911,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1624,6 +1934,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1665,6 +1977,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1680,6 +2000,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1722,6 +2044,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1737,6 +2067,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1779,6 +2111,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -1803,6 +2143,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1832,6 +2174,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 1) {
             spdm_error_response_t *spdm_response;
@@ -1839,6 +2189,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1866,6 +2218,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -1891,6 +2251,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1920,6 +2282,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else {
             spdm_error_response_t *spdm_response;
@@ -1927,6 +2297,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -1954,6 +2326,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -1979,6 +2359,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2008,6 +2390,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 1) {
             spdm_error_response_t *spdm_response;
@@ -2015,6 +2405,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2043,6 +2435,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
@@ -2050,6 +2450,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2079,6 +2481,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -2104,6 +2514,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2133,6 +2545,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 1) {
             spdm_error_response_t *spdm_response;
@@ -2140,6 +2560,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2167,6 +2589,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -2192,6 +2622,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2221,6 +2653,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else {
             spdm_error_response_data_response_not_ready_t *spdm_response;
@@ -2228,6 +2668,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2260,6 +2702,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -2285,6 +2735,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2314,6 +2766,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 1) {
             spdm_error_response_data_response_not_ready_t *spdm_response;
@@ -2321,6 +2781,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2353,6 +2815,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
         else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
@@ -2360,6 +2830,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2389,6 +2861,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             ((libspdm_secured_message_context_t
               *)(session_info->secured_message_context))
             ->application_secret.response_data_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->application_secret.response_data_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->application_secret.response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -2420,6 +2900,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
                 size_t transport_header_size;
                 uint8_t *scratch_buffer;
                 size_t scratch_buffer_size;
+                uint64_t sequence_number;
+                uint8_t *salt;
 
                 spdm_response_size = sizeof(spdm_key_update_response_t);
                 transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2449,6 +2931,15 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
                 ((libspdm_secured_message_context_t
                   *)(session_info->secured_message_context))
                 ->application_secret.response_data_sequence_number--;
+                salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                       ->application_secret.response_data_salt;
+                sequence_number = ((libspdm_secured_message_context_t
+                                    *)(session_info->secured_message_context))
+                                  ->application_secret.response_data_sequence_number;
+                if (sequence_number > 0) {
+                    *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+                }
+
             }
             else {
                 spdm_error_response_t *spdm_response;
@@ -2456,6 +2947,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
                 size_t transport_header_size;
                 uint8_t *scratch_buffer;
                 size_t scratch_buffer_size;
+                uint64_t sequence_number;
+                uint8_t *salt;
 
                 spdm_response_size = sizeof(spdm_error_response_t);
                 transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2484,6 +2977,15 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
                 ((libspdm_secured_message_context_t
                   *)(session_info->secured_message_context))
                 ->application_secret.response_data_sequence_number--;
+                salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                       ->application_secret.response_data_salt;
+                sequence_number = ((libspdm_secured_message_context_t
+                                    *)(session_info->secured_message_context))
+                                  ->application_secret.response_data_sequence_number;
+                if (sequence_number > 0) {
+                    *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+                }
+
 
                 error_code++;
                 /*busy is treated in cases 5 and 6*/
@@ -2515,6 +3017,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2561,6 +3065,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -2576,6 +3088,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2618,6 +3132,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -2633,6 +3155,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2675,6 +3199,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -2690,6 +3222,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t        *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_key_update_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -2734,6 +3268,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
 
         sub_index++;
     }
@@ -2878,6 +3420,11 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         .response_data_sequence_number = m_libspdm_last_rsp_sequence_number;
 
         /* once the sequence number is used, it should be increased for next BUSY message.*/
+        if (m_libspdm_last_rsp_sequence_number > 0) {
+            *(uint64_t *)m_libspdm_last_rsp_salt = *(uint64_t *)m_libspdm_last_rsp_salt ^
+                                                   (m_libspdm_last_rsp_sequence_number -
+                                                    1) ^ m_libspdm_last_rsp_sequence_number;
+        }
         m_libspdm_last_rsp_sequence_number++;
 
         spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
@@ -3011,6 +3558,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -3039,12 +3588,20 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
              * message and then decode message */
             secured_message_context->application_secret
             .response_data_sequence_number--;
+            salt = secured_message_context->application_secret.response_data_salt;
+            sequence_number = secured_message_context->application_secret.
+                              response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -3073,6 +3630,12 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
              * message and then decode message */
             secured_message_context->application_secret
             .response_data_sequence_number--;
+            salt = secured_message_context->application_secret.response_data_salt;
+            sequence_number = secured_message_context->application_secret.
+                              response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -3363,6 +3926,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -3391,12 +3956,20 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
              * message and then decode message */
             secured_message_context->application_secret
             .response_data_sequence_number--;
+            salt = secured_message_context->application_secret.response_data_salt;
+            sequence_number = secured_message_context->application_secret.
+                              response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index == 2) {
             spdm_key_update_response_t *spdm_response;
             size_t spdm_response_size;
             size_t transport_header_size;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_key_update_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -3425,6 +3998,12 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
              * message and then decode message */
             secured_message_context->application_secret
             .response_data_sequence_number--;
+            salt = secured_message_context->application_secret.response_data_salt;
+            sequence_number = secured_message_context->application_secret.
+                              response_data_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         sub_index++;
@@ -3551,6 +4130,8 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         libspdm_session_info_t    *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -3583,6 +4164,14 @@ libspdm_return_t libspdm_requester_key_update_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -150,6 +150,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -182,6 +184,15 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -193,6 +204,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -224,6 +237,16 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
+
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -235,6 +258,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -266,6 +291,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -277,6 +310,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -308,6 +343,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -321,6 +364,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -355,6 +400,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->handshake_secret.response_handshake_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->handshake_secret.response_handshake_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index1 == 1) {
             spdm_psk_finish_response_t *spdm_response;
             size_t spdm_response_size;
@@ -363,6 +416,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -397,6 +452,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->handshake_secret.response_handshake_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->handshake_secret.response_handshake_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -409,6 +472,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -440,6 +505,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -451,6 +524,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
         transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -487,6 +562,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -501,6 +584,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             spdm_response_size = sizeof(spdm_error_response_data_response_not_ready_t);
             transport_header_size = libspdm_transport_test_get_header_size(spdm_context);
@@ -541,6 +626,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->handshake_secret.response_handshake_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->handshake_secret.response_handshake_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         } else if (sub_index2 == 1) {
             spdm_psk_finish_response_t *spdm_response;
             size_t spdm_response_size;
@@ -549,6 +642,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
             libspdm_session_info_t *session_info;
             uint8_t *scratch_buffer;
             size_t scratch_buffer_size;
+            uint64_t sequence_number;
+            uint8_t *salt;
 
             session_id = 0xFFFFFFFF;
             spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -583,6 +678,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
               *)(session_info->secured_message_context))
             ->handshake_secret
             .response_handshake_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->handshake_secret.response_handshake_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->handshake_secret.response_handshake_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
     }
         return LIBSPDM_STATUS_SUCCESS;
@@ -598,6 +701,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t      *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
 
@@ -626,6 +731,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
             session_info = libspdm_get_session_info_via_session_id (spdm_context, session_id);
             ((libspdm_secured_message_context_t*)(session_info->secured_message_context))->
             handshake_secret.response_handshake_sequence_number--;
+            salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+                   ->handshake_secret.response_handshake_salt;
+            sequence_number = ((libspdm_secured_message_context_t
+                                *)(session_info->secured_message_context))
+                              ->handshake_secret.response_handshake_sequence_number;
+            if (sequence_number > 0) {
+                *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+            }
         }
 
         error_code++;
@@ -648,6 +761,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -680,6 +795,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -691,6 +814,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -723,6 +848,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -734,6 +867,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -766,6 +901,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -777,6 +920,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -809,6 +954,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -820,6 +973,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
 
@@ -852,6 +1007,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 
@@ -863,6 +1026,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
         spdm_response_size = sizeof(spdm_psk_finish_response_t);
@@ -899,6 +1064,14 @@ libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
         /* WALKAROUND: If just use single context to encode message and then decode message */
         ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
         ->handshake_secret.response_handshake_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->handshake_secret.response_handshake_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->handshake_secret.response_handshake_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -148,6 +148,8 @@ libspdm_return_t libspdm_requester_set_certificate_test_receive_message(
         libspdm_session_info_t *session_info;
         uint8_t *scratch_buffer;
         size_t scratch_buffer_size;
+        uint64_t sequence_number;
+        uint8_t *salt;
 
         session_id = 0xFFFFFFFF;
 
@@ -181,6 +183,14 @@ libspdm_return_t libspdm_requester_set_certificate_test_receive_message(
         ((libspdm_secured_message_context_t
           *)(session_info->secured_message_context))
         ->application_secret.response_data_sequence_number--;
+        salt = ((libspdm_secured_message_context_t*)(session_info->secured_message_context))
+               ->application_secret.response_data_salt;
+        sequence_number = ((libspdm_secured_message_context_t
+                            *)(session_info->secured_message_context))
+                          ->application_secret.response_data_sequence_number;
+        if (sequence_number > 0) {
+            *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        }
     }
         return LIBSPDM_STATUS_SUCCESS;
 


### PR DESCRIPTION
Reference: #1260

**2023/1/7**  Commit 1: Zero key for FIPS when encode and decode.
**2023/1/13**  Commit 2: Fix unit test because of the salt change.
**2023/1/9**   Commit 3: Zero salt1 in `libspdm_generate_session_data_key`.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>