### PR TITLE
Move secured message functions

### DIFF
--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -76,4 +76,373 @@ typedef struct {
 
 #define LIBSPDM_SECURED_MESSAGE_CONTEXT_SIZE (sizeof(libspdm_secured_message_context_t))
 
+/**
+ * Initialize an SPDM secured message context.
+ *
+ * The size in bytes of the spdm_secured_message_context can be returned by libspdm_secured_message_get_context_size.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ */
+void libspdm_secured_message_init_context(void *spdm_secured_message_context);
+
+/**
+ * Set use_psk to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  use_psk                       Indicate if the SPDM session use PSK.
+ */
+void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context, bool use_psk);
+
+/**
+ * Set session_state to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  session_state                 Indicate the SPDM session state.
+ */
+void libspdm_secured_message_set_session_state(
+    void *spdm_secured_message_context,
+    libspdm_session_state_t session_state);
+
+/**
+ * Set session_type to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  session_type                  Indicate the SPDM session type.
+ */
+void libspdm_secured_message_set_session_type(void *spdm_secured_message_context,
+                                              libspdm_session_type_t session_type);
+
+/**
+ * Set algorithm to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  base_hash_algo                 Indicate the negotiated base_hash_algo for the SPDM session.
+ * @param  dhe_named_group                Indicate the negotiated dhe_named_group for the SPDM session.
+ * @param  aead_cipher_suite              Indicate the negotiated aead_cipher_suite for the SPDM session.
+ * @param  key_schedule                  Indicate the negotiated key_schedule for the SPDM session.
+ */
+void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
+                                            const spdm_version_number_t version,
+                                            const spdm_version_number_t secured_message_version,
+                                            uint32_t base_hash_algo,
+                                            uint16_t dhe_named_group,
+                                            uint16_t aead_cipher_suite,
+                                            uint16_t key_schedule);
+
+/**
+ * Set the psk_hint to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  psk_hint                      Indicate the PSK hint.
+ * @param  psk_hint_size                  The size in bytes of the PSK hint.
+ */
+void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
+                                          const void *psk_hint,
+                                          size_t psk_hint_size);
+
+/**
+ * Allocates and Initializes one Diffie-Hellman Ephemeral (DHE) context for subsequent use,
+ * based upon negotiated DHE algorithm.
+ *
+ * @param  dhe_named_group                SPDM dhe_named_group
+ * @param  is_initiator                   if the caller is initiator.
+ *                                       true: initiator
+ *                                       false: not an initiator
+ *
+ * @return  Pointer to the Diffie-Hellman context that has been initialized.
+ **/
+void *libspdm_secured_message_dhe_new(spdm_version_number_t spdm_version,
+                                      uint16_t dhe_named_group, bool is_initiator);
+
+/**
+ * Release the specified DHE context,
+ * based upon negotiated DHE algorithm.
+ *
+ * @param  dhe_named_group                SPDM dhe_named_group
+ * @param  dhe_context                   Pointer to the DHE context to be released.
+ **/
+void libspdm_secured_message_dhe_free(uint16_t dhe_named_group, void *dhe_context);
+
+/**
+ * Generates DHE public key,
+ * based upon negotiated DHE algorithm.
+ *
+ * This function generates random secret exponent, and computes the public key, which is
+ * returned via parameter public_key and public_key_size. DH context is updated accordingly.
+ * If the public_key buffer is too small to hold the public key, false is returned and
+ * public_key_size is set to the required buffer size to obtain the public key.
+ *
+ * @param  dhe_named_group                SPDM dhe_named_group
+ * @param  dhe_context                   Pointer to the DHE context.
+ * @param  public_key                    Pointer to the buffer to receive generated public key.
+ * @param  public_key_size                On input, the size of public_key buffer in bytes.
+ *                                     On output, the size of data returned in public_key buffer in bytes.
+ *
+ * @retval true   DHE public key generation succeeded.
+ * @retval false  DHE public key generation failed.
+ * @retval false  public_key_size is not large enough.
+ **/
+bool libspdm_secured_message_dhe_generate_key(uint16_t dhe_named_group,
+                                              void *dhe_context,
+                                              uint8_t *public_key,
+                                              size_t *public_key_size);
+
+/**
+ * Computes exchanged common key,
+ * based upon negotiated DHE algorithm.
+ *
+ * Given peer's public key, this function computes the exchanged common key, based on its own
+ * context including value of prime modulus and random secret exponent.
+ *
+ * @param  dhe_named_group                SPDM dhe_named_group
+ * @param  dhe_context                   Pointer to the DHE context.
+ * @param  peer_public_key                Pointer to the peer's public key.
+ * @param  peer_public_key_size            size of peer's public key in bytes.
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ *
+ * @retval true   DHE exchanged key generation succeeded.
+ * @retval false  DHE exchanged key generation failed.
+ * @retval false  key_size is not large enough.
+ **/
+bool libspdm_secured_message_dhe_compute_key(
+    uint16_t dhe_named_group, void *dhe_context,
+    const uint8_t *peer_public, size_t peer_public_size,
+    void *spdm_secured_message_context);
+
+/**
+ * Allocates and initializes one HMAC context for subsequent use, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ *
+ * @return Pointer to the HMAC context that has been initialized.
+ **/
+void *libspdm_hmac_new_with_request_finished_key(void *spdm_secured_message_context);
+
+/**
+ * Release the specified HMAC context, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx                   Pointer to the HMAC context to be released.
+ **/
+void libspdm_hmac_free_with_request_finished_key(
+    void *spdm_secured_message_context, void *hmac_ctx);
+
+/**
+ * Set request_finished_key for subsequent use. It must be done before any
+ * calling to hmac_update().
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx  Pointer to HMAC context.
+ *
+ * @retval true   The key is set successfully.
+ * @retval false  The key is set unsuccessfully.
+ **/
+bool libspdm_hmac_init_with_request_finished_key(
+    void *spdm_secured_message_context, void *hmac_ctx);
+
+/**
+ * Makes a copy of an existing HMAC context, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  new_hmac_ctx  Pointer to new HMAC context.
+ *
+ * @retval true   HMAC context copy succeeded.
+ * @retval false  HMAC context copy failed.
+ **/
+bool libspdm_hmac_duplicate_with_request_finished_key(
+    void *spdm_secured_message_context,
+    const void *hmac_ctx, void *new_hmac_ctx);
+
+/**
+ * Digests the input data and updates HMAC context, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  data              Pointer to the buffer containing the data to be digested.
+ * @param  data_size          size of data buffer in bytes.
+ *
+ * @retval true   HMAC data digest succeeded.
+ * @retval false  HMAC data digest failed.
+ **/
+bool libspdm_hmac_update_with_request_finished_key(
+    void *spdm_secured_message_context,
+    void *hmac_ctx, const void *data,
+    size_t data_size);
+
+/**
+ * Completes computation of the HMAC digest value, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+ *
+ * @retval true   HMAC data digest succeeded.
+ * @retval false  HMAC data digest failed.
+ **/
+bool libspdm_hmac_final_with_request_finished_key(
+    void *spdm_secured_message_context,
+    void *hmac_ctx,  uint8_t *hmac_value);
+
+/**
+ * Computes the HMAC of a input data buffer, with request_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  data                         Pointer to the buffer containing the data to be HMACed.
+ * @param  data_size                     size of data buffer in bytes.
+ * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
+ *
+ * @retval true   HMAC computation succeeded.
+ * @retval false  HMAC computation failed.
+ **/
+bool libspdm_hmac_all_with_request_finished_key(void *spdm_secured_message_context,
+                                                const void *data, size_t data_size,
+                                                uint8_t *hmac_value);
+
+/**
+ * Allocates and initializes one HMAC context for subsequent use, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ *
+ * @return Pointer to the HMAC context that has been initialized.
+ **/
+void *libspdm_hmac_new_with_response_finished_key(void *spdm_secured_message_context);
+
+/**
+ * Release the specified HMAC context, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx                   Pointer to the HMAC context to be released.
+ **/
+void libspdm_hmac_free_with_response_finished_key(
+    void *spdm_secured_message_context, void *hmac_ctx);
+
+/**
+ * Set response_finished_key for subsequent use. It must be done before any
+ * calling to hmac_update().
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx  Pointer to HMAC context.
+ *
+ * @retval true   The key is set successfully.
+ * @retval false  The key is set unsuccessfully.
+ **/
+bool libspdm_hmac_init_with_response_finished_key(
+    void *spdm_secured_message_context, void *hmac_ctx);
+
+/**
+ * Makes a copy of an existing HMAC context, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  new_hmac_ctx  Pointer to new HMAC context.
+ *
+ * @retval true   HMAC context copy succeeded.
+ * @retval false  HMAC context copy failed.
+ **/
+bool libspdm_hmac_duplicate_with_response_finished_key(
+    void *spdm_secured_message_context,
+    const void *hmac_ctx, void *new_hmac_ctx);
+
+/**
+ * Digests the input data and updates HMAC context, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  data              Pointer to the buffer containing the data to be digested.
+ * @param  data_size          size of data buffer in bytes.
+ *
+ * @retval true   HMAC data digest succeeded.
+ * @retval false  HMAC data digest failed.
+ **/
+bool libspdm_hmac_update_with_response_finished_key(
+    void *spdm_secured_message_context,
+    void *hmac_ctx, const void *data,
+    size_t data_size);
+
+/**
+ * Completes computation of the HMAC digest value, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  hmac_ctx     Pointer to HMAC context being copied.
+ * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
+ *
+ * @retval true   HMAC data digest succeeded.
+ * @retval false  HMAC data digest failed.
+ **/
+bool libspdm_hmac_final_with_response_finished_key(
+    void *spdm_secured_message_context,
+    void *hmac_ctx,  uint8_t *hmac_value);
+
+/**
+ * Computes the HMAC of a input data buffer, with response_finished_key.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  data                         Pointer to the buffer containing the data to be HMACed.
+ * @param  data_size                     size of data buffer in bytes.
+ * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
+ *
+ * @retval true   HMAC computation succeeded.
+ * @retval false  HMAC computation failed.
+ **/
+bool libspdm_hmac_all_with_response_finished_key(
+    void *spdm_secured_message_context, const void *data,
+    size_t data_size, uint8_t *hmac_value);
+
+/**
+ * Set the last SPDM error struct of an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  last_spdm_error                Last SPDM error struct of an SPDM secured message context.
+ */
+void libspdm_secured_message_set_last_spdm_error_struct(
+    void *spdm_secured_message_context,
+    const libspdm_error_struct_t *last_spdm_error);
+
+/**
+ * This function generates SPDM HandshakeKey for a session.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  th1_hash_data                  th1 hash
+ *
+ * @retval RETURN_SUCCESS  SPDM HandshakeKey for a session is generated.
+ **/
+bool libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
+                                            const uint8_t *th1_hash_data);
+
+/**
+ * This function generates SPDM DataKey for a session.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  th2_hash_data                  th2 hash
+ *
+ * @retval RETURN_SUCCESS  SPDM DataKey for a session is generated.
+ **/
+bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
+                                       const uint8_t *th2_hash_data);
+
+/**
+ * This function creates the updates of SPDM DataKey for a session.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  action                       Indicate of the key update action.
+ *
+ * @retval RETURN_SUCCESS  SPDM DataKey update is created.
+ **/
+bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
+                                            libspdm_key_update_action_t action);
+
+/**
+ * This function activates the update of SPDM DataKey for a session.
+ *
+ * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  action                       Indicate of the key update action.
+ * @param  use_new_key                    Indicate if the new key should be used.
+ *
+ * @retval RETURN_SUCCESS  SPDM DataKey update is activated.
+ **/
+bool libspdm_activate_update_session_data_key(void *spdm_secured_message_context,
+                                              libspdm_key_update_action_t action,
+                                              bool use_new_key);
+
 #endif /* SPDM_SECURED_MESSAGE_LIB_INTERNAL_H */

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -8,6 +8,7 @@
 #define SPDM_RESPONDER_LIB_H
 
 #include "library/spdm_common_lib.h"
