### PR TITLE
Update CMake minimum required version

### DIFF
--- a/os_stub/armbuild_lib/CMakeLists.txt
+++ b/os_stub/armbuild_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 SET(src_armbuild_lib
     div64.c

--- a/os_stub/platform_lib/CMakeLists.txt
+++ b/os_stub/platform_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal)

--- a/os_stub/platform_lib_null/CMakeLists.txt
+++ b/os_stub/platform_lib_null/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/include/hal)


### PR DESCRIPTION
Fix: #1928
Update few remaining CMake minimum required version
from 2.6 to 2.8.12 to avoid CMake deprecation warning.

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>