### PR TITLE
Prevent extra sleep in busy-retry process

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -352,7 +352,7 @@ libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
         status = libspdm_try_challenge(context, slot_id,
                                        measurement_hash_type,
                                        measurement_hash, slot_mask, NULL, NULL, NULL);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 
@@ -387,7 +387,7 @@ libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
                                        slot_mask,
                                        requester_nonce_in,
                                        requester_nonce, responder_nonce);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -161,7 +161,7 @@ libspdm_return_t libspdm_send_receive_end_session(libspdm_context_t *spdm_contex
     do {
         status = libspdm_try_send_receive_end_session(
             spdm_context, session_id, end_session_attributes);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -611,7 +611,7 @@ libspdm_return_t libspdm_send_receive_finish(libspdm_context_t *spdm_context,
     do {
         status = libspdm_try_send_receive_finish(spdm_context, session_id,
                                                  req_slot_id_param);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -330,7 +330,7 @@ libspdm_return_t libspdm_get_capabilities(libspdm_context_t *spdm_context)
     retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_get_capabilities(spdm_context);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -418,7 +418,7 @@ libspdm_return_t libspdm_get_certificate_choose_length(void *spdm_context,
     do {
         status = libspdm_try_get_certificate(context, session_id, slot_id, length,
                                              cert_chain_size, cert_chain, NULL, NULL);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 
@@ -450,7 +450,7 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
         status = libspdm_try_get_certificate(context, session_id, slot_id, length,
                                              cert_chain_size, cert_chain, trust_anchor,
                                              trust_anchor_size);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_csr.c
+++ b/library/spdm_requester_lib/libspdm_req_get_csr.c
@@ -187,7 +187,7 @@ libspdm_return_t libspdm_get_csr(void * spdm_context,
                                      requester_info, requester_info_length,
                                      opaque_data, opaque_data_length,
                                      csr, csr_len);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -237,7 +237,7 @@ libspdm_return_t libspdm_get_digest(void *spdm_context, const uint32_t *session_
     retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_get_digest(context, session_id, slot_mask, total_digest_buffer);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -619,7 +619,7 @@ libspdm_return_t libspdm_get_measurement(void *spdm_context, const uint32_t *ses
             context, session_id, request_attribute,
             measurement_operation, slot_id_param, content_changed, number_of_blocks,
             measurement_record_length, measurement_record, NULL, NULL, NULL);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 
@@ -657,7 +657,7 @@ libspdm_return_t libspdm_get_measurement_ex(void *spdm_context, const uint32_t *
             measurement_record_length, measurement_record,
             requester_nonce_in,
             requester_nonce, responder_nonce);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -215,7 +215,7 @@ libspdm_return_t libspdm_get_version(libspdm_context_t *spdm_context,
     do {
         status = libspdm_try_get_version(spdm_context,
                                          version_number_entry_count, version_number_entry);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -152,7 +152,7 @@ libspdm_return_t libspdm_heartbeat(void *spdm_context, uint32_t session_id)
     retry_delay_time = context->retry_delay_time;
     do {
         status = libspdm_try_heartbeat(context, session_id);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -744,7 +744,7 @@ libspdm_return_t libspdm_send_receive_key_exchange(
             spdm_context, measurement_hash_type, slot_id, session_policy,
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, NULL, NULL, NULL);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 
@@ -776,7 +776,7 @@ libspdm_return_t libspdm_send_receive_key_exchange_ex(
             session_id, heartbeat_period, req_slot_id_param,
             measurement_hash, requester_random_in,
             requester_random, responder_random);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -327,7 +327,7 @@ libspdm_return_t libspdm_key_update(void *spdm_context, uint32_t session_id,
     do {
         status = libspdm_try_key_update(spdm_context, session_id,
                                         single_direction, &key_updated);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -524,7 +524,7 @@ libspdm_return_t libspdm_negotiate_algorithms(libspdm_context_t *spdm_context)
     retry_delay_time = spdm_context->retry_delay_time;
     do {
         status = libspdm_try_negotiate_algorithms(spdm_context);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -526,7 +526,7 @@ libspdm_return_t libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_conte
             spdm_context, measurement_hash_type, session_policy, session_id,
             heartbeat_period, measurement_hash,
             NULL, 0, NULL, NULL, NULL, NULL);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 
@@ -563,7 +563,7 @@ libspdm_return_t libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_co
             requester_context_in, requester_context_in_size,
             requester_context, requester_context_size,
             responder_context, responder_context_size);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -295,7 +295,7 @@ libspdm_return_t libspdm_send_receive_psk_finish(libspdm_context_t *spdm_context
     do {
         status = libspdm_try_send_receive_psk_finish(spdm_context,
                                                      session_id);
-        if (LIBSPDM_STATUS_BUSY_PEER != status) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -176,7 +176,7 @@ libspdm_return_t libspdm_set_certificate(void *spdm_context,
     do {
         status = libspdm_try_set_certificate(context, session_id, slot_id,
                                              cert_chain, cert_chain_size);
-        if (status != LIBSPDM_STATUS_BUSY_PEER) {
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;
         }
 


### PR DESCRIPTION
Fix: #1746
When there is no more retry (`retry` value is 0),
no sleep should be introduced.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>