### PR TITLE
If a SPDM message size is greater than the transmit buffer siz…

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -592,9 +592,13 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
         }
     }
 
+    /* large SPDM message is the SPDM message whose size is greater than the DataTransferSize of the receiving
+     * SPDM endpoint or greater than the transmit buffer size of the sending SPDM endpoint */
     if ((status == LIBSPDM_STATUS_SUCCESS) &&
-        (context->connection_info.capability.data_transfer_size != 0) &&
-        (my_response_size > context->connection_info.capability.data_transfer_size) &&
+        (((context->connection_info.capability.data_transfer_size != 0) &&
+          (my_response_size > context->connection_info.capability.data_transfer_size)) ||
+         ((context->local_context.capability.sender_data_transfer_size != 0) &&
+          (my_response_size > context->local_context.capability.sender_data_transfer_size))) &&
         libspdm_is_capabilities_flag_supported(
             context, false, 0,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -90,6 +90,12 @@ libspdm_return_t libspdm_requester_chunk_send_test_send_message(
     if (spdm_test_context->case_id == 9) {
         return LIBSPDM_STATUS_SUCCESS;
     }
+    if (spdm_test_context->case_id == 10) {
+        if (chunk_send->header.request_response_code == SPDM_CHUNK_SEND) {
+            return LIBSPDM_STATUS_SUCCESS;
+        }
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
     return LIBSPDM_STATUS_SEND_FAIL;
 }
 
@@ -108,7 +114,7 @@ libspdm_return_t libspdm_requester_chunk_send_test_receive_message(
     spdm_test_context = libspdm_get_test_context();
     spdm_context = context;
 
-    if (spdm_test_context->case_id == 1) {
+    if ((spdm_test_context->case_id == 1) || (spdm_test_context->case_id == 10)) {
         /* Successful chunk send of algorithms request */
         chunk_send_ack_rsp
             = (void*) ((uint8_t*) *response + sizeof(libspdm_test_message_header_t));
@@ -299,8 +305,17 @@ libspdm_return_t libspdm_test_requester_chunk_send_generic_test_case(
     spdm_context->connection_info.capability.flags |=
         (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP
          | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP);
-    spdm_context->connection_info.capability.data_transfer_size
-        = CHUNK_SEND_REQUESTER_UNIT_TEST_DATA_TRANSFER_SIZE;
+    if (case_id != 10) {
+        spdm_context->connection_info.capability.data_transfer_size
+            = CHUNK_SEND_REQUESTER_UNIT_TEST_DATA_TRANSFER_SIZE;
+        spdm_context->local_context.capability.sender_data_transfer_size
+            = LIBSPDM_DATA_TRANSFER_SIZE;
+    } else {
+        spdm_context->connection_info.capability.data_transfer_size
+            = LIBSPDM_DATA_TRANSFER_SIZE;
+        spdm_context->local_context.capability.sender_data_transfer_size
+            = CHUNK_SEND_REQUESTER_UNIT_TEST_DATA_TRANSFER_SIZE;
+    }
 
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
@@ -379,6 +394,13 @@ void libspdm_test_requester_chunk_send_case9(void** state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
+void libspdm_test_requester_chunk_send_case10(void** state)
+{
+    libspdm_return_t status;
+    status = libspdm_test_requester_chunk_send_generic_test_case(state, 10);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+}
+
 libspdm_test_context_t m_libspdm_requester_chunk_send_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     true,
@@ -408,6 +430,8 @@ int libspdm_requester_chunk_send_test_main(void)
         cmocka_unit_test(libspdm_test_requester_chunk_send_case8),
         /* Chunk Response has bad chunk seq no */
         cmocka_unit_test(libspdm_test_requester_chunk_send_case9),
+        /* sent in chunks due to greater than the sending transmit buffer size. */
+        cmocka_unit_test(libspdm_test_requester_chunk_send_case10),
     };
 
     libspdm_setup_test_context(

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -11,6 +11,16 @@
 
 #define CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE (64)
 
+libspdm_return_t my_test_get_response_func(
+    void *spdm_context, const uint32_t *session_id, bool is_app_message,
+    size_t request_size, const void *request, size_t *response_size,
+    void *response)
+{
+    /* response message size is greater than the sending transmit buffer size of responder */
+    *response_size = CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE + 1;
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
 /**
  * Test 1: Test Responder Receive Send flow triggers chunk get mode
  * if response buffer is larger than requester data_transfer_size.
@@ -134,6 +144,82 @@ void libspdm_test_responder_receive_send_rsp_case1(void** state)
     #endif
 }
 
+/**
+ * Test 2: Test Responder Receive Send flow triggers chunk get mode
+ * if response message size is larger than responder sending transmit buffer size.
+ **/
+void libspdm_test_responder_receive_send_rsp_case2(void** state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t* spdm_test_context;
+    libspdm_context_t* spdm_context;
+    size_t response_size;
+    uint8_t* response;
+    spdm_error_response_t* spdm_response;
+    spdm_vendor_defined_request_msg_t spdm_request;
+    void* message;
+    size_t message_size;
+    uint32_t transport_header_size;
+    uint8_t chunk_handle;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+
+    spdm_context->local_context.capability.flags |=
+        (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP
+         | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP);
+
+    /* The local Responder transmit buffer size for sending a single and complete SPDM message */
+    spdm_context->local_context.capability.sender_data_transfer_size =
+        CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE;
+    /* The peer Requester buffer size for receiving a single and complete SPDM message */
+    spdm_context->connection_info.capability.data_transfer_size =
+        LIBSPDM_DATA_TRANSFER_SIZE;
+
+    libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    spdm_request.header.request_response_code = SPDM_VENDOR_DEFINED_REQUEST;
+
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     sizeof(spdm_context->last_spdm_request),
+                     &spdm_request, sizeof(spdm_request));
+    spdm_context->last_spdm_request_size = sizeof(spdm_request);
+
+    assert_int_equal(spdm_context->chunk_context.get.chunk_in_use, false);
+    libspdm_acquire_sender_buffer(spdm_context, &message_size, (void**) &message);
+
+    response = message;
+    response_size = message_size;
+    libspdm_zero_mem(response, response_size);
+
+    /* Make response message size greater than the sending transmit buffer size of responder */
+    spdm_context->get_response_func = (void *)my_test_get_response_func;
+
+    status = libspdm_build_response(spdm_context, NULL, false,
+                                    &response_size, (void**)&response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    transport_header_size = spdm_context->transport_get_header_size(spdm_context);
+
+    /* Verify responder returned error large response with chunk_handle == 1
+     * and responder is in chunking mode (get.chunk_in_use). */
+    spdm_response = (spdm_error_response_t*) ((uint8_t*)message + transport_header_size);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_LARGE_RESPONSE);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    chunk_handle = *(uint8_t*)(spdm_response + 1);
+    assert_int_equal(chunk_handle, spdm_context->chunk_context.get.chunk_handle);
+    assert_int_equal(spdm_context->chunk_context.get.chunk_in_use, true);
+    libspdm_release_sender_buffer(spdm_context);
+}
+
 libspdm_test_context_t m_libspdm_responder_receive_send_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     false,
@@ -142,8 +228,11 @@ libspdm_test_context_t m_libspdm_responder_receive_send_test_context = {
 int libspdm_responder_receive_send_test_main(void)
 {
     const struct CMUnitTest spdm_responder_receive_send_tests[] = {
-        /* Responder has no response flag chunk cap */
+        /* response message size is larger than requester data_transfer_size */
         cmocka_unit_test(libspdm_test_responder_receive_send_rsp_case1),
+        /* response message size is larger than responder sending transmit buffer size */
+        cmocka_unit_test_setup(libspdm_test_responder_receive_send_rsp_case2,
+                               libspdm_unit_test_group_setup),
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_receive_send_test_context);


### PR DESCRIPTION
…e of the sending SPDM endpoint, then it is also a large SPDM message.

Fix: #1865