### PR TITLE
Add delay time between retry requests

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -383,6 +383,9 @@ typedef struct {
 
     /* Register for the retry times when receive "BUSY" Error response (requester only) */
     uint8_t retry_times;
+    /* Register for the delay time in microseconds between retry requests
+     * when receive "BUSY" Error response (requester only) */
+    uint64_t retry_delay_time;
     bool crypto_request;
 
     /* App context data for use by application */

--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -10,6 +10,7 @@
 #include "library/spdm_requester_lib.h"
 #include "library/spdm_secured_message_lib.h"
 #include "internal/libspdm_common_lib.h"
+#include "hal/library/platform_lib.h"
 
 /**
  * This function handles simple error code.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -114,6 +114,13 @@ typedef enum {
      **/
     LIBSPDM_DATA_REQUEST_RETRY_TIMES,
 
+    /* If the Responder replies with a Busy `ERROR` response to a request
+     * then the Requester is free to retry sending the request.
+     * This value specifies the delay time in microseconds between each retry requests.
+     * If its value is 0 then libspdm will send retry request immediately.
+     **/
+    LIBSPDM_DATA_REQUEST_RETRY_DELAY_TIME,
+
     /* MAX */
     LIBSPDM_DATA_MAX
 } libspdm_data_type_t;

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -486,6 +486,12 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         }
         context->retry_times = *(uint8_t *)data;
         break;
