### PR TITLE
Remove the checking of extended_key_usage

### DIFF
--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -819,15 +819,6 @@ bool libspdm_x509_certificate_check(const uint8_t *cert, size_t cert_size,
         goto cleanup;
     }
 
-    /* 11. extended_key_usage*/
-    value = 0;
-    status = libspdm_x509_get_extended_key_usage(cert, cert_size, NULL, &value);
-    if (value == 0) {
-        status = false;
-        goto cleanup;
-    }
-    status = true;
-
 cleanup:
     libspdm_asym_free(base_asym_algo, context);
     return status;


### PR DESCRIPTION
Fixes #1592

extended_key_usage was required in spec 1.1 but has been fixed in 1.1.1. It appears more like an 'errta' fix. This commit removes such checking to be compatible with all the different versions.

Signed-off-by: Liming Sun <limings@nvidia.com>