### PR TITLE
Support runtime scratch buffer size based upon max_spdm_msg_size

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -522,6 +522,52 @@ void libspdm_internal_dump_hex(const uint8_t *data, size_t size);
 #define LIBSPDM_INTERNAL_DUMP_DATA(data, size)
 #endif /* LIBSPDM_DEBUG_PRINT_ENABLE */
 
+/* Required scratch buffer size for libspdm internal usage.
+ * It may be used to hold the encrypted/decrypted message and/or last sent/received message.
+ * It may be used to hold the large request/response and intermediate send/receive buffer
+ * in case of chunking.
+ *
+ * If chunking is not supported, it should be at least below.
+ * +--------------------------+
+ * |    SENDER_RECEIVER       |
+ * +--------------------------+
+ * |<-Snd/Rcv buf for chunk ->|
+ *
+ *
+ * If chunking is supported, it should be at least below.
+ * +---------------+--------------+--------------------------+------------------------------+
+ * |SECURE_MESSAGE |LARGE_MESSAGE |    SENDER_RECEIVER       | LARGE SENDER_RECEIVER        |
+ * +---------------+--------------+--------------------------+------------------------------+
+ * |<-Secure msg ->|<-Large msg ->|<-Snd/Rcv buf for chunk ->|<-Snd/Rcv buf for large msg ->|
+ *
+ *
+ * The value is NOT configurable.
+ * The value MAY be changed in different libspdm version.
+ * It is exposed here, just in case the libspdm consumer wants to configure the setting at build time.
+ */
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+/* first section */
+uint32_t libspdm_get_scratch_buffer_secure_message_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_secure_message_capacity(libspdm_context_t *spdm_context);
+
+/* second section */
+uint32_t libspdm_get_scratch_buffer_large_message_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_large_message_capacity(libspdm_context_t *spdm_context);
+#endif
+
+/* third section */
+uint32_t libspdm_get_scratch_buffer_sender_receiver_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_sender_receiver_capacity(libspdm_context_t *spdm_context);
+
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+/* fourth section */
+uint32_t libspdm_get_scratch_buffer_large_sender_receiver_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_large_sender_receiver_capacity(libspdm_context_t *spdm_context);
+#endif
+
+/* combination */
+uint32_t libspdm_get_scratch_buffer_capacity(libspdm_context_t *spdm_context);
+
 /**
  * Append a new data buffer to the managed buffer.
  *

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -543,7 +543,7 @@ void libspdm_internal_dump_hex(const uint8_t *data, size_t size);
  * |<-Secure msg ->|<-Large msg ->|<-Snd/Rcv buf for chunk ->|<-Snd/Rcv buf for large msg ->|<-last request ->|<-cache request->|
  *
  *
- * The value is NOT configurable.
+ * The value is configurable based on max_spdm_msg_size.
  * The value MAY be changed in different libspdm version.
  * It is exposed here, just in case the libspdm consumer wants to configure the setting at build time.
  */

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -370,7 +370,7 @@ typedef struct {
 
     /* Cached plain text command
      * If the command is cipher text, decrypt then cache it. */
-    uint8_t last_spdm_request[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    uint8_t *last_spdm_request;
     size_t last_spdm_request_size;
 
     /* scratch buffer */
@@ -424,8 +424,10 @@ typedef struct {
 
     /* Cached data for SPDM_ERROR_CODE_RESPONSE_NOT_READY/SPDM_RESPOND_IF_READY */
     spdm_error_data_response_not_ready_t error_data;
-    uint8_t cache_spdm_request[LIBSPDM_MAX_SPDM_MSG_SIZE];
+#if LIBSPDM_RESPOND_IF_READY_SUPPORT
+    uint8_t *cache_spdm_request;
     size_t cache_spdm_request_size;
+#endif
     uint8_t current_token;
 
     /* Register for the retry times when receive "BUSY" Error response (requester only) */
@@ -528,17 +530,17 @@ void libspdm_internal_dump_hex(const uint8_t *data, size_t size);
  * in case of chunking.
  *
  * If chunking is not supported, it should be at least below.
- * +--------------------------+
- * |    SENDER_RECEIVER       |
- * +--------------------------+
- * |<-Snd/Rcv buf for chunk ->|
+ * +--------------------------+-----------------+-----------------+
+ * |    SENDER_RECEIVER       |MAX_SPDM_MSG_SIZE|MAX_SPDM_MSG_SIZE|
+ * +--------------------------+-----------------+-----------------+
+ * |<-Snd/Rcv buf for chunk ->|<-last request ->|<-cache request->|
  *
  *
  * If chunking is supported, it should be at least below.
- * +---------------+--------------+--------------------------+------------------------------+
- * |SECURE_MESSAGE |LARGE_MESSAGE |    SENDER_RECEIVER       | LARGE SENDER_RECEIVER        |
- * +---------------+--------------+--------------------------+------------------------------+
- * |<-Secure msg ->|<-Large msg ->|<-Snd/Rcv buf for chunk ->|<-Snd/Rcv buf for large msg ->|
+ * +---------------+--------------+--------------------------+------------------------------+-----------------+-----------------+
+ * |SECURE_MESSAGE |LARGE_MESSAGE |    SENDER_RECEIVER       | LARGE SENDER_RECEIVER        |MAX_SPDM_MSG_SIZE|MAX_SPDM_MSG_SIZE|
+ * +---------------+--------------+--------------------------+------------------------------+-----------------+-----------------+
+ * |<-Secure msg ->|<-Large msg ->|<-Snd/Rcv buf for chunk ->|<-Snd/Rcv buf for large msg ->|<-last request ->|<-cache request->|
  *
  *
  * The value is NOT configurable.
@@ -563,6 +565,16 @@ uint32_t libspdm_get_scratch_buffer_sender_receiver_capacity(libspdm_context_t *
 /* fourth section */
 uint32_t libspdm_get_scratch_buffer_large_sender_receiver_offset(libspdm_context_t *spdm_context);
 uint32_t libspdm_get_scratch_buffer_large_sender_receiver_capacity(libspdm_context_t *spdm_context);
+#endif
+
+/* fifth section */
+uint32_t libspdm_get_scratch_buffer_last_spdm_request_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_last_spdm_request_capacity(libspdm_context_t *spdm_context);
+
+#if LIBSPDM_RESPOND_IF_READY_SUPPORT
+/* sixth section */
+uint32_t libspdm_get_scratch_buffer_cache_spdm_request_offset(libspdm_context_t *spdm_context);
+uint32_t libspdm_get_scratch_buffer_cache_spdm_request_capacity(libspdm_context_t *spdm_context);
 #endif
 
 /* combination */

--- a/include/internal/libspdm_macro_check.h
+++ b/include/internal/libspdm_macro_check.h
@@ -84,10 +84,6 @@
     #error LIBSPDM_MAX_SESSION_COUNT must be less than 65536.
 #endif
 
-#if (LIBSPDM_MAX_SPDM_MSG_SIZE < SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12)
-    #error LIBSPDM_MAX_SPDM_MSG_SIZE should be no less than SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12
-#endif
-
 #if LIBSPDM_FIPS_MODE
 #if (LIBSPDM_ASYM_ALGO_SUPPORT) && !LIBSPDM_FIPS_ASYM_ALGO_SUPPORT
     #error ASYM algo is cleared after FIPS enforcement.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -647,7 +647,7 @@ void libspdm_register_transport_layer_func(
  *
  * @return the size of required scratch buffer.
  **/
-size_t libspdm_get_sizeof_required_scratch_buffer (void *spdm_context);
+size_t libspdm_get_sizeof_required_scratch_buffer (void *spdm_context, uint32_t max_spdm_msg_size);
 
 /**
  * Set the scratch buffer.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -207,63 +207,6 @@ typedef enum {
     LIBSPDM_RESPONSE_STATE_MAX
 } libspdm_response_state_t;
 
-/* Required scratch buffer size for libspdm internal usage.
- * It may be used to hold the encrypted/decrypted message and/or last sent/received message.
- * It may be used to hold the large request/response and intermediate send/receive buffer
- * in case of chunking.
- *
- * If chunking is not supported, it may be just SENDER_RECEIVER buffer size.
- * If chunking is supported, it should be at least below.
- *
- * +---------------+--------------+--------------------------+------------------------------+
- * |SECURE_MESSAGE |LARGE_MESSAGE |    SENDER_RECEIVER       | LARGE_SENDER_RECEIVER        |
- * +---------------+--------------+--------------------------+------------------------------+
- * |<-Secure msg ->|<-Large msg ->|<-Snd/Rcv buf for chunk ->|<-Snd/Rcv buf for large msg ->|
- *
- * The value is NOT configurable.
- * The value MAY be changed in different libspdm version.
- * It is exposed here, just in case the libspdm consumer wants to configure the setting at build time.
- */
-#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
-
-/* first section */
-#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_OFFSET 0
-
-#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
-                                                        LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
-
-/* second section */
-#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY)
-
-#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
-
-/* third section */
-#define LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET  \
-    (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
-     LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY)
-
-#define LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
-                                                         LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
-
-/* fourth section */
-#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_OFFSET  \
-    (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
-     LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
-     LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY)
-
-#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
-                                                               LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
-
-#define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
-                                     LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
-                                     LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY + \
-                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY \
-                                     )
-
-#else
-#define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_MAX_SPDM_MSG_SIZE + LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
-#endif
-
 /**
  * Set an SPDM context data.
  *

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -382,14 +382,6 @@
 #define LIBSPDM_TRANSPORT_ADDITIONAL_SIZE    64
 #endif
 
-/* Maximum size of a large SPDM message.
- * If chunk is unsupported, it must be same as DATA_TRANSFER_SIZE.
- * If chunk is supported, it must be larger than DATA_TRANSFER_SIZE.
- * It matches MaxSPDMmsgSize in SPDM specification. */
-#ifndef LIBSPDM_MAX_SPDM_MSG_SIZE
-#define LIBSPDM_MAX_SPDM_MSG_SIZE 0x1200
-#endif
-
 /* Enable message logging.
  * See https://github.com/DMTF/libspdm/blob/main/doc/user_guide.md#message-logging
  * for more information */

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -272,7 +272,7 @@ libspdm_return_t libspdm_encapsulated_request(libspdm_context_t *spdm_context,
             spdm_response_size - sizeof(spdm_encapsulated_request_response_t);
 
         libspdm_copy_mem (spdm_context->last_spdm_request,
-                          sizeof(spdm_context->last_spdm_request),
+                          libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                           encapsulated_request,
                           encapsulated_request_size);
         spdm_context->last_spdm_request_size = encapsulated_request_size;
@@ -421,7 +421,7 @@ libspdm_return_t libspdm_encapsulated_request(libspdm_context_t *spdm_context,
         encapsulated_request_size = spdm_response_size - ack_header_size;
 
         libspdm_copy_mem (spdm_context->last_spdm_request,
-                          sizeof(spdm_context->last_spdm_request),
+                          libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                           encapsulated_request,
                           encapsulated_request_size
                           );

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -229,16 +229,15 @@ libspdm_return_t libspdm_handle_error_large_response(
     transport_header_size = spdm_context->transport_get_header_size(spdm_context);
 
     libspdm_get_scratch_buffer(spdm_context, (void**)&scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
     /* The first section of the scratch
      * buffer may be used for other purposes. Use only after that section. */
-    large_response = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
-    large_response_capacity = LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY;
+    large_response = scratch_buffer + libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_response_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
 
     /* Temporary send/receive buffers for chunking are in the scratch space */
-    message = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET;
-    message_size = LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY;
+    message = scratch_buffer + libspdm_get_scratch_buffer_sender_receiver_offset(spdm_context);
+    message_size = libspdm_get_scratch_buffer_sender_receiver_capacity(spdm_context);
 
     libspdm_zero_mem(large_response, large_response_capacity);
     large_response_size = 0;

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -49,18 +49,24 @@ libspdm_return_t libspdm_send_request(void *spdm_context, const uint32_t *sessio
         message_size = sender_buffer_size;
     }
     else {
-        if ((uint8_t*)request >= scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET
-            && (uint8_t*)request < scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET
-            + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY) {
-            message = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET;
-            message_size = LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY;
+        if ((uint8_t*)request >=
+            scratch_buffer + libspdm_get_scratch_buffer_sender_receiver_offset(spdm_context)
+            && (uint8_t*)request <
+            scratch_buffer + libspdm_get_scratch_buffer_sender_receiver_offset(spdm_context)
+            + libspdm_get_scratch_buffer_sender_receiver_capacity(spdm_context)) {
+            message = scratch_buffer +
+                      libspdm_get_scratch_buffer_sender_receiver_offset(spdm_context);
+            message_size = libspdm_get_scratch_buffer_sender_receiver_capacity(spdm_context);
         } else if ((uint8_t*)request >=
-                   scratch_buffer + LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_OFFSET
+                   scratch_buffer +
+                   libspdm_get_scratch_buffer_large_sender_receiver_offset(spdm_context)
                    && (uint8_t*)request <
-                   scratch_buffer + LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_OFFSET
-                   + LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY) {
-            message = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_OFFSET;
-            message_size = LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY;
+                   scratch_buffer +
+                   libspdm_get_scratch_buffer_large_sender_receiver_offset(spdm_context) +
+                   libspdm_get_scratch_buffer_large_sender_receiver_capacity(spdm_context)) {
+            message = scratch_buffer +
+                      libspdm_get_scratch_buffer_large_sender_receiver_offset(spdm_context);
+            message_size = libspdm_get_scratch_buffer_large_sender_receiver_capacity(spdm_context);
         }
     }
     #else /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
@@ -162,9 +168,10 @@ libspdm_return_t libspdm_receive_response(void *spdm_context, const uint32_t *se
     transport_header_size = context->transport_get_header_size(context);
     libspdm_get_scratch_buffer (context, (void **)&scratch_buffer, &scratch_buffer_size);
     #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
-    *response = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_OFFSET +
+    *response = scratch_buffer + libspdm_get_scratch_buffer_secure_message_offset(context) +
                 transport_header_size;
-    *response_size = LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY - transport_header_size;
+    *response_size = libspdm_get_scratch_buffer_secure_message_capacity(context) -
+                     transport_header_size;
     #else
     *response = scratch_buffer + transport_header_size;
     *response_size = scratch_buffer_size - transport_header_size;
@@ -323,19 +330,20 @@ libspdm_return_t libspdm_handle_large_request(
     transport_header_size = spdm_context->transport_get_header_size(spdm_context);
 
     libspdm_get_scratch_buffer(spdm_context, (void**) &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
     /* Temporary send/receive buffers for chunking are in the scratch space */
-    message = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_OFFSET;
-    message_size = LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY;
+    message = scratch_buffer + libspdm_get_scratch_buffer_sender_receiver_offset(spdm_context);
+    message_size = libspdm_get_scratch_buffer_sender_receiver_capacity(spdm_context);
 
     send_info = &spdm_context->chunk_context.send;
     send_info->chunk_in_use = true;
 
     /* The first section of the scratch
      * buffer may be used for other purposes. Use only after that section. */
-    send_info->large_message = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
-    send_info->large_message_capacity = LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY;
+    send_info->large_message = scratch_buffer +
+                               libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    send_info->large_message_capacity =
+        libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
 
     libspdm_zero_mem(send_info->large_message, send_info->large_message_capacity);
     libspdm_copy_mem(send_info->large_message, send_info->large_message_capacity,

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -89,7 +89,7 @@ libspdm_return_t libspdm_send_request(void *spdm_context, const uint32_t *sessio
         && ((const spdm_message_header_t *)request)->request_response_code != SPDM_CHUNK_GET
         && ((const spdm_message_header_t*) request)->request_response_code != SPDM_CHUNK_SEND) {
         libspdm_copy_mem (context->last_spdm_request,
-                          sizeof(context->last_spdm_request),
+                          libspdm_get_scratch_buffer_last_spdm_request_capacity(context),
                           request,
                           request_size
                           );
@@ -574,7 +574,8 @@ libspdm_return_t libspdm_send_spdm_request(libspdm_context_t *spdm_context,
             && ((const spdm_message_header_t*) request)->request_response_code != SPDM_CHUNK_GET
             && ((const spdm_message_header_t*) request)->request_response_code != SPDM_CHUNK_SEND) {
             libspdm_copy_mem(
-                spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+                spdm_context->last_spdm_request,
+                libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                 request, request_size);
             spdm_context->last_spdm_request_size = request_size;
         }

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -100,15 +100,15 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
         else {
             libspdm_get_scratch_buffer(spdm_context, (void**) &scratch_buffer,
                                        &scratch_buffer_size);
-            LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
             send_info->chunk_in_use = true;
             send_info->chunk_handle = spdm_request->header.param2;
             send_info->chunk_seq_no = spdm_request->chunk_seq_no;
 
             send_info->large_message = scratch_buffer +
-                                       LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
-            send_info->large_message_capacity = LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY;
+                                       libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+            send_info->large_message_capacity =
+                libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
             send_info->large_message_size = large_message_size;
             send_info->chunk_bytes_transferred = spdm_request->chunk_size;
 

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -35,7 +35,7 @@ libspdm_return_t libspdm_responder_handle_response_state(libspdm_context_t *spdm
         if(request_code != SPDM_RESPOND_IF_READY) {
             spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
             libspdm_copy_mem(spdm_context->cache_spdm_request,
-                             sizeof(spdm_context->cache_spdm_request),
+                             libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                              spdm_context->last_spdm_request,
                              spdm_context->last_spdm_request_size);
             spdm_context->error_data.rd_exponent = 1;

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -158,7 +158,8 @@ libspdm_return_t libspdm_process_request(void *spdm_context, uint32_t **session_
 
     message_session_id = NULL;
     context->last_spdm_request_session_id_valid = false;
-    context->last_spdm_request_size = sizeof(context->last_spdm_request);
+    context->last_spdm_request_size =
+        libspdm_get_scratch_buffer_last_spdm_request_capacity(context);
 
     /* always use scratch buffer to response.
      * if it is secured message, this scratch buffer will be used.
@@ -261,7 +262,7 @@ libspdm_return_t libspdm_process_request(void *spdm_context, uint32_t **session_
 
     context->last_spdm_request_size = decoded_message_size;
     libspdm_copy_mem (context->last_spdm_request,
-                      sizeof(context->last_spdm_request),
+                      libspdm_get_scratch_buffer_last_spdm_request_capacity(context),
                       decoded_message_ptr,
                       decoded_message_size);
 

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -166,9 +166,11 @@ libspdm_return_t libspdm_process_request(void *spdm_context, uint32_t **session_
     transport_header_size = context->transport_get_header_size(context);
     libspdm_get_scratch_buffer (context, (void **)&scratch_buffer, &scratch_buffer_size);
     #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
-    decoded_message_ptr = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_OFFSET +
+    decoded_message_ptr = scratch_buffer +
+                          libspdm_get_scratch_buffer_secure_message_offset(context) +
                           transport_header_size;
-    decoded_message_size = LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY - transport_header_size;
+    decoded_message_size = libspdm_get_scratch_buffer_secure_message_capacity(context) -
+                           transport_header_size;
     #else
     decoded_message_ptr = scratch_buffer + transport_header_size;
     decoded_message_size = scratch_buffer_size - transport_header_size;
@@ -442,9 +444,10 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
     if (session_id != NULL) {
         libspdm_get_scratch_buffer (context, (void **)&scratch_buffer, &scratch_buffer_size);
         #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
-        my_response = scratch_buffer + LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_OFFSET +
+        my_response = scratch_buffer + libspdm_get_scratch_buffer_secure_message_offset(context) +
                       transport_header_size;
-        my_response_size = LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY - transport_header_size;
+        my_response_size = libspdm_get_scratch_buffer_secure_message_capacity(context) -
+                           transport_header_size;
         #else
         my_response = scratch_buffer + transport_header_size;
         my_response_size = scratch_buffer_size - transport_header_size;
@@ -611,13 +614,13 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
         }
 
         libspdm_get_scratch_buffer(context, (void **)&scratch_buffer, &scratch_buffer_size);
-        LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
         /* The first section of the scratch
          * buffer may be used for other purposes. Use only after that section. */
 
-        large_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-        large_buffer_size = LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY;
+        large_buffer = (uint8_t*)scratch_buffer +
+                       libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+        large_buffer_size = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
 
         if (my_response_size < large_buffer_size) {
             get_info->chunk_in_use = true;

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/common.c
@@ -75,7 +75,7 @@ size_t libspdm_unit_test_group_setup(void **State)
 
     libspdm_init_context(spdm_context);
     spdm_test_context->scratch_buffer_size =
-        libspdm_get_sizeof_required_scratch_buffer(spdm_context);
+        libspdm_get_sizeof_required_scratch_buffer(spdm_context, LIBSPDM_MAX_SPDM_MSG_SIZE);
     spdm_test_context->scratch_buffer = (void *)malloc(spdm_test_context->scratch_buffer_size);
 
     libspdm_register_device_io_func(spdm_context,

--- a/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
+++ b/unit_test/fuzzing/spdm_unit_fuzzing_common/spdm_unit_fuzzing.h
@@ -90,6 +90,14 @@ typedef struct {
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+/* Maximum size of a large SPDM message.
+ * If chunk is unsupported, it must be same as DATA_TRANSFER_SIZE.
+ * If chunk is supported, it must be larger than DATA_TRANSFER_SIZE.
+ * It matches MaxSPDMmsgSize in SPDM specification. */
+#ifndef LIBSPDM_MAX_SPDM_MSG_SIZE
+#define LIBSPDM_MAX_SPDM_MSG_SIZE 0x1200
+#endif
+
 extern uint8_t m_libspdm_use_measurement_spec;
 extern uint32_t m_libspdm_use_measurement_hash_algo;
 extern uint32_t m_libspdm_use_hash_algo;

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
@@ -52,10 +52,11 @@ void libspdm_test_responder_chunk_get_case1(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     first_chunk_size = data_transfer_size -
@@ -119,10 +120,11 @@ void libspdm_test_responder_chunk_get_case2(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     first_chunk_size = data_transfer_size -
@@ -184,10 +186,11 @@ void libspdm_test_responder_chunk_get_case3(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     first_chunk_size = data_transfer_size -
@@ -250,10 +253,11 @@ void libspdm_test_responder_chunk_get_case4(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     first_chunk_size = data_transfer_size -

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -57,12 +57,14 @@ void libspdm_test_responder_respond_if_ready(void **State)
                     (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = spdm_test_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &spdm_test_get_digest_request,  spdm_test_get_digest_request_size);
 
     spdm_context->cache_spdm_request_size =
         spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm = 1;

--- a/unit_test/spdm_unit_test_common/common.c
+++ b/unit_test/spdm_unit_test_common/common.c
@@ -85,7 +85,7 @@ int libspdm_unit_test_group_setup(void **state)
 
     libspdm_init_context(spdm_context);
     spdm_test_context->scratch_buffer_size =
-        libspdm_get_sizeof_required_scratch_buffer(spdm_context);
+        libspdm_get_sizeof_required_scratch_buffer(spdm_context, LIBSPDM_MAX_SPDM_MSG_SIZE);
     spdm_test_context->scratch_buffer = (void *)malloc(spdm_test_context->scratch_buffer_size);
 
     libspdm_register_device_io_func(spdm_context,

--- a/unit_test/spdm_unit_test_common/spdm_unit_test.h
+++ b/unit_test/spdm_unit_test_common/spdm_unit_test.h
@@ -92,6 +92,14 @@ typedef struct {
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+/* Maximum size of a large SPDM message.
+ * If chunk is unsupported, it must be same as DATA_TRANSFER_SIZE.
+ * If chunk is supported, it must be larger than DATA_TRANSFER_SIZE.
+ * It matches MaxSPDMmsgSize in SPDM specification. */
+#ifndef LIBSPDM_MAX_SPDM_MSG_SIZE
+#define LIBSPDM_MAX_SPDM_MSG_SIZE 0x1200
+#endif
+
 extern uint8_t m_libspdm_use_measurement_spec;
 extern uint32_t m_libspdm_use_measurement_hash_algo;
 extern uint32_t m_libspdm_use_hash_algo;

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
@@ -52,10 +52,20 @@
 #define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY 0
 #endif
 
+#define LIBSPDM_SCRATCH_BUFFER_LAST_SPDM_REQUEST_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+
+#if LIBSPDM_RESPOND_IF_READY_SUPPORT
+#define LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY 0
+#endif
+
 #define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
                                      LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
                                      LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY + \
-                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY)
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LAST_SPDM_REQUEST_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY)
 
 libspdm_return_t spdm_requester_send_message(void *spdm_context,
                                              size_t message_size, const void *message,

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
@@ -29,6 +29,14 @@
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+/* Maximum size of a large SPDM message.
+ * If chunk is unsupported, it must be same as DATA_TRANSFER_SIZE.
+ * If chunk is supported, it must be larger than DATA_TRANSFER_SIZE.
+ * It matches MaxSPDMmsgSize in SPDM specification. */
+#ifndef LIBSPDM_MAX_SPDM_MSG_SIZE
+#define LIBSPDM_MAX_SPDM_MSG_SIZE 0x1200
+#endif
+
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 #define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
                                                         LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_init.c
@@ -29,6 +29,34 @@
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                        LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY 0
+#endif
+
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY 0
+#endif
+
+#define LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                         LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                               LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY 0
+#endif
+
+#define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY)
+
 libspdm_return_t spdm_requester_send_message(void *spdm_context,
                                              size_t message_size, const void *message,
                                              uint64_t timeout)

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
@@ -52,10 +52,20 @@
 #define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY 0
 #endif
 
+#define LIBSPDM_SCRATCH_BUFFER_LAST_SPDM_REQUEST_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+
+#if LIBSPDM_RESPOND_IF_READY_SUPPORT
+#define LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY 0
+#endif
+
 #define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
                                      LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
                                      LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY + \
-                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY)
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LAST_SPDM_REQUEST_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_CACHE_SPDM_REQUEST_CAPACITY)
 
 libspdm_return_t spdm_responder_send_message(void *spdm_context,
                                              size_t message_size, const void *message,

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
@@ -29,6 +29,34 @@
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                        LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY 0
+#endif
+
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY 0
+#endif
+
+#define LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                         LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
+                                                               LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)
+#else
+#define LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY 0
+#endif
+
+#define LIBSPDM_SCRATCH_BUFFER_SIZE (LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_SENDER_RECEIVER_CAPACITY + \
+                                     LIBSPDM_SCRATCH_BUFFER_LARGE_SENDER_RECEIVER_CAPACITY)
+
 libspdm_return_t spdm_responder_send_message(void *spdm_context,
                                              size_t message_size, const void *message,
                                              uint64_t timeout)

--- a/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
+++ b/unit_test/test_size/test_size_of_spdm_responder/spdm_responder_init.c
@@ -29,6 +29,14 @@
 #define LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE LIBSPDM_RECEIVER_BUFFER_SIZE
 #endif
 
+/* Maximum size of a large SPDM message.
+ * If chunk is unsupported, it must be same as DATA_TRANSFER_SIZE.
+ * If chunk is supported, it must be larger than DATA_TRANSFER_SIZE.
+ * It matches MaxSPDMmsgSize in SPDM specification. */
+#ifndef LIBSPDM_MAX_SPDM_MSG_SIZE
+#define LIBSPDM_MAX_SPDM_MSG_SIZE 0x1200
+#endif
+
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 #define LIBSPDM_SCRATCH_BUFFER_SECURE_MESSAGE_CAPACITY (LIBSPDM_MAX_SPDM_MSG_SIZE + \
                                                         LIBSPDM_TRANSPORT_ADDITIONAL_SIZE)

--- a/unit_test/test_spdm_responder/chunk_get.c
+++ b/unit_test/test_spdm_responder/chunk_get.c
@@ -375,10 +375,11 @@ void libspdm_test_responder_chunk_get_rsp_case7(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     chunk_handle = (uint8_t) spdm_test_context->case_id;
@@ -444,10 +445,11 @@ void libspdm_test_responder_chunk_get_rsp_case8(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     chunk_handle = (uint8_t) spdm_test_context->case_id;
@@ -513,10 +515,11 @@ void libspdm_test_responder_chunk_get_rsp_case9(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     chunk_handle = (uint8_t) spdm_test_context->case_id;
@@ -592,10 +595,11 @@ void libspdm_test_responder_chunk_get_rsp_case10(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     /* Fill 1st chunk with 1, 2nd chunk with 2, 3rd chunk with 3 */
@@ -695,10 +699,11 @@ void libspdm_test_responder_chunk_get_rsp_case11(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     /* Fill 1st chunk with 1, 2nd chunk with 2, 3rd chunk with 3 */
@@ -796,10 +801,11 @@ void libspdm_test_responder_chunk_get_rsp_case12(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     /* Fill 1st chunk with 1, 2nd chunk with 2, 3rd chunk with 3 */
@@ -899,10 +905,11 @@ void libspdm_test_responder_chunk_get_rsp_case13(void** state)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
-    LIBSPDM_ASSERT(scratch_buffer_size >= LIBSPDM_SCRATCH_BUFFER_SIZE);
 
-    scratch_buffer = (((uint8_t*) scratch_buffer) + LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET);
-    scratch_buffer_size = scratch_buffer_size - LIBSPDM_SCRATCH_BUFFER_LARGE_MESSAGE_OFFSET;
+    scratch_buffer = (uint8_t*)scratch_buffer +
+                     libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    scratch_buffer_size = scratch_buffer_size -
+                          libspdm_get_scratch_buffer_large_message_offset(spdm_context);
     libspdm_zero_mem(scratch_buffer, scratch_buffer_size);
 
     /* Fill 1st chunk with 1, 2nd chunk with 2, 3rd chunk with 3, 4th chunk with 4 */

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -96,7 +96,7 @@ void libspdm_test_responder_receive_send_rsp_case1(void** state)
     spdm_request.slot_id_param = 0;
 
     libspdm_copy_mem(spdm_context->last_spdm_request,
-                     sizeof(spdm_context->last_spdm_request),
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &spdm_request, sizeof(spdm_request));
     spdm_context->last_spdm_request_size = sizeof(spdm_request);
 

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -307,12 +307,14 @@ void libspdm_test_responder_respond_if_ready_case1(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -377,12 +379,14 @@ void libspdm_test_responder_respond_if_ready_case2(void **state) {
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
 
     spdm_context->last_spdm_request_size = m_libspdm_get_certificate_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_certificate_request, m_libspdm_get_certificate_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -455,12 +459,14 @@ void libspdm_test_responder_respond_if_ready_case3(void **state) {
     spdm_context->local_context.opaque_challenge_auth_rsp_size = 0;
 
     spdm_context->last_spdm_request_size = m_libspdm_challenge_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_challenge_request, m_libspdm_challenge_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -526,12 +532,14 @@ void libspdm_test_responder_respond_if_ready_case4(void **state) {
     spdm_context->local_context.opaque_measurement_rsp = NULL;
 
     spdm_context->last_spdm_request_size = m_libspdm_get_measurements_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_measurements_request, m_libspdm_get_measurements_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -628,12 +636,14 @@ void libspdm_test_responder_respond_if_ready_case5(void **state) {
     ptr += opaque_key_exchange_req_size;
 
     spdm_context->last_spdm_request_size = m_libspdm_key_exchange_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_key_exchange_request, m_libspdm_key_exchange_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -759,12 +769,14 @@ void libspdm_test_responder_respond_if_ready_case6(void **state) {
                      request_finished_key, hash_size, ptr);
 
     spdm_context->last_spdm_request_size = sizeof(spdm_finish_request_t) + hmac_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_finish_request, m_libspdm_finish_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -856,12 +868,14 @@ void libspdm_test_responder_respond_if_ready_case7(void **state) {
     ptr += opaque_psk_exchange_req_size;
 
     spdm_context->last_spdm_request_size = m_libspdm_psk_exchange_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_psk_exchange_request, m_libspdm_psk_exchange_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -979,12 +993,14 @@ void libspdm_test_responder_respond_if_ready_case8(void **state) {
                      request_finished_key, hash_size, ptr);
 
     spdm_context->last_spdm_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_psk_finish_request, m_libspdm_psk_finish_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -1049,12 +1065,14 @@ void libspdm_test_responder_respond_if_ready_case10(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -1110,12 +1128,14 @@ void libspdm_test_responder_respond_if_ready_case11(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -1173,12 +1193,14 @@ void libspdm_test_responder_respond_if_ready_case12(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -1239,12 +1261,14 @@ void libspdm_test_responder_respond_if_ready_case13(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
@@ -1298,12 +1322,14 @@ void libspdm_test_responder_respond_if_ready_case14(void **state) {
                      (uint8_t)(0xFF));
 
     spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
-    libspdm_copy_mem(spdm_context->last_spdm_request, sizeof(spdm_context->last_spdm_request),
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
                      &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
 
     /*RESPOND_IF_READY specific data*/
     spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
-    libspdm_copy_mem(spdm_context->cache_spdm_request, sizeof(spdm_context->cache_spdm_request),
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;


### PR DESCRIPTION
Fix https://github.com/DMTF/libspdm/issues/1909

The main idea is as follows. The integrator input `max_spdm_msg_size` and `libspdm_get_sizeof_required_scratch_buffer`.

```
size_t libspdm_get_sizeof_required_scratch_buffer (
    void *spdm_context, uint32_t max_spdm_msg_size)
{
    libspdm_context_t *context;
    size_t scratch_buffer_size;

    context = spdm_context;
    context->local_context.capability.max_spdm_msg_size = max_spdm_msg_size;
    scratch_buffer_size = libspdm_get_scratch_buffer_capacity(context);
    return scratch_buffer_size;
}
```

Or the integrator can pre-calculate the size based upon `libspdm_get_scratch_buffer_capacity`, then set `LIBSPDM_DATA_CAPABILITY_MAX_SPDM_MSG_SIZE`.
