### PR TITLE
Check MCTP transport buffer size

### DIFF
--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -109,8 +109,12 @@ libspdm_return_t libspdm_transport_mctp_encode_message(
             return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         }
 
+        transport_header_size = libspdm_transport_mctp_get_header_size(spdm_context);
+
         if (!is_app_message) {
             /* SPDM message to APP message*/
+            app_message = NULL;
+            app_message_size = transport_header_size + message_size;
             status = libspdm_mctp_encode_message(NULL, message_size,
                                                  message,
                                                  &app_message_size,
@@ -126,7 +130,6 @@ libspdm_return_t libspdm_transport_mctp_encode_message(
             app_message_size = message_size;
         }
         /* APP message to secured message*/
-        transport_header_size = libspdm_transport_mctp_get_header_size(spdm_context);
         secured_message = (uint8_t *)*transport_message + transport_header_size;
         secured_message_size = *transport_message_size - transport_header_size;
         status = libspdm_encode_secured_message(

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -76,6 +76,15 @@ libspdm_return_t libspdm_mctp_encode_message(const uint32_t *session_id, size_t 
     aligned_message_size =
         (message_size + (alignment - 1)) & ~(alignment - 1);
 
+    LIBSPDM_ASSERT(*transport_message_size >=
+                   aligned_message_size + sizeof(mctp_message_header_t));
+    if (*transport_message_size <
+        aligned_message_size + sizeof(mctp_message_header_t)) {
+        *transport_message_size = aligned_message_size +
+                                  sizeof(mctp_message_header_t);
+        return LIBSPDM_STATUS_BUFFER_TOO_SMALL;
+    }
+
     *transport_message_size =
         aligned_message_size + sizeof(mctp_message_header_t);
     *transport_message = (uint8_t *)message - sizeof(mctp_message_header_t);


### PR DESCRIPTION
Fix: #796
Fix: #1824
Ref: #1715, #1818, #1823
Ref: DMTF/spdm-emu#225

Fix `app_message` not initialized issue
and add transport buffer size check in `libspdm_mctp_encode_message()`.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>