### PR TITLE
Remove *_in_session() public functions

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -158,8 +158,8 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
 
    Send GET_DIGESTES, GET_CERTIFICATES and CHALLENGE.
    ```
-   libspdm_get_digest (spdm_context, slot_mask, total_digest_buffer);
-   libspdm_get_certificate (spdm_context, slot_id, cert_chain_size, cert_chain);
+   libspdm_get_digest (spdm_context, NULL, slot_mask, total_digest_buffer);
+   libspdm_get_certificate (spdm_context, NULL, slot_id, cert_chain_size, cert_chain);
    libspdm_challenge (spdm_context, slot_id, measurement_hash_type, measurement_hash);
    ```
 

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -73,32 +73,9 @@ libspdm_return_t libspdm_init_connection(void *spdm_context, bool get_version_on
 /**
  * This function sends GET_DIGEST to get all digest of the certificate chains from device.
  *
- * If the peer certificate chain is deployed, this function also verifies the digest with the
- * certificate chain.
- *
  * TotalDigestSize = sizeof(digest) * count in slot_mask
  *
  * @param  spdm_context         A pointer to the SPDM context.
- * @param  slot_mask            The slots which deploy the CertificateChain.
- * @param  total_digest_buffer  A pointer to a destination buffer to store the digest buffer.
- *
- * @retval RETURN_SUCCESS               The digests are got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_digest(void *spdm_context, uint8_t *slot_mask,
-                                    void *total_digest_buffer);
-
-/**
- * This function sends GET_DIGESTS and receives DIGESTS. It may retry GET_DIGESTS multiple times
- * if the Responder replies with a Busy error.
- *
- * If the peer certificate chain is deployed, this function also verifies the digest with the
- * certificate chain.
- *
- * TotalDigestSize = sizeof(digest) * count in slot_mask
- *
- * @param  context              A pointer to the SPDM context.
  * @param  session_id           Indicates if it is a secured message protected via SPDM session.
  *                              If session_id is NULL, it is a normal message.
  *                              If session_id is not NULL, it is a secured message.
@@ -124,8 +101,8 @@ libspdm_return_t libspdm_get_digest(void *spdm_context, uint8_t *slot_mask,
  * @retval LIBSPDM_STATUS_BUFFER_FULL
  *         The buffer used to store transcripts is exhausted.
  **/
-libspdm_return_t libspdm_get_digest_in_session(void *context, const uint32_t *session_id,
-                                               uint8_t *slot_mask, void *total_digest_buffer);
+libspdm_return_t libspdm_get_digest(void *spdm_context, const uint32_t *session_id,
+                                    uint8_t *slot_mask, void *total_digest_buffer);
 
 /**
  * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
@@ -137,152 +114,12 @@ libspdm_return_t libspdm_get_digest_in_session(void *context, const uint32_t *se
  * this function also verifies the digest with the root hash in the certificate chain.
  *
  * @param  spdm_context     A pointer to the SPDM context.
+ * @param  session_id       Indicates if it is a secured message protected via SPDM session.
+ *                          If session_id is NULL, it is a normal message.
  * @param  slot_id          The number of slot for the certificate chain.
  * @param  cert_chain_size  On input, indicate the size in bytes of the destination buffer to store the digest buffer.
  *                          On output, indicate the size in bytes of the certificate chain.
  * @param  cert_chain       A pointer to a destination buffer to store the certificate chain.
- *
- * @retval RETURN_SUCCESS               The certificate chain is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_certificate(void *spdm_context, uint8_t slot_id,
-                                         size_t *cert_chain_size,
-                                         void *cert_chain);
-
-/**
- * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
- *
- * This function verify the integrity of the certificate chain.
- * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
- *
- * If the peer root certificate hash is deployed,
- * this function also verifies the digest with the root hash in the certificate chain.
- *
- * @param  spdm_context       A pointer to the SPDM context.
- * @param  slot_id            The number of slot for the certificate chain.
- * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store the digest buffer.
- *                            On output, indicate the size in bytes of the certificate chain.
- * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
- * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
- * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
- *
- * @retval RETURN_SUCCESS               The certificate chain is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_certificate_ex(void *context, uint8_t slot_id,
-                                            size_t *cert_chain_size,
-                                            void *cert_chain,
-                                            const void **trust_anchor,
-                                            size_t *trust_anchor_size);
-
-/**
- * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
- *
- * This function verify the integrity of the certificate chain.
- * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
- *
- * If the peer root certificate hash is deployed,
- * this function also verifies the digest with the root hash in the certificate chain.
- *
- * @param  spdm_context       A pointer to the SPDM context.
- * @param  session_id         Indicates if it is a secured message protected via SPDM session.
- *                            If session_id is NULL, it is a normal message.
- *                            If session_id is NOT NULL, it is a secured message.
- * @param  slot_id            The number of slot for the certificate chain.
- * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store the digest buffer.
- *                            On output, indicate the size in bytes of the certificate chain.
- * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
- * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
- * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
- *
- * @retval RETURN_SUCCESS               The certificate chain is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_certificate_in_session(void *context, const uint32_t *session_id,
-                                                    uint8_t slot_id,
-                                                    size_t *cert_chain_size,
-                                                    void *cert_chain,
-                                                    const void **trust_anchor,
-                                                    size_t *trust_anchor_size);
-
-/**
- * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
- *
- * This function verify the integrity of the certificate chain.
- * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
- *
- * If the peer root certificate hash is deployed,
- * this function also verifies the digest with the root hash in the certificate chain.
- *
- * @param  spdm_context     A pointer to the SPDM context.
- * @param  slot_id          The number of slot for the certificate chain.
- * @param  length           LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN.
- * @param  cert_chain_size  On input, indicate the size in bytes of the destination buffer to store the digest buffer.
- *                          On output, indicate the size in bytes of the certificate chain.
- * @param  cert_chain       A pointer to a destination buffer to store the certificate chain.
- *
- * @retval RETURN_SUCCESS               The certificate chain is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_certificate_choose_length(void *spdm_context,
-                                                       uint8_t slot_id,
-                                                       uint16_t length,
-                                                       size_t *cert_chain_size,
-                                                       void *cert_chain);
-
-/**
- * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
- *
- * This function verify the integrity of the certificate chain.
- * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
- *
- * If the peer root certificate hash is deployed,
- * this function also verifies the digest with the root hash in the certificate chain.
- *
- * @param  spdm_context       A pointer to the SPDM context.
- * @param  slot_id            The number of slot for the certificate chain.
- * @param  length             LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN.
- * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store the digest buffer.
- *                            On output, indicate the size in bytes of the certificate chain.
- * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
- * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
- * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
- *
- * @retval RETURN_SUCCESS               The certificate chain is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
- **/
-libspdm_return_t libspdm_get_certificate_choose_length_ex(void *context,
-                                                          uint8_t slot_id,
-                                                          uint16_t length,
-                                                          size_t *cert_chain_size,
-                                                          void *cert_chain,
-                                                          const void **trust_anchor,
-                                                          size_t *trust_anchor_size);
-
-/**
- * This function sends GET_CERTIFICATE and receives CERTIFICATE. It may retry GET_CERTIFICATE
- * multiple times if the Responder replies with a Busy error.
- *
- * This function verify the integrity of the certificate chain.
- * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
- *
- * If the peer root certificate hash is deployed,
- * this function also verifies the digest with the root hash in the certificate chain.
- *
- * @param  spdm_context       A pointer to the SPDM context.
- * @param  slot_id            The number of slot for the certificate chain.
- * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store
- *                            the digest buffer.
- *                            On output, indicate the size in bytes of the certificate chain.
- * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
- * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer
- *                            certificate, if not NULL.
- * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
  *
  * @retval LIBSPDM_STATUS_SUCCESS
  *         GET_CERTIFICATE was sent and CERTIFICATE was received.
@@ -309,14 +146,104 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *context,
  * @retval LIBSPDM_STATUS_CRYPTO_ERROR
  *         A generic cryptography error occurred.
  **/
-libspdm_return_t libspdm_get_certificate_choose_length_in_session(void *context,
-                                                                  const uint32_t *session_id,
-                                                                  uint8_t slot_id,
-                                                                  uint16_t length,
-                                                                  size_t *cert_chain_size,
-                                                                  void *cert_chain,
-                                                                  const void **trust_anchor,
-                                                                  size_t *trust_anchor_size);
+libspdm_return_t libspdm_get_certificate(void *spdm_context,
+                                         const uint32_t *session_id,
+                                         uint8_t slot_id,
+                                         size_t *cert_chain_size,
+                                         void *cert_chain);
+
+/**
+ * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
+ *
+ * This function verify the integrity of the certificate chain.
+ * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
+ *
+ * If the peer root certificate hash is deployed,
+ * this function also verifies the digest with the root hash in the certificate chain.
+ *
+ * @param  spdm_context       A pointer to the SPDM context.
+ * @param  session_id         Indicates if it is a secured message protected via SPDM session.
+ *                            If session_id is NULL, it is a normal message.
+ * @param  slot_id            The number of slot for the certificate chain.
+ * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store the digest buffer.
+ *                            On output, indicate the size in bytes of the certificate chain.
+ * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
+ * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+ * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
+ *
+ * @retval RETURN_SUCCESS               The certificate chain is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_get_certificate_ex(void *spdm_context,
+                                            const uint32_t *session_id,
+                                            uint8_t slot_id,
+                                            size_t *cert_chain_size,
+                                            void *cert_chain,
+                                            const void **trust_anchor,
+                                            size_t *trust_anchor_size);
+
+/**
+ * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
+ *
+ * This function verify the integrity of the certificate chain.
+ * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
+ *
+ * If the peer root certificate hash is deployed,
+ * this function also verifies the digest with the root hash in the certificate chain.
+ *
+ * @param  spdm_context     A pointer to the SPDM context.
+ * @param  session_id       Indicates if it is a secured message protected via SPDM session.
+ *                          If session_id is NULL, it is a normal message.
+ * @param  slot_id          The number of slot for the certificate chain.
+ * @param  length           LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN.
+ * @param  cert_chain_size  On input, indicate the size in bytes of the destination buffer to store the digest buffer.
+ *                          On output, indicate the size in bytes of the certificate chain.
+ * @param  cert_chain       A pointer to a destination buffer to store the certificate chain.
+ *
+ * @retval RETURN_SUCCESS               The certificate chain is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_get_certificate_choose_length(void *spdm_context,
+                                                       const uint32_t *session_id,
+                                                       uint8_t slot_id,
+                                                       uint16_t length,
+                                                       size_t *cert_chain_size,
+                                                       void *cert_chain);
+
+/**
+ * This function sends GET_CERTIFICATE to get certificate chain in one slot from device.
+ *
+ * This function verify the integrity of the certificate chain.
+ * root_hash -> Root certificate -> Intermediate certificate -> Leaf certificate.
+ *
+ * If the peer root certificate hash is deployed,
+ * this function also verifies the digest with the root hash in the certificate chain.
+ *
+ * @param  spdm_context       A pointer to the SPDM context.
+ * @param  session_id         Indicates if it is a secured message protected via SPDM session.
+ *                            If session_id is NULL, it is a normal message.
+ * @param  slot_id            The number of slot for the certificate chain.
+ * @param  length             LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN.
+ * @param  cert_chain_size    On input, indicate the size in bytes of the destination buffer to store the digest buffer.
+ *                            On output, indicate the size in bytes of the certificate chain.
+ * @param  cert_chain         A pointer to a destination buffer to store the certificate chain.
+ * @param  trust_anchor       A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+ * @param  trust_anchor_size  A buffer to hold the trust_anchor_size, if not NULL.
+ *
+ * @retval RETURN_SUCCESS               The certificate chain is got successfully.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
+                                                          const uint32_t *session_id,
+                                                          uint8_t slot_id,
+                                                          uint16_t length,
+                                                          size_t *cert_chain_size,
+                                                          void *cert_chain,
+                                                          const void **trust_anchor,
+                                                          size_t *trust_anchor_size);
 
 /**
  * This function sends CHALLENGE to authenticate the device based upon the key in one slot.

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -372,43 +372,30 @@ done:
     return status;
 }
 
-libspdm_return_t libspdm_get_certificate(void *context, uint8_t slot_id,
+libspdm_return_t libspdm_get_certificate(void *context, const uint32_t *session_id,
+                                         uint8_t slot_id,
                                          size_t *cert_chain_size,
                                          void *cert_chain)
 {
-    return libspdm_get_certificate_choose_length(context, slot_id,
+    return libspdm_get_certificate_choose_length(context, session_id, slot_id,
                                                  LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN,
                                                  cert_chain_size, cert_chain);
 }
 
-libspdm_return_t libspdm_get_certificate_ex(void *context, uint8_t slot_id,
+libspdm_return_t libspdm_get_certificate_ex(void *context, const uint32_t *session_id,
+                                            uint8_t slot_id,
                                             size_t *cert_chain_size,
                                             void *cert_chain,
                                             const void **trust_anchor,
                                             size_t *trust_anchor_size)
 {
-    return libspdm_get_certificate_choose_length_ex(context, slot_id,
+    return libspdm_get_certificate_choose_length_ex(context, session_id, slot_id,
                                                     LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN,
                                                     cert_chain_size, cert_chain,
                                                     trust_anchor, trust_anchor_size);
 }
 
-libspdm_return_t libspdm_get_certificate_in_session(void *context, const uint32_t *session_id,
-                                                    uint8_t slot_id,
-                                                    size_t *cert_chain_size,
-                                                    void *cert_chain,
-                                                    const void **trust_anchor,
-                                                    size_t *trust_anchor_size)
-{
-    return libspdm_get_certificate_choose_length_in_session(context,
-                                                            session_id,
-                                                            slot_id,
-                                                            LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN,
-                                                            cert_chain_size, cert_chain,
-                                                            trust_anchor, trust_anchor_size);
-}
-
-libspdm_return_t libspdm_get_certificate_choose_length(void *context,
+libspdm_return_t libspdm_get_certificate_choose_length(void *context, const uint32_t *session_id,
                                                        uint8_t slot_id,
                                                        uint16_t length,
                                                        size_t *cert_chain_size,
@@ -422,7 +409,7 @@ libspdm_return_t libspdm_get_certificate_choose_length(void *context,
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
     do {
-        status = libspdm_try_get_certificate(spdm_context, NULL, slot_id, length,
+        status = libspdm_try_get_certificate(spdm_context, session_id, slot_id, length,
                                              cert_chain_size, cert_chain, NULL, NULL);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
@@ -432,41 +419,13 @@ libspdm_return_t libspdm_get_certificate_choose_length(void *context,
     return status;
 }
 
-libspdm_return_t libspdm_get_certificate_choose_length_ex(void *context,
+libspdm_return_t libspdm_get_certificate_choose_length_ex(void *context, const uint32_t *session_id,
                                                           uint8_t slot_id,
                                                           uint16_t length,
                                                           size_t *cert_chain_size,
                                                           void *cert_chain,
                                                           const void **trust_anchor,
                                                           size_t *trust_anchor_size)
-{
-    libspdm_context_t *spdm_context;
-    size_t retry;
-    libspdm_return_t status;
-
-    spdm_context = context;
-    spdm_context->crypto_request = true;
-    retry = spdm_context->retry_times;
-    do {
-        status = libspdm_try_get_certificate(spdm_context, NULL, slot_id, length,
-                                             cert_chain_size, cert_chain, trust_anchor,
-                                             trust_anchor_size);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
-            return status;
-        }
-    } while (retry-- != 0);
-
-    return status;
-}
-
-libspdm_return_t libspdm_get_certificate_choose_length_in_session(void *context,
-                                                                  const uint32_t *session_id,
-                                                                  uint8_t slot_id,
-                                                                  uint16_t length,
-                                                                  size_t *cert_chain_size,
-                                                                  void *cert_chain,
-                                                                  const void **trust_anchor,
-                                                                  size_t *trust_anchor_size)
 {
     libspdm_context_t *spdm_context;
     size_t retry;

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -220,27 +220,8 @@ receive_done:
     return status;
 }
 
-libspdm_return_t libspdm_get_digest(void *context, uint8_t *slot_mask, void *total_digest_buffer)
-{
-    libspdm_context_t *spdm_context;
-    size_t retry;
-    libspdm_return_t status;
-
-    spdm_context = context;
-    spdm_context->crypto_request = true;
-    retry = spdm_context->retry_times;
-    do {
-        status = libspdm_try_get_digest(spdm_context, NULL, slot_mask, total_digest_buffer);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
-            return status;
-        }
-    } while (retry-- != 0);
-
-    return status;
-}
-
-libspdm_return_t libspdm_get_digest_in_session(void *context, const uint32_t *session_id,
-                                               uint8_t *slot_mask, void *total_digest_buffer)
+libspdm_return_t libspdm_get_digest(void *context, const uint32_t *session_id,
+                                    uint8_t *slot_mask, void *total_digest_buffer)
 {
     libspdm_context_t *spdm_context;
     size_t retry;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
@@ -117,7 +117,7 @@ void libspdm_test_requester_get_certificate_case1(void **State)
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
 
-    libspdm_get_certificate(spdm_context, 0, &cert_chain_size, cert_chain);
+    libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     free(data);
     libspdm_reset_message_b(spdm_context);
 }
@@ -168,7 +168,7 @@ void libspdm_test_requester_get_certificate_case2(void **State)
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
 
-    libspdm_get_certificate(spdm_context, 0, &cert_chain_size, cert_chain);
+    libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     free(data);
     libspdm_reset_message_b(spdm_context);
 }
@@ -218,7 +218,7 @@ void libspdm_test_requester_get_certificate_ex_case1(void **State)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    libspdm_get_certificate_ex(spdm_context, 0, &cert_chain_size, cert_chain,NULL,NULL);
+    libspdm_get_certificate_ex(spdm_context, NULL, 0, &cert_chain_size, cert_chain,NULL,NULL);
 
     free(data);
     libspdm_reset_message_b(spdm_context);
@@ -303,8 +303,8 @@ void libspdm_test_requester_get_certificate_in_session_case1(void **State)
 #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    libspdm_get_certificate_in_session(spdm_context, &session_id, 0, &cert_chain_size, cert_chain,
-                                       NULL,NULL);
+    libspdm_get_certificate_ex(spdm_context, &session_id, 0, &cert_chain_size, cert_chain,
+                               NULL, NULL);
 
     free(data);
     libspdm_reset_message_b(spdm_context);

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
@@ -132,7 +132,7 @@ void libspdm_test_requester_get_digests_case1(void **State)
 #endif
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     libspdm_reset_message_b(spdm_context);
 }
 
@@ -184,8 +184,7 @@ void libspdm_test_requester_get_digests_case2(void **State)
         session_info->session_transcript.message_m.max_buffer_size;
 #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    libspdm_get_digest_in_session(spdm_context, &session_id, &slot_mask,
-                                  &total_digest_buffer);
+    libspdm_get_digest(spdm_context, &session_id, &slot_mask, &total_digest_buffer);
 }
 
 libspdm_test_context_t m_libspdm_requester_get_diges_test_context = {

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
@@ -38,13 +38,13 @@ spdm_authentication(void *context, uint8_t *slot_mask,
     status = LIBSPDM_STATUS_SUCCESS;
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-    status = libspdm_get_digest(context, slot_mask, total_digest_buffer);
+    status = libspdm_get_digest(context, NULL, slot_mask, total_digest_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return status;
     }
 
     if (slot_id != 0xFF) {
-        status = libspdm_get_certificate(context, slot_id, cert_chain_size,
+        status = libspdm_get_certificate(context, NULL, slot_id, cert_chain_size,
                                          cert_chain);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             return status;

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -582,7 +582,7 @@ void libspdm_test_requester_chunk_get_case1(void** state)
     #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size, cert_chain);
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -803,7 +803,7 @@ void libspdm_test_requester_chunk_get_case4(void** state)
         spdm_context->transcript.message_m.max_buffer_size;
     #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(slot_mask, 0xFF);

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -894,7 +894,7 @@ static void libspdm_test_requester_get_digests_err_case1(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -928,7 +928,7 @@ static void libspdm_test_requester_get_digests_err_case2(void **state)
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 
     libspdm_force_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     libspdm_release_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
 
     assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
@@ -960,7 +960,7 @@ static void libspdm_test_requester_get_digests_err_case3(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -992,7 +992,7 @@ static void libspdm_test_requester_get_digests_err_case4(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -1024,7 +1024,7 @@ static void libspdm_test_requester_get_digests_err_case5(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -1058,7 +1058,7 @@ static void libspdm_test_requester_get_digests_err_case6(void **state)
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 
     libspdm_force_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     libspdm_release_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
 
     assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
@@ -1090,7 +1090,7 @@ static void libspdm_test_requester_get_digests_err_case7(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_RESYNCH_PEER);
     assert_int_equal(spdm_context->connection_info.connection_state,
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
@@ -1125,7 +1125,7 @@ static void libspdm_test_requester_get_digests_err_case8(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
 }
 
@@ -1154,7 +1154,7 @@ static void libspdm_test_requester_get_digests_err_case9(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
 
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
@@ -1185,7 +1185,7 @@ static void libspdm_test_requester_get_digests_err_case10(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -1217,7 +1217,7 @@ static void libspdm_test_requester_get_digests_err_case11(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1258,7 +1258,7 @@ static void libspdm_test_requester_get_digests_err_case13(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size, 0);
@@ -1290,7 +1290,7 @@ static void libspdm_test_requester_get_digests_err_case14(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1333,7 +1333,7 @@ static void libspdm_test_requester_get_digests_err_case16(void **state)
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_BUFFER_FULL);
 #endif
 }
@@ -1372,7 +1372,7 @@ static void libspdm_test_requester_get_digests_err_case18(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1406,7 +1406,7 @@ static void libspdm_test_requester_get_digests_err_case19(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
 }
 
@@ -1436,7 +1436,7 @@ static void libspdm_test_requester_get_digests_err_case20(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1470,7 +1470,7 @@ static void libspdm_test_requester_get_digests_err_case21(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(spdm_context->transcript.message_b.buffer_size,
@@ -1511,7 +1511,7 @@ static void libspdm_test_requester_get_digests_err_case22(void **state) {
         libspdm_reset_message_b(spdm_context);
 
         libspdm_zero_mem (total_digest_buffer, sizeof(total_digest_buffer));
-        status = libspdm_get_digest (spdm_context, &slot_mask, &total_digest_buffer);
+        status = libspdm_get_digest (spdm_context, NULL, &slot_mask, &total_digest_buffer);
         LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         LIBSPDM_ASSERT_INT_EQUAL_CASE (spdm_context->transcript.message_b.buffer_size, 0,

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -2009,7 +2009,7 @@ void libspdm_test_requester_get_certificate_case1(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2075,7 +2075,7 @@ void libspdm_test_requester_get_certificate_case2(void **state)
 #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2136,7 +2136,7 @@ void libspdm_test_requester_get_certificate_case3(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2191,7 +2191,7 @@ void libspdm_test_requester_get_certificate_case4(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2246,7 +2246,7 @@ void libspdm_test_requester_get_certificate_case5(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2304,7 +2304,7 @@ void libspdm_test_requester_get_certificate_case6(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2364,7 +2364,7 @@ void libspdm_test_requester_get_certificate_case7(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_RESYNCH_PEER);
     assert_int_equal(spdm_context->connection_info.connection_state,
@@ -2421,7 +2421,7 @@ void libspdm_test_requester_get_certificate_case8(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
     free(data);
@@ -2476,7 +2476,7 @@ void libspdm_test_requester_get_certificate_case9(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2539,7 +2539,7 @@ void libspdm_test_requester_get_certificate_case10(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2606,7 +2606,7 @@ void libspdm_test_requester_get_certificate_case11(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2679,7 +2679,7 @@ void libspdm_test_requester_get_certificate_case12(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2746,7 +2746,7 @@ void libspdm_test_requester_get_certificate_case13(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2817,7 +2817,7 @@ void libspdm_test_requester_get_certificate_case14(void **state)
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
     status = libspdm_get_certificate_choose_length(
-        spdm_context, 0, get_cert_length, &cert_chain_size, cert_chain);
+        spdm_context, NULL, 0, get_cert_length, &cert_chain_size, cert_chain);
     /* It may fail because the spdm does not support too many messages.
      * assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);*/
     if (status == LIBSPDM_STATUS_SUCCESS) {
@@ -2888,7 +2888,7 @@ void libspdm_test_requester_get_certificate_case15(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     /* It may fail because the spdm does not support too long message.
      * assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);*/
@@ -2954,7 +2954,7 @@ void libspdm_test_requester_get_certificate_case16(void **state) {
 
         cert_chain_size = sizeof(cert_chain);
         libspdm_zero_mem (cert_chain, sizeof(cert_chain));
-        status = libspdm_get_certificate (spdm_context, 0, &cert_chain_size, cert_chain);
+        status = libspdm_get_certificate (spdm_context, NULL, 0, &cert_chain_size, cert_chain);
         LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         /* assert_int_equal (spdm_context->transcript.message_b.buffer_size, 0);*/
@@ -3023,7 +3023,7 @@ void libspdm_test_requester_get_certificate_case17(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     free(data);
@@ -3075,7 +3075,7 @@ void libspdm_test_requester_get_certificate_case18(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
     free(data);
@@ -3136,7 +3136,7 @@ void libspdm_test_requester_get_certificate_case19(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -3200,7 +3200,7 @@ void libspdm_test_requester_get_certificate_case20(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -3256,7 +3256,7 @@ void libspdm_test_requester_get_certificate_case21(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -3314,7 +3314,7 @@ void libspdm_test_requester_get_certificate_case22(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -3375,7 +3375,7 @@ void libspdm_test_requester_get_certificate_case23(void **state)
 #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size, cert_chain);
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
@@ -3443,7 +3443,7 @@ void libspdm_test_requester_get_certificate_case24(void **state)
 
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
     free(data);
@@ -3530,7 +3530,7 @@ void libspdm_test_requester_get_certificate_case25(void **state)
     for (slot_id = 0; slot_id < 2; slot_id++) {
         cert_chain_size = sizeof(cert_chain);
         libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-        status = libspdm_get_certificate(spdm_context, slot_id, &cert_chain_size,
+        status = libspdm_get_certificate(spdm_context, NULL, slot_id, &cert_chain_size,
                                          cert_chain);
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "libspdm_get_certificate - %p\n", status));
         assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -3635,9 +3635,9 @@ void libspdm_test_requester_get_certificate_case26(void **state)
 #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate_in_session(spdm_context, &session_id,
-                                                0, &cert_chain_size,
-                                                cert_chain, NULL, 0);
+    status = libspdm_get_certificate_ex(spdm_context, &session_id,
+                                        0, &cert_chain_size,
+                                        cert_chain, NULL, 0);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     assert_int_equal(session_info->session_transcript.message_m.buffer_size, 0);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -979,7 +979,7 @@ static void libspdm_test_requester_get_digests_case2(void **state)
         spdm_context->transcript.message_m.max_buffer_size;
 #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(slot_mask, 0x01);
@@ -1205,7 +1205,7 @@ static void libspdm_test_requester_get_digests_case23(void **state)
     libspdm_reset_message_b(spdm_context);
 
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     arbitrary_size = 8;
@@ -1277,7 +1277,7 @@ static void libspdm_test_requester_get_digests_case24(void **state)
 #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
     /* first GetDigest */
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(slot_mask, 0x01);
     libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
@@ -1322,7 +1322,7 @@ static void libspdm_test_requester_get_digests_case24(void **state)
 #endif
     cert_chain_size = sizeof(cert_chain);
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
-    status = libspdm_get_certificate(spdm_context, 0, &cert_chain_size,
+    status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1337,7 +1337,7 @@ static void libspdm_test_requester_get_digests_case24(void **state)
 #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
     /* second GetDigest */
-    status = libspdm_get_digest(spdm_context, &slot_mask, &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, NULL, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(slot_mask, 0x01);
     libspdm_zero_mem(my_total_digest_buffer, sizeof(my_total_digest_buffer));
@@ -1431,8 +1431,7 @@ static void libspdm_test_requester_get_digests_case25(void **state)
         session_info->session_transcript.message_m.max_buffer_size;
 #endif
     libspdm_zero_mem(total_digest_buffer, sizeof(total_digest_buffer));
-    status = libspdm_get_digest_in_session(spdm_context, &session_id, &slot_mask,
-                                           &total_digest_buffer);
+    status = libspdm_get_digest(spdm_context, &session_id, &slot_mask, &total_digest_buffer);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(slot_mask, 0x80);


### PR DESCRIPTION
Fix: #1580
Remove all `*_in_session()` functions
and add `session_id` parameter to the appropriate functions.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>