### PR TITLE
set LIB_INSTALL_DIR to build mbedtls with cmake

### DIFF
--- a/os_stub/mbedtlslib/CMakeLists.txt
+++ b/os_stub/mbedtlslib/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+if(LIB_INSTALL_DIR)
+else()
+    set(LIB_INSTALL_DIR lib)
+endif()
+
 ADD_SUBDIRECTORY(${CMAKE_CURRENT_LIST_DIR}/mbedtls/library)
 
 # mbedtls


### PR DESCRIPTION
Resolves #1670

Signed-off-by: Ray Wang <ray.wang1@broadcom.com>
