### PR TITLE
Fix potential alignment and byte-order issue

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -49,10 +49,12 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
 {
     libspdm_context_t *context;
     uint32_t session_id;
+    uint32_t data32;
     libspdm_session_info_t *session_info;
     uint8_t slot_id;
     uint8_t mut_auth_requested;
     uint8_t root_cert_index;
+    uint16_t data16;
 #if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
     bool status;
 #endif
@@ -122,31 +124,33 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
 
+        data32 = libspdm_read_uint32((const uint8_t *)data);
+
     #if !(LIBSPDM_ENABLE_CAPABILITY_CERT_CAP)
-        LIBSPDM_ASSERT(((*(uint32_t *)data) & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP) == 0);
+        LIBSPDM_ASSERT((data32 & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP) == 0);
     #endif /* !LIBSPDM_ENABLE_CAPABILITY_CERT_CAP */
 
     #if !(LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP)
-        LIBSPDM_ASSERT(((*(uint32_t *)data) & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP) == 0);
+        LIBSPDM_ASSERT((data32 & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP) == 0);
     #endif /* !LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP */
 
     #if !(LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP)
-        LIBSPDM_ASSERT(((*(uint32_t *)data) & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) == 0);
+        LIBSPDM_ASSERT((data32 & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP) == 0);
     #endif /* !LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP */
 
     #if !(LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP)
-        LIBSPDM_ASSERT(((*(uint32_t *)data) & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP) ==
+        LIBSPDM_ASSERT((data32 & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP) ==
                        0);
     #endif /* !LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP */
 
     #if !(LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)
-        LIBSPDM_ASSERT(((*(uint32_t *)data) & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP) == 0);
+        LIBSPDM_ASSERT((data32 & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP) == 0);
     #endif /* !LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP */
 
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.capability.flags = *(uint32_t *)data;
+            context->connection_info.capability.flags = data32;
         } else {
-            context->local_context.capability.flags = *(uint32_t *)data;
+            context->local_context.capability.flags = data32;
         }
         break;
     case LIBSPDM_DATA_CAPABILITY_CT_EXPONENT:
@@ -159,23 +163,25 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         if (data_size != sizeof(uint64_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
-        context->local_context.capability.rtt = *(uint64_t *)data;
+        context->local_context.capability.rtt = libspdm_read_uint64((const uint8_t *)data);
         break;
     case LIBSPDM_DATA_CAPABILITY_DATA_TRANSFER_SIZE:
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data32 = libspdm_read_uint32((const uint8_t *)data);
         /* Only allow set smaller value*/
-        LIBSPDM_ASSERT (*(uint32_t *)data <= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-        context->local_context.capability.data_transfer_size = *(uint32_t *)data;
+        LIBSPDM_ASSERT (data32 <= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        context->local_context.capability.data_transfer_size = data32;
         break;
     case LIBSPDM_DATA_CAPABILITY_MAX_SPDM_MSG_SIZE:
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data32 = libspdm_read_uint32((const uint8_t *)data);
         /* Only allow set smaller value. Need different value for CHUNK - TBD*/
-        LIBSPDM_ASSERT (*(uint32_t *)data <= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
-        context->local_context.capability.max_spdm_msg_size = *(uint32_t *)data;
+        LIBSPDM_ASSERT (data32 <= LIBSPDM_MAX_MESSAGE_BUFFER_SIZE);
+        context->local_context.capability.max_spdm_msg_size = data32;
         break;
     case LIBSPDM_DATA_MEASUREMENT_SPEC:
         if (data_size != sizeof(uint8_t)) {
@@ -191,70 +197,77 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data32 = libspdm_read_uint32((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.measurement_hash_algo = *(uint32_t *)data;
+            context->connection_info.algorithm.measurement_hash_algo = data32;
         } else {
-            context->local_context.algorithm.measurement_hash_algo = *(uint32_t *)data;
+            context->local_context.algorithm.measurement_hash_algo = data32;
         }
         break;
     case LIBSPDM_DATA_BASE_ASYM_ALGO:
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data32 = libspdm_read_uint32((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.base_asym_algo = *(uint32_t *)data;
+            context->connection_info.algorithm.base_asym_algo = data32;
         } else {
-            context->local_context.algorithm.base_asym_algo = *(uint32_t *)data;
+            context->local_context.algorithm.base_asym_algo = data32;
         }
         break;
     case LIBSPDM_DATA_BASE_HASH_ALGO:
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data32 = libspdm_read_uint32((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.base_hash_algo = *(uint32_t *)data;
+            context->connection_info.algorithm.base_hash_algo = data32;
         } else {
-            context->local_context.algorithm.base_hash_algo = *(uint32_t *)data;
+            context->local_context.algorithm.base_hash_algo = data32;
         }
         break;
     case LIBSPDM_DATA_DHE_NAME_GROUP:
         if (data_size != sizeof(uint16_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data16 = libspdm_read_uint16((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.dhe_named_group = *(uint16_t *)data;
+            context->connection_info.algorithm.dhe_named_group = data16;
         } else {
-            context->local_context.algorithm.dhe_named_group = *(uint16_t *)data;
+            context->local_context.algorithm.dhe_named_group = data16;
         }
         break;
     case LIBSPDM_DATA_AEAD_CIPHER_SUITE:
         if (data_size != sizeof(uint16_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data16 = libspdm_read_uint16((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.aead_cipher_suite = *(uint16_t *)data;
+            context->connection_info.algorithm.aead_cipher_suite = data16;
         } else {
-            context->local_context.algorithm.aead_cipher_suite = *(uint16_t *)data;
+            context->local_context.algorithm.aead_cipher_suite = data16;
         }
         break;
     case LIBSPDM_DATA_REQ_BASE_ASYM_ALG:
         if (data_size != sizeof(uint16_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data16 = libspdm_read_uint16((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.req_base_asym_alg = *(uint16_t *)data;
+            context->connection_info.algorithm.req_base_asym_alg = data16;
         } else {
-            context->local_context.algorithm.req_base_asym_alg = *(uint16_t *)data;
+            context->local_context.algorithm.req_base_asym_alg = data16;
         }
         break;
     case LIBSPDM_DATA_KEY_SCHEDULE:
         if (data_size != sizeof(uint16_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        data16 = libspdm_read_uint16((const uint8_t *)data);
         if (parameter->location == LIBSPDM_DATA_LOCATION_CONNECTION) {
-            context->connection_info.algorithm.key_schedule = *(uint16_t *)data;
+            context->connection_info.algorithm.key_schedule = data16;
         } else {
-            context->local_context.algorithm.key_schedule = *(uint16_t *)data;
+            context->local_context.algorithm.key_schedule = data16;
         }
         break;
     case LIBSPDM_DATA_OTHER_PARAMS_SUPPORT:
@@ -271,13 +284,13 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
-        context->connection_info.connection_state = *(uint32_t *)data;
+        context->connection_info.connection_state = libspdm_read_uint32((const uint8_t *)data);
         break;
     case LIBSPDM_DATA_RESPONSE_STATE:
         if (data_size != sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
-        context->response_state = *(uint32_t *)data;
+        context->response_state = libspdm_read_uint32((const uint8_t *)data);
         break;
     case LIBSPDM_DATA_PEER_PUBLIC_ROOT_CERT:
         root_cert_index = 0;

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -246,7 +246,7 @@ static libspdm_return_t libspdm_try_challenge(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(measurement_summary_hash, measurement_summary_hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    opaque_length = *(uint16_t *)ptr;
+    opaque_length = libspdm_read_uint16((const uint8_t *)ptr);
     if (opaque_length > SPDM_MAX_OPAQUE_DATA_SIZE) {
         status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
         goto receive_done;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -380,7 +380,7 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
             libspdm_copy_mem(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
         }
 
-        opaque_length = *(uint16_t *)ptr;
+        opaque_length = libspdm_read_uint16((const uint8_t *)ptr);
         if (opaque_length > SPDM_MAX_OPAQUE_DATA_SIZE) {
             status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
             goto receive_done;
@@ -454,7 +454,7 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
             libspdm_copy_mem(responder_nonce, SPDM_NONCE_SIZE, nonce, SPDM_NONCE_SIZE);
         }
 
-        opaque_length = *(uint16_t *)ptr;
+        opaque_length = libspdm_read_uint16((const uint8_t *)ptr);
         if (opaque_length > SPDM_MAX_OPAQUE_DATA_SIZE) {
             status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
             goto receive_done;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -381,7 +381,7 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
 
     opaque_key_exchange_req_size =
         libspdm_get_opaque_data_supported_version_data_size(spdm_context);
-    *(uint16_t *)ptr = (uint16_t)opaque_key_exchange_req_size;
+    libspdm_write_uint16(ptr, (uint16_t)opaque_key_exchange_req_size);
     ptr += sizeof(uint16_t);
     libspdm_build_opaque_data_supported_version_data(
         spdm_context, &opaque_key_exchange_req_size, ptr);
@@ -558,7 +558,7 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
 
     ptr += measurement_summary_hash_size;
 
-    opaque_length = *(uint16_t *)ptr;
+    opaque_length = libspdm_read_uint16((const uint8_t *)ptr);
     if (opaque_length > SPDM_MAX_OPAQUE_DATA_SIZE) {
         libspdm_secured_message_dhe_free(
             spdm_context->connection_info.algorithm.dhe_named_group, dhe_context);

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -481,7 +481,7 @@ libspdm_return_t libspdm_get_response_key_exchange(libspdm_context_t *spdm_conte
     }
     ptr += measurement_summary_hash_size;
 
-    *(uint16_t *)ptr = (uint16_t)opaque_key_exchange_rsp_size;
+    libspdm_write_uint16(ptr, (uint16_t)opaque_key_exchange_rsp_size);
     ptr += sizeof(uint16_t);
     libspdm_build_opaque_data_version_selection_data(
         spdm_context, &opaque_key_exchange_rsp_size, ptr);

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -53,6 +53,7 @@ libspdm_return_t libspdm_encode_secured_message(
     uint8_t *salt;
     uint64_t sequence_number;
     uint64_t sequence_num_in_header;
+    uint64_t data64;
     uint8_t sequence_num_in_header_size;
     libspdm_session_type_t session_type;
     uint32_t rand_count;
@@ -118,7 +119,9 @@ libspdm_return_t libspdm_encode_secured_message(
     }
 
     if (sequence_number > 0) {
-        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        data64 = libspdm_read_uint64((const uint8_t *)salt) ^
+                 (sequence_number - 1) ^ sequence_number;
+        libspdm_write_uint64(salt, data64);
     }
 
     sequence_num_in_header = 0;
@@ -308,6 +311,7 @@ libspdm_return_t libspdm_decode_secured_message(
     uint8_t *salt;
     uint64_t sequence_number;
     uint64_t sequence_num_in_header;
+    uint64_t data64;
     uint8_t sequence_num_in_header_size;
     libspdm_session_type_t session_type;
     libspdm_session_state_t session_state;
@@ -380,7 +384,9 @@ libspdm_return_t libspdm_decode_secured_message(
     }
 
     if (sequence_number > 0) {
-        *(uint64_t *)salt = *(uint64_t *)salt ^ (sequence_number - 1) ^ sequence_number;
+        data64 = libspdm_read_uint64((const uint8_t *)salt) ^
+                 (sequence_number - 1) ^ sequence_number;
+        libspdm_write_uint64(salt, data64);
     }
 
     sequence_num_in_header = 0;

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -6,6 +6,7 @@
 
 #include "library/spdm_transport_mctp_lib.h"
 #include "industry_standard/mctp.h"
+#include "internal/libspdm_common_lib.h"
 #include "hal/library/debuglib.h"
 #include "hal/library/memlib.h"
 
@@ -68,6 +69,7 @@ libspdm_return_t libspdm_mctp_encode_message(const uint32_t *session_id, size_t 
 {
     size_t aligned_message_size;
     size_t alignment;
+    uint32_t data32;
     mctp_message_header_t *mctp_message_header;
 
     alignment = MCTP_ALIGNMENT;
@@ -81,8 +83,9 @@ libspdm_return_t libspdm_mctp_encode_message(const uint32_t *session_id, size_t 
     if (session_id != NULL) {
         mctp_message_header->message_type =
             MCTP_MESSAGE_TYPE_SECURED_MCTP;
-        LIBSPDM_ASSERT(*session_id == *(uint32_t *)(message));
-        if (*session_id != *(uint32_t *)(message)) {
+        data32 = libspdm_read_uint32((const uint8_t *)message);
+        LIBSPDM_ASSERT(*session_id == data32);
+        if (*session_id != data32) {
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
     } else {

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -6,6 +6,7 @@
 
 #include "library/spdm_transport_pcidoe_lib.h"
 #include "industry_standard/pcidoe.h"
+#include "internal/libspdm_common_lib.h"
 #include "hal/library/debuglib.h"
 #include "hal/library/memlib.h"
 
@@ -68,6 +69,7 @@ libspdm_return_t libspdm_pci_doe_encode_message(const uint32_t *session_id,
 {
     size_t aligned_message_size;
     size_t alignment;
+    uint32_t data32;
     pci_doe_data_object_header_t *pci_doe_header;
 
     alignment = PCI_DOE_ALIGNMENT;
@@ -90,8 +92,9 @@ libspdm_return_t libspdm_pci_doe_encode_message(const uint32_t *session_id,
     if (session_id != NULL) {
         pci_doe_header->data_object_type =
             PCI_DOE_DATA_OBJECT_TYPE_SECURED_SPDM;
-        LIBSPDM_ASSERT(*session_id == *(uint32_t *)(message));
-        if (*session_id != *(uint32_t *)(message)) {
+        data32 = libspdm_read_uint32((const uint8_t *)message);
+        LIBSPDM_ASSERT(*session_id == data32);
+        if (*session_id != data32) {
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
     } else {


### PR DESCRIPTION
Direct usage of '*(uint32_t *)' or '*(uint16_t *)' could cause potential alignment issue, or byte-ordering issue if the data buffer is transmitted from another host with different endiness. This commit converts them into libspdm_read_uintxx()/libspdm_write_uintxx().

Code in os_stub and unit_test are not covered in this commit for now.

Resolves #1669

Signed-off-by: Liming Sun <limings@nvidia.com>