### PR TITLE
Fix bug when checking Requester's capabilities

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,1 +1,1 @@
-libspdm version 2.3.0 (released)
+libspdm version 2.3.1 (released)

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -74,7 +74,7 @@ static bool libspdm_check_request_flag_compability(uint32_t capabilities_flag, u
             }
         } else {
             if ((mac_cap == 1) || (encrypt_cap == 1) || (handshake_in_the_clear_cap == 1) ||
-                (hbeat_cap == 1) || (key_upd_cap == 1) || (mut_auth_cap == 1)) {
+                (hbeat_cap == 1) || (key_upd_cap == 1)) {
                 return false;
             }
         }
@@ -96,7 +96,7 @@ static bool libspdm_check_request_flag_compability(uint32_t capabilities_flag, u
         } else {
             /* If certificates or public keys are not enabled then these capabilities
              * cannot be enabled. */
-            if ((chal_cap == 1) || (key_ex_cap == 1) || (mut_auth_cap == 1)) {
+            if ((chal_cap == 1) || (mut_auth_cap == 1)) {
                 return false;
             }
         }

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -27,21 +27,6 @@ spdm_get_capabilities_request_t m_libspdm_get_capabilities_request2 = {
 };
 size_t m_libspdm_get_capabilities_request2_size = LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
 
-spdm_get_capabilities_request_t m_libspdm_get_capabilities_request3 = {
-    {
-        SPDM_MESSAGE_VERSION_11,
-        SPDM_GET_CAPABILITIES,
-    }, /*header*/
-    0x00, /*reserved*/
-    0x01, /*ct_exponent*/
-    0x0000, /*reserved, 2 bytes*/
-    0x12345678 /*flags*/
-};
-size_t m_libspdm_get_capabilities_request3_size =
-    sizeof(m_libspdm_get_capabilities_request3) -
-    sizeof(m_libspdm_get_capabilities_request3.data_transfer_size) -
-    sizeof(m_libspdm_get_capabilities_request3.max_spdm_msg_size);
-
 spdm_get_capabilities_request_t m_libspdm_get_capabilities_request4 = {
     {
         SPDM_MESSAGE_VERSION_11,
@@ -622,37 +607,9 @@ void libspdm_test_responder_capabilities_case6(void **state)
                      SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
     assert_int_equal(spdm_response->header.param2, 0);
 }
-/*New from here*/
+
 void libspdm_test_responder_capabilities_case7(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_capabilities_response_t *spdm_response;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x7;
-    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
-
-    response_size = sizeof(response);
-    status = libspdm_get_response_capabilities(
-        spdm_context, m_libspdm_get_capabilities_request3_size,
-        &m_libspdm_get_capabilities_request3, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(m_libspdm_get_capabilities_request3.header.spdm_version,
-                     spdm_response->header.spdm_version);
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
 }
 
 void libspdm_test_responder_capabilities_case8(void **state)


### PR DESCRIPTION
Increment patch number and delete a unit test that used a "random" capabilities flags. The test needs to be replaced with individual and targeted tests.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>