### PR TITLE
Allow message size check to accept transport layer padding

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -44,7 +44,6 @@ libspdm_return_t libspdm_handle_simple_error_response(libspdm_context_t *spdm_co
  * @param  response                     The SPDM response message.
  * @param  original_request_code          Indicate the original request code.
  * @param  expected_response_code         Indicate the expected response code.
- * @param  expected_response_size         Indicate the expected response size.
  *
  * @retval RETURN_SUCCESS               The error code is RESPONSE_NOT_READY. The RESPOND_IF_READY is sent and an expected SPDM response is received.
  * @retval RETURN_NO_RESPONSE           The error code is BUSY.
@@ -55,8 +54,7 @@ libspdm_return_t libspdm_handle_simple_error_response(libspdm_context_t *spdm_co
 libspdm_return_t libspdm_handle_error_response_main(
     libspdm_context_t *spdm_context, const uint32_t *session_id,
     size_t *response_size, void **response,
-    uint8_t original_request_code, uint8_t expected_response_code,
-    size_t expected_response_size);
+    uint8_t original_request_code, uint8_t expected_response_code);
 
 /**
  * This function handles the error response handling for large responses.

--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -161,8 +161,7 @@ static libspdm_return_t libspdm_try_challenge(libspdm_context_t *spdm_context,
         status = libspdm_handle_error_response_main(
             spdm_context, NULL,
             &spdm_response_size,
-            (void **)&spdm_response, SPDM_CHALLENGE, SPDM_CHALLENGE_AUTH,
-            sizeof(libspdm_challenge_auth_response_max_t));
+            (void **)&spdm_response, SPDM_CHALLENGE, SPDM_CHALLENGE_AUTH);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_requester_lib/libspdm_req_encap_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_certificate.c
@@ -41,7 +41,7 @@ libspdm_return_t libspdm_get_encap_response_certificate(void *spdm_context,
             SPDM_GET_CERTIFICATE, response_size, response);
     }
 
-    if (request_size != sizeof(spdm_get_certificate_request_t)) {
+    if (request_size < sizeof(spdm_get_certificate_request_t)) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -44,7 +44,7 @@ libspdm_return_t libspdm_get_encap_response_challenge_auth(
             SPDM_CHALLENGE, response_size, response);
     }
 
-    if (request_size != sizeof(spdm_challenge_request_t)) {
+    if (request_size < sizeof(spdm_challenge_request_t)) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);

--- a/library/spdm_requester_lib/libspdm_req_encap_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_digests.c
@@ -44,7 +44,7 @@ libspdm_return_t libspdm_get_encap_response_digest(void *spdm_context,
             SPDM_GET_DIGESTS, response_size, response);
     }
 
-    if (request_size != sizeof(spdm_get_digest_request_t)) {
+    if (request_size < sizeof(spdm_get_digest_request_t)) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
             response_size, response);

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -63,6 +63,8 @@ libspdm_return_t libspdm_get_encap_response_key_update(void *spdm_context,
             response_size, response);
     }
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (request_size != sizeof(spdm_key_update_request_t)) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -114,8 +114,7 @@ static libspdm_return_t libspdm_try_send_receive_end_session(libspdm_context_t *
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
-            (void **)&spdm_response, SPDM_END_SESSION, SPDM_END_SESSION_ACK,
-            sizeof(libspdm_end_session_response_mine_t));
+            (void **)&spdm_response, SPDM_END_SESSION, SPDM_END_SESSION_ACK);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }
@@ -123,6 +122,8 @@ static libspdm_return_t libspdm_try_send_receive_end_session(libspdm_context_t *
         status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
         goto receive_done;
     }
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (spdm_response_size != sizeof(spdm_end_session_response_t)) {
         status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
         goto receive_done;

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -506,8 +506,7 @@ static libspdm_return_t libspdm_try_send_receive_finish(libspdm_context_t *spdm_
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, (void **)&spdm_response,
-            SPDM_FINISH, SPDM_FINISH_RSP,
-            sizeof(libspdm_finish_response_mine_t));
+            SPDM_FINISH, SPDM_FINISH_RSP);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }
@@ -523,7 +522,7 @@ static libspdm_return_t libspdm_try_send_receive_finish(libspdm_context_t *spdm_
         hmac_size = 0;
     }
 
-    if (spdm_response_size != sizeof(spdm_finish_response_t) + hmac_size) {
+    if (spdm_response_size < sizeof(spdm_finish_response_t) + hmac_size) {
         status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
         goto receive_done;
     }

--- a/library/spdm_requester_lib/libspdm_req_get_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_get_certificate.c
@@ -206,8 +206,7 @@ static libspdm_return_t libspdm_try_get_certificate(libspdm_context_t *spdm_cont
                 spdm_context, session_id,
                 &spdm_response_size,
                 (void **)&spdm_response, SPDM_GET_CERTIFICATE,
-                SPDM_CERTIFICATE,
-                sizeof(libspdm_certificate_response_max_t));
+                SPDM_CERTIFICATE);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
                 libspdm_release_receiver_buffer (spdm_context);
                 goto done;

--- a/library/spdm_requester_lib/libspdm_req_get_csr.c
+++ b/library/spdm_requester_lib/libspdm_req_get_csr.c
@@ -136,8 +136,7 @@ static libspdm_return_t libspdm_try_get_csr(libspdm_context_t *spdm_context,
         status = libspdm_handle_error_response_main(
             spdm_context, session_id,
             &spdm_response_size,
-            (void **)&spdm_response, SPDM_GET_CSR, SPDM_CSR,
-            sizeof(spdm_csr_response_t));
+            (void **)&spdm_response, SPDM_GET_CSR, SPDM_CSR);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_digests.c
+++ b/library/spdm_requester_lib/libspdm_req_get_digests.c
@@ -139,8 +139,7 @@ static libspdm_return_t libspdm_try_get_digest(libspdm_context_t *spdm_context,
         status = libspdm_handle_error_response_main(
             spdm_context, session_id,
             &spdm_response_size,
-            (void **)&spdm_response, SPDM_GET_DIGESTS, SPDM_DIGESTS,
-            sizeof(libspdm_digests_response_max_t));
+            (void **)&spdm_response, SPDM_GET_DIGESTS, SPDM_DIGESTS);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -300,8 +300,7 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
         status = libspdm_handle_error_response_main(
             spdm_context, session_id,
             &spdm_response_size, (void **)&spdm_response,
-            SPDM_GET_MEASUREMENTS, SPDM_MEASUREMENTS,
-            message_size);
+            SPDM_GET_MEASUREMENTS, SPDM_MEASUREMENTS);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_requester_lib/libspdm_req_heartbeat.c
+++ b/library/spdm_requester_lib/libspdm_req_heartbeat.c
@@ -113,8 +113,7 @@ static libspdm_return_t libspdm_try_heartbeat(libspdm_context_t *spdm_context, u
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id, &spdm_response_size,
-            (void **)&spdm_response, SPDM_HEARTBEAT, SPDM_HEARTBEAT_ACK,
-            sizeof(libspdm_heartbeat_response_mine_t));
+            (void **)&spdm_response, SPDM_HEARTBEAT, SPDM_HEARTBEAT_ACK);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }
@@ -122,6 +121,8 @@ static libspdm_return_t libspdm_try_heartbeat(libspdm_context_t *spdm_context, u
         status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
         goto receive_done;
     }
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (spdm_response_size != sizeof(spdm_heartbeat_response_t)) {
         status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
         goto receive_done;

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -440,7 +440,7 @@ static libspdm_return_t libspdm_try_send_receive_key_exchange(
         status = libspdm_handle_error_response_main(
             spdm_context, NULL, &spdm_response_size,
             (void **)&spdm_response, SPDM_KEY_EXCHANGE,
-            SPDM_KEY_EXCHANGE_RSP, sizeof(libspdm_key_exchange_response_max_t));
+            SPDM_KEY_EXCHANGE_RSP);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             libspdm_secured_message_dhe_free(
                 spdm_context->connection_info.algorithm.dhe_named_group, dhe_context);

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -304,8 +304,7 @@ static libspdm_return_t libspdm_try_send_receive_psk_exchange(
         status = libspdm_handle_error_response_main(
             spdm_context, NULL, &spdm_response_size,
             (void **)&spdm_response, SPDM_PSK_EXCHANGE,
-            SPDM_PSK_EXCHANGE_RSP,
-            sizeof(libspdm_psk_exchange_response_max_t));
+            SPDM_PSK_EXCHANGE_RSP);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -225,8 +225,7 @@ static libspdm_return_t libspdm_try_send_receive_psk_finish(libspdm_context_t *s
         status = libspdm_handle_error_response_main(
             spdm_context, &session_id,
             &spdm_response_size, (void **)&spdm_response,
-            SPDM_PSK_FINISH, SPDM_PSK_FINISH_RSP,
-            sizeof(libspdm_psk_finish_response_max_t));
+            SPDM_PSK_FINISH, SPDM_PSK_FINISH_RSP);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }
@@ -235,6 +234,8 @@ static libspdm_return_t libspdm_try_send_receive_psk_finish(libspdm_context_t *s
         status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
         goto receive_done;
     }
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (spdm_response_size != sizeof(spdm_psk_finish_response_t)) {
         status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
         goto receive_done;

--- a/library/spdm_requester_lib/libspdm_req_set_certificate.c
+++ b/library/spdm_requester_lib/libspdm_req_set_certificate.c
@@ -134,8 +134,7 @@ static libspdm_return_t libspdm_try_set_certificate(libspdm_context_t *spdm_cont
         status = libspdm_handle_error_response_main(
             spdm_context, NULL,
             &spdm_response_size,
-            (void **)&spdm_response, SPDM_SET_CERTIFICATE, SPDM_SET_CERTIFICATE_RSP,
-            sizeof(spdm_set_certificate_response_t));
+            (void **)&spdm_response, SPDM_SET_CERTIFICATE, SPDM_SET_CERTIFICATE_RSP);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;
         }

--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -70,7 +70,7 @@ libspdm_return_t libspdm_get_response_certificate(libspdm_context_t *spdm_contex
             SPDM_GET_CERTIFICATE, response_size, response);
     }
 
-    if (request_size != sizeof(spdm_get_certificate_request_t)) {
+    if (request_size < sizeof(spdm_get_certificate_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -60,7 +60,7 @@ libspdm_return_t libspdm_get_response_challenge_auth(libspdm_context_t *spdm_con
                                                0, response_size, response);
     }
 
-    if (request_size != sizeof(spdm_challenge_request_t)) {
+    if (request_size < sizeof(spdm_challenge_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -75,7 +75,7 @@ libspdm_return_t libspdm_get_response_digests(libspdm_context_t *spdm_context, s
         }
     }
 
-    if (request_size != sizeof(spdm_get_digest_request_t)) {
+    if (request_size < sizeof(spdm_get_digest_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -177,6 +177,8 @@ libspdm_return_t libspdm_process_encap_response_key_update(
         }
     }
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if ((spdm_response_size != sizeof(spdm_key_update_response_t)) ||
         (spdm_response->header.request_response_code !=
          SPDM_KEY_UPDATE_ACK) ||

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -337,7 +337,7 @@ libspdm_return_t libspdm_get_response_encapsulated_request(
             response_size, response);
     }
 
-    if (request_size != sizeof(spdm_get_encapsulated_request_request_t)) {
+    if (request_size < sizeof(spdm_get_encapsulated_request_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_end_session.c
+++ b/library/spdm_responder_lib/libspdm_rsp_end_session.c
@@ -56,6 +56,8 @@ libspdm_return_t libspdm_get_response_end_session(libspdm_context_t *spdm_contex
                                                response_size, response);
     }
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (request_size != sizeof(spdm_end_session_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -448,7 +448,7 @@ libspdm_return_t libspdm_get_response_finish(libspdm_context_t *spdm_context, si
     }
 #endif
 
-    if (request_size !=
+    if (request_size <
         sizeof(spdm_finish_request_t) + signature_size + hmac_size) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
+++ b/library/spdm_responder_lib/libspdm_rsp_heartbeat.c
@@ -64,6 +64,8 @@ libspdm_return_t libspdm_get_response_heartbeat(libspdm_context_t *spdm_context,
                                                response_size, response);
     }
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (request_size != sizeof(spdm_heartbeat_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -88,6 +88,8 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
                                                response_size, response);
     }
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (request_size != sizeof(spdm_key_update_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -243,7 +243,7 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
                            sizeof(spdm_request->slot_id_param);
         }
     } else {
-        if (request_size != sizeof(spdm_message_header_t)) {
+        if (request_size < sizeof(spdm_message_header_t)) {
             return libspdm_generate_error_response(
                 spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
                 0, response_size, response);

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -133,6 +133,8 @@ libspdm_return_t libspdm_get_response_psk_finish(libspdm_context_t *spdm_context
     hmac_size = libspdm_get_hash_size(
         spdm_context->connection_info.algorithm.base_hash_algo);
 
+    /* this message can only be in secured session
+     * thus don't need to consider transport layer padding, just check its exact size */
     if (request_size != sizeof(spdm_psk_finish_request_t) + hmac_size) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -32,7 +32,7 @@ libspdm_return_t libspdm_get_response_respond_if_ready(libspdm_context_t *spdm_c
             response_size, response);
     }
 
