### PR TITLE
library: spdm_requester: Pass along reset required error messages

### DIFF
--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -137,6 +137,10 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_STATUS_SESSION_TRY_DISCARD_KEY_UPDATE \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0011)
 
+/* The device needs a reset after the operation (such as set certificate). */
+#define LIBSPDM_STATUS_RESET_REQUIRED_PEER \
+    LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_CORE, 0x0012)
+
 /* - Cryptography Errors - */
 
 /* Generic failure originating from the cryptography module. */

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -103,12 +103,22 @@ static libspdm_return_t libspdm_requester_respond_if_ready(libspdm_context_t *sp
 libspdm_return_t libspdm_handle_simple_error_response(libspdm_context_t *spdm_context,
                                                       uint8_t error_code)
 {
+    spdm_set_certificate_request_t *last_spdm_request;
+
     if (error_code == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
         return LIBSPDM_STATUS_NOT_READY_PEER;
     }
 
     if (error_code == SPDM_ERROR_CODE_BUSY) {
         return LIBSPDM_STATUS_BUSY_PEER;
+    }
+
+    last_spdm_request = (void *)spdm_context->last_spdm_request;
+    if (last_spdm_request->header.request_response_code == SPDM_SET_CERTIFICATE ||
+        last_spdm_request->header.request_response_code == SPDM_GET_CSR) {
+        if (error_code == SPDM_ERROR_CODE_RESET_REQUIRED) {
+            return LIBSPDM_STATUS_RESET_REQUIRED_PEER;
+        }
     }
 
     if (error_code == SPDM_ERROR_CODE_REQUEST_RESYNCH) {


### PR DESCRIPTION
If a device provides a ResetRequired error message we want to report that up the stack so that applications can reset the device. This patch exposes that reset error information to users.