### PR TITLE
Add LIBSPDM_CERT_PARSE_SUPPORT for device image size reduction.

### DIFF
--- a/include/hal/library/cryptlib/cryptlib_cert.h
+++ b/include/hal/library/cryptlib/cryptlib_cert.h
@@ -7,6 +7,8 @@
 #ifndef CRYPTLIB_CERT_H
 #define CRYPTLIB_CERT_H
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
+
 /**
  * Retrieve the tag and length of the tag.
  *
@@ -412,5 +414,7 @@ extern bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                                  void *context, char *subject_name,
                                  size_t *csr_len, uint8_t **csr_pointer);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP */
+
+#endif /* LIBSPDM_CERT_PARSE_SUPPORT */
 
 #endif /* CRYPTLIB_CERT_H */

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -764,6 +764,8 @@ bool libspdm_aead_decryption(const spdm_version_number_t secured_message_version
  **/
 bool libspdm_get_random_number(size_t size, uint8_t *rand);
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
+
 /**
  * Certificate Check for SPDM leaf cert.
  *
@@ -897,6 +899,8 @@ bool libspdm_get_leaf_cert_public_key_from_cert_chain(uint32_t base_hash_algo,
                                                       uint8_t *cert_chain_data,
                                                       size_t cert_chain_data_size,
                                                       void **public_key);
+
+#endif
 
 /**
  * Verify req info format refer to PKCS#10.

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -166,6 +166,11 @@
 #define LIBSPDM_SM3_256_SUPPORT 1
 #endif
 
+/* This can be set to 0 for the device which does not need X509 parser.*/
+#ifndef LIBSPDM_CERT_PARSE_SUPPORT
+#define LIBSPDM_CERT_PARSE_SUPPORT 1
+#endif
+
 /* Code space optimization for Optional request/response messages.*/
 
 /* Consumers of libspdm may wish to not fully implement all of the optional

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -345,6 +345,7 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
             libspdm_get_hash_size(context->connection_info.algorithm.base_hash_algo);
 
         status = false;
+#if LIBSPDM_CERT_PARSE_SUPPORT
 #if (LIBSPDM_RSA_SSA_SUPPORT) || (LIBSPDM_RSA_PSS_SUPPORT)
         if (!status) {
             status = libspdm_rsa_get_public_key_from_x509(
@@ -376,7 +377,10 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         if (!status) {
             return LIBSPDM_STATUS_INVALID_CERT;
         }
-#endif
+#else
+        LIBSPDM_ASSERT (false);
+#endif /* LIBSPDM_CERT_PARSE_SUPPORT */
+#endif /* LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT */
         break;
     case LIBSPDM_DATA_PEER_PUBLIC_KEY:
         context->local_context.peer_public_key_provision_size = data_size;

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -574,6 +574,7 @@ uint8_t libspdm_get_cert_slot_count(libspdm_context_t *spdm_context)
     return slot_count;
 }
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
 /**
  * This function verifies the integrity of peer certificate chain buffer including
  * spdm_cert_chain_t header.
@@ -766,6 +767,7 @@ bool libspdm_verify_peer_cert_chain_buffer(libspdm_context_t *spdm_context,
 
     return true;
 }
+#endif
 
 /**
  * This function generates the challenge signature based upon m1m2 for authentication.

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -6,6 +6,8 @@
 
 #include "internal/libspdm_crypt_lib.h"
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
+
 /**pathLenConstraint is optional.
  * In https://www.pkisolutions.com/basic-constraints-certificate-extension/:
  * pathLenConstraint: How many CAs are allowed in the chain below current CA certificate.
@@ -1315,3 +1317,5 @@ bool libspdm_verify_req_info(uint8_t *req_info, uint16_t req_info_len)
         return false;
     }
 }
+
+#endif

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -20,6 +20,8 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
+
 /* OID*/
 
 #define OID_COMMON_NAME       { 0x55, 0x04, 0x03 }
@@ -1841,3 +1843,5 @@ free_all:
 
     return(ret == 0);
 }
+
+#endif

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -18,6 +18,8 @@
 #include <openssl/pem.h>
 #include <openssl/bio.h>
 
+#if LIBSPDM_CERT_PARSE_SUPPORT
+
 /*buffer size to store subject object*/
 #define MAX_SBUJECT_NAME_LEN 0x100
 
@@ -2559,3 +2561,5 @@ free_all:
 
     return (ret != 0);
 }
+
+#endif


### PR DESCRIPTION
Fix https://github.com/DMTF/libspdm/issues/1761

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>

