### PR TITLE
Remove libspdm_hkdf_sha256_extract_and_expand and extend crypto header from FIPS

### DIFF
--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
@@ -5,7 +5,6 @@
  **/
 
 #include "internal/libspdm_crypt_lib.h"
-#include "spdm_crypt_ext_lib/cryptlib_ext.h"
 
 #if LIBSPDM_FIPS_MODE
 

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
@@ -80,22 +80,6 @@ bool libspdm_fips_selftest_hkdf(void)
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
         return false;
     }
-
-    libspdm_zero_mem(out, sizeof(out));
-    result = libspdm_hkdf_sha256_extract_and_expand (hkdf_sha256_ikm, sizeof(hkdf_sha256_ikm),
-                                                     hkdf_sha256_salt, sizeof(hkdf_sha256_salt),
-                                                     hkdf_sha256_info, sizeof(hkdf_sha256_info),
-                                                     out, sizeof(out));
-    if (!result) {
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF extract and expand failed \n"));
-        return false;
-    }
-
-    if (!libspdm_consttime_is_mem_equal(out, hkdf_sha256_okm, sizeof(hkdf_sha256_okm))) {
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HKDF KAT failed \n"));
-        return false;
-    }
-
 #endif/*LIBSPDM_SHA256_SUPPORT*/
 
     return result;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
@@ -5,7 +5,6 @@
  **/
 
 #include "internal/libspdm_crypt_lib.h"
-#include "spdm_crypt_ext_lib/cryptlib_ext.h"
 
 #if LIBSPDM_FIPS_MODE
 


### PR DESCRIPTION
Fix: #1931
Fix: #1930