-    if (request_size != sizeof(spdm_message_header_t)) {
+    if (request_size < sizeof(spdm_message_header_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);

--- a/unit_test/test_spdm_requester/encap_certificate.c
+++ b/unit_test/test_spdm_requester/encap_certificate.c
@@ -98,47 +98,11 @@ void libspdm_test_requester_encap_certificate_case1(void **state)
 }
 
 /**
- * Test 2: Wrong GET_CERTIFICATE message size (larger than expected)
- * Expected Behavior: generate an ERROR_RESPONSE with code
- * SPDM_ERROR_CODE_INVALID_REQUEST
+ * Test 2:
+ * Expected Behavior:
  **/
 void libspdm_test_requester_encap_certificate_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_certificate_response_t *spdm_response;
-    void *data;
-    size_t data_size;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10
-                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo,
-                                                    &data, &data_size, NULL, NULL);
-    spdm_context->local_context.local_cert_chain_provision[0] = data;
-    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-
-    response_size = sizeof(response);
-    status = libspdm_get_encap_response_certificate(
-        spdm_context, m_spdm_get_certificate_request2_size,
-        &m_spdm_get_certificate_request2, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
-    free(data);
 }
 
 /**
@@ -523,7 +487,7 @@ int libspdm_requester_encap_certificate_test_main(void)
     const struct CMUnitTest spdm_requester_encap_certificate_tests[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_requester_encap_certificate_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_requester_encap_certificate_case2),
         /* Tests varying offset*/
         cmocka_unit_test(libspdm_test_requester_encap_certificate_case4),

