### PR TITLE
Add sha3 self_test

### DIFF
--- a/include/internal/libspdm_fips_lib.h
+++ b/include/internal/libspdm_fips_lib.h
@@ -52,4 +52,17 @@ bool libspdm_fips_selftest_sha384(void);
  **/
 bool libspdm_fips_selftest_sha512(void);
 
+/**
+ * SHA3_256 KAT
+ **/
+bool libspdm_fips_selftest_sha3_256(void);
+/**
+ * SHA3_384 KAT
+ **/
+bool libspdm_fips_selftest_sha3_384(void);
+/**
+ * SHA3_512 KAT
+ **/
+bool libspdm_fips_selftest_sha3_512(void);
+
 #endif/*LIBSPDM_FIPS_MODE*/

--- a/library/spdm_crypt_lib/CMakeLists.txt
+++ b/library/spdm_crypt_lib/CMakeLists.txt
@@ -19,6 +19,13 @@ SET(src_spdm_crypt_lib
     fips/libspdm_selftest_hkdf.c
     fips/libspdm_selftest_ecdh.c
     fips/libspdm_selftest_sha2.c
+    fips/libspdm_selftest_sha3.c
 )
+
+if(CRYPTO STREQUAL "mbedtls")
+    add_definitions(-DLIBSPDM_SHA3_SUPPORT_TEST=0)
+elseif(CRYPTO STREQUAL "openssl")
+    add_definitions(-DLIBSPDM_SHA3_SUPPORT_TEST=1)
+endif()
 
 ADD_LIBRARY(spdm_crypt_lib STATIC ${src_spdm_crypt_lib})

--- a/library/spdm_crypt_lib/fips/libspdm_get_selftest_result.c
+++ b/library/spdm_crypt_lib/fips/libspdm_get_selftest_result.c
@@ -79,6 +79,22 @@ bool libspdm_fips_run_selftest(void)
         last_result = false;
     }
 
