### PR TITLE
Change request retry times to a runtime parameter

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -101,6 +101,14 @@ typedef enum {
      **/
     LIBSPDM_DATA_IS_REQUESTER,
 
+    /* If the Responder replies with a Busy `ERROR` response to a request
+     * then the Requester is free to retry sending the request.
+     * This value specifies the maximum number of times libspdm will retry
+     * sending the request before returning an error.
+     * If its value is 0 then libspdm will not send any retry requests.
+     **/
+    LIBSPDM_DATA_REQUEST_RETRY_TIMES,
+
     /* MAX */
     LIBSPDM_DATA_MAX
 } libspdm_data_type_t;

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -86,15 +86,6 @@
 #define LIBSPDM_MAX_MESSAGE_MEDIUM_BUFFER_SIZE 0x300 /* to hold message_k before finished_key is ready*/
 #endif
 
-/* If the Responder replies with a Busy `ERROR` response to a request then the Requester is free to
- * retry sending the request. This value specifies the maximum number of times libspdm will retry
- * sending the request before returning an error. If its value is 0 then libspdm will not send any
- * retry requests.
- */
-#ifndef LIBSPDM_MAX_REQUEST_RETRY_TIMES
-#define LIBSPDM_MAX_REQUEST_RETRY_TIMES 3
-#endif
-
 #ifndef LIBSPDM_MAX_CSR_SIZE
 #define LIBSPDM_MAX_CSR_SIZE 0x1000
 #endif

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -467,6 +467,12 @@ libspdm_return_t libspdm_set_data(void *context, libspdm_data_type_t data_type,
         }
         spdm_context->local_context.is_requester = *(bool *)data;
         break;
+    case LIBSPDM_DATA_REQUEST_RETRY_TIMES:
+        if (data_size != sizeof(uint8_t)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        spdm_context->retry_times = *(uint8_t *)data;
+        break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;
@@ -2149,7 +2155,6 @@ libspdm_return_t libspdm_init_context_with_secured_context(void *context,
     spdm_context->transcript.message_m.max_buffer_size =
         sizeof(spdm_context->transcript.message_m.buffer);
 #endif
-    spdm_context->retry_times = LIBSPDM_MAX_REQUEST_RETRY_TIMES;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     spdm_context->current_token = 0;
     spdm_context->local_context.version.spdm_version_count = 3;
@@ -2260,7 +2265,6 @@ void libspdm_reset_context(void *context)
     spdm_context->connection_info.local_used_cert_chain_buffer_size = 0;
     spdm_context->connection_info.local_used_cert_chain_buffer = NULL;
     spdm_context->cache_spdm_request_size = 0;
-    spdm_context->retry_times = LIBSPDM_MAX_REQUEST_RETRY_TIMES;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     spdm_context->current_token = 0;
     spdm_context->last_spdm_request_session_id = INVALID_SESSION_ID;

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1957,6 +1957,7 @@ void libspdm_test_requester_challenge_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.connection_state =
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->connection_info.capability.flags = 0;

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -1130,6 +1130,7 @@ void libspdm_test_requester_end_session_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -2077,6 +2077,7 @@ void libspdm_test_requester_finish_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -1046,6 +1046,7 @@ static void libspdm_test_requester_get_capabilities_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -2278,6 +2278,7 @@ void libspdm_test_requester_get_certificate_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -3390,6 +3390,7 @@ static void libspdm_test_requester_get_measurements_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -603,6 +603,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
 
+    spdm_context->retry_times = 3;
     status = libspdm_get_version(spdm_context, NULL, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -1130,6 +1130,7 @@ void libspdm_test_requester_heartbeat_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -5274,6 +5274,7 @@ static void libspdm_test_requester_key_exchange_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
@@ -5488,6 +5489,7 @@ static void libspdm_test_requester_key_exchange_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -3854,6 +3854,7 @@ void libspdm_test_requester_key_update_case6(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
 
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_set_standard_key_update_test_state(
@@ -4598,6 +4599,7 @@ void libspdm_test_requester_key_update_case19(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x13;
 
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_set_standard_key_update_test_state(
@@ -5268,6 +5270,7 @@ void libspdm_test_requester_key_update_case30(void **state)
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x1E;
 
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     libspdm_set_standard_key_update_test_state(

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -1373,6 +1373,7 @@ static void libspdm_test_requester_negotiate_algorithms_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -3384,6 +3384,7 @@ void libspdm_test_requester_psk_exchange_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =
@@ -3571,6 +3572,7 @@ void libspdm_test_requester_psk_exchange_case9(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x9;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -1416,6 +1416,7 @@ void libspdm_test_requester_psk_finish_case6(void **state)
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0x6;
+    spdm_context->retry_times = 3;
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
                                             SPDM_VERSION_NUMBER_SHIFT_BIT;
     spdm_context->connection_info.connection_state =


### PR DESCRIPTION
Fix: #1588
Remove the macro `LIBSPDM_MAX_REQUEST_RETRY_TIMES` and expose it via `libspdm_set_data()`.
Default value is 0 (no retry).

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>