### PR TITLE
Change parameter order

### DIFF
--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -626,13 +626,13 @@ libspdm_return_t libspdm_generate_encap_extended_error_response(
  * to get csr from the device.
  *
  * @param[in]  context                A pointer to the SPDM context.
+ * @param[in]  session_id             Indicates if it is a secured message protected via SPDM session.
+ *                                    If session_id is NULL, it is a normal message.
+ *                                    If session_id is NOT NULL, it is a secured message.
  * @param[in]  requester_info         Requester info to gen CSR
  * @param[in]  requester_info_length  The length of requester info
  * @param[in]  opaque_data            opaque data.
  * @param[in]  opaque_data_length     The length of opaque data.
- * @param[in]  session_id             Indicates if it is a secured message protected via SPDM session.
- *                                    If session_id is NULL, it is a normal message.
- *                                    If session_id is NOT NULL, it is a secured message.
  * @param[out] csr                    Address to store CSR.
  * @param[out] csr_len                On input, *csr_len indicates the max csr buffer size.
  *                                    On output, *csr_len indicates the actual csr buffer size.
@@ -642,9 +642,9 @@ libspdm_return_t libspdm_generate_encap_extended_error_response(
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
 libspdm_return_t libspdm_get_csr(void *spdm_context,
+                                 const uint32_t *session_id,
                                  void *requester_info, uint16_t requester_info_length,
                                  void *opaque_data, uint16_t opaque_data_length,
-                                 const uint32_t *session_id,
                                  void *csr, size_t *csr_len);
 #endif /*LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP*/
 
@@ -654,21 +654,21 @@ libspdm_return_t libspdm_get_csr(void *spdm_context,
  * to set certificate from the device.
  *
  * @param  context          A pointer to the SPDM context.
+ * @param  session_id       Indicates if it is a secured message protected via SPDM session.
+ *                          If session_id is NULL, it is a normal message.
+ *                          If session_id is NOT NULL, it is a secured message.
  * @param  slot_id          The number of slot for the certificate chain.
  * @param  cert_chain       The pointer for the certificate chain to set.
  *                          The cert chain is a full SPDM certificate chain, including Length and Root Cert Hash.
  * @param  cert_chain_size  The size of the certificate chain to set.
- * @param  session_id       Indicates if it is a secured message protected via SPDM session.
- *                          If session_id is NULL, it is a normal message.
- *                          If session_id is NOT NULL, it is a secured message.
  *
  * @retval RETURN_SUCCESS               The measurement is got successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
-libspdm_return_t libspdm_set_certificate(void * spdm_context, uint8_t slot_id,
-                                         void * cert_chain, size_t cert_chain_size,
-                                         const uint32_t *session_id);
+libspdm_return_t libspdm_set_certificate(void *spdm_context,
+                                         const uint32_t *session_id, uint8_t slot_id,
+                                         void *cert_chain, size_t cert_chain_size);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_SET_CERTIFICATE_CAP */
 

--- a/library/spdm_requester_lib/libspdm_req_get_csr.c
+++ b/library/spdm_requester_lib/libspdm_req_get_csr.c
@@ -13,13 +13,13 @@
  * to get csr from the device.
  *
  * @param[in]  context                      A pointer to the SPDM context.
+ * @param[in]  session_id                   Indicates if it is a secured message protected via SPDM session.
+ *                                          If session_id is NULL, it is a normal message.
+ *                                          If session_id is NOT NULL, it is a secured message.
  * @param[in]  requester_info               requester info to gen CSR
  * @param[in]  requester_info_length        The len of requester info
  * @param[in]  opaque_data                  opaque data
  * @param[in]  opaque_data_length           The len of opaque data
- * @param[in]  session_id                   Indicates if it is a secured message protected via SPDM session.
- *                                          If session_id is NULL, it is a normal message.
- *                                          If session_id is NOT NULL, it is a secured message.
  * @param[out] csr                          address to store CSR.
  * @param[out] csr_len                      on input, *csr_len indicates the max csr buffer size.
  *                                          on output, *csr_len indicates the actual csr buffer size.
@@ -29,9 +29,9 @@
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
 static libspdm_return_t libspdm_try_get_csr(libspdm_context_t *spdm_context,
+                                            const uint32_t *session_id,
                                             void *requester_info, uint16_t requester_info_length,
                                             void *opaque_data, uint16_t opaque_data_length,
-                                            const uint32_t *session_id,
                                             void *csr, size_t *csr_len)
 {
     libspdm_return_t status;
@@ -168,9 +168,9 @@ receive_done:
 }
 
 libspdm_return_t libspdm_get_csr(void * spdm_context,
+                                 const uint32_t *session_id,
                                  void * requester_info, uint16_t requester_info_length,
                                  void * opaque_data, uint16_t opaque_data_length,
-                                 const uint32_t *session_id,
                                  void *csr, size_t *csr_len)
 {
     libspdm_context_t *context;
@@ -181,10 +181,10 @@ libspdm_return_t libspdm_get_csr(void * spdm_context,
     context->crypto_request = true;
     retry = context->retry_times;
     do {
-        status = libspdm_try_get_csr(context,
+        status = libspdm_try_get_csr(context, session_id,
                                      requester_info, requester_info_length,
                                      opaque_data, opaque_data_length,
-                                     session_id, csr, csr_len);
+                                     csr, csr_len);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -12,22 +12,21 @@
  * to set certificate from the device.
  *
  * @param  context                      A pointer to the SPDM context.
+ * @param  session_id                   Indicates if it is a secured message protected via SPDM session.
+ *                                      If session_id is NULL, it is a normal message.
+ *                                      If session_id is NOT NULL, it is a secured message.
  * @param  slot_id                      The number of slot for the certificate chain.
  * @param  cert_chain                   The pointer for the certificate chain to set.
  *                                      The cert chain is a full SPDM certificate chain, including Length and Root Cert Hash.
  * @param  cert_chain_size              The size of the certificate chain to set.
- * @param  session_id                   Indicates if it is a secured message protected via SPDM session.
- *                                      If session_id is NULL, it is a normal message.
- *                                      If session_id is NOT NULL, it is a secured message.
  *
  * @retval RETURN_SUCCESS               The measurement is got successfully.
  * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
  * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
 static libspdm_return_t libspdm_try_set_certificate(libspdm_context_t *spdm_context,
-                                                    uint8_t slot_id,
-                                                    void * cert_chain, size_t cert_chain_size,
-                                                    const uint32_t *session_id)
+                                                    const uint32_t *session_id, uint8_t slot_id,
+                                                    void *cert_chain, size_t cert_chain_size)
 {
     libspdm_return_t status;
     spdm_set_certificate_request_t *spdm_request;
@@ -156,9 +155,9 @@ receive_done:
     return status;
 }
 
-libspdm_return_t libspdm_set_certificate(void * spdm_context, uint8_t slot_id,
-                                         void * cert_chain, size_t cert_chain_size,
-                                         const uint32_t *session_id)
+libspdm_return_t libspdm_set_certificate(void *spdm_context,
+                                         const uint32_t *session_id, uint8_t slot_id,
+                                         void *cert_chain, size_t cert_chain_size)
 {
     libspdm_context_t *context;
     size_t retry;
@@ -168,8 +167,8 @@ libspdm_return_t libspdm_set_certificate(void * spdm_context, uint8_t slot_id,
     context->crypto_request = true;
     retry = context->retry_times;
     do {
-        status = libspdm_try_set_certificate(context, slot_id,
-                                             cert_chain, cert_chain_size, session_id);
+        status = libspdm_try_set_certificate(context, session_id, slot_id,
+                                             cert_chain, cert_chain_size);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
@@ -194,7 +194,7 @@ void libspdm_test_requester_get_csr_case1(void **State)
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
 
-    libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, (void *)&csr_form_get,
+    libspdm_get_csr(spdm_context, NULL, NULL, 0, NULL, 0, (void *)&csr_form_get,
                     &csr_len);
 }
 
@@ -244,7 +244,7 @@ void libspdm_test_requester_get_csr_case2(void **State)
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
 
-    libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, &session_id, (void *)&csr_form_get,
+    libspdm_get_csr(spdm_context, &session_id, NULL, 0, NULL, 0, (void *)&csr_form_get,
                     &csr_len);
 }
 

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
@@ -194,7 +194,7 @@ void libspdm_test_requester_set_certificate_case1(void **State)
                                                     m_libspdm_use_asym_algo,
                                                     &data, &data_size, NULL, NULL);
 
-    libspdm_set_certificate(spdm_context, 0, data, data_size, NULL);
+    libspdm_set_certificate(spdm_context, NULL, 0, data, data_size);
     free(data);
 }
 
@@ -243,7 +243,7 @@ void libspdm_test_requester_set_certificate_case2(void **State)
     libspdm_secured_message_set_session_state(session_info->secured_message_context,
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
 
-    libspdm_set_certificate(spdm_context, 0, data, data_size, &session_id);
+    libspdm_set_certificate(spdm_context, &session_id, 0, data, data_size);
     free(data);
 }
 

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -118,7 +118,7 @@ void libspdm_test_requester_get_csr_case1(void **state)
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
 
-    status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, (void *)&csr_form_get,
+    status = libspdm_get_csr(spdm_context, NULL, NULL, 0, NULL, 0, (void *)&csr_form_get,
                              &csr_len);
 
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
@@ -150,7 +150,7 @@ void libspdm_test_requester_get_csr_case2(void **state)
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP;
 
-    status = libspdm_get_csr(spdm_context, NULL, 0, NULL, 0, NULL, (void *)&csr_form_get,
+    status = libspdm_get_csr(spdm_context, NULL, NULL, 0, NULL, 0, (void *)&csr_form_get,
                              &csr_len);
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -228,7 +228,7 @@ void libspdm_test_requester_set_certificate_case1(void **state)
                                                     m_libspdm_use_asym_algo,
                                                     &data, &data_size, NULL, NULL);
 
-    status = libspdm_set_certificate(spdm_context, 0, data, data_size, NULL);
+    status = libspdm_set_certificate(spdm_context, NULL, 0, data, data_size);
 
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
     free(data);
@@ -262,7 +262,7 @@ void libspdm_test_requester_set_certificate_case2(void **state)
                                                     m_libspdm_use_asym_algo,
                                                     &data, &data_size, NULL, NULL);
 
-    status = libspdm_set_certificate(spdm_context, 0, data, data_size, NULL);
+    status = libspdm_set_certificate(spdm_context, NULL, 0, data, data_size);
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     free(data);
@@ -289,7 +289,7 @@ void libspdm_test_requester_set_certificate_case3(void **state)
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_CERT_CAP;
 
-    status = libspdm_set_certificate(spdm_context, 0, NULL, 0, NULL);
+    status = libspdm_set_certificate(spdm_context, NULL, 0, NULL, 0);
 
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
 }
@@ -323,7 +323,7 @@ void libspdm_test_requester_set_certificate_case4(void **state)
                                                     &data, &data_size, NULL, NULL);
 
     /* slot id is 1*/
-    status = libspdm_set_certificate(spdm_context, 1, data, data_size, NULL);
+    status = libspdm_set_certificate(spdm_context, NULL, 1, data, data_size);
 
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
     free(data);
@@ -382,7 +382,7 @@ void libspdm_test_requester_set_certificate_case5(void **state)
                                               LIBSPDM_SESSION_STATE_ESTABLISHED);
 
     /* slot id is 1*/
-    status = libspdm_set_certificate(spdm_context, 1, data, data_size, &session_id);
+    status = libspdm_set_certificate(spdm_context, &session_id, 1, data, data_size);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     free(data);


### PR DESCRIPTION
Fix: #1640
Move `session_id` to the 2nd parameter of
`libspdm_get_csr()` and `libspdm_set_certificate()` to make it consistent with other APIs.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>