### PR TITLE
spdm_responder_lib: add code name to response dump

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -409,6 +409,15 @@ typedef struct {
                                   LIBSPDM_SECURED_MESSAGE_CONTEXT_SIZE * LIBSPDM_MAX_SESSION_COUNT)
 
 #if LIBSPDM_DEBUG_PRINT_ENABLE
+/**
+ * Return the request code name based on given request code.
+ *
+ * @param  request_code                  The SPDM request code.
+ *
+ * @return request code name according to the request code.
+ **/
+const char *libspdm_get_code_str(uint8_t request_code);
+
 #ifdef LIBSPDM_INTERNAL_DUMP_HEX_STR_OVERRIDE
 extern void LIBSPDM_INTERNAL_DUMP_HEX_STR_OVERRIDE(const uint8_t *data, size_t size);
 #define LIBSPDM_INTERNAL_DUMP_HEX_STR(data, size) LIBSPDM_INTERNAL_DUMP_HEX_STR_OVERRIDE(data, size)

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -7,6 +7,79 @@
 #include "internal/libspdm_common_lib.h"
 
 #if LIBSPDM_DEBUG_PRINT_ENABLE
+typedef struct {
+    uint8_t code;
+    const char *code_str;
+} libspdm_code_str_struct_t;
+
+const char *libspdm_get_code_str(uint8_t request_code)
+{
+    size_t index;
+
+    static libspdm_code_str_struct_t code_str_struct[] = {
+        /* SPDM response code (1.0) */
+        { SPDM_DIGESTS, "SPDM_DIGESTS" },
+        { SPDM_CERTIFICATE, "SPDM_CERTIFICATE" },
+        { SPDM_CHALLENGE_AUTH, "SPDM_CHALLENGE_AUTH" },
+        { SPDM_VERSION, "SPDM_VERSION" },
+        { SPDM_MEASUREMENTS, "SPDM_MEASUREMENTS" },
+        { SPDM_CAPABILITIES, "SPDM_CAPABILITIES" },
+        { SPDM_ALGORITHMS, "SPDM_ALGORITHMS" },
+        { SPDM_VENDOR_DEFINED_RESPONSE, "SPDM_VENDOR_DEFINED_RESPONSE" },
+        { SPDM_ERROR, "SPDM_ERROR" },
+        /* SPDM response code (1.1) */
+        { SPDM_KEY_EXCHANGE_RSP, "SPDM_KEY_EXCHANGE_RSP" },
+        { SPDM_FINISH_RSP, "SPDM_FINISH_RSP" },
+        { SPDM_PSK_EXCHANGE_RSP, "SPDM_PSK_EXCHANGE_RSP" },
+        { SPDM_PSK_FINISH_RSP, "SPDM_PSK_FINISH_RSP" },
+        { SPDM_HEARTBEAT_ACK, "SPDM_HEARTBEAT_ACK" },
+        { SPDM_KEY_UPDATE_ACK, "SPDM_KEY_UPDATE_ACK" },
+        { SPDM_ENCAPSULATED_REQUEST, "SPDM_ENCAPSULATED_REQUEST" },
+        { SPDM_ENCAPSULATED_RESPONSE_ACK, "SPDM_ENCAPSULATED_RESPONSE_ACK" },
+        { SPDM_END_SESSION_ACK, "SPDM_END_SESSION_ACK" },
+        /* SPDM response code (1.2) */
+        { SPDM_CSR, "SPDM_CSR" },
+        { SPDM_SET_CERTIFICATE_RSP, "SPDM_SET_CERTIFICATE_RSP" },
+        { SPDM_CHUNK_SEND_ACK, "SPDM_CHUNK_SEND_ACK" },
+        { SPDM_CHUNK_RESPONSE, "SPDM_CHUNK_RESPONSE" },
+        /* SPDM request code (1.0) */
+        { SPDM_GET_DIGESTS, "SPDM_GET_DIGESTS" },
+        { SPDM_GET_CERTIFICATE, "SPDM_GET_CERTIFICATE" },
+        { SPDM_CHALLENGE, "SPDM_CHALLENGE" },
+        { SPDM_GET_VERSION, "SPDM_GET_VERSION" },
+        { SPDM_GET_MEASUREMENTS, "SPDM_GET_MEASUREMENTS" },
+        { SPDM_GET_CAPABILITIES, "SPDM_GET_CAPABILITIES" },
+        { SPDM_NEGOTIATE_ALGORITHMS, "SPDM_NEGOTIATE_ALGORITHMS" },
+        { SPDM_VENDOR_DEFINED_REQUEST, "SPDM_VENDOR_DEFINED_REQUEST" },
+        { SPDM_RESPOND_IF_READY, "SPDM_RESPOND_IF_READY" },
+        /* SPDM request code (1.1) */
+        { SPDM_KEY_EXCHANGE, "SPDM_KEY_EXCHANGE" },
+        { SPDM_FINISH, "SPDM_FINISH" },
+        { SPDM_PSK_EXCHANGE, "SPDM_PSK_EXCHANGE" },
+        { SPDM_PSK_FINISH, "SPDM_PSK_FINISH" },
+        { SPDM_HEARTBEAT, "SPDM_HEARTBEAT" },
+        { SPDM_KEY_UPDATE, "SPDM_KEY_UPDATE" },
+        { SPDM_GET_ENCAPSULATED_REQUEST, "SPDM_GET_ENCAPSULATED_REQUEST" },
+        { SPDM_DELIVER_ENCAPSULATED_RESPONSE, "SPDM_DELIVER_ENCAPSULATED_RESPONSE" },
+        { SPDM_END_SESSION, "SPDM_END_SESSION" },
+        /* SPDM request code (1.2) */
+        { SPDM_GET_CSR, "SPDM_GET_CSR" },
+        { SPDM_SET_CERTIFICATE, "SPDM_SET_CERTIFICATE" },
+        { SPDM_CHUNK_SEND, "SPDM_CHUNK_SEND" },
+        { SPDM_CHUNK_GET, "SPDM_CHUNK_GET" }
+    };
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(code_str_struct); index++) {
+        if (request_code == code_str_struct[index].code) {
+            return code_str_struct[index].code_str;
+        }
+    }
+
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "msg code 0x%x not found!!!\n", request_code));
+
+    return "<unknown>";
+}
+
 void libspdm_internal_dump_hex_str(const uint8_t *data, size_t size)
 {
     size_t index;

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -23,8 +23,13 @@ libspdm_return_t libspdm_send_request(void *spdm_context, const uint32_t *sessio
 
     context = spdm_context;
 
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "libspdm_send_spdm_request[%x] (0x%x): \n",
-                   (session_id != NULL) ? *session_id : 0x0, request_size));
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                   "libspdm_send_spdm_request[%x] msg %s(0x%x), size (0x%x): \n",
+                   (session_id != NULL) ? *session_id : 0x0,
+                   libspdm_get_code_str(((spdm_message_header_t *)request)->
+                                        request_response_code),
+                   ((spdm_message_header_t *)request)->request_response_code,
+                   request_size));
     LIBSPDM_INTERNAL_DUMP_HEX(request, request_size);
 
     transport_header_size = context->transport_get_header_size(context);
@@ -237,13 +242,18 @@ libspdm_return_t libspdm_receive_response(void *spdm_context, const uint32_t *se
         goto error;
     }
 
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "libspdm_receive_spdm_response[%x] (0x%x): \n",
-                   (session_id != NULL) ? *session_id : 0x0, *response_size));
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
                        "libspdm_receive_spdm_response[%x] status - %p\n",
                        (session_id != NULL) ? *session_id : 0x0, status));
     } else {
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                       "libspdm_receive_spdm_response[%x] msg %s(0x%x), size (0x%x): \n",
+                       (session_id != NULL) ? *session_id : 0x0,
+                       libspdm_get_code_str(((spdm_message_header_t *)*response)->
+                                            request_response_code),
+                       ((spdm_message_header_t *)*response)->request_response_code,
+                       *response_size));
         LIBSPDM_INTERNAL_DUMP_HEX(*response, *response_size);
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -282,8 +282,11 @@ libspdm_return_t libspdm_process_request(void *spdm_context, uint32_t **session_
         context->last_spdm_request_session_id_valid = true;
     }
 
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmReceiveRequest[%x] (0x%x): \n",
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmReceiveRequest[%x] msg %s(0x%x), size (0x%x): \n",
                    (message_session_id != NULL) ? *message_session_id : 0,