+#include "library/spdm_secured_message_lib.h"
 
 /**
  * Process the SPDM or APP request and return the response.

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -40,32 +40,7 @@ typedef enum {
  **/
 size_t libspdm_secured_message_get_context_size(void);
 
-/**
- * Initialize an SPDM secured message context.
- *
- * The size in bytes of the spdm_secured_message_context can be returned by libspdm_secured_message_get_context_size.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- */
-void libspdm_secured_message_init_context(void *spdm_secured_message_context);
 
-/**
- * Set use_psk to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  use_psk                       Indicate if the SPDM session use PSK.
- */
-void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context, bool use_psk);
-
-/**
- * Set session_state to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  session_state                 Indicate the SPDM session state.
- */
-void libspdm_secured_message_set_session_state(
-    void *spdm_secured_message_context,
-    libspdm_session_state_t session_state);
 
 /**
  * Return session_state of an SPDM secured message context.
@@ -77,42 +52,7 @@ void libspdm_secured_message_set_session_state(
 libspdm_session_state_t
 libspdm_secured_message_get_session_state(void *spdm_secured_message_context);
 
-/**
- * Set session_type to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  session_type                  Indicate the SPDM session type.
- */
-void libspdm_secured_message_set_session_type(void *spdm_secured_message_context,
-                                              libspdm_session_type_t session_type);
 
