### PR TITLE
Rename libspdm_sleep_in_us to libspdm_sleep

### DIFF
--- a/include/hal/library/platform_lib.h
+++ b/include/hal/library/platform_lib.h
@@ -11,20 +11,11 @@
 
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
- * This API is deprecated. Please use libspdm_sleep_in_us().
  *
- * @param milliseconds     The time interval for which execution is to be suspended, in milliseconds.
- *
- **/
-void libspdm_sleep(uint64_t milliseconds);
-
-/**
- * Suspends the execution of the current thread until the time-out interval elapses.
- *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
-void libspdm_sleep_in_us(uint64_t microseconds);
+void libspdm_sleep(uint64_t microseconds);
 
 #if LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP
 /**

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -356,7 +356,7 @@ libspdm_return_t libspdm_challenge(void *spdm_context, void *reserved,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -391,7 +391,7 @@ libspdm_return_t libspdm_challenge_ex(void *spdm_context, void *reserved,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -165,7 +165,7 @@ libspdm_return_t libspdm_send_receive_end_session(libspdm_context_t *spdm_contex
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -615,7 +615,7 @@ libspdm_return_t libspdm_send_receive_finish(libspdm_context_t *spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -334,7 +334,7 @@ libspdm_return_t libspdm_get_capabilities(libspdm_context_t *spdm_context)
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -422,7 +422,7 @@ libspdm_return_t libspdm_get_certificate_choose_length(void *spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -454,7 +454,7 @@ libspdm_return_t libspdm_get_certificate_choose_length_ex(void *spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_csr.c
+++ b/library/spdm_requester_lib/libspdm_req_get_csr.c
@@ -191,7 +191,7 @@ libspdm_return_t libspdm_get_csr(void * spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -241,7 +241,7 @@ libspdm_return_t libspdm_get_digest(void *spdm_context, const uint32_t *session_
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -623,7 +623,7 @@ libspdm_return_t libspdm_get_measurement(void *spdm_context, const uint32_t *ses
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -661,7 +661,7 @@ libspdm_return_t libspdm_get_measurement_ex(void *spdm_context, const uint32_t *
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -219,7 +219,7 @@ libspdm_return_t libspdm_get_version(libspdm_context_t *spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -169,7 +169,7 @@ static libspdm_return_t libspdm_handle_response_not_ready(libspdm_context_t *spd
     spdm_context->error_data.token = extend_error_data->token;
     spdm_context->error_data.rd_tm = extend_error_data->rd_tm;
 
-    libspdm_sleep_in_us((2 << extend_error_data->rd_exponent));
+    libspdm_sleep((2 << extend_error_data->rd_exponent));
     return libspdm_requester_respond_if_ready(spdm_context, session_id,
                                               response_size, response,
                                               expected_response_code,

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -156,7 +156,7 @@ libspdm_return_t libspdm_heartbeat(void *spdm_context, uint32_t session_id)
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -748,7 +748,7 @@ libspdm_return_t libspdm_send_receive_key_exchange(
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -780,7 +780,7 @@ libspdm_return_t libspdm_send_receive_key_exchange_ex(
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -331,7 +331,7 @@ libspdm_return_t libspdm_key_update(void *spdm_context, uint32_t session_id,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -528,7 +528,7 @@ libspdm_return_t libspdm_negotiate_algorithms(libspdm_context_t *spdm_context)
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -530,7 +530,7 @@ libspdm_return_t libspdm_send_receive_psk_exchange(libspdm_context_t *spdm_conte
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;
@@ -567,7 +567,7 @@ libspdm_return_t libspdm_send_receive_psk_exchange_ex(libspdm_context_t *spdm_co
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -299,7 +299,7 @@ libspdm_return_t libspdm_send_receive_psk_finish(libspdm_context_t *spdm_context
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -180,7 +180,7 @@ libspdm_return_t libspdm_set_certificate(void *spdm_context,
             return status;
         }
 
-        libspdm_sleep_in_us(retry_delay_time);
+        libspdm_sleep(retry_delay_time);
     } while (retry-- != 0);
 
     return status;

--- a/os_stub/platform_lib/time_linux.c
+++ b/os_stub/platform_lib/time_linux.c
@@ -12,10 +12,10 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
-void libspdm_sleep_in_us(uint64_t microseconds)
+void libspdm_sleep(uint64_t microseconds)
 {
     struct timeval tv;
     int err;

--- a/os_stub/platform_lib/time_sample.c
+++ b/os_stub/platform_lib/time_sample.c
@@ -17,11 +17,11 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
 
-void libspdm_sleep_in_us(uint64_t microseconds)
+void libspdm_sleep(uint64_t microseconds)
 {
     /*the feature for armclang build is TBD*/
     LIBSPDM_ASSERT(false);

--- a/os_stub/platform_lib/time_win.c
+++ b/os_stub/platform_lib/time_win.c
@@ -12,10 +12,10 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
-void libspdm_sleep_in_us(uint64_t microseconds)
+void libspdm_sleep(uint64_t microseconds)
 {
     uint64_t milliseconds;
 

--- a/os_stub/platform_lib_null/time_linux.c
+++ b/os_stub/platform_lib_null/time_linux.c
@@ -9,9 +9,9 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
-void libspdm_sleep_in_us(uint64_t microseconds)
+void libspdm_sleep(uint64_t microseconds)
 {
 }

--- a/os_stub/platform_lib_null/time_win.c
+++ b/os_stub/platform_lib_null/time_win.c
@@ -9,9 +9,9 @@
 /**
  * Suspends the execution of the current thread until the time-out interval elapses.
  *
- * @param microseconds     The time interval for which execution is to be suspended, in milliseconds.
+ * @param microseconds     The time interval for which execution is to be suspended, in microseconds.
  *
  **/
-void libspdm_sleep_in_us(uint64_t microseconds)
+void libspdm_sleep(uint64_t microseconds)
 {
 }


### PR DESCRIPTION
Fix: #1723

Replace old `libspdm_sleep()`, which is deprecated
and has no implementation, with `libspdm_sleep_in_us()`.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>