--- a/unit_test/test_spdm_requester/encap_challenge_auth.c
+++ b/unit_test/test_spdm_requester/encap_challenge_auth.c
@@ -122,65 +122,11 @@ void test_libspdm_requester_encap_challenge_auth_case1(void **state)
 }
 
 /**
- * Test 2: receiving a CHALLENGE message larger than specified.
- * Expected behavior: the requester refuses the CHALLENGE message and produces an
- * ERROR message indicating the InvalidRequest.
+ * Test 2:
+ * Expected behavior:
  **/
 void test_libspdm_requester_encap_challenge_auth_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_challenge_auth_response_t *spdm_response;
-    void *data;
-    size_t data_size;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->local_context.capability.flags = 0;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.measurement_spec =
-        m_libspdm_use_measurement_spec;
-    spdm_context->connection_info.algorithm.measurement_hash_algo =
-        m_libspdm_use_measurement_hash_algo;
-
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11
-                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo, &data,
-                                                    &data_size, NULL, NULL);
-    spdm_context->local_context.local_cert_chain_provision[0] = data;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size;
-
-    spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-    libspdm_reset_message_c(spdm_context);
-
-    response_size = sizeof(response);
-    libspdm_get_random_number(SPDM_NONCE_SIZE,
-                              m_spdm_challenge_request2.nonce);
-    status = libspdm_get_encap_response_challenge_auth(
-        spdm_context, m_spdm_challenge_request2_size,
-        &m_spdm_challenge_request2, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
-    free(data);
 }
 
 /**
@@ -422,7 +368,7 @@ int libspdm_requester_encap_challenge_auth_test_main(void)
     const struct CMUnitTest spdm_requester_challenge_auth_tests[] = {
         /* Success Case*/
         cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case2),
         /* connection_state Check*/
         cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case3),

