### PR TITLE
Add LIBSPDM_CPU_ARM to fix armclang build error

### DIFF
--- a/os_stub/openssllib/CMakeLists.txt
+++ b/os_stub/openssllib/CMakeLists.txt
@@ -559,4 +559,8 @@ SET(src_openssllib
     rand_pool.c
 )
 
+if ((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
+    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
+endif()
+
 ADD_LIBRARY(openssllib STATIC ${src_openssllib})

--- a/os_stub/spdm_device_secret_lib_sample/CMakeLists.txt
+++ b/os_stub/spdm_device_secret_lib_sample/CMakeLists.txt
@@ -11,4 +11,8 @@ SET(src_spdm_device_secret_lib_sample
     cert.c
 )
 
+if ((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
+    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
+endif()
+
 ADD_LIBRARY(spdm_device_secret_lib_sample STATIC ${src_spdm_device_secret_lib_sample})


### PR DESCRIPTION
Fix: #1721 