-/**
- * Set algorithm to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  base_hash_algo                 Indicate the negotiated base_hash_algo for the SPDM session.
- * @param  dhe_named_group                Indicate the negotiated dhe_named_group for the SPDM session.
- * @param  aead_cipher_suite              Indicate the negotiated aead_cipher_suite for the SPDM session.
- * @param  key_schedule                  Indicate the negotiated key_schedule for the SPDM session.
- */
-void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
-                                            const spdm_version_number_t version,
-                                            const spdm_version_number_t secured_message_version,
-                                            uint32_t base_hash_algo,
-                                            uint16_t dhe_named_group,
-                                            uint16_t aead_cipher_suite,
-                                            uint16_t key_schedule);
-
-/**
- * Set the psk_hint to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  psk_hint                      Indicate the PSK hint.
- * @param  psk_hint_size                  The size in bytes of the PSK hint.
- */
-void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
-                                          const void *psk_hint,
-                                          size_t psk_hint_size);
 
 /**
  * Import the DHE Secret to an SPDM secured message context.
@@ -195,74 +135,7 @@ bool libspdm_secured_message_import_session_keys(void *spdm_secured_message_cont
                                                  const void *session_keys,
                                                  size_t session_keys_size);
 
-/**
- * Allocates and Initializes one Diffie-Hellman Ephemeral (DHE) context for subsequent use,
- * based upon negotiated DHE algorithm.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  is_initiator                   if the caller is initiator.
- *                                       true: initiator
- *                                       false: not an initiator
- *
- * @return  Pointer to the Diffie-Hellman context that has been initialized.
- **/
-void *libspdm_secured_message_dhe_new(spdm_version_number_t spdm_version,
-                                      uint16_t dhe_named_group, bool is_initiator);
 