--- a/unit_test/test_spdm_requester/encap_digests.c
+++ b/unit_test/test_spdm_requester/encap_digests.c
@@ -83,49 +83,11 @@ void test_spdm_requester_challenge_auth_case1(void **state)
 }
 
 /**
- * Test 2: receives a GET_DIGESTS request message with bad size from Requester
- * Expected Behavior: produces an ERROR response message with error code = InvalidRequest
+ * Test 2:
+ * Expected Behavior:
  **/
 void test_spdm_requester_challenge_auth_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_digest_response_t *spdm_response;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10
-                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->local_context.local_cert_chain_provision[0] =
-        m_local_certificate_chain;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem(m_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                    (uint8_t)(0xFF));
-
-    response_size = sizeof(response);
-    status = libspdm_get_encap_response_digest(spdm_context,
-                                               m_spdm_get_digests_request2_size,
-                                               &m_spdm_get_digests_request2,
-                                               &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
 }
 
 /**
@@ -253,7 +215,7 @@ int libspdm_requester_encap_digests_test_main(void)
     const struct CMUnitTest spdm_requester_digests_tests[] = {
         /* Success Case*/
         cmocka_unit_test(test_spdm_requester_challenge_auth_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(test_spdm_requester_challenge_auth_case2),
         /* Internal cache full (request message)*/
         cmocka_unit_test(test_spdm_requester_challenge_auth_case3),

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -105,51 +105,11 @@ void libspdm_test_responder_certificate_case1(void **state)
 }
 
 /**
- * Test 2: Wrong GET_CERTIFICATE message size (larger than expected)
- * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ * Test 2:
+ * Expected Behavior:
  **/
 void libspdm_test_responder_certificate_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_certificate_response_t *spdm_response;
