### PR TITLE
Add reserved parameter to libspdm_challenge function

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -160,7 +160,7 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
    ```
    libspdm_get_digest (spdm_context, NULL, slot_mask, total_digest_buffer);
    libspdm_get_certificate (spdm_context, NULL, slot_id, cert_chain_size, cert_chain);
-   libspdm_challenge (spdm_context, slot_id, measurement_hash_type, measurement_hash);
+   libspdm_challenge (spdm_context, NULL, slot_id, measurement_hash_type, measurement_hash);
    ```
 
 4. Get the measurement from the Responder

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -254,6 +254,7 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
  * this function also perform the basic mutual authentication.
  *
  * @param  spdm_context           A pointer to the SPDM context.
+ * @param  reserved               Reserved for session_id and is ignored.
  * @param  slot_id                The number of slot for the challenge.
  * @param  measurement_hash_type  The type of the measurement hash.
  * @param  measurement_hash       A pointer to a destination buffer to store the measurement hash.
@@ -263,7 +264,8 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-libspdm_return_t libspdm_challenge(void *spdm_context, uint8_t slot_id,
+libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
+                                   uint8_t slot_id,
                                    uint8_t measurement_hash_type,
                                    void *measurement_hash,
                                    uint8_t *slot_mask);
@@ -277,6 +279,7 @@ libspdm_return_t libspdm_challenge(void *spdm_context, uint8_t slot_id,
  * this function also perform the basic mutual authentication.
  *
  * @param  spdm_context           A pointer to the SPDM context.
+ * @param  reserved               Reserved for session_id and is ignored.
  * @param  slot_id                The number of slot for the challenge.
  * @param  measurement_hash_type  The type of the measurement hash.
  * @param  measurement_hash       A pointer to a destination buffer to store the measurement hash.
@@ -289,7 +292,8 @@ libspdm_return_t libspdm_challenge(void *spdm_context, uint8_t slot_id,
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-libspdm_return_t libspdm_challenge_ex(void *spdm_context, uint8_t slot_id,
+libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
+                                      uint8_t slot_id,
                                       uint8_t measurement_hash_type,
                                       void *measurement_hash,
                                       uint8_t *slot_mask,

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -330,7 +330,8 @@ receive_done:
     return status;
 }
 
-libspdm_return_t libspdm_challenge(void *spdm_context, uint8_t slot_id,
+libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
+                                   uint8_t slot_id,
                                    uint8_t measurement_hash_type,
                                    void *measurement_hash,
                                    uint8_t *slot_mask)
@@ -354,7 +355,8 @@ libspdm_return_t libspdm_challenge(void *spdm_context, uint8_t slot_id,
     return status;
 }
 
-libspdm_return_t libspdm_challenge_ex(void *spdm_context, uint8_t slot_id,
+libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
+                                      uint8_t slot_id,
                                       uint8_t measurement_hash_type,
                                       void *measurement_hash,
                                       uint8_t *slot_mask,

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -163,7 +163,7 @@ void libspdm_test_requester_challenge_case1(void **State)
 #endif
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
-    libspdm_challenge(spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    libspdm_challenge(spdm_context, NULL, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                       measurement_hash, NULL);
     free(data);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -224,7 +224,7 @@ void libspdm_test_requester_challenge_ex_case1(void **State)
 #endif
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
-    libspdm_challenge_ex(spdm_context, 0,
+    libspdm_challenge_ex(spdm_context, NULL, 0,
                          SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                          measurement_hash, NULL, requester_nonce_in, requester_nonce,
                          responder_nonce);

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
@@ -53,7 +53,7 @@ spdm_authentication(void *context, uint8_t *slot_mask,
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-    status = libspdm_challenge(context, slot_id, measurement_hash_type,
+    status = libspdm_challenge(context, NULL, slot_id, measurement_hash_type,
                                measurement_hash, auth_slot_mask);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return status;

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1631,7 +1631,7 @@ void libspdm_test_requester_challenge_case1(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
@@ -1709,7 +1709,7 @@ void libspdm_test_requester_challenge_case2(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -1785,7 +1785,7 @@ void libspdm_test_requester_challenge_case3(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_STATE_LOCAL);
@@ -1856,7 +1856,7 @@ void libspdm_test_requester_challenge_case4(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
@@ -1927,7 +1927,7 @@ void libspdm_test_requester_challenge_case5(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_BUSY_PEER);
@@ -1999,7 +1999,7 @@ void libspdm_test_requester_challenge_case6(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -2068,7 +2068,7 @@ void libspdm_test_requester_challenge_case7(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_RESYNCH_PEER);
@@ -2141,7 +2141,7 @@ void libspdm_test_requester_challenge_case8(void **state)
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
 
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
@@ -2208,7 +2208,7 @@ void libspdm_test_requester_challenge_case9(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     if (LIBSPDM_RESPOND_IF_READY_SUPPORT) {
@@ -2277,7 +2277,8 @@ void libspdm_test_requester_challenge_case10(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -2341,7 +2342,8 @@ void libspdm_test_requester_challenge_case11(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -2403,7 +2405,8 @@ void libspdm_test_requester_challenge_case12(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -2466,7 +2469,8 @@ void libspdm_test_requester_challenge_case13(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -2528,7 +2532,8 @@ void libspdm_test_requester_challenge_case14(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
     free(data);
@@ -2603,7 +2608,8 @@ void libspdm_test_requester_challenge_case16(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     free(data);
@@ -2672,7 +2678,8 @@ void libspdm_test_requester_challenge_case17(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, NULL);
     assert_int_equal (status, LIBSPDM_STATUS_VERIF_FAIL);
     free(data);
@@ -2742,7 +2749,7 @@ void libspdm_test_requester_challenge_case18(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0,
+    status = libspdm_challenge (spdm_context, NULL, 0,
                                 SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH,
                                 measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -2812,7 +2819,8 @@ void libspdm_test_requester_challenge_case19(void **state) {
 #endif
 
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH,
                                 measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
@@ -2879,7 +2887,7 @@ void libspdm_test_requester_challenge_case20(void **state) {
         libspdm_reset_message_c(spdm_context);
 
         libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
-        status = libspdm_challenge (spdm_context, 0,
+        status = libspdm_challenge (spdm_context, NULL, 0,
                                     SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                     measurement_hash, NULL);
         LIBSPDM_ASSERT_INT_EQUAL_CASE (status, LIBSPDM_STATUS_ERROR_PEER, error_code);
@@ -2960,7 +2968,7 @@ void libspdm_test_requester_challenge_case21(void **state) {
     libspdm_zero_mem (measurement_hash, sizeof(measurement_hash));
 
     slot_id = 0;
-    status = libspdm_challenge (spdm_context, slot_id,
+    status = libspdm_challenge (spdm_context, NULL, slot_id,
                                 SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
                                 measurement_hash, &slot_mask);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -3039,7 +3047,7 @@ void libspdm_test_requester_challenge_case22(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -3151,7 +3159,7 @@ void libspdm_test_requester_challenge_case23(void **state)
     for (slot_id = 0; slot_id < 2; slot_id++) {
         libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
         status = libspdm_challenge(
-            spdm_context, slot_id,
+            spdm_context, NULL, slot_id,
             SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
             measurement_hash, NULL);
         assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
@@ -3200,7 +3208,7 @@ void libspdm_test_requester_challenge_case24(void **state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0xFF,
+        spdm_context, NULL, 0xFF,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -749,7 +749,7 @@ void libspdm_test_requester_chunk_get_case3(void** state)
 
     libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
     status = libspdm_challenge(
-        spdm_context, 0,
+        spdm_context, NULL, 0,
         SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
         measurement_hash, NULL);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -3550,7 +3550,7 @@ void libspdm_test_requester_get_certificate_case25(void **state)
     for (slot_id = 0; slot_id < 2; slot_id++) {
         libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
         status = libspdm_challenge(
-            spdm_context, slot_id,
+            spdm_context, NULL, slot_id,
             SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
             measurement_hash, NULL);
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "libspdm_challenge - %p\n", status));


### PR DESCRIPTION
Fix: #1642
add `void *reserved` parameter for session_id to libspdm_challenge function.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>