-/**
- * Release the specified DHE context,
- * based upon negotiated DHE algorithm.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context to be released.
- **/
-void libspdm_secured_message_dhe_free(uint16_t dhe_named_group, void *dhe_context);
-
-/**
- * Generates DHE public key,
- * based upon negotiated DHE algorithm.
- *
- * This function generates random secret exponent, and computes the public key, which is
- * returned via parameter public_key and public_key_size. DH context is updated accordingly.
- * If the public_key buffer is too small to hold the public key, false is returned and
- * public_key_size is set to the required buffer size to obtain the public key.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context.
- * @param  public_key                    Pointer to the buffer to receive generated public key.
- * @param  public_key_size                On input, the size of public_key buffer in bytes.
- *                                     On output, the size of data returned in public_key buffer in bytes.
- *
- * @retval true   DHE public key generation succeeded.
- * @retval false  DHE public key generation failed.
- * @retval false  public_key_size is not large enough.
- **/
-bool libspdm_secured_message_dhe_generate_key(uint16_t dhe_named_group,
-                                              void *dhe_context,
-                                              uint8_t *public_key,
-                                              size_t *public_key_size);
-
-/**
- * Computes exchanged common key,
- * based upon negotiated DHE algorithm.
- *
- * Given peer's public key, this function computes the exchanged common key, based on its own
- * context including value of prime modulus and random secret exponent.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context.
- * @param  peer_public_key                Pointer to the peer's public key.
- * @param  peer_public_key_size            size of peer's public key in bytes.
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true   DHE exchanged key generation succeeded.
- * @retval false  DHE exchanged key generation failed.
- * @retval false  key_size is not large enough.
- **/
-bool libspdm_secured_message_dhe_compute_key(
-    uint16_t dhe_named_group, void *dhe_context,
-    const uint8_t *peer_public, size_t peer_public_size,
-    void *spdm_secured_message_context);
 
 /**
  * This function is used to clear handshake secret.
@@ -277,186 +150,6 @@ void libspdm_clear_handshake_secret(void *spdm_secured_message_context);
  * @param spdm_secured_message_context  A pointer to the SPDM secured message context.
  **/
 void libspdm_clear_master_secret(void *spdm_secured_message_context);