-    void *data;
-    size_t data_size;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo, &data,
-                                                    &data_size, NULL, NULL);
-    spdm_context->local_context.local_cert_chain_provision[0] = data;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size;
-
-    response_size = sizeof(response);
-    status = libspdm_get_response_certificate(
-        spdm_context, m_libspdm_get_certificate_request2_size,
-        &m_libspdm_get_certificate_request2, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
-    free(data);
 }
 
 /**
@@ -1321,7 +1281,7 @@ int libspdm_responder_certificate_test_main(void)
     const struct CMUnitTest spdm_responder_certificate_tests[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_certificate_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_responder_certificate_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
         cmocka_unit_test(libspdm_test_responder_certificate_case3),

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -119,65 +119,11 @@ void libspdm_test_responder_challenge_auth_case1(void **state)
 }
 
 /**
- * Test 2: receiving a CHALLENGE message larger than specified.
- * Expected behavior: the responder refuses the CHALLENGE message and produces an
- * ERROR message indicating the InvalidRequest.
+ * Test 2:
+ * Expected behavior:
  **/
 void libspdm_test_responder_challenge_auth_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_challenge_auth_response_t *spdm_response;
-    void *data1;
-    size_t data_size1;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->local_context.capability.flags = 0;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.measurement_spec =
-        m_libspdm_use_measurement_spec;
-    spdm_context->connection_info.algorithm.measurement_hash_algo =
-        m_libspdm_use_measurement_hash_algo;
-
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
-                                                    m_libspdm_use_asym_algo, &data1,
-                                                    &data_size1, NULL, NULL);
-    spdm_context->local_context.local_cert_chain_provision[0] = data1;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-
-    spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
-    libspdm_reset_message_c(spdm_context);
-
-    response_size = sizeof(response);
-    libspdm_get_random_number(SPDM_NONCE_SIZE,
-                              m_libspdm_challenge_request2.nonce);
-    status = libspdm_get_response_challenge_auth(
-        spdm_context, m_libspdm_challenge_request2_size,
-        &m_libspdm_challenge_request2, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
-    free(data1);
 }
 
 /**
@@ -1116,7 +1062,7 @@ int libspdm_responder_challenge_auth_test_main(void)
     const struct CMUnitTest spdm_responder_challenge_auth_tests[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case3),

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -84,49 +84,11 @@ void libspdm_test_responder_digests_case1(void **state)
 }
 
 /**
- * Test 2: receives a GET_DIGESTS request message with bad size from Requester
- * Expected Behavior: produces an ERROR response message with error code = InvalidRequest
+ * Test 2:
+ * Expected Behavior:
  **/
 void libspdm_test_responder_digests_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_digest_response_t *spdm_response;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->local_context.local_cert_chain_provision[0] =
-        m_libspdm_local_certificate_chain;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem(m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                    (uint8_t)(0xFF));
-
-    response_size = sizeof(response);
-    status = libspdm_get_response_digests(spdm_context,
-                                          m_libspdm_get_digests_request2_size,
-                                          &m_libspdm_get_digests_request2,
-                                          &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
 }
 
 /**
@@ -456,7 +418,7 @@ int libspdm_responder_digests_test_main(void)
     const struct CMUnitTest spdm_responder_digests_tests[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_digests_case1),
-        /* Bad request size*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_responder_digests_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
         cmocka_unit_test(libspdm_test_responder_digests_case3),

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -175,56 +175,11 @@ void libspdm_test_responder_measurements_case1(void **state)
 }
 
 /**
- * Test 2: Error case, Bad request size (LIBSPDM_MAX_MESSAGE_BUFFER_SIZE) to get measurement number without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Test 2:
+ * Expected Behavior:
  **/
 void libspdm_test_responder_measurements_case2(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_measurements_response_t *spdm_response;
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x2;
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.measurement_spec =
-        m_libspdm_use_measurement_spec;
-    spdm_context->connection_info.algorithm.measurement_hash_algo =
-        m_libspdm_use_measurement_hash_algo;
-    libspdm_reset_message_m(spdm_context, NULL);
-    spdm_context->local_context.opaque_measurement_rsp_size = 0;
-    spdm_context->local_context.opaque_measurement_rsp = NULL;
-
-    response_size = sizeof(response);
-    libspdm_get_random_number(SPDM_NONCE_SIZE,
-                              m_libspdm_get_measurements_request2.nonce);
-    status = libspdm_get_response_measurements(
-        spdm_context, m_libspdm_get_measurements_request2_size,
-        &m_libspdm_get_measurements_request2, &response_size, response);
-    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal(spdm_response->header.request_response_code,
-                     SPDM_ERROR);
-    assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(spdm_response->header.param2, 0);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    assert_int_equal(spdm_context->transcript.message_m.buffer_size, 0);
-#endif
 }
 
 /**
@@ -829,73 +784,11 @@ void libspdm_test_responder_measurements_case12(void **state)
 }
 
 /**
- * Test 13: Error case, even though signature was not required, there is nonce and/or slotID
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Test 13:
+ * Expected Behavior:
  **/
 void libspdm_test_responder_measurements_case13(void **state)
 {
-    libspdm_return_t status;
-    libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_measurements_response_t *spdm_response;
-    uint16_t TestMsgSizes[3];
-
-    TestMsgSizes[0] =
-        (uint16_t)(m_libspdm_get_measurements_request9_size +
-                   sizeof(m_libspdm_get_measurements_request9.slot_id_param) +
-                   sizeof(m_libspdm_get_measurements_request9.nonce));
-    TestMsgSizes[1] =
-        (uint16_t)(m_libspdm_get_measurements_request9_size +
-                   sizeof(m_libspdm_get_measurements_request9.slot_id_param));
-    TestMsgSizes[2] =
-        (uint16_t)(m_libspdm_get_measurements_request9_size +
-                   sizeof(m_libspdm_get_measurements_request9.nonce));
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0xD;
-    spdm_context->connection_info.connection_state =
-        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
-    spdm_context->local_context.capability.flags = 0;
-    spdm_context->local_context.capability.flags |=
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG;
-    spdm_context->connection_info.algorithm.base_hash_algo =
-        m_libspdm_use_hash_algo;
-    spdm_context->connection_info.algorithm.base_asym_algo =
-        m_libspdm_use_asym_algo;
-    spdm_context->connection_info.algorithm.measurement_hash_algo =
-        m_libspdm_use_measurement_hash_algo;
-
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    libspdm_reset_message_m(spdm_context, NULL);
-    spdm_context->local_context.opaque_measurement_rsp_size = 0;
-    spdm_context->local_context.opaque_measurement_rsp = NULL;
-
-    libspdm_get_random_number(SPDM_NONCE_SIZE,
-                              m_libspdm_get_measurements_request9.nonce);
-    for (int i = 0; i < sizeof(TestMsgSizes) / sizeof(TestMsgSizes[0]);
-         i++) {
-        response_size = sizeof(response);
-        status = libspdm_get_response_measurements(
-            spdm_context, TestMsgSizes[i],
-            &m_libspdm_get_measurements_request9, &response_size,
-            response);
-        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-        assert_int_equal(response_size, sizeof(spdm_error_response_t));
-        spdm_response = (void *)response;
-        assert_int_equal(spdm_response->header.request_response_code,
-                         SPDM_ERROR);
-        assert_int_equal(spdm_response->header.param1,
-                         SPDM_ERROR_CODE_INVALID_REQUEST);
-        assert_int_equal(spdm_response->header.param2, 0);
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-        assert_int_equal(spdm_context->transcript.message_m.buffer_size,
-                         0);
-#endif
-    }
 }
 
 /**
@@ -1853,7 +1746,7 @@ int libspdm_responder_measurements_test_main(void)
     const struct CMUnitTest spdm_responder_measurements_tests[] = {
         /* Success Case to get measurement number without signature*/
         cmocka_unit_test(libspdm_test_responder_measurements_case1),