+    case LIBSPDM_DATA_REQUEST_RETRY_DELAY_TIME:
+        if (data_size != sizeof(uint64_t)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        context->retry_delay_time = *(uint64_t *)data;
+        break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -338,11 +338,13 @@ libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_challenge(context, slot_id,
                                        measurement_hash_type,
@@ -350,6 +352,8 @@ libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -366,11 +370,13 @@ libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_challenge(context, slot_id,
                                        measurement_hash_type,
@@ -381,6 +387,8 @@ libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -152,16 +152,20 @@ libspdm_return_t libspdm_send_receive_end_session(libspdm_context_t *spdm_contex
                                                   uint8_t end_session_attributes)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_end_session(
             spdm_context, session_id, end_session_attributes);
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -602,16 +602,20 @@ libspdm_return_t libspdm_send_receive_finish(libspdm_context_t *spdm_context,
                                              uint8_t req_slot_id_param)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_finish(spdm_context, session_id,
                                                  req_slot_id_param);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -322,15 +322,19 @@ receive_done:
 libspdm_return_t libspdm_get_capabilities(libspdm_context_t *spdm_context)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_get_capabilities(spdm_context);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -408,17 +408,21 @@ libspdm_return_t libspdm_get_certificate_choose_length(void *spdm_context,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_certificate(context, session_id, slot_id, length,
                                              cert_chain_size, cert_chain, NULL, NULL);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -435,11 +439,13 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_certificate(context, session_id, slot_id, length,
                                              cert_chain_size, cert_chain, trust_anchor,
@@ -447,6 +453,8 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_csr.c
+++ b/library/spdm_requester_lib/libspdm_req_get_csr.c
@@ -175,11 +175,13 @@ libspdm_return_t libspdm_get_csr(void * spdm_context,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_csr(context, session_id,
                                      requester_info, requester_info_length,
@@ -188,6 +190,8 @@ libspdm_return_t libspdm_get_csr(void * spdm_context,
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -228,16 +228,20 @@ libspdm_return_t libspdm_get_digest(void *spdm_context, const uint32_t *session_
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_digest(context, session_id, slot_mask, total_digest_buffer);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -598,11 +598,13 @@ libspdm_return_t libspdm_get_measurement(void *spdm_context, const uint32_t *ses
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_measurement(
             context, session_id, request_attribute,
@@ -611,6 +613,8 @@ libspdm_return_t libspdm_get_measurement(void *spdm_context, const uint32_t *ses
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -630,11 +634,13 @@ libspdm_return_t libspdm_get_measurement_ex(void *spdm_context, const uint32_t *
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_measurement(
             context, session_id, request_attribute,
@@ -645,6 +651,8 @@ libspdm_return_t libspdm_get_measurement_ex(void *spdm_context, const uint32_t *
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -206,16 +206,20 @@ libspdm_return_t libspdm_get_version(libspdm_context_t *spdm_context,
                                      spdm_version_number_t *version_number_entry)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_get_version(spdm_context,
                                          version_number_entry_count, version_number_entry);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -142,17 +142,21 @@ receive_done:
 libspdm_return_t libspdm_heartbeat(void *spdm_context, uint32_t session_id)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
     libspdm_context_t *context;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_heartbeat(context, session_id);
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -730,10 +730,12 @@ libspdm_return_t libspdm_send_receive_key_exchange(
     uint8_t *req_slot_id_param, void *measurement_hash)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
@@ -742,6 +744,8 @@ libspdm_return_t libspdm_send_receive_key_exchange(
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -757,10 +761,12 @@ libspdm_return_t libspdm_send_receive_key_exchange_ex(
     void *responder_random)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
@@ -770,6 +776,8 @@ libspdm_return_t libspdm_send_receive_key_exchange_ex(
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -315,6 +315,7 @@ libspdm_return_t libspdm_key_update(void *spdm_context, uint32_t session_id,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
     bool key_updated;
 
@@ -322,12 +323,15 @@ libspdm_return_t libspdm_key_update(void *spdm_context, uint32_t session_id,
     key_updated = false;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_key_update(spdm_context, session_id,
                                         single_direction, &key_updated);
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -516,15 +516,19 @@ receive_done:
 libspdm_return_t libspdm_negotiate_algorithms(libspdm_context_t *spdm_context)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = false;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_negotiate_algorithms(spdm_context);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -513,10 +513,12 @@ libspdm_return_t libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_conte
                                                    void *measurement_hash)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_psk_exchange(
             spdm_context, measurement_hash_type, session_policy, session_id,
@@ -525,6 +527,8 @@ libspdm_return_t libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_conte
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -544,10 +548,12 @@ libspdm_return_t libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_co
                                                       size_t *responder_context_size)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_psk_exchange(
             spdm_context, measurement_hash_type, session_policy, session_id,
@@ -558,6 +564,8 @@ libspdm_return_t libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_co
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -286,16 +286,20 @@ libspdm_return_t libspdm_send_receive_psk_finish(libspdm_context_t *spdm_context
                                                  uint32_t session_id)
 {
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     spdm_context->crypto_request = true;
     retry = spdm_context->retry_times;
+    retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_send_receive_psk_finish(spdm_context,
                                                      session_id);
         if (LIBSPDM_STATUS_BUSY_PEER != status) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -166,17 +166,21 @@ libspdm_return_t libspdm_set_certificate(void *spdm_context,
 {
     libspdm_context_t *context;
     size_t retry;
+    uint64_t retry_delay_time;
     libspdm_return_t status;
 
     context = spdm_context;
     context->crypto_request = true;
     retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_set_certificate(context, session_id, slot_id,
                                              cert_chain, cert_chain_size);
         if (status != LIBSPDM_STATUS_BUSY_PEER) {
             return status;
         }
+
+        libspdm_sleep_in_us(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/os_stub/platform_lib/time_win.c
+++ b/os_stub/platform_lib/time_win.c
@@ -19,6 +19,13 @@ void libspdm_sleep_in_us(uint64_t microseconds)
 {
     uint64_t milliseconds;
 
+    /* If 0 is given as the sleep time interval, the thread will relinquish the remainder of its time slice.
+     * https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep
+     * Return immediately to avoid unexpected re-scheduling. */
+    if (microseconds == 0) {
+        return;
+    }
+
     milliseconds = (microseconds + 1000 - 1) / 1000;
     Sleep((DWORD)milliseconds);
 }


### PR DESCRIPTION
Fix: #717
This patch adds integrator configurable
delay time in microseconds between retry requests.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>