### PR TITLE
Document target architecture

### DIFF
--- a/doc/programming_environment.md
+++ b/doc/programming_environment.md
@@ -9,7 +9,7 @@ freestanding headers.
 - stdef.h
 
 If a compiler does not provide at least one of these headers or if at least one of the compiler's
-headers must be overriden by the Integrator's headers then they can be overriden with the
+headers must be overriden by the Integrator's headers then they can be overridden with the
 `LIBSPDM_STDINT_ALT`, `LIBSPDM_STDBOOL_ALT`, or `LIBSPDM_STDDEF_ALT` macros. The inclusion of only
 freestanding headers indicates that the core libraries are suitable for embedded and systems
 programming. Any functionality beyond the freestanding headers is indicated through the
@@ -19,8 +19,9 @@ dynamically allocate memory.
 
 ### Core Library Assumptions
 
-libspdm has the following assumptions against the compiler, target harware architecture, and target
+libspdm has the following assumptions against the compiler, target hardware architecture, and target
 operating environment.
+- The endianness of the target architecture is little-endian.
 - The compiler supports the `#pragma pack()` directive.
 - If a pointer has been `memset` to a value of `0` then the pointer is equal to `NULL`.
 - Characters are encoded as ASCII so that, for example, `('A' == 65)` evaluates to `1`.


### PR DESCRIPTION
Fixes #115.

Note that if libspdm ever support big-endian architectures then we can remove the first bullet point.