### PR TITLE
Change return type of `libspdm_const_compare_mem`

### DIFF
--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -87,20 +87,17 @@ void *libspdm_set_mem(void *buffer, size_t length, uint8_t value);
 void *libspdm_zero_mem(void *buffer, size_t length);
 
 /**
- * Compares the contents of two buffers in const time.
+ * Compares the contents of two buffers in constant time.
  *
- * This function compares length bytes of source_buffer to length bytes of destination_buffer.
- * If all length bytes of the two buffers are identical, then 0 is returned.  Otherwise, the
- * value returned is the first mismatched byte in source_buffer subtracted from the first
- * mismatched byte in destination_buffer.
- *
+ * For a given length, the time to complete the comparison is always the same regardless of the
+ * contents of the two buffers.
  *
  * @param  destination_buffer  A pointer to the destination buffer to compare.
  * @param  source_buffer       A pointer to the source buffer to compare.
  * @param  length              The number of bytes to compare.
  *
  * @return true   The contents of the two buffers are the same.
- * @retval false  The contents of the two buffers are not the same. *
+ * @retval false  The contents of the two buffers are not the same.
  **/
 bool libspdm_const_compare_mem(const void *destination_buffer,
                                const void *source_buffer, size_t length);

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -94,20 +94,15 @@ void *libspdm_zero_mem(void *buffer, size_t length);
  * value returned is the first mismatched byte in source_buffer subtracted from the first
  * mismatched byte in destination_buffer.
  *
- * If length > 0 and destination_buffer is NULL, then ASSERT().
- * If length > 0 and source_buffer is NULL, then ASSERT().
- * If length is greater than (MAX_ADDRESS - destination_buffer + 1), then ASSERT().
- * If length is greater than (MAX_ADDRESS - source_buffer + 1), then ASSERT().
  *
- * @param  destination_buffer A pointer to the destination buffer to compare.
- * @param  source_buffer      A pointer to the source buffer to compare.
- * @param  length            The number of bytes to compare.
+ * @param  destination_buffer  A pointer to the destination buffer to compare.
+ * @param  source_buffer       A pointer to the source buffer to compare.
+ * @param  length              The number of bytes to compare.
  *
- * @return 0                 All length bytes of the two buffers are identical.
- * @retval Non-zero          There is mismatched between source_buffer and destination_buffer.
- *
+ * @return true   The contents of the two buffers are the same.
+ * @retval false  The contents of the two buffers are not the same. *
  **/
-int32_t libspdm_const_compare_mem(const void *destination_buffer,
-                                  const void *source_buffer, size_t length);
+bool libspdm_const_compare_mem(const void *destination_buffer,
+                               const void *source_buffer, size_t length);
 
 #endif /* BASE_MEMORY_LIB */

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -100,6 +100,6 @@ void *libspdm_zero_mem(void *buffer, size_t length);
  * @retval false  The contents of the two buffers are not the same.
  **/
 bool libspdm_consttime_is_mem_equal(const void *destination_buffer,
-                               const void *source_buffer, size_t length);
+                                    const void *source_buffer, size_t length);
 
 #endif /* BASE_MEMORY_LIB */

--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -99,7 +99,7 @@ void *libspdm_zero_mem(void *buffer, size_t length);
  * @return true   The contents of the two buffers are the same.
  * @retval false  The contents of the two buffers are not the same.
  **/
-bool libspdm_const_compare_mem(const void *destination_buffer,
+bool libspdm_consttime_is_mem_equal(const void *destination_buffer,
                                const void *source_buffer, size_t length);
 
 #endif /* BASE_MEMORY_LIB */

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -663,7 +663,7 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
                 return false;
             }
 
-            if (libspdm_const_compare_mem((const uint8_t *)cert_chain_buffer +
+            if (libspdm_consttime_is_mem_equal((const uint8_t *)cert_chain_buffer +
                                           sizeof(spdm_cert_chain_t),
                                           root_cert_hash, root_cert_hash_size)) {
                 break;
@@ -698,7 +698,7 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
         }
         if (libspdm_is_root_certificate(received_root_cert, received_root_cert_size)) {
             if ((root_cert != NULL) &&
-                !libspdm_const_compare_mem(received_root_cert, root_cert, root_cert_size)) {
+                !libspdm_consttime_is_mem_equal(received_root_cert, root_cert, root_cert_size)) {
                 LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
                                "!!! verify_peer_cert_chain_buffer - "
                                "FAIL (root cert mismatch) !!!\n"));
@@ -901,7 +901,7 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
-    if (!libspdm_const_compare_mem(certificate_chain_hash, cert_chain_buffer_hash,
+    if (!libspdm_consttime_is_mem_equal(certificate_chain_hash, cert_chain_buffer_hash,
                                    certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
@@ -919,7 +919,7 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
         return false;
     }
 
-    if (!libspdm_const_compare_mem(certificate_chain_hash,
+    if (!libspdm_consttime_is_mem_equal(certificate_chain_hash,
                                    spdm_context->connection_info.peer_used_cert_chain[slot_id].
                                    buffer_hash, certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
@@ -964,7 +964,7 @@ bool libspdm_verify_public_key_hash(libspdm_context_t *spdm_context,
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_public_key_hash - FAIL !!!\n"));
         return false;
     }
-    if (!libspdm_const_compare_mem(public_key_hash, public_key_buffer_hash,
+    if (!libspdm_consttime_is_mem_equal(public_key_hash, public_key_buffer_hash,
                                    public_key_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_public_key_hash - FAIL !!!\n"));
         return false;

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -664,8 +664,8 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
             }
 
             if (libspdm_consttime_is_mem_equal((const uint8_t *)cert_chain_buffer +
-                                          sizeof(spdm_cert_chain_t),
-                                          root_cert_hash, root_cert_hash_size)) {
+                                               sizeof(spdm_cert_chain_t),
+                                               root_cert_hash, root_cert_hash_size)) {
                 break;
             }
 
@@ -902,7 +902,7 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
         return false;
     }
     if (!libspdm_consttime_is_mem_equal(certificate_chain_hash, cert_chain_buffer_hash,
-                                   certificate_chain_hash_size)) {
+                                        certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
@@ -920,8 +920,8 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
     }
 
     if (!libspdm_consttime_is_mem_equal(certificate_chain_hash,
-                                   spdm_context->connection_info.peer_used_cert_chain[slot_id].
-                                   buffer_hash, certificate_chain_hash_size)) {
+                                        spdm_context->connection_info.peer_used_cert_chain[slot_id].
+                                        buffer_hash, certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
@@ -965,7 +965,7 @@ bool libspdm_verify_public_key_hash(libspdm_context_t *spdm_context,
         return false;
     }
     if (!libspdm_consttime_is_mem_equal(public_key_hash, public_key_buffer_hash,
-                                   public_key_hash_size)) {
+                                        public_key_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_public_key_hash - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -665,7 +665,7 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
 
             if (libspdm_const_compare_mem((const uint8_t *)cert_chain_buffer +
                                           sizeof(spdm_cert_chain_t),
-                                          root_cert_hash, root_cert_hash_size) == 0) {
+                                          root_cert_hash, root_cert_hash_size)) {
                 break;
             }
 
@@ -698,7 +698,7 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
         }
         if (libspdm_is_root_certificate(received_root_cert, received_root_cert_size)) {
             if ((root_cert != NULL) &&
-                (libspdm_const_compare_mem(received_root_cert, root_cert, root_cert_size) != 0)) {
+                !libspdm_const_compare_mem(received_root_cert, root_cert, root_cert_size)) {
                 LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
                                "!!! verify_peer_cert_chain_buffer - "
                                "FAIL (root cert mismatch) !!!\n"));
@@ -901,8 +901,8 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
-    if (libspdm_const_compare_mem(certificate_chain_hash, cert_chain_buffer_hash,
-                                  certificate_chain_hash_size) != 0) {
+    if (!libspdm_const_compare_mem(certificate_chain_hash, cert_chain_buffer_hash,
+                                   certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
@@ -919,9 +919,9 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
         return false;
     }
 
-    if (libspdm_const_compare_mem(certificate_chain_hash,
-                                  spdm_context->connection_info.peer_used_cert_chain[slot_id].
-                                  buffer_hash, certificate_chain_hash_size) != 0) {
+    if (!libspdm_const_compare_mem(certificate_chain_hash,
+                                   spdm_context->connection_info.peer_used_cert_chain[slot_id].
+                                   buffer_hash, certificate_chain_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_certificate_chain_hash - FAIL !!!\n"));
         return false;
     }
@@ -964,8 +964,8 @@ bool libspdm_verify_public_key_hash(libspdm_context_t *spdm_context,
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_public_key_hash - FAIL !!!\n"));
         return false;
     }
-    if (libspdm_const_compare_mem(public_key_hash, public_key_buffer_hash,
-                                  public_key_hash_size) != 0) {
+    if (!libspdm_const_compare_mem(public_key_hash, public_key_buffer_hash,
+                                   public_key_hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_public_key_hash - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
@@ -105,13 +105,13 @@ bool libspdm_fips_selftest_aes_gcm(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(output_ciphertext, expected_ciphertext,
-                                  sizeof(expected_ciphertext))) {
+    if (!libspdm_const_compare_mem(output_ciphertext, expected_ciphertext,
+                                   sizeof(expected_ciphertext))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm KAT failed \n"));
         return false;
     }
 
-    if (libspdm_const_compare_mem(output_tag, expected_tag, sizeof(expected_tag))) {
+    if (!libspdm_const_compare_mem(output_tag, expected_tag, sizeof(expected_tag))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm KAT failed \n"));
         return false;
     }
@@ -131,7 +131,7 @@ bool libspdm_fips_selftest_aes_gcm(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(output_plaintext, input, sizeof(input))) {
+    if (!libspdm_const_compare_mem(output_plaintext, input, sizeof(input))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm selftest failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
@@ -106,7 +106,7 @@ bool libspdm_fips_selftest_aes_gcm(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(output_ciphertext, expected_ciphertext,
-                                   sizeof(expected_ciphertext))) {
+                                        sizeof(expected_ciphertext))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
@@ -105,13 +105,13 @@ bool libspdm_fips_selftest_aes_gcm(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(output_ciphertext, expected_ciphertext,
+    if (!libspdm_consttime_is_mem_equal(output_ciphertext, expected_ciphertext,
                                    sizeof(expected_ciphertext))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm KAT failed \n"));
         return false;
     }
 
-    if (!libspdm_const_compare_mem(output_tag, expected_tag, sizeof(expected_tag))) {
+    if (!libspdm_consttime_is_mem_equal(output_tag, expected_tag, sizeof(expected_tag))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm KAT failed \n"));
         return false;
     }
@@ -131,7 +131,7 @@ bool libspdm_fips_selftest_aes_gcm(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(output_plaintext, input, sizeof(input))) {
+    if (!libspdm_consttime_is_mem_equal(output_plaintext, input, sizeof(input))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "aes_gcm selftest failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
@@ -80,7 +80,7 @@ bool libspdm_fips_selftest_ecdh(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(common_key, expected_ecdh_secret,
-                                   sizeof(expected_ecdh_secret))) {
+                                        sizeof(expected_ecdh_secret))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDH KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
@@ -79,8 +79,8 @@ bool libspdm_fips_selftest_ecdh(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(common_key, expected_ecdh_secret,
-                                  sizeof(expected_ecdh_secret))) {
+    if (!libspdm_const_compare_mem(common_key, expected_ecdh_secret,
+                                   sizeof(expected_ecdh_secret))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDH KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
@@ -79,7 +79,7 @@ bool libspdm_fips_selftest_ecdh(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(common_key, expected_ecdh_secret,
+    if (!libspdm_consttime_is_mem_equal(common_key, expected_ecdh_secret,
                                    sizeof(expected_ecdh_secret))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDH KAT failed \n"));
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
@@ -117,7 +117,7 @@ bool libspdm_fips_selftest_ecdsa(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(signature, expected_signature,
-                                   sizeof(expected_signature))) {
+                                        sizeof(expected_signature))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDSA KAT failed \n"));
         libspdm_ec_free(ec_context);
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
@@ -116,7 +116,7 @@ bool libspdm_fips_selftest_ecdsa(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(signature, expected_signature,
+    if (!libspdm_consttime_is_mem_equal(signature, expected_signature,
                                    sizeof(expected_signature))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDSA KAT failed \n"));
         libspdm_ec_free(ec_context);

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
@@ -116,8 +116,8 @@ bool libspdm_fips_selftest_ecdsa(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(signature, expected_signature,
-                                  sizeof(expected_signature))) {
+    if (!libspdm_const_compare_mem(signature, expected_signature,
+                                   sizeof(expected_signature))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ECDSA KAT failed \n"));
         libspdm_ec_free(ec_context);
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
@@ -88,7 +88,7 @@ bool libspdm_fips_selftest_ffdh(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(ff_key1, ff_key2, ff_key1_length)) {
+    if (!libspdm_consttime_is_mem_equal(ff_key1, ff_key2, ff_key1_length)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "FFDH self_test failed \n"));
         libspdm_dh_free(dh1);
         libspdm_dh_free(dh2);

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
@@ -88,7 +88,7 @@ bool libspdm_fips_selftest_ffdh(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(ff_key1, ff_key2, ff_key1_length) != 0) {
+    if (!libspdm_const_compare_mem(ff_key1, ff_key2, ff_key1_length)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "FFDH self_test failed \n"));
         libspdm_dh_free(dh1);
         libspdm_dh_free(dh2);

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
@@ -62,7 +62,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(prk_out, hkdf_sha256_prk, sizeof(hkdf_sha256_prk)) != 0) {
+    if (!libspdm_const_compare_mem(prk_out, hkdf_sha256_prk, sizeof(hkdf_sha256_prk))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }
@@ -76,7 +76,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm)) != 0) {
+    if (!libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }
@@ -91,7 +91,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm)) != 0) {
+    if (!libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
@@ -62,7 +62,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(prk_out, hkdf_sha256_prk, sizeof(hkdf_sha256_prk))) {
+    if (!libspdm_consttime_is_mem_equal(prk_out, hkdf_sha256_prk, sizeof(hkdf_sha256_prk))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }
@@ -76,7 +76,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
+    if (!libspdm_consttime_is_mem_equal(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }
@@ -91,7 +91,7 @@ bool libspdm_fips_selftest_hkdf(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
+    if (!libspdm_consttime_is_mem_equal(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
@@ -33,7 +33,7 @@ bool libspdm_fips_selftest_hmac_sha256(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(hmac_256_result, hmac_sha256_answer,
+    if (!libspdm_consttime_is_mem_equal(hmac_256_result, hmac_sha256_answer,
                                    sizeof(hmac_sha256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha256 KAT failed \n"));
         return false;
@@ -71,7 +71,7 @@ bool libspdm_fips_selftest_hmac_sha384(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(hmac_384_result, hmac_sha384_answer,
+    if (!libspdm_consttime_is_mem_equal(hmac_384_result, hmac_sha384_answer,
                                    sizeof(hmac_sha384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha384 KAT failed \n"));
         return false;
@@ -111,7 +111,7 @@ bool libspdm_fips_selftest_hmac_sha512(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(hmac_512_result, hmac_sha512_answer,
+    if (!libspdm_consttime_is_mem_equal(hmac_512_result, hmac_sha512_answer,
                                    sizeof(hmac_sha512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha512 KAT failed \n"));
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
@@ -34,7 +34,7 @@ bool libspdm_fips_selftest_hmac_sha256(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(hmac_256_result, hmac_sha256_answer,
-                                   sizeof(hmac_sha256_answer))) {
+                                        sizeof(hmac_sha256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha256 KAT failed \n"));
         return false;
     }
@@ -72,7 +72,7 @@ bool libspdm_fips_selftest_hmac_sha384(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(hmac_384_result, hmac_sha384_answer,
-                                   sizeof(hmac_sha384_answer))) {
+                                        sizeof(hmac_sha384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha384 KAT failed \n"));
         return false;
     }
@@ -112,7 +112,7 @@ bool libspdm_fips_selftest_hmac_sha512(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(hmac_512_result, hmac_sha512_answer,
-                                   sizeof(hmac_sha512_answer))) {
+                                        sizeof(hmac_sha512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha512 KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
@@ -33,8 +33,8 @@ bool libspdm_fips_selftest_hmac_sha256(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(hmac_256_result, hmac_sha256_answer,
-                                  sizeof(hmac_sha256_answer))) {
+    if (!libspdm_const_compare_mem(hmac_256_result, hmac_sha256_answer,
+                                   sizeof(hmac_sha256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha256 KAT failed \n"));
         return false;
     }
@@ -71,8 +71,8 @@ bool libspdm_fips_selftest_hmac_sha384(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(hmac_384_result, hmac_sha384_answer,
-                                  sizeof(hmac_sha384_answer))) {
+    if (!libspdm_const_compare_mem(hmac_384_result, hmac_sha384_answer,
+                                   sizeof(hmac_sha384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha384 KAT failed \n"));
         return false;
     }
@@ -111,8 +111,8 @@ bool libspdm_fips_selftest_hmac_sha512(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(hmac_512_result, hmac_sha512_answer,
-                                  sizeof(hmac_sha512_answer))) {
+    if (!libspdm_const_compare_mem(hmac_512_result, hmac_sha512_answer,
+                                   sizeof(hmac_sha512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "hmac_sha512 KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
@@ -183,7 +183,7 @@ bool libspdm_fips_selftest_rsa_ssa(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(signature, expected_sig,
-                                   sizeof(expected_sig))) {
+                                        sizeof(expected_sig))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "RSA_PSS KAT failed \n"));
         libspdm_rsa_free(rsa);
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
@@ -182,8 +182,8 @@ bool libspdm_fips_selftest_rsa_ssa(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(signature, expected_sig,
-                                  sizeof(expected_sig))) {
+    if (!libspdm_const_compare_mem(signature, expected_sig,
+                                   sizeof(expected_sig))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "RSA_PSS KAT failed \n"));
         libspdm_rsa_free(rsa);
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
@@ -182,7 +182,7 @@ bool libspdm_fips_selftest_rsa_ssa(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(signature, expected_sig,
+    if (!libspdm_consttime_is_mem_equal(signature, expected_sig,
                                    sizeof(expected_sig))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "RSA_PSS KAT failed \n"));
         libspdm_rsa_free(rsa);

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
@@ -32,7 +32,7 @@ bool libspdm_fips_selftest_sha3_256(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(sha3_256_result, sha3_256_answer,
+    if (!libspdm_consttime_is_mem_equal(sha3_256_result, sha3_256_answer,
                                    sizeof(sha3_256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_256 KAT failed \n"));
         return false;
@@ -69,7 +69,7 @@ bool libspdm_fips_selftest_sha3_384(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(sha3_384_result, sha3_384_answer,
+    if (!libspdm_consttime_is_mem_equal(sha3_384_result, sha3_384_answer,
                                    sizeof(sha3_384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_384 KAT failed \n"));
         return false;
@@ -108,7 +108,7 @@ bool libspdm_fips_selftest_sha3_512(void)
         return false;
     }
 
-    if (!libspdm_const_compare_mem(sha3_512_result, sha3_512_answer,
+    if (!libspdm_consttime_is_mem_equal(sha3_512_result, sha3_512_answer,
                                    sizeof(sha3_512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_512 KAT failed \n"));
         return false;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
@@ -32,8 +32,8 @@ bool libspdm_fips_selftest_sha3_256(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(sha3_256_result, sha3_256_answer,
-                                  sizeof(sha3_256_answer))) {
+    if (!libspdm_const_compare_mem(sha3_256_result, sha3_256_answer,
+                                   sizeof(sha3_256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_256 KAT failed \n"));
         return false;
     }
@@ -69,8 +69,8 @@ bool libspdm_fips_selftest_sha3_384(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(sha3_384_result, sha3_384_answer,
-                                  sizeof(sha3_384_answer))) {
+    if (!libspdm_const_compare_mem(sha3_384_result, sha3_384_answer,
+                                   sizeof(sha3_384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_384 KAT failed \n"));
         return false;
     }
@@ -108,8 +108,8 @@ bool libspdm_fips_selftest_sha3_512(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(sha3_512_result, sha3_512_answer,
-                                  sizeof(sha3_512_answer))) {
+    if (!libspdm_const_compare_mem(sha3_512_result, sha3_512_answer,
+                                   sizeof(sha3_512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_512 KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
@@ -33,7 +33,7 @@ bool libspdm_fips_selftest_sha3_256(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(sha3_256_result, sha3_256_answer,
-                                   sizeof(sha3_256_answer))) {
+                                        sizeof(sha3_256_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_256 KAT failed \n"));
         return false;
     }
@@ -70,7 +70,7 @@ bool libspdm_fips_selftest_sha3_384(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(sha3_384_result, sha3_384_answer,
-                                   sizeof(sha3_384_answer))) {
+                                        sizeof(sha3_384_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_384 KAT failed \n"));
         return false;
     }
@@ -109,7 +109,7 @@ bool libspdm_fips_selftest_sha3_512(void)
     }
 
     if (!libspdm_consttime_is_mem_equal(sha3_512_result, sha3_512_answer,
-                                   sizeof(sha3_512_answer))) {
+                                        sizeof(sha3_512_answer))) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "sha3_512 KAT failed \n"));
         return false;
     }

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -572,10 +572,10 @@ static bool libspdm_verify_cert_subject_public_key_info(const uint8_t *cert, siz
     /*get public key encrypt algo OID from cert*/
     status = libspdm_get_public_key_oid(cert, cert_size, cert_public_key_crypt_algo_oid, oid_len,
                                         base_asym_algo);
-    if (!status || (libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
-                                              libspdm_public_key_crypt_algo_oid, oid_len) &&
-                    libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
-                                              libspdm_public_key_crypt_algo_oid_other, oid_len))) {
+    if (!status || (!libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
+                                               libspdm_public_key_crypt_algo_oid, oid_len) &&
+                    !libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
+                                               libspdm_public_key_crypt_algo_oid_other, oid_len))) {
         return false;
     }
 

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -573,9 +573,10 @@ static bool libspdm_verify_cert_subject_public_key_info(const uint8_t *cert, siz
     status = libspdm_get_public_key_oid(cert, cert_size, cert_public_key_crypt_algo_oid, oid_len,
                                         base_asym_algo);
     if (!status || (!libspdm_consttime_is_mem_equal(cert_public_key_crypt_algo_oid,
-                                               libspdm_public_key_crypt_algo_oid, oid_len) &&
+                                                    libspdm_public_key_crypt_algo_oid, oid_len) &&
                     !libspdm_consttime_is_mem_equal(cert_public_key_crypt_algo_oid,
-                                               libspdm_public_key_crypt_algo_oid_other, oid_len))) {
+                                                    libspdm_public_key_crypt_algo_oid_other,
+                                                    oid_len))) {
         return false;
     }
 
@@ -621,15 +622,15 @@ static bool libspdm_verify_leaf_cert_basic_constraints(const uint8_t *cert, size
 
     if ((len == sizeof(basic_constraints_case1)) &&
         (libspdm_consttime_is_mem_equal(cert_basic_constraints,
-                                   basic_constraints_case1,
-                                   sizeof(basic_constraints_case1)))) {
+                                        basic_constraints_case1,
+                                        sizeof(basic_constraints_case1)))) {
         return true;
     }
 
     if ((len == sizeof(basic_constraints_case2)) &&
         (libspdm_consttime_is_mem_equal(cert_basic_constraints,
-                                   basic_constraints_case2,
-                                   sizeof(basic_constraints_case2)))) {
+                                        basic_constraints_case2,
+                                        sizeof(basic_constraints_case2)))) {
         return true;
     }
 
@@ -682,7 +683,7 @@ static bool libspdm_verify_leaf_cert_eku_spdm_OID(const uint8_t *cert, size_t ce
     find_sucessful = false;
     for(index = 0; index <= len - sizeof(hardware_identity_oid); index++) {
         if (!libspdm_consttime_is_mem_equal(spdm_extension + index, hardware_identity_oid,
-                                       sizeof(hardware_identity_oid))) {
+                                            sizeof(hardware_identity_oid))) {
             find_sucessful = true;
             break;
         }
@@ -1155,8 +1156,8 @@ bool libspdm_verify_certificate_chain_buffer(uint32_t base_hash_algo, uint32_t b
             return false;
         }
         if (!libspdm_consttime_is_mem_equal((const uint8_t *)cert_chain_buffer +
-                                       sizeof(spdm_cert_chain_t),
-                                       calc_root_cert_hash, hash_size)) {
+                                            sizeof(spdm_cert_chain_t),
+                                            calc_root_cert_hash, hash_size)) {
             LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
                            "!!! VerifyCertificateChainBuffer - FAIL (cert root hash mismatch) !!!\n"));
             return false;

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -620,16 +620,16 @@ static bool libspdm_verify_leaf_cert_basic_constraints(const uint8_t *cert, size
     }
 
     if ((len == sizeof(basic_constraints_case1)) &&
-        (!libspdm_const_compare_mem(cert_basic_constraints,
-                                    basic_constraints_case1,
-                                    sizeof(basic_constraints_case1)))) {
+        (libspdm_const_compare_mem(cert_basic_constraints,
+                                   basic_constraints_case1,
+                                   sizeof(basic_constraints_case1)))) {
         return true;
     }
 
     if ((len == sizeof(basic_constraints_case2)) &&
-        (!libspdm_const_compare_mem(cert_basic_constraints,
-                                    basic_constraints_case2,
-                                    sizeof(basic_constraints_case2)))) {
+        (libspdm_const_compare_mem(cert_basic_constraints,
+                                   basic_constraints_case2,
+                                   sizeof(basic_constraints_case2)))) {
         return true;
     }
 
@@ -863,7 +863,7 @@ bool libspdm_is_root_certificate(const uint8_t *cert, size_t cert_size)
     if (issuer_name_len != subject_name_len) {
         return false;
     }
-    if (libspdm_const_compare_mem(issuer_name, subject_name, issuer_name_len) != 0) {
+    if (!libspdm_const_compare_mem(issuer_name, subject_name, issuer_name_len)) {
         return false;
     }
 
@@ -1154,9 +1154,9 @@ bool libspdm_verify_certificate_chain_buffer(uint32_t base_hash_algo, uint32_t b
                            "!!! VerifyCertificateChainBuffer - FAIL (hash calculation fail) !!!\n"));
             return false;
         }
-        if (libspdm_const_compare_mem((const uint8_t *)cert_chain_buffer +
-                                      sizeof(spdm_cert_chain_t),
-                                      calc_root_cert_hash, hash_size) != 0) {
+        if (!libspdm_const_compare_mem((const uint8_t *)cert_chain_buffer +
+                                       sizeof(spdm_cert_chain_t),
+                                       calc_root_cert_hash, hash_size)) {
             LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
                            "!!! VerifyCertificateChainBuffer - FAIL (cert root hash mismatch) !!!\n"));
             return false;

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -572,9 +572,9 @@ static bool libspdm_verify_cert_subject_public_key_info(const uint8_t *cert, siz
     /*get public key encrypt algo OID from cert*/
     status = libspdm_get_public_key_oid(cert, cert_size, cert_public_key_crypt_algo_oid, oid_len,
                                         base_asym_algo);
-    if (!status || (!libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
+    if (!status || (!libspdm_consttime_is_mem_equal(cert_public_key_crypt_algo_oid,
                                                libspdm_public_key_crypt_algo_oid, oid_len) &&
-                    !libspdm_const_compare_mem(cert_public_key_crypt_algo_oid,
+                    !libspdm_consttime_is_mem_equal(cert_public_key_crypt_algo_oid,
                                                libspdm_public_key_crypt_algo_oid_other, oid_len))) {
         return false;
     }
@@ -620,14 +620,14 @@ static bool libspdm_verify_leaf_cert_basic_constraints(const uint8_t *cert, size
     }
 
     if ((len == sizeof(basic_constraints_case1)) &&
-        (libspdm_const_compare_mem(cert_basic_constraints,
+        (libspdm_consttime_is_mem_equal(cert_basic_constraints,
                                    basic_constraints_case1,
                                    sizeof(basic_constraints_case1)))) {
         return true;
     }
 
     if ((len == sizeof(basic_constraints_case2)) &&
-        (libspdm_const_compare_mem(cert_basic_constraints,
+        (libspdm_consttime_is_mem_equal(cert_basic_constraints,
                                    basic_constraints_case2,
                                    sizeof(basic_constraints_case2)))) {
         return true;
@@ -681,7 +681,7 @@ static bool libspdm_verify_leaf_cert_eku_spdm_OID(const uint8_t *cert, size_t ce
     /*find the spdm hardware identity OID*/
     find_sucessful = false;
     for(index = 0; index <= len - sizeof(hardware_identity_oid); index++) {
-        if (!libspdm_const_compare_mem(spdm_extension + index, hardware_identity_oid,
+        if (!libspdm_consttime_is_mem_equal(spdm_extension + index, hardware_identity_oid,
                                        sizeof(hardware_identity_oid))) {
             find_sucessful = true;
             break;
@@ -863,7 +863,7 @@ bool libspdm_is_root_certificate(const uint8_t *cert, size_t cert_size)
     if (issuer_name_len != subject_name_len) {
         return false;
     }
-    if (!libspdm_const_compare_mem(issuer_name, subject_name, issuer_name_len)) {
+    if (!libspdm_consttime_is_mem_equal(issuer_name, subject_name, issuer_name_len)) {
         return false;
     }
 
@@ -1154,7 +1154,7 @@ bool libspdm_verify_certificate_chain_buffer(uint32_t base_hash_algo, uint32_t b
                            "!!! VerifyCertificateChainBuffer - FAIL (hash calculation fail) !!!\n"));
             return false;
         }
-        if (!libspdm_const_compare_mem((const uint8_t *)cert_chain_buffer +
+        if (!libspdm_consttime_is_mem_equal((const uint8_t *)cert_chain_buffer +
                                        sizeof(spdm_cert_chain_t),
                                        calc_root_cert_hash, hash_size)) {
             LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -79,8 +79,8 @@ libspdm_return_t libspdm_get_encap_response_key_update(void *spdm_context,
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
         if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
-                                      &spdm_key_init_update_operation,
-                                      sizeof(spdm_key_update_request_t))) {
+                                           &spdm_key_init_update_operation,
+                                           sizeof(spdm_key_update_request_t))) {
             result = false;
             break;
         }

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -78,7 +78,7 @@ libspdm_return_t libspdm_get_encap_response_key_update(void *spdm_context,
     result = true;
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
-        if(!libspdm_const_compare_mem(prev_spdm_request,
+        if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
                                       &spdm_key_init_update_operation,
                                       sizeof(spdm_key_update_request_t))) {
             result = false;

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -78,9 +78,9 @@ libspdm_return_t libspdm_get_encap_response_key_update(void *spdm_context,
     result = true;
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
-        if(libspdm_const_compare_mem(prev_spdm_request,
-                                     &spdm_key_init_update_operation,
-                                     sizeof(spdm_key_update_request_t)) != 0) {
+        if(!libspdm_const_compare_mem(prev_spdm_request,
+                                      &spdm_key_init_update_operation,
+                                      sizeof(spdm_key_update_request_t))) {
             result = false;
             break;
         }

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -105,7 +105,7 @@ bool libspdm_verify_finish_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size) != 0) {
+    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_finish_rsp_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -105,7 +105,7 @@ bool libspdm_verify_finish_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
+    if (!libspdm_consttime_is_mem_equal(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_finish_rsp_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -100,7 +100,7 @@ bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size) != 0) {
+    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_key_exchange_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -100,7 +100,7 @@ bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
+    if (!libspdm_consttime_is_mem_equal(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_key_exchange_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -82,7 +82,7 @@ bool libspdm_verify_psk_exchange_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
+    if (!libspdm_consttime_is_mem_equal(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_psk_exchange_rsp_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -82,7 +82,7 @@ bool libspdm_verify_psk_exchange_rsp_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(calc_hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size) != 0) {
+    if (!libspdm_const_compare_mem(calc_hmac_data, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_psk_exchange_rsp_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -94,7 +94,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (!libspdm_const_compare_mem(hmac, hmac_data, hash_size)) {
+    if (!libspdm_consttime_is_mem_equal(hmac, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_finish_req_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -94,7 +94,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (libspdm_const_compare_mem(hmac, hmac_data, hash_size) != 0) {
+    if (!libspdm_const_compare_mem(hmac, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_finish_req_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -102,7 +102,7 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
 
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
-        if(!libspdm_const_compare_mem(prev_spdm_request,
+        if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
                                       &spdm_key_init_update_operation,
                                       sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,
@@ -128,7 +128,7 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
                          spdm_request, request_size);
         break;
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS:
-        if(!libspdm_const_compare_mem(prev_spdm_request,
+        if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
                                       &spdm_key_init_update_operation,
                                       sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -103,8 +103,8 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
         if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
-                                      &spdm_key_init_update_operation,
-                                      sizeof(spdm_key_update_request_t))) {
+                                           &spdm_key_init_update_operation,
+                                           sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,
                                                    SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                    response_size, response);
@@ -129,8 +129,8 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
         break;
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS:
         if(!libspdm_consttime_is_mem_equal(prev_spdm_request,
-                                      &spdm_key_init_update_operation,
-                                      sizeof(spdm_key_update_request_t))) {
+                                           &spdm_key_init_update_operation,
+                                           sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,
                                                    SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                    response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -102,9 +102,9 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
 
     switch (spdm_request->header.param1) {
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_KEY:
-        if(libspdm_const_compare_mem(prev_spdm_request,
-                                     &spdm_key_init_update_operation,
-                                     sizeof(spdm_key_update_request_t)) != 0) {
+        if(!libspdm_const_compare_mem(prev_spdm_request,
+                                      &spdm_key_init_update_operation,
+                                      sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,
                                                    SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                    response_size, response);
@@ -128,9 +128,9 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
                          spdm_request, request_size);
         break;
     case SPDM_KEY_UPDATE_OPERATIONS_TABLE_UPDATE_ALL_KEYS:
-        if(libspdm_const_compare_mem(prev_spdm_request,
-                                     &spdm_key_init_update_operation,
-                                     sizeof(spdm_key_update_request_t)) != 0) {
+        if(!libspdm_const_compare_mem(prev_spdm_request,
+                                      &spdm_key_init_update_operation,
+                                      sizeof(spdm_key_update_request_t))) {
             return libspdm_generate_error_response(spdm_context,
                                                    SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                    response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -57,7 +57,7 @@ bool libspdm_verify_psk_finish_req_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (!libspdm_const_compare_mem(hmac, hmac_data, hash_size)) {
+    if (!libspdm_consttime_is_mem_equal(hmac, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_psk_finish_req_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -57,7 +57,7 @@ bool libspdm_verify_psk_finish_req_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_INTERNAL_DUMP_DATA(hmac_data, hash_size);
     LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
 
-    if (libspdm_const_compare_mem(hmac, hmac_data, hash_size) != 0) {
+    if (!libspdm_const_compare_mem(hmac, hmac_data, hash_size)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "!!! verify_psk_finish_req_hmac - FAIL !!!\n"));
         return false;
     }

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -437,7 +437,7 @@ libspdm_return_t libspdm_decode_secured_message(
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
         if (!libspdm_consttime_is_mem_equal(record_header1 + 1, &sequence_num_in_header,
-                                       sequence_num_in_header_size) != 0) {
+                                            sequence_num_in_header_size) != 0) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
@@ -509,7 +509,7 @@ libspdm_return_t libspdm_decode_secured_message(
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
         if (!libspdm_consttime_is_mem_equal(record_header1 + 1, &sequence_num_in_header,
-                                       sequence_num_in_header_size)) {
+                                            sequence_num_in_header_size)) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -436,8 +436,8 @@ libspdm_return_t libspdm_decode_secured_message(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
-        if (libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
-                                      sequence_num_in_header_size) != 0) {
+        if (!libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
+                                       sequence_num_in_header_size) != 0) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
@@ -508,8 +508,8 @@ libspdm_return_t libspdm_decode_secured_message(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
-        if (libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
-                                      sequence_num_in_header_size) != 0) {
+        if (!libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
+                                       sequence_num_in_header_size)) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -436,7 +436,7 @@ libspdm_return_t libspdm_decode_secured_message(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
-        if (!libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
+        if (!libspdm_consttime_is_mem_equal(record_header1 + 1, &sequence_num_in_header,
                                        sequence_num_in_header_size) != 0) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
@@ -508,7 +508,7 @@ libspdm_return_t libspdm_decode_secured_message(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
-        if (!libspdm_const_compare_mem(record_header1 + 1, &sequence_num_in_header,
+        if (!libspdm_consttime_is_mem_equal(record_header1 + 1, &sequence_num_in_header,
                                        sequence_num_in_header_size)) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -1132,7 +1132,7 @@ libspdm_internal_x509_find_extension_data(uint8_t *start, uint8_t *end, const ui
             break;
         }
 
-        if (ret == 0 && libspdm_const_compare_mem(ptr, oid, oid_size)) {
+        if (ret == 0 && libspdm_consttime_is_mem_equal(ptr, oid, oid_size)) {
             ptr += obj_len;
 
             ret = mbedtls_asn1_get_tag(&ptr, end, &obj_len,
@@ -1561,7 +1561,7 @@ int32_t libspdm_x509_compare_date_time(const void *date_time1, const void *date_
     if (date_time1 == NULL || date_time2 == NULL) {
         return -2;
     }
-    if (libspdm_const_compare_mem(date_time2, date_time1, sizeof(mbedtls_x509_time)) ==
+    if (libspdm_consttime_is_mem_equal(date_time2, date_time1, sizeof(mbedtls_x509_time)) ==
         0) {
         return 0;
     }

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -1132,7 +1132,7 @@ libspdm_internal_x509_find_extension_data(uint8_t *start, uint8_t *end, const ui
             break;
         }
 
-        if (ret == 0 && libspdm_const_compare_mem(ptr, oid, oid_size) == 0) {
+        if (ret == 0 && libspdm_const_compare_mem(ptr, oid, oid_size)) {
             ptr += obj_len;
 
             ret = mbedtls_asn1_get_tag(&ptr, end, &obj_len,

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1400,8 +1400,8 @@ bool libspdm_x509_get_extension_data(const uint8_t *cert, size_t cert_size,
         obj_length = OBJ_length(asn1_obj);
         oct_length = ASN1_STRING_length(asn1_oct);
 
-        if (oid_size == obj_length &&
-            libspdm_const_compare_mem(OBJ_get0_data(asn1_obj), oid, oid_size) == 0) {
+        if ((oid_size == obj_length) &&
+            libspdm_const_compare_mem(OBJ_get0_data(asn1_obj), oid, oid_size)) {
 
             /* Extension Found*/
 
@@ -2203,7 +2203,7 @@ char *libspdm_strstr(char *src, char *dst)
 
     for (index = 0; index < libspdm_get_str_len(src) - libspdm_get_str_len(dst); index++) {
         if ((*(src + index) == *dst) &&
-            (libspdm_const_compare_mem(src + index, dst, libspdm_get_str_len(dst)) == 0)) {
+            libspdm_const_compare_mem(src + index, dst, libspdm_get_str_len(dst))) {
             return (src + index);
         }
     }

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1401,7 +1401,7 @@ bool libspdm_x509_get_extension_data(const uint8_t *cert, size_t cert_size,
         oct_length = ASN1_STRING_length(asn1_oct);
 
         if ((oid_size == obj_length) &&
-            libspdm_const_compare_mem(OBJ_get0_data(asn1_obj), oid, oid_size)) {
+            libspdm_consttime_is_mem_equal(OBJ_get0_data(asn1_obj), oid, oid_size)) {
 
             /* Extension Found*/
 
@@ -2203,7 +2203,7 @@ char *libspdm_strstr(char *src, char *dst)
 
     for (index = 0; index < libspdm_get_str_len(src) - libspdm_get_str_len(dst); index++) {
         if ((*(src + index) == *dst) &&
-            libspdm_const_compare_mem(src + index, dst, libspdm_get_str_len(dst))) {
+            libspdm_consttime_is_mem_equal(src + index, dst, libspdm_get_str_len(dst))) {
             return (src + index);
         }
     }

--- a/os_stub/memlib/compare_mem.c
+++ b/os_stub/memlib/compare_mem.c
@@ -4,35 +4,10 @@
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
-/** @file
- * libspdm_const_compare_mem() implementation.
- **/
-
 #include "base.h"
 
-/**
- * Compares the contents of two buffers in const time.
- *
- * This function compares length bytes of source_buffer to length bytes of destination_buffer.
- * If all length bytes of the two buffers are identical, then 0 is returned.  Otherwise, the
- * value returned is the first mismatched byte in source_buffer subtracted from the first
- * mismatched byte in destination_buffer.
- *
- * If length > 0 and destination_buffer is NULL, then LIBSPDM_ASSERT().
- * If length > 0 and source_buffer is NULL, then LIBSPDM_ASSERT().
- * If length is greater than (MAX_ADDRESS - destination_buffer + 1), then LIBSPDM_ASSERT().
- * If length is greater than (MAX_ADDRESS - source_buffer + 1), then LIBSPDM_ASSERT().
- *
- * @param  destination_buffer A pointer to the destination buffer to compare.
- * @param  source_buffer      A pointer to the source buffer to compare.
- * @param  length            The number of bytes to compare.
- *
- * @return 0                 All length bytes of the two buffers are identical.
- * @retval Non-zero          There is mismatched between source_buffer and destination_buffer.
- *
- **/
-int32_t libspdm_const_compare_mem(const void *destination_buffer,
-                                  const void *source_buffer, size_t length)
+bool libspdm_const_compare_mem(const void *destination_buffer,
+                               const void *source_buffer, size_t length)
 {
     const volatile uint8_t *pointer_dst;
     const volatile uint8_t *pointer_src;
@@ -45,5 +20,5 @@ int32_t libspdm_const_compare_mem(const void *destination_buffer,
         delta |= *(pointer_dst++) ^ *(pointer_src++);
     }
 
-    return delta;
+    return ((delta == 0) ? true : false);
 }

--- a/os_stub/memlib/compare_mem.c
+++ b/os_stub/memlib/compare_mem.c
@@ -6,7 +6,7 @@
 
 #include "base.h"
 
-bool libspdm_const_compare_mem(const void *destination_buffer,
+bool libspdm_consttime_is_mem_equal(const void *destination_buffer,
                                const void *source_buffer, size_t length)
 {
     const volatile uint8_t *pointer_dst;

--- a/os_stub/memlib/compare_mem.c
+++ b/os_stub/memlib/compare_mem.c
@@ -7,7 +7,7 @@
 #include "base.h"
 
 bool libspdm_consttime_is_mem_equal(const void *destination_buffer,
-                               const void *source_buffer, size_t length)
+                                    const void *source_buffer, size_t length)
 {
     const volatile uint8_t *pointer_dst;
     const volatile uint8_t *pointer_src;

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1139,7 +1139,7 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
         /*get the cached requester info and csr*/
         if ((result) &&
             (cached_req_info_length == requester_info_length) &&
-            (libspdm_const_compare_mem(cached_req_info, requester_info, requester_info_length)) &&
+            (libspdm_consttime_is_mem_equal(cached_req_info, requester_info, requester_info_length)) &&
             (libspdm_read_cached_csr(base_asym_algo, &cached_csr, csr_len))) {
 
             /*get and save cached csr*/

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1139,7 +1139,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
         /*get the cached requester info and csr*/
         if ((result) &&
             (cached_req_info_length == requester_info_length) &&
-            (libspdm_consttime_is_mem_equal(cached_req_info, requester_info, requester_info_length)) &&
+            (libspdm_consttime_is_mem_equal(cached_req_info, requester_info,
+                                            requester_info_length)) &&
             (libspdm_read_cached_csr(base_asym_algo, &cached_csr, csr_len))) {
 
             /*get and save cached csr*/

--- a/unit_test/test_crypt/aead_verify.c
+++ b/unit_test/test_crypt/aead_verify.c
@@ -162,11 +162,11 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_gcm_ct, sizeof(m_libspdm_gcm_ct)) != 0) {
+    if (memcmp(OutBuffer, m_libspdm_gcm_ct, sizeof(m_libspdm_gcm_ct)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutTag, m_libspdm_gcm_tag, sizeof(m_libspdm_gcm_tag)) != 0) {
+    if (memcmp(OutTag, m_libspdm_gcm_tag, sizeof(m_libspdm_gcm_tag)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -185,7 +185,7 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_gcm_pt, sizeof(m_libspdm_gcm_pt)) != 0) {
+    if (memcmp(OutBuffer, m_libspdm_gcm_pt, sizeof(m_libspdm_gcm_pt)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -212,12 +212,12 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_chacha20_poly1305_ct,
+    if (memcmp(OutBuffer, m_libspdm_chacha20_poly1305_ct,
                                   sizeof(m_libspdm_chacha20_poly1305_ct)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutTag, m_libspdm_chacha20_poly1305_tag,
+    if (memcmp(OutTag, m_libspdm_chacha20_poly1305_tag,
                                   sizeof(m_libspdm_chacha20_poly1305_tag)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -240,7 +240,7 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_chacha20_poly1305_pt,
+    if (memcmp(OutBuffer, m_libspdm_chacha20_poly1305_pt,
                                   sizeof(m_libspdm_chacha20_poly1305_pt)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -268,12 +268,12 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_sm4_gcm_ct,
+    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_ct,
                                   sizeof(m_libspdm_sm4_gcm_ct)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutTag, m_libspdm_sm4_gcm_tag,
+    if (memcmp(OutTag, m_libspdm_sm4_gcm_tag,
                                   sizeof(m_libspdm_sm4_gcm_tag)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -295,7 +295,7 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(OutBuffer, m_libspdm_sm4_gcm_pt,
+    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_pt,
                                   sizeof(m_libspdm_sm4_gcm_pt)) != 0) {
         libspdm_my_print("[Fail]");
         return false;

--- a/unit_test/test_crypt/aead_verify.c
+++ b/unit_test/test_crypt/aead_verify.c
@@ -213,12 +213,12 @@ bool libspdm_validate_crypt_aead_cipher(void)
         return false;
     }
     if (memcmp(OutBuffer, m_libspdm_chacha20_poly1305_ct,
-                                  sizeof(m_libspdm_chacha20_poly1305_ct)) != 0) {
+               sizeof(m_libspdm_chacha20_poly1305_ct)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
     if (memcmp(OutTag, m_libspdm_chacha20_poly1305_tag,
-                                  sizeof(m_libspdm_chacha20_poly1305_tag)) != 0) {
+               sizeof(m_libspdm_chacha20_poly1305_tag)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -241,7 +241,7 @@ bool libspdm_validate_crypt_aead_cipher(void)
         return false;
     }
     if (memcmp(OutBuffer, m_libspdm_chacha20_poly1305_pt,
-                                  sizeof(m_libspdm_chacha20_poly1305_pt)) != 0) {
+               sizeof(m_libspdm_chacha20_poly1305_pt)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -268,13 +268,11 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_ct,
-                                  sizeof(m_libspdm_sm4_gcm_ct)) != 0) {
+    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_ct, sizeof(m_libspdm_sm4_gcm_ct)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(OutTag, m_libspdm_sm4_gcm_tag,
-                                  sizeof(m_libspdm_sm4_gcm_tag)) != 0) {
+    if (memcmp(OutTag, m_libspdm_sm4_gcm_tag, sizeof(m_libspdm_sm4_gcm_tag)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -295,8 +293,7 @@ bool libspdm_validate_crypt_aead_cipher(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_pt,
-                                  sizeof(m_libspdm_sm4_gcm_pt)) != 0) {
+    if (memcmp(OutBuffer, m_libspdm_sm4_gcm_pt, sizeof(m_libspdm_sm4_gcm_pt)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }

--- a/unit_test/test_crypt/dh_verify.c
+++ b/unit_test/test_crypt/dh_verify.c
@@ -96,7 +96,7 @@ bool libspdm_validate_crypt_dh(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(ff_key1, ff_key2, ff_key1_length) != 0) {
+    if (memcmp(ff_key1, ff_key2, ff_key1_length) != 0) {
         libspdm_my_print("[Fail]");
         libspdm_dh_free(dh1);
         libspdm_dh_free(dh2);

--- a/unit_test/test_crypt/ec_verify.c
+++ b/unit_test/test_crypt/ec_verify.c
@@ -117,7 +117,7 @@ bool libspdm_validate_crypt_ec(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(key1, key2, key1_length) != 0) {
+    if (memcmp(key1, key2, key1_length) != 0) {
         libspdm_my_print("[Fail]");
         libspdm_ec_free(ec1);
         libspdm_ec_free(ec2);
@@ -198,7 +198,7 @@ bool libspdm_validate_crypt_ec(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(key1, key2, key1_length) != 0) {
+    if (memcmp(key1, key2, key1_length) != 0) {
         libspdm_my_print("[Fail]");
         libspdm_ec_free(ec1);
         libspdm_ec_free(ec2);

--- a/unit_test/test_crypt/hash_verify.c
+++ b/unit_test/test_crypt/hash_verify.c
@@ -131,8 +131,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha256_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (memcmp(digest, m_libspdm_sha256_digest,
-                                  LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha256_digest, LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -144,8 +143,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(digest, m_libspdm_sha256_digest,
-                                  LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha256_digest, LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -191,8 +189,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha384_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (memcmp(digest, m_libspdm_sha384_digest,
-                                  LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha384_digest, LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -204,8 +201,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(digest, m_libspdm_sha384_digest,
-                                  LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha384_digest, LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -251,8 +247,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha512_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (memcmp(digest, m_libspdm_sha512_digest,
-                                  LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha512_digest, LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -264,8 +259,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (memcmp(digest, m_libspdm_sha512_digest,
-                                  LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_sha512_digest, LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -296,8 +290,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (memcmp(digest, m_libspdm_sha3_256_digest,
-                                      LIBSPDM_SHA3_256_DIGEST_SIZE) == 0) {
+        if (memcmp(digest, m_libspdm_sha3_256_digest, LIBSPDM_SHA3_256_DIGEST_SIZE) == 0) {
             status = true;
         } else {
             status = false;
@@ -344,8 +337,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (memcmp(digest, m_libspdm_sha3_384_digest,
-                                      LIBSPDM_SHA3_384_DIGEST_SIZE) == 0) {
+        if (memcmp(digest, m_libspdm_sha3_384_digest, LIBSPDM_SHA3_384_DIGEST_SIZE) == 0) {
             status = true;
         } else {
             status = false;
@@ -392,8 +384,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (memcmp(digest, m_libspdm_sha3_512_digest,
-                                      LIBSPDM_SHA3_512_DIGEST_SIZE) == 0) {
+        if (memcmp(digest, m_libspdm_sha3_512_digest, LIBSPDM_SHA3_512_DIGEST_SIZE) == 0) {
             status = true;
         } else {
             status = false;
@@ -425,8 +416,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_zero_mem(digest, LIBSPDM_SM3_256_DIGEST_SIZE);
     status = libspdm_sm3_256_hash_all(m_libspdm_hash_data, data_size, digest);
     if (status) {
-        if (memcmp(digest, m_libspdm_sm3_256_digest,
-                                      LIBSPDM_SM3_256_DIGEST_SIZE) == 0) {
+        if (memcmp(digest, m_libspdm_sm3_256_digest, LIBSPDM_SM3_256_DIGEST_SIZE) == 0) {
             status = true;
         } else {
             status = false;

--- a/unit_test/test_crypt/hash_verify.c
+++ b/unit_test/test_crypt/hash_verify.c
@@ -131,7 +131,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha256_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha256_digest,
+    if (memcmp(digest, m_libspdm_sha256_digest,
                                   LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -144,7 +144,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha256_digest,
+    if (memcmp(digest, m_libspdm_sha256_digest,
                                   LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -191,7 +191,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha384_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha384_digest,
+    if (memcmp(digest, m_libspdm_sha384_digest,
                                   LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -204,7 +204,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha384_digest,
+    if (memcmp(digest, m_libspdm_sha384_digest,
                                   LIBSPDM_SHA384_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -251,7 +251,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_sha512_free(hash_ctx);
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha512_digest,
+    if (memcmp(digest, m_libspdm_sha512_digest,
                                   LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -264,7 +264,7 @@ bool libspdm_validate_crypt_digest(void)
         libspdm_my_print("[Fail]");
         return false;
     }
-    if (libspdm_const_compare_mem(digest, m_libspdm_sha512_digest,
+    if (memcmp(digest, m_libspdm_sha512_digest,
                                   LIBSPDM_SHA512_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
@@ -296,7 +296,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (libspdm_const_compare_mem(digest, m_libspdm_sha3_256_digest,
+        if (memcmp(digest, m_libspdm_sha3_256_digest,
                                       LIBSPDM_SHA3_256_DIGEST_SIZE) == 0) {
             status = true;
         } else {
@@ -344,7 +344,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (libspdm_const_compare_mem(digest, m_libspdm_sha3_384_digest,
+        if (memcmp(digest, m_libspdm_sha3_384_digest,
                                       LIBSPDM_SHA3_384_DIGEST_SIZE) == 0) {
             status = true;
         } else {
@@ -392,7 +392,7 @@ bool libspdm_validate_crypt_digest(void)
 
     if (status) {
         libspdm_my_print("Check value... ");
-        if (libspdm_const_compare_mem(digest, m_libspdm_sha3_512_digest,
+        if (memcmp(digest, m_libspdm_sha3_512_digest,
                                       LIBSPDM_SHA3_512_DIGEST_SIZE) == 0) {
             status = true;
         } else {
@@ -425,7 +425,7 @@ bool libspdm_validate_crypt_digest(void)
     libspdm_zero_mem(digest, LIBSPDM_SM3_256_DIGEST_SIZE);
     status = libspdm_sm3_256_hash_all(m_libspdm_hash_data, data_size, digest);
     if (status) {
-        if (libspdm_const_compare_mem(digest, m_libspdm_sm3_256_digest,
+        if (memcmp(digest, m_libspdm_sm3_256_digest,
                                       LIBSPDM_SM3_256_DIGEST_SIZE) == 0) {
             status = true;
         } else {

--- a/unit_test/test_crypt/hkdf_verify.c
+++ b/unit_test/test_crypt/hkdf_verify.c
@@ -116,9 +116,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(prk_out, m_libspdm_hkdf_sha256_prk,
-                                  sizeof(m_libspdm_hkdf_sha256_prk)) !=
-        0) {
+    if (memcmp(prk_out, m_libspdm_hkdf_sha256_prk, sizeof(m_libspdm_hkdf_sha256_prk)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -136,9 +134,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(out, m_libspdm_hkdf_sha256_okm,
-                                  sizeof(m_libspdm_hkdf_sha256_okm)) !=
-        0) {
+    if (memcmp(out, m_libspdm_hkdf_sha256_okm, sizeof(m_libspdm_hkdf_sha256_okm)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -157,9 +153,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(out, m_libspdm_hkdf_sha256_okm,
-                                  sizeof(m_libspdm_hkdf_sha256_okm)) !=
-        0) {
+    if (memcmp(out, m_libspdm_hkdf_sha256_okm, sizeof(m_libspdm_hkdf_sha256_okm)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -272,9 +266,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(prk_out48, m_libspdm_hkdf_sha384_prk,
-                                  sizeof(m_libspdm_hkdf_sha384_prk)) !=
-        0) {
+    if (memcmp(prk_out48, m_libspdm_hkdf_sha384_prk, sizeof(m_libspdm_hkdf_sha384_prk)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -292,9 +284,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(out64, m_libspdm_hkdf_sha384_okm,
-                                  sizeof(m_libspdm_hkdf_sha384_okm)) !=
-        0) {
+    if (memcmp(out64, m_libspdm_hkdf_sha384_okm, sizeof(m_libspdm_hkdf_sha384_okm)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }
@@ -313,9 +303,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (memcmp(out64, m_libspdm_hkdf_sha384_okm,
-                                  sizeof(m_libspdm_hkdf_sha384_okm)) !=
-        0) {
+    if (memcmp(out64, m_libspdm_hkdf_sha384_okm, sizeof(m_libspdm_hkdf_sha384_okm)) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }

--- a/unit_test/test_crypt/hkdf_verify.c
+++ b/unit_test/test_crypt/hkdf_verify.c
@@ -116,7 +116,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(prk_out, m_libspdm_hkdf_sha256_prk,
+    if (memcmp(prk_out, m_libspdm_hkdf_sha256_prk,
                                   sizeof(m_libspdm_hkdf_sha256_prk)) !=
         0) {
         libspdm_my_print("[Fail]");
@@ -136,7 +136,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(out, m_libspdm_hkdf_sha256_okm,
+    if (memcmp(out, m_libspdm_hkdf_sha256_okm,
                                   sizeof(m_libspdm_hkdf_sha256_okm)) !=
         0) {
         libspdm_my_print("[Fail]");
@@ -157,7 +157,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(out, m_libspdm_hkdf_sha256_okm,
+    if (memcmp(out, m_libspdm_hkdf_sha256_okm,
                                   sizeof(m_libspdm_hkdf_sha256_okm)) !=
         0) {
         libspdm_my_print("[Fail]");
@@ -272,7 +272,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(prk_out48, m_libspdm_hkdf_sha384_prk,
+    if (memcmp(prk_out48, m_libspdm_hkdf_sha384_prk,
                                   sizeof(m_libspdm_hkdf_sha384_prk)) !=
         0) {
         libspdm_my_print("[Fail]");
@@ -292,7 +292,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(out64, m_libspdm_hkdf_sha384_okm,
+    if (memcmp(out64, m_libspdm_hkdf_sha384_okm,
                                   sizeof(m_libspdm_hkdf_sha384_okm)) !=
         0) {
         libspdm_my_print("[Fail]");
@@ -313,7 +313,7 @@ bool libspdm_validate_crypt_hkdf(void)
     }
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(out64, m_libspdm_hkdf_sha384_okm,
+    if (memcmp(out64, m_libspdm_hkdf_sha384_okm,
                                   sizeof(m_libspdm_hkdf_sha384_okm)) !=
         0) {
         libspdm_my_print("[Fail]");

--- a/unit_test/test_crypt/hmac_verify.c
+++ b/unit_test/test_crypt/hmac_verify.c
@@ -79,8 +79,7 @@ bool libspdm_validate_crypt_hmac(void)
     free_pool(hmac_ctx);
 
     libspdm_my_print("Check value... ");
-    if (memcmp(digest, m_libspdm_hmac_sha256_digest,
-                                  LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
+    if (memcmp(digest, m_libspdm_hmac_sha256_digest, LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;
     }

--- a/unit_test/test_crypt/hmac_verify.c
+++ b/unit_test/test_crypt/hmac_verify.c
@@ -79,7 +79,7 @@ bool libspdm_validate_crypt_hmac(void)
     free_pool(hmac_ctx);
 
     libspdm_my_print("Check value... ");
-    if (libspdm_const_compare_mem(digest, m_libspdm_hmac_sha256_digest,
+    if (memcmp(digest, m_libspdm_hmac_sha256_digest,
                                   LIBSPDM_SHA256_DIGEST_SIZE) != 0) {
         libspdm_my_print("[Fail]");
         return false;

--- a/unit_test/test_crypt/rand_verify.c
+++ b/unit_test/test_crypt/rand_verify.c
@@ -33,7 +33,7 @@ bool libspdm_validate_crypt_prng(void)
             return false;
         }
 
-        if (libspdm_const_compare_mem(m_libspdm_previous_random_buffer, m_libspdm_random_buffer,
+        if (memcmp(m_libspdm_previous_random_buffer, m_libspdm_random_buffer,
                                       LIBSPDM_RANDOM_NUMBER_SIZE) == 0) {
             libspdm_my_print("[Fail]");
             return false;

--- a/unit_test/test_crypt/rand_verify.c
+++ b/unit_test/test_crypt/rand_verify.c
@@ -34,7 +34,7 @@ bool libspdm_validate_crypt_prng(void)
         }
 
         if (memcmp(m_libspdm_previous_random_buffer, m_libspdm_random_buffer,
-                                      LIBSPDM_RANDOM_NUMBER_SIZE) == 0) {
+                   LIBSPDM_RANDOM_NUMBER_SIZE) == 0) {
             libspdm_my_print("[Fail]");
             return false;
         }

--- a/unit_test/test_crypt/rsa_verify.c
+++ b/unit_test/test_crypt/rsa_verify.c
@@ -166,7 +166,7 @@ bool libspdm_validate_crypt_rsa(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(KeyBuffer, m_libspdm_rsa_n, key_size) != 0) {
+    if (memcmp(KeyBuffer, m_libspdm_rsa_n, key_size) != 0) {
         libspdm_my_print("[Fail]");
         free_pool(KeyBuffer);
         libspdm_rsa_free(rsa);
@@ -205,7 +205,7 @@ bool libspdm_validate_crypt_rsa(void)
         return false;
     }
 
-    if (libspdm_const_compare_mem(KeyBuffer, m_libspdm_rsa_e, key_size) != 0) {
+    if (memcmp(KeyBuffer, m_libspdm_rsa_e, key_size) != 0) {
         libspdm_my_print("[Fail]");
         free_pool(KeyBuffer);
         libspdm_rsa_free(rsa);
@@ -275,7 +275,7 @@ bool libspdm_validate_crypt_rsa(void)
     }
 
     if (key_size != 3 ||
-        libspdm_const_compare_mem(KeyBuffer, m_libspdm_default_public_key, 3) != 0) {
+        memcmp(KeyBuffer, m_libspdm_default_public_key, 3) != 0) {
         libspdm_my_print("[Fail]");
         free_pool(KeyBuffer);
         libspdm_rsa_free(rsa);
@@ -452,7 +452,7 @@ bool libspdm_validate_crypt_rsa(void)
     }
 
     if (sig_size != sizeof(m_libspdm_rsa_pkcs1_signature) ||
-        libspdm_const_compare_mem(m_libspdm_rsa_pkcs1_signature, signature, sig_size)) {
+        memcmp(m_libspdm_rsa_pkcs1_signature, signature, sig_size)) {
         libspdm_my_print("[Fail]");
         free_pool(signature);
         libspdm_rsa_free(rsa);

--- a/unit_test/test_crypt/sm2_verify.c
+++ b/unit_test/test_crypt/sm2_verify.c
@@ -126,7 +126,7 @@ bool libspdm_validate_crypt_sm2(void)
 
     libspdm_my_print("Compare Keys ... ");
 
-    if (libspdm_const_compare_mem(key1, key2, key1_length) != 0) {
+    if (memcmp(key1, key2, key1_length) != 0) {
         libspdm_my_print("[Fail]");
         libspdm_sm2_key_exchange_free(Sm2_1);
         libspdm_sm2_key_exchange_free(Sm2_2);

--- a/unit_test/test_crypt/test_crypt.h
+++ b/unit_test/test_crypt/test_crypt.h
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
+#include <string.h>
 
 #include "hal/base.h"
 #include "internal/libspdm_lib_config.h"

--- a/unit_test/test_crypt/x509_verify.c
+++ b/unit_test/test_crypt/x509_verify.c
@@ -187,7 +187,7 @@ bool libspdm_validate_crypt_x509(char *Path, size_t len)
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     }
-    if (libspdm_const_compare_mem(leaf_cert, test_end_cert, leaf_cert_len) != 0) {
+    if (memcmp(leaf_cert, test_end_cert, leaf_cert_len) != 0) {
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     } else {
@@ -208,7 +208,7 @@ bool libspdm_validate_crypt_x509(char *Path, size_t len)
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     }
-    if (libspdm_const_compare_mem(leaf_cert, test_end_cert, leaf_cert_len) != 0) {
+    if (memcmp(leaf_cert, test_end_cert, leaf_cert_len) != 0) {
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     } else {
@@ -229,7 +229,7 @@ bool libspdm_validate_crypt_x509(char *Path, size_t len)
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     }
-    if (libspdm_const_compare_mem(leaf_cert, test_ca_cert, leaf_cert_len) != 0) {
+    if (memcmp(leaf_cert, test_ca_cert, leaf_cert_len) != 0) {
         libspdm_my_print("[Fail]\n");
         goto cleanup;
     } else {

--- a/unit_test/test_size/intrinsiclib/memory_intrinsics.c
+++ b/unit_test/test_size/intrinsiclib/memory_intrinsics.c
@@ -73,7 +73,7 @@ void *memmove(void *dest, const void *src, size_t count)
 /* Compare bytes in two buffers. */
 int memcmp(const void *buf1, const void *buf2, size_t count)
 {
-    return (int)libspdm_const_compare_mem(buf1, buf2, count);
+    return (int)libspdm_consttime_is_mem_equal(buf1, buf2, count);
 }
 
 #if defined(__clang__) && !defined(__APPLE__)

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -63,7 +63,7 @@ bool libspdm_find_buffer(char *src, size_t src_len, char *dst, size_t dst_len)
 
     for (index = 0; index < src_len - dst_len; index++) {
         if ((*(src + index) == *dst) &&
-            (libspdm_const_compare_mem(src + index, dst, dst_len) == 0)) {
+            (libspdm_consttime_is_mem_equal(src + index, dst, dst_len) == 0)) {
             return true;
         }
     }


### PR DESCRIPTION
libspdm does not need to know the number of bytes that are the same, as is with `memcmp`. It just needs to know if the contents of the two buffers are equal or not.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>