### PR TITLE
libspdm_rsp_psk_exchange: Fixup PSK Hint Length comparison

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_exchange.c
@@ -257,7 +257,7 @@ libspdm_return_t libspdm_get_response_psk_exchange(libspdm_context_t *spdm_conte
     if (spdm_request->psk_hint_length == 0) {
         psk_hint_size = 0;
         psk_hint = NULL;
-    } else if(spdm_request->psk_hint_length < LIBSPDM_PSK_MAX_HINT_LENGTH ) {
+    } else if(spdm_request->psk_hint_length <= LIBSPDM_PSK_MAX_HINT_LENGTH ) {
         psk_hint_size = spdm_request->psk_hint_length;
         psk_hint = (const uint8_t *)request +
                    sizeof(spdm_psk_exchange_request_t);


### PR DESCRIPTION
The maximum length of the PSK hint is referenced by the LIBSPDM_PSK_MAX_HINT_LENGTH macro (16). We need to ensure that the length is less then equal to the length of LIBSPDM_PSK_MAX_HINT_LENGTH, not less then.

This patch ensures that the psk hint is less then or equal to LIBSPDM_PSK_MAX_HINT_LENGTH which also matches the check when setting the psk_hint buffer for the local context.