+    result = libspdm_fips_selftest_sha3_256();
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SHA3_256 self_test failed\n"));
+        last_result = false;
+    }
+    result = libspdm_fips_selftest_sha3_384();
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SHA3_384 self_test failed\n"));
+        last_result = false;
+    }
+    result = libspdm_fips_selftest_sha3_512();
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SHA3_512 self_test failed\n"));
+        last_result = false;
+    }
+
     return last_result;
 }
 

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
@@ -1,0 +1,122 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2023 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_crypt_lib.h"
+
+#if LIBSPDM_FIPS_MODE
+
+/**
+ * SHA3_256 KAT
+ **/
+bool libspdm_fips_selftest_sha3_256(void)
+{
+    bool result = true;
+
+#if (LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_256_SUPPORT)
+    const uint8_t msg[] = {0x7f, 0x94};
+    /*Test Vectors: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing#sha3vsha3vss */
+    uint8_t sha3_256_result[32];
+    const uint8_t sha3_256_answer[] = {
+        0xde, 0x01, 0x6a, 0xcf, 0xc1, 0xa2, 0xe2, 0x2e,
+        0x39, 0x52, 0x6c, 0x60, 0x9d, 0x9c, 0x69, 0xd8,
+        0x56, 0xa5, 0x43, 0xfe, 0xbb, 0x3c, 0xb4, 0x26,
+        0xee, 0x1f, 0x13, 0x18, 0xd7, 0x80, 0xea, 0x88
+    };
+    libspdm_zero_mem(sha3_256_result, sizeof(sha3_256_result));
+    result = libspdm_sha3_256_hash_all(msg, sizeof(msg), sha3_256_result);
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "gen sha3_256 failed \n"));
+        return false;
+    }
+
+    if (libspdm_const_compare_mem(sha3_256_result, sha3_256_answer,
+                                  sizeof(sha3_256_answer))) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_256 KAT failed \n"));
+        return false;
+    }
+
+#endif/*(LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_256_SUPPORT)*/
+
+    return result;
+}
+
+/**
+ * SHA3_384 KAT
+ **/
+bool libspdm_fips_selftest_sha3_384(void)
+{
+    bool result = true;
+
+#if (LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_384_SUPPORT)
+    uint8_t sha3_384_result[48];
+    /*Test Vectors: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing#sha3vsha3vss */
+    const uint8_t msg[] = {0x89, 0xcc};
+    const uint8_t sha3_384_answer[] = {
+        0xcf, 0x9b, 0xe5, 0x91, 0x0e, 0x2c, 0x4f, 0x89,
+        0x5b, 0x9e, 0x92, 0x08, 0x02, 0x26, 0x52, 0xbb,
+        0x4d, 0x6a, 0x7e, 0x85, 0x84, 0x5b, 0x2a, 0x6c,
+        0x22, 0x1c, 0x22, 0x84, 0x1e, 0xc0, 0x74, 0x64,
+        0xae, 0xe9, 0xfb, 0x5f, 0x89, 0x38, 0xb2, 0xda,
+        0xa8, 0x7b, 0xe3, 0x37, 0xf0, 0x38, 0xcb, 0xcf
+    };
+    libspdm_zero_mem(sha3_384_result, sizeof(sha3_384_result));
+    result = libspdm_sha3_384_hash_all(msg, sizeof(msg), sha3_384_result);
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "gen sha3_384 failed \n"));
+        return false;
+    }
+
+    if (libspdm_const_compare_mem(sha3_384_result, sha3_384_answer,
+                                  sizeof(sha3_384_answer))) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_384 KAT failed \n"));
+        return false;
+    }
+
+#endif/*(LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_384_SUPPORT)*/
+
+    return result;
+}
+
+/**
+ * SHA3_512 KAT
+ **/
+bool libspdm_fips_selftest_sha3_512(void)
+{
+    bool result = true;
+
+#if (LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_512_SUPPORT)
+    uint8_t sha3_512_result[64];
+    /*Test Vectors: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing#sha3vsha3vss */
+    const uint8_t msg[] = {0xb1, 0x39};
+    const uint8_t sha3_512_answer[] = {
+        0xd3, 0xe5, 0xc0, 0x26, 0x47, 0x05, 0xe8, 0x1d,
+        0x0c, 0x90, 0xf9, 0x9d, 0xae, 0xff, 0x00, 0x89,
+        0xfa, 0x3e, 0x91, 0x77, 0xd3, 0xd5, 0xbc, 0x74,
+        0x9c, 0xde, 0x10, 0xf0, 0x35, 0xf4, 0x95, 0x65,
+        0x55, 0x44, 0xf8, 0x57, 0x79, 0x91, 0x71, 0x2e,
+        0xb5, 0x18, 0x01, 0x5b, 0xe2, 0x9d, 0x19, 0x5b,
+        0x7e, 0xbf, 0x61, 0xe8, 0xd2, 0x93, 0x90, 0xea,
+        0xf1, 0x47, 0x88, 0x08, 0x2b, 0x11, 0x97, 0x6d
+    };
+    libspdm_zero_mem(sha3_512_result, sizeof(sha3_512_result));
+    result = libspdm_sha3_512_hash_all(msg, sizeof(msg), sha3_512_result);
+    if (!result) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "gen sha3_512 failed \n"));
+        return false;
+    }
+
+    if (libspdm_const_compare_mem(sha3_512_result, sha3_512_answer,
+                                  sizeof(sha3_512_answer))) {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_512 KAT failed \n"));
+        return false;
+    }
+
+#endif/*(LIBSPDM_SHA3_SUPPORT_TEST && LIBSPDM_SHA3_512_SUPPORT)*/
+
+    return result;
+}
+
+#endif/*LIBSPDM_FIPS_MODE*/


### PR DESCRIPTION
Reference: #1260

For openssl, sha3 self_test is passed.
For mbedtls, sha3 self_test just return ture: because mbedtsl doesn't support sha3 in libspdm now.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>