### PR TITLE
fix test to not put response buffer in local stack.

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -13,6 +13,7 @@
 
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_M1M2_BUFFER_SIZE];
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
 
 size_t libspdm_get_max_buffer_size(void)
 {
@@ -39,7 +40,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     libspdm_test_context_t *spdm_test_context;
     spdm_challenge_auth_response_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
     void *data;
     size_t data_size;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_chunk_get/chunk_get.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_chunk_get/chunk_get.c
@@ -11,6 +11,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 #define CHUNK_GET_REQUESTER_UNIT_TEST_DATA_TRANSFER_SIZE (44)
 
 size_t libspdm_get_max_buffer_size(void)
@@ -33,7 +35,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
     libspdm_test_context_t *spdm_test_context;
     static uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
     static bool error_large_response_sent = false;
     static size_t chunk_rsp_buf = 0;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_chunk_send/chunk_send.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_chunk_send/chunk_send.c
@@ -12,6 +12,7 @@
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 
 static bool m_libspdm_chunk_send_last_chunk = true;
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
 
 size_t libspdm_get_max_buffer_size(void)
 {
@@ -44,7 +45,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
 
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     test_message_header_size = libspdm_transport_test_get_header_size(context);

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_finish/finish.c
@@ -12,6 +12,7 @@
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
 uint8_t m_dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
 
 void libspdm_secured_message_set_response_finished_key(void *spdm_secured_message_context,
                                                        const void *key, size_t key_size)
@@ -42,7 +43,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
@@ -8,6 +8,8 @@
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -28,7 +30,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
@@ -14,6 +14,8 @@
 static void *m_libspdm_local_certificate_chain;
 static size_t m_libspdm_local_certificate_chain_size;
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t calling_index = 0;
 
 bool libspdm_test_verify_spdm_cert_chain(void *spdm_context, uint8_t slot_id,
@@ -42,7 +44,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     spdm_certificate_response_t *spdm_response;
 
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
     uint16_t portion_length;
     uint16_t remainder_length;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_certificate/get_certificate.c
@@ -173,6 +173,14 @@ void libspdm_test_requester_get_certificate_case1(void **State)
     libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     free(data);
     libspdm_reset_message_b(spdm_context);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+#else
+    if (spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key != NULL) {
+        libspdm_asym_free(
+            spdm_context->connection_info.algorithm.base_asym_algo,
+            spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+    }
+#endif
 }
 
 void libspdm_test_requester_get_certificate_case2(void **State)
@@ -225,6 +233,14 @@ void libspdm_test_requester_get_certificate_case2(void **State)
     libspdm_get_certificate(spdm_context, NULL, 0, &cert_chain_size, cert_chain);
     free(data);
     libspdm_reset_message_b(spdm_context);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+#else
+    if (spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key != NULL) {
+        libspdm_asym_free(
+            spdm_context->connection_info.algorithm.base_asym_algo,
+            spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+    }
+#endif
 }
 
 void libspdm_test_requester_get_certificate_ex_case1(void **State)
@@ -277,6 +293,14 @@ void libspdm_test_requester_get_certificate_ex_case1(void **State)
 
     free(data);
     libspdm_reset_message_b(spdm_context);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+#else
+    if (spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key != NULL) {
+        libspdm_asym_free(
+            spdm_context->connection_info.algorithm.base_asym_algo,
+            spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+    }
+#endif
 }
 
 void libspdm_test_requester_get_certificate_in_session_case1(void **State)
@@ -364,6 +388,14 @@ void libspdm_test_requester_get_certificate_in_session_case1(void **State)
 
     free(data);
     libspdm_reset_message_b(spdm_context);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+#else
+    if (spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key != NULL) {
+        libspdm_asym_free(
+            spdm_context->connection_info.algorithm.base_asym_algo,
+            spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+    }
+#endif
 }
 
 libspdm_test_context_t m_libspdm_requester_get_certificate_test_context = {

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_csr/get_csr.c
@@ -13,6 +13,8 @@
 
 bool m_secured_on_off;
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -82,7 +84,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         libspdm_test_context_t *spdm_test_context;
         uint8_t *spdm_response;
         size_t spdm_response_size;
-        uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
         size_t test_message_header_size;
 
         spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_digests/get_digests.c
@@ -11,6 +11,7 @@
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
 bool m_secured_on_off;
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
 
 size_t libspdm_get_max_buffer_size(void)
 {
@@ -32,7 +33,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_measurements/get_measurements.c
@@ -15,6 +15,8 @@ bool m_secured_on_off;
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_L1L2_BUFFER_SIZE];
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -82,7 +84,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_MAX_SPDM_MSG_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_version/get_version.c
@@ -8,6 +8,8 @@
 #include "toolchain_harness.h"
 #include "internal/libspdm_requester_lib.h"
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -28,7 +30,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -20,6 +20,8 @@ static uint8_t m_libspdm_zero_filled_buffer[LIBSPDM_MAX_HASH_SIZE];
 
 static libspdm_th_managed_buffer_t th_curr;
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_test_get_key_exchange_request_size(const void *spdm_context, const void *buffer,
                                                   size_t buffer_size)
 {
@@ -87,7 +89,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     libspdm_test_context_t *spdm_test_context;
     spdm_key_exchange_response_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
@@ -8,6 +8,8 @@
 #include "spdm_unit_fuzzing.h"
 #include "toolchain_harness.h"
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -25,7 +27,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     libspdm_test_context_t *spdm_test_context;
     uint8_t *spdm_response;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
 
     spdm_test_context = libspdm_get_test_context();

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -17,6 +17,8 @@ static size_t m_libspdm_local_buffer_size;
 
 static libspdm_th_managed_buffer_t th_curr;
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_test_get_psk_exchange_request_size(const void *spdm_context, const void *buffer,
                                                   size_t buffer_size)
 {
@@ -75,7 +77,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     spdm_psk_exchange_response_t *spdm_response;
     libspdm_test_context_t *spdm_test_context;
     size_t spdm_response_size;
-    uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
     size_t test_message_header_size;
     uint32_t hash_size;
     uint32_t hmac_size;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_set_certificate/set_certificate.c
@@ -13,6 +13,8 @@
 
 bool m_secured_on_off;
 
+uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
 size_t libspdm_get_max_buffer_size(void)
 {
     return LIBSPDM_MAX_SPDM_MSG_SIZE;
@@ -82,7 +84,6 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context,
         libspdm_test_context_t *spdm_test_context;
         uint8_t *spdm_response;
         size_t spdm_response_size;
-        uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
         size_t test_message_header_size;
 
         spdm_test_context = libspdm_get_test_context();


### PR DESCRIPTION
Otherwise, the response buffer will be overridden by other program.

Fix: https://github.com/DMTF/libspdm/issues/1925