-
-/**
- * Allocates and initializes one HMAC context for subsequent use, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @return Pointer to the HMAC context that has been initialized.
- **/
-void *libspdm_hmac_new_with_request_finished_key(void *spdm_secured_message_context);
-
-/**
- * Release the specified HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx                   Pointer to the HMAC context to be released.
- **/
-void libspdm_hmac_free_with_request_finished_key(
-    void *spdm_secured_message_context, void *hmac_ctx);
-
-/**
- * Set request_finished_key for subsequent use. It must be done before any
- * calling to hmac_update().
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx  Pointer to HMAC context.
- *
- * @retval true   The key is set successfully.
- * @retval false  The key is set unsuccessfully.
- **/
-bool libspdm_hmac_init_with_request_finished_key(
-    void *spdm_secured_message_context, void *hmac_ctx);
-
-/**
- * Makes a copy of an existing HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  new_hmac_ctx  Pointer to new HMAC context.
- *
- * @retval true   HMAC context copy succeeded.
- * @retval false  HMAC context copy failed.
- **/
-bool libspdm_hmac_duplicate_with_request_finished_key(
-    void *spdm_secured_message_context,
-    const void *hmac_ctx, void *new_hmac_ctx);
-
-/**
- * Digests the input data and updates HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  data              Pointer to the buffer containing the data to be digested.
- * @param  data_size          size of data buffer in bytes.
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
-bool libspdm_hmac_update_with_request_finished_key(
-    void *spdm_secured_message_context,
-    void *hmac_ctx, const void *data,
-    size_t data_size);
-
-/**
- * Completes computation of the HMAC digest value, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
-bool libspdm_hmac_final_with_request_finished_key(
-    void *spdm_secured_message_context,
-    void *hmac_ctx,  uint8_t *hmac_value);
-
-/**
- * Computes the HMAC of a input data buffer, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  data                         Pointer to the buffer containing the data to be HMACed.
- * @param  data_size                     size of data buffer in bytes.
- * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
- *
- * @retval true   HMAC computation succeeded.
- * @retval false  HMAC computation failed.
- **/
-bool libspdm_hmac_all_with_request_finished_key(void *spdm_secured_message_context,
-                                                const void *data, size_t data_size,
-                                                uint8_t *hmac_value);
-
-/**
- * Allocates and initializes one HMAC context for subsequent use, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @return Pointer to the HMAC context that has been initialized.
- **/
-void *libspdm_hmac_new_with_response_finished_key(void *spdm_secured_message_context);
-
-/**
- * Release the specified HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx                   Pointer to the HMAC context to be released.
- **/
-void libspdm_hmac_free_with_response_finished_key(
-    void *spdm_secured_message_context, void *hmac_ctx);
-
-/**
- * Set response_finished_key for subsequent use. It must be done before any
- * calling to hmac_update().
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx  Pointer to HMAC context.
- *
- * @retval true   The key is set successfully.
- * @retval false  The key is set unsuccessfully.
- **/
-bool libspdm_hmac_init_with_response_finished_key(
-    void *spdm_secured_message_context, void *hmac_ctx);
-
-/**
- * Makes a copy of an existing HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  new_hmac_ctx  Pointer to new HMAC context.
- *
- * @retval true   HMAC context copy succeeded.
- * @retval false  HMAC context copy failed.
- **/
-bool libspdm_hmac_duplicate_with_response_finished_key(
-    void *spdm_secured_message_context,
-    const void *hmac_ctx, void *new_hmac_ctx);
-
-/**
- * Digests the input data and updates HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  data              Pointer to the buffer containing the data to be digested.
- * @param  data_size          size of data buffer in bytes.
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
-bool libspdm_hmac_update_with_response_finished_key(
-    void *spdm_secured_message_context,
-    void *hmac_ctx, const void *data,
-    size_t data_size);
-
-/**
- * Completes computation of the HMAC digest value, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
-bool libspdm_hmac_final_with_response_finished_key(
-    void *spdm_secured_message_context,
-    void *hmac_ctx,  uint8_t *hmac_value);
-
-/**
- * Computes the HMAC of a input data buffer, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  data                         Pointer to the buffer containing the data to be HMACed.
- * @param  data_size                     size of data buffer in bytes.
- * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
- *
- * @retval true   HMAC computation succeeded.
- * @retval false  HMAC computation failed.
- **/
-bool libspdm_hmac_all_with_response_finished_key(
-    void *spdm_secured_message_context, const void *data,
-    size_t data_size, uint8_t *hmac_value);
 
 /**
  * This function concatenates binary data, which is used as info in HKDF expand later.
@@ -475,28 +168,6 @@ void libspdm_bin_concat(spdm_version_number_t spdm_version,
                         size_t hash_size, uint8_t *out_bin,
                         size_t *out_bin_size);
 
-/**
- * This function generates SPDM HandshakeKey for a session.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  th1_hash_data                  th1 hash
- *
- * @retval RETURN_SUCCESS  SPDM HandshakeKey for a session is generated.
- **/
-bool libspdm_generate_session_handshake_key(void *spdm_secured_message_context,
-                                            const uint8_t *th1_hash_data);
-
-/**
- * This function generates SPDM DataKey for a session.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  th2_hash_data                  th2 hash
- *
- * @retval RETURN_SUCCESS  SPDM DataKey for a session is generated.
- **/
-bool libspdm_generate_session_data_key(void *spdm_secured_message_context,
-                                       const uint8_t *th2_hash_data);
-
 typedef enum {
     LIBSPDM_KEY_UPDATE_OPERATION_CREATE_UPDATE,
     LIBSPDM_KEY_UPDATE_OPERATION_COMMIT_UPDATE,
@@ -509,30 +180,6 @@ typedef enum {
     LIBSPDM_KEY_UPDATE_ACTION_RESPONDER,
     LIBSPDM_KEY_UPDATE_ACTION_MAX
 } libspdm_key_update_action_t;
-
-/**
- * This function creates the updates of SPDM DataKey for a session.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  action                       Indicate of the key update action.
- *
- * @retval RETURN_SUCCESS  SPDM DataKey update is created.
- **/
-bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
-                                            libspdm_key_update_action_t action);
-
-/**
- * This function activates the update of SPDM DataKey for a session.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  action                       Indicate of the key update action.
- * @param  use_new_key                    Indicate if the new key should be used.
- *
- * @retval RETURN_SUCCESS  SPDM DataKey update is activated.
- **/
-bool libspdm_activate_update_session_data_key(void *spdm_secured_message_context,
-                                              libspdm_key_update_action_t action,
-                                              bool use_new_key);
 
 /**
  * Get sequence number in an SPDM secure message.
@@ -636,15 +283,5 @@ libspdm_return_t libspdm_decode_secured_message(
 void libspdm_secured_message_get_last_spdm_error_struct(
     void *spdm_secured_message_context,
     libspdm_error_struct_t *last_spdm_error);
-
-/**
- * Set the last SPDM error struct of an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  last_spdm_error                Last SPDM error struct of an SPDM secured message context.
- */
-void libspdm_secured_message_set_last_spdm_error_struct(
-    void *spdm_secured_message_context,
-    const libspdm_error_struct_t *last_spdm_error);
 
 #endif /* SPDM_SECURED_MESSAGE_LIB_H */

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -4,7 +4,7 @@
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
-#include "internal/libspdm_common_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 /**
  * This function initializes the session info.

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -4,7 +4,7 @@
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
-#include "internal/libspdm_common_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
 /*

--- a/library/spdm_requester_lib/libspdm_req_encap_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_key_update.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
 

--- a/library/spdm_requester_lib/libspdm_req_end_session.c
+++ b/library/spdm_requester_lib/libspdm_req_end_session.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if (LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP) || (LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP)
 

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/library/spdm_requester_lib/libspdm_req_key_update.c
+++ b/library/spdm_requester_lib/libspdm_req_key_update.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #pragma pack(1)
 typedef struct {

--- a/library/spdm_requester_lib/libspdm_req_psk_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_exchange.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/library/spdm_requester_lib/libspdm_req_psk_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_psk_finish.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 libspdm_return_t libspdm_send_request(void *spdm_context, const uint32_t *session_id,
                                       bool is_app_message,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_key_update.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
 

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -6,6 +6,7 @@
 
 #include "internal/libspdm_responder_lib.h"
 #include "hal/library/platform_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 

--- a/library/spdm_responder_lib/libspdm_rsp_key_update.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 /**
  * Process the SPDM KEY_UPDATE request and return the response.

--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP
 

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 #include "hal/library/platform_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -5,6 +5,7 @@
  **/
 
 #include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
 #include "hal/library/platform_lib.h"
 
 typedef struct {

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -24,6 +24,7 @@
 #include "library/spdm_transport_test_lib.h"
 #include "internal/libspdm_common_lib.h"
 #include "spdm_device_secret_lib_internal.h"
+#include "internal/libspdm_secured_message_lib.h"
 
 extern uint8_t m_libspdm_use_measurement_spec;
 extern uint32_t m_libspdm_use_measurement_hash_algo;


### PR DESCRIPTION
Move appropriate secured message functions from the public header to the internal header.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>