-        /* Bad request size to get measurement number without signature*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_responder_measurements_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
         cmocka_unit_test(libspdm_test_responder_measurements_case3),
@@ -1877,7 +1770,7 @@ int libspdm_responder_measurements_test_main(void)
         cmocka_unit_test(libspdm_test_responder_measurements_case11),
         /* Success Case to get all measurements without signature*/
         cmocka_unit_test(libspdm_test_responder_measurements_case12),
-        /* Error Case: no sig required, but there is nonce and/or slotID (special case of Test Case 2)*/
+        /* Can be populated with new test.*/
         cmocka_unit_test(libspdm_test_responder_measurements_case13),
         /* Error Case: sig required, but no nonce and/or SlotID*/
         cmocka_unit_test(libspdm_test_responder_measurements_case14),

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -1033,60 +1033,10 @@ void libspdm_test_responder_respond_if_ready_case8(void **state) {
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
 /**
- * Test 9: receiving a RESPOND_IF_READY message larger than specified (more parameters
- * than the header), after a GET_DIGESTS could not be processed.
- * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
- * ERROR message indicating the InvalidRequest.
+ * Test 9:
+ * Expected behavior:
  **/
 void libspdm_test_responder_respond_if_ready_case9(void **state) {
-    libspdm_return_t status;
-    libspdm_test_context_t    *spdm_test_context;
-    libspdm_context_t  *spdm_context;
-    size_t response_size;
-    uint8_t response[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
-    spdm_digest_response_t *spdm_response; /*response to the original request (DIGESTS)*/
-
-    spdm_test_context = *state;
-    spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x9;
-    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
-
-    /*state for the the original request (GET_DIGESTS)*/
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
-    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
-    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
-    spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
-    spdm_context->local_context.local_cert_chain_provision_size[0] =
-        LIBSPDM_MAX_MESSAGE_BUFFER_SIZE;
-    libspdm_set_mem (m_libspdm_local_certificate_chain, LIBSPDM_MAX_MESSAGE_BUFFER_SIZE,
-                     (uint8_t)(0xFF));
-
-    spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
-                     &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
-
-    /*RESPOND_IF_READY specific data*/
-    spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
-                     spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
-    spdm_context->error_data.rd_exponent = 1;
-    spdm_context->error_data.rd_tm        = 1;
-    spdm_context->error_data.request_code = SPDM_GET_DIGESTS;
-    spdm_context->error_data.token       = LIBSPDM_MY_TEST_TOKEN;
-
-    /*check ERROR response*/
-    response_size = sizeof(response);
-    status = libspdm_get_response_respond_if_ready(spdm_context,
-                                                   m_libspdm_respond_if_ready_request9_size,
-                                                   &m_libspdm_respond_if_ready_request9,
-                                                   &response_size,
-                                                   response);
-    assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal (response_size, sizeof(spdm_error_response_t));
-    spdm_response = (void *)response;
-    assert_int_equal (spdm_response->header.request_response_code, SPDM_ERROR);
-    assert_int_equal (spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal (spdm_response->header.param2, 0);
 }
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/


### PR DESCRIPTION
This pull request change the strict message size check to that
message size won't be less that the minimum expected size
so that message with transport layer padding can be properly handled.

For example, PCI-DOE requires 4 bytes alignment and may have at most
3 bytes padding data.

Messages can only be in secure session remains the strict size check
since no transport layer padding is involved in such case.

Fix: #1183
Fix: #1422
Fix: #1526
Related to: #1512

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>