### PR TITLE
Add new cert verify status

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -596,6 +596,40 @@ bool libspdm_generate_public_key_hash(libspdm_context_t *spdm_context,
                                       uint8_t *hash);
 
 /**
+ * This function verifies the integrity of peer certificate chain buffer including
+ * spdm_cert_chain_t header.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  cert_chain_buffer              Certificate chain buffer including spdm_cert_chain_t header.
+ * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
+ *
+ * @retval true  Peer certificate chain buffer integrity verification passed.
+ * @retval false Peer certificate chain buffer integrity verification failed.
+ **/
+bool libspdm_verify_peer_cert_chain_buffer_integrity(libspdm_context_t *spdm_context,
+                                                     const void *cert_chain_buffer,
+                                                     size_t cert_chain_buffer_size);
+
+/**
+ * This function verifies peer certificate chain authority.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  cert_chain_buffer              Certificate chain buffer including spdm_cert_chain_t header.
+ * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
+ * @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
+ * @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
+ *
+ * @retval true  Peer certificate chain buffer authority verification passed.
+ *               Or there is no root_cert in local_context.
+ * @retval false Peer certificate chain buffer authority verification failed.
+ **/
+bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_context,
+                                                     const void *cert_chain_buffer,
+                                                     size_t cert_chain_buffer_size,
+                                                     const void **trust_anchor,
+                                                     size_t *trust_anchor_size);
+
+/**
  * This function verifies peer certificate chain buffer including spdm_cert_chain_t header.
  *
  * @param  spdm_context                  A pointer to the SPDM context.
@@ -603,7 +637,6 @@ bool libspdm_generate_public_key_hash(libspdm_context_t *spdm_context,
  * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
  * @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
  * @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
- * @param  is_requester                   Indicates if it is a requester message.
  *
  * @retval true  Peer certificate chain buffer verification passed.
  * @retval false Peer certificate chain buffer verification failed.
@@ -612,8 +645,7 @@ bool libspdm_verify_peer_cert_chain_buffer(libspdm_context_t *spdm_context,
                                            const void *cert_chain_buffer,
                                            size_t cert_chain_buffer_size,
                                            const void **trust_anchor,
-                                           size_t *trust_anchor_size,
-                                           bool is_requester);
+                                           size_t *trust_anchor_size);
 
 /**
  * This function generates the challenge signature based upon m1m2 for authentication.

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -150,6 +150,10 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CRYPTO, 0x0002)
 
+/* Provided cert is valid but is not authoritative(mismatch the root cert). */
+#define LIBSPDM_STATUS_VERIF_NO_AUTHORITY \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CRYPTO, 0x0003)
+
 /* - Certificate Parsing Errors - */
 
 /* Certificate is malformed or does not comply to x.509 standard. */

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -310,14 +310,23 @@ static libspdm_return_t libspdm_try_get_certificate(libspdm_context_t *spdm_cont
             goto done;
         }
     } else {
-        result = libspdm_verify_peer_cert_chain_buffer(
+        result = libspdm_verify_peer_cert_chain_buffer_integrity(
             spdm_context, libspdm_get_managed_buffer(&certificate_chain_buffer),
-            libspdm_get_managed_buffer_size(&certificate_chain_buffer),
-            trust_anchor, trust_anchor_size, true);
+            libspdm_get_managed_buffer_size(&certificate_chain_buffer));
         if (!result) {
             status = LIBSPDM_STATUS_VERIF_FAIL;
             goto done;
         }
+    }
+
+    /*verify peer cert chain authority*/
+    result = libspdm_verify_peer_cert_chain_buffer_authority(
+        spdm_context, libspdm_get_managed_buffer(&certificate_chain_buffer),
+        libspdm_get_managed_buffer_size(&certificate_chain_buffer),
+        trust_anchor, trust_anchor_size);
+    if (!result) {
+        status = LIBSPDM_STATUS_VERIF_NO_AUTHORITY;
+        goto done;
     }
 
     spdm_context->connection_info.peer_used_cert_chain_slot_id = slot_id;

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -159,16 +159,27 @@ libspdm_return_t libspdm_process_encap_response_certificate(
             return LIBSPDM_STATUS_VERIF_FAIL;
         }
     } else {
-        result = libspdm_verify_peer_cert_chain_buffer(
+        result = libspdm_verify_peer_cert_chain_buffer_integrity(
             spdm_context,
             libspdm_get_managed_buffer(
                 &spdm_context->encap_context.certificate_chain_buffer),
             libspdm_get_managed_buffer_size(
-                &spdm_context->encap_context.certificate_chain_buffer),
-            NULL, NULL, false);
+                &spdm_context->encap_context.certificate_chain_buffer));
         if (!result) {
             return LIBSPDM_STATUS_VERIF_FAIL;
         }
+    }
+
+    /*verify peer cert chain authority*/
+    result = libspdm_verify_peer_cert_chain_buffer_authority(
+        spdm_context,
+        libspdm_get_managed_buffer(
+            &spdm_context->encap_context.certificate_chain_buffer),
+        libspdm_get_managed_buffer_size(
+            &spdm_context->encap_context.certificate_chain_buffer),
+        NULL, NULL);
+    if (!result) {
+        return LIBSPDM_STATUS_VERIF_NO_AUTHORITY;
     }
 
     spdm_context->connection_info.peer_used_cert_chain_slot_id =

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -533,7 +533,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case5(void **state)
         spdm_context->local_context.peer_root_cert_provision[root_cert_index] = NULL;
     }
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
 
     free(data);
@@ -607,14 +607,14 @@ void libspdm_test_verify_peer_cert_chain_buffer_case6(void **state)
     spdm_context->local_context.peer_root_cert_provision_size[0] =root_cert_size_test;
     spdm_context->local_context.peer_root_cert_provision[0] = root_cert_test;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, false);
 
     /*case: mismatch root cert case*/
     spdm_context->local_context.peer_root_cert_provision_size[0] =root_cert_size;
     spdm_context->local_context.peer_root_cert_provision[0] = root_cert;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
     assert_ptr_equal (trust_anchor, root_cert);
 
@@ -695,7 +695,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case7(void **state)
         spdm_context->local_context.peer_root_cert_provision[root_cert_index] = root_cert_test;
     }
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, false);
 
     /*case: there is no match root cert in the end*/
@@ -704,7 +704,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case7(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT / 2 -
                                                          1] = root_cert;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
     assert_ptr_equal (trust_anchor, root_cert);
 
@@ -714,7 +714,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case7(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT /
                                                          4] = root_cert;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
     assert_ptr_equal (trust_anchor, root_cert);
 
@@ -789,7 +789,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case8(void **state)
         spdm_context->local_context.peer_root_cert_provision[root_cert_index] = root_cert_test;
     }
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, false);
 
     /*case: there is no match root cert in the end*/
@@ -798,7 +798,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case8(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT -
                                                          1] = root_cert;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
     assert_ptr_equal (trust_anchor, root_cert);
 
@@ -813,7 +813,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case8(void **state)
     spdm_context->local_context.peer_root_cert_provision[LIBSPDM_MAX_ROOT_CERT_SUPPORT /
                                                          2] = root_cert;
     result = libspdm_verify_peer_cert_chain_buffer(spdm_context, data, data_size, &trust_anchor,
-                                                   &trust_anchor_size, true);
+                                                   &trust_anchor_size);
     assert_int_equal (result, true);
     assert_ptr_equal (trust_anchor, root_cert);
 

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -2703,7 +2703,7 @@ void libspdm_test_requester_get_certificate_case11(void **state)
 
 /**
  * Test 12: Normal procedure, but the retrieved root certificate does not match
- * Expected Behavior: get a LIBSPDM_STATUS_VERIF_FAIL, and receives the correct number of Certificate messages
+ * Expected Behavior: get a LIBSPDM_STATUS_VERIF_NO_AUTHORITY, and receives the correct number of Certificate messages
  **/
 void libspdm_test_requester_get_certificate_case12(void **state)
 {
@@ -2762,7 +2762,7 @@ void libspdm_test_requester_get_certificate_case12(void **state)
     libspdm_zero_mem(cert_chain, sizeof(cert_chain));
     status = libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size,
                                      cert_chain);
-    assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
+    assert_int_equal(status, LIBSPDM_STATUS_VERIF_NO_AUTHORITY);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     count = (data_size + LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN - 1) /
             LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN;


### PR DESCRIPTION
Fix: #1718

Commit 1： Add new status to distinguish verify cert chain status.

- When verify cert chain integrity failed, the status is VERIF_FAIL.
- When verify cert chain authority failed, the status is NO_AUTHORITY.

Commit 2： Fix the unit_test for adding new verify status