+                   libspdm_get_code_str(((spdm_message_header_t *)context->last_spdm_request)->
+                                        request_response_code),
+                   ((spdm_message_header_t *)context->last_spdm_request)->request_response_code,
                    context->last_spdm_request_size));
     LIBSPDM_INTERNAL_DUMP_HEX((uint8_t *)context->last_spdm_request,
                               context->last_spdm_request_size);
@@ -453,6 +456,8 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
     }
     libspdm_zero_mem(my_response, my_response_size);
 
+    spdm_response = (void *)my_response;
+
     if (context->last_spdm_error.error_code != 0) {
 
         /* Error in libspdm_process_request(), and we need send error message directly.*/
@@ -492,8 +497,11 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
             return status;
         }
 
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmSendResponse[%x] (0x%x): \n",
-                       (session_id != NULL) ? *session_id : 0, my_response_size));
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmSendResponse[%x]: msg %s(0x%x), size (0x%x): \n",
+                       (session_id != NULL) ? *session_id : 0,
+                       libspdm_get_code_str(spdm_response->request_response_code),
+                       spdm_response->request_response_code,
+                       my_response_size));
         LIBSPDM_INTERNAL_DUMP_HEX(my_response, my_response_size);
 
         status = context->transport_encode_message(
@@ -683,8 +691,11 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
         }
     }
 
-    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmSendResponse[%x] (0x%x): \n",
-                   (session_id != NULL) ? *session_id : 0, my_response_size));
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "SpdmSendResponse[%x]: msg %s(0x%x), size (0x%x): \n",
+                   (session_id != NULL) ? *session_id : 0,
+                   libspdm_get_code_str(spdm_response->request_response_code),
+                   spdm_response->request_response_code,
+                   my_response_size));
     LIBSPDM_INTERNAL_DUMP_HEX(my_response, my_response_size);
 
     status = context->transport_encode_message(
@@ -695,7 +706,6 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
         return status;
     }
 
-    spdm_response = (void *)my_response;
     request_response_code = spdm_response->request_response_code;
     #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
     switch (request_response_code) {


### PR DESCRIPTION
This patch extend the request (and response) msg with command name.
check reference below using spdm-emu

Before:
SpdmReceiveRequest[.] ...
SpdmReceiveRequest[0] (0x14):
0000: 12 e1 00 00 00 00 00 00 c6 f7 02 00 00 12 00 00 00 12 00 00
SpdmSendResponse[0] ...
SpdmSendResponse[0] (0x14):
0000: 12 61 00 00 00 00 00 00 f7 fb 1a 00 00 12 00 00 00 12 00 00

After:
SpdmReceiveRequest[.] ...
SpdmReceiveRequest[0] **msg SPDM_GET_CAPABILITIES(0xe1)**, size (0x14):
0000: 12 e1 00 00 00 00 00 00 c6 f7 02 00 00 12 00 00 00 12 00 00
SpdmSendResponse[0] ...
SpdmSendResponse[0]: **msg SPDM_CAPABILITIES(0x61)**, size (0x14):
0000: 12 61 00 00 00 00 00 00 f7 fb 1a 00 00 12 00 00 00 12 00 00