### PR TITLE
Need enhance the fuzzing test cases to improve the target code coverage

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_encap_certificate/encap_certificate.c
@@ -58,7 +58,11 @@ void libspdm_test_requester_encap_certificate(void **State)
     libspdm_get_encap_response_certificate(spdm_context, request_size,
                                            (uint8_t *)spdm_test_context->test_buffer,
                                            &response_size, response);
-    libspdm_reset_message_mut_b(spdm_context);
+    spdm_error_response_t *spdm_response = (spdm_error_response_t *)response;
+    if (spdm_response->header.request_response_code != SPDM_ERROR)
+    {
+        libspdm_reset_message_mut_b(spdm_context);
+    }
     free(data);
 }
 

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -500,6 +500,188 @@ void libspdm_test_requester_key_exchange_case3(void **State)
 #endif
 }
 
+void libspdm_test_requester_key_exchange_case4(void **State)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t slot_id_param;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *State;
+    m_libspdm_test_case_id = 0x01;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11
+                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.secured_message_version = SPDM_MESSAGE_VERSION_11
+                                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    libspdm_session_info_init(spdm_context,
+                              spdm_context->session_info,
+                              INVALID_SESSION_ID, false);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.base_asym_algo,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+
+    status = libspdm_send_receive_key_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0xFF,
+        &session_id, &heartbeat_period, &slot_id_param,
+        measurement_hash);
+
+    free(data);
+    if (status == LIBSPDM_STATUS_SUCCESS) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+    libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo,
+                      spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+}
+
+void libspdm_test_requester_key_exchange_case5(void **State)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t slot_id_param;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *State;
+    m_libspdm_test_case_id = 0x02;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11
+                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.secured_message_version = SPDM_MESSAGE_VERSION_11
+                                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    libspdm_session_info_init(spdm_context,
+                              spdm_context->session_info,
+                              INVALID_SESSION_ID, false);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.base_asym_algo,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+
+    status = libspdm_send_receive_key_exchange(
+        spdm_context,
+        SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, 0xFF,
+        &session_id, &heartbeat_period, &slot_id_param,
+        measurement_hash);
+
+    free(data);
+    if (status == LIBSPDM_STATUS_SUCCESS) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+    libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo,
+                      spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+}
+
 void libspdm_test_requester_key_exchange_ex_case1(void **State)
 {
     libspdm_return_t status;
@@ -605,6 +787,15 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     /* Successful response V1.2*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_requester_key_exchange_case3(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /* mut_auth cap check*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_requester_key_exchange_case4(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_requester_key_exchange_case5(&State);
     libspdm_unit_test_group_teardown(&State);
 
     libspdm_unit_test_group_setup(&State);

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_psk_exchange/psk_exchange.c
@@ -300,6 +300,71 @@ void libspdm_test_requester_psk_exchange_case2(void **State)
     free(data);
 }
 
+void libspdm_test_requester_psk_exchange_case3(void **State)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    uint32_t session_id;
+    uint8_t heartbeat_period;
+    uint8_t measurement_hash[LIBSPDM_MAX_HASH_SIZE];
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11
+                                            << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags &=
+        ~(SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP);
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP_REQUESTER;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.secured_message_version =
+        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size,
+                                                    &hash, &hash_size);
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule =
+        m_libspdm_use_key_schedule_algo;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size =
+        data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#endif
+
+    heartbeat_period = 0;
+    libspdm_zero_mem(measurement_hash, sizeof(measurement_hash));
+    status = libspdm_send_receive_psk_exchange(spdm_context,
+                                               LIBSPDM_TEST_PSK_HINT_STRING,
+                                               sizeof(LIBSPDM_TEST_PSK_HINT_STRING),
+                                               SPDM_CHALLENGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH,
+                                               0, &session_id, &heartbeat_period, measurement_hash);
+    if (status == LIBSPDM_STATUS_SUCCESS) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+    free(data);
+}
+
 void libspdm_test_requester_psk_exchange_ex_case1(void **State)
 {
     libspdm_return_t status;
@@ -390,6 +455,11 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 
     libspdm_unit_test_group_setup(&State);
     libspdm_test_requester_psk_exchange_ex_case1(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /*  PSK_CAP and context check*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_requester_psk_exchange_case3(&State);
     libspdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -80,6 +80,120 @@ void libspdm_test_responder_respond_if_ready(void **State)
     libspdm_reset_message_c(spdm_context);
 }
 
+void libspdm_test_responder_respond_if_ready_case2(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    uint8_t local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NOT_READY;
+    spdm_get_digest_request_t spdm_test_get_digest_request = {
+        { SPDM_MESSAGE_VERSION_11, SPDM_GET_DIGESTS, 0, 0 },
+    };
+    size_t spdm_test_get_digest_request_size = sizeof(spdm_message_header_t);
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.local_cert_chain_provision[0] =
+        local_certificate_chain;
+    spdm_context->local_context.local_cert_chain_provision_size[0] =
+        sizeof(local_certificate_chain);
+    libspdm_set_mem(local_certificate_chain, sizeof(local_certificate_chain),
+                    (uint8_t)(0xFF));
+
+    spdm_context->last_spdm_request_size = spdm_test_get_digest_request_size;
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
+                     &spdm_test_get_digest_request,  spdm_test_get_digest_request_size);
+
+    spdm_context->cache_spdm_request_size =
+        spdm_context->last_spdm_request_size;
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
+                     spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
+    spdm_context->error_data.rd_exponent = 1;
+    spdm_context->error_data.rd_tm = 1;
+    spdm_context->error_data.request_code = SPDM_GET_DIGESTS;
+    spdm_context->error_data.token = LIBSPDM_MY_TEST_TOKEN;
+
+    response_size = sizeof(response);
+    libspdm_get_response_respond_if_ready(spdm_context,
+                                          spdm_test_context->test_buffer_size,
+                                          spdm_test_context->test_buffer,
+                                          &response_size, response);
+    libspdm_reset_message_b(spdm_context);
+    libspdm_reset_message_c(spdm_context);
+}
+
+void libspdm_test_responder_respond_if_ready_case3(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    uint8_t local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC;
+    spdm_get_digest_request_t spdm_test_get_digest_request = {
+        { SPDM_MESSAGE_VERSION_11, SPDM_GET_DIGESTS, 0, 0 },
+    };
+    size_t spdm_test_get_digest_request_size = sizeof(spdm_message_header_t);
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.local_cert_chain_provision[0] =
+        local_certificate_chain;
+    spdm_context->local_context.local_cert_chain_provision_size[0] =
+        sizeof(local_certificate_chain);
+    libspdm_set_mem(local_certificate_chain, sizeof(local_certificate_chain),
+                    (uint8_t)(0xFF));
+
+    spdm_context->last_spdm_request_size = spdm_test_get_digest_request_size;
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
+                     &spdm_test_get_digest_request,  spdm_test_get_digest_request_size);
+
+    spdm_context->cache_spdm_request_size =
+        spdm_context->last_spdm_request_size;
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
+                     spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
+    spdm_context->error_data.rd_exponent = 1;
+    spdm_context->error_data.rd_tm = 1;
+    spdm_context->error_data.request_code = SPDM_GET_DIGESTS;
+    spdm_context->error_data.token = LIBSPDM_MY_TEST_TOKEN;
+
+    response_size = sizeof(response);
+    libspdm_get_response_respond_if_ready(spdm_context,
+                                          spdm_test_context->test_buffer_size,
+                                          spdm_test_context->test_buffer,
+                                          &response_size, response);
+    libspdm_reset_message_b(spdm_context);
+    libspdm_reset_message_c(spdm_context);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -95,6 +209,15 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_respond_if_ready(&State);
     libspdm_unit_test_group_teardown(&State);
 
+#if LIBSPDM_RESPOND_IF_READY_SUPPORT
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_respond_if_ready_case2(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_respond_if_ready_case3(&State);
+    libspdm_unit_test_group_teardown(&State);
+#endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
 }
 #else
 size_t libspdm_get_max_buffer_size(void)

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_key_exchange/key_exchange.c
@@ -258,6 +258,7 @@ void libspdm_test_responder_key_exchange_case4(void **State)
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP |
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP |
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
     spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
@@ -331,6 +332,8 @@ void libspdm_test_responder_key_exchange_case5(void **State)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP |
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
     spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
@@ -399,6 +402,7 @@ void libspdm_test_responder_key_exchange_case6(void **State)
     spdm_context->connection_info.capability.flags |=
         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
     spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
     spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
     spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
@@ -508,6 +512,97 @@ void libspdm_test_responder_key_exchange_case7(void **State)
     free(data);
 }
 
+void libspdm_test_responder_key_exchange_case8(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    libspdm_key_exchange_request_mine_t *spdm_test_key_exchange_request;
+    size_t spdm_test_key_exchange_request_size;
+    void *data1;
+    size_t data_size1;
+    void *data2;
+    size_t data_size2;
+    uint8_t *ptr;
+    size_t dhe_key_size;
+    void *dhe_context;
+    size_t opaque_key_exchange_req_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_key_exchange_request =
+        (libspdm_key_exchange_request_mine_t *)spdm_test_context->test_buffer;
+    spdm_test_key_exchange_request_size = spdm_test_context->test_buffer_size;
+    spdm_test_key_exchange_request->header.param2 = 0xFF;
+
+    /* Clear previous sessions */
+    if(spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_free_session_id(spdm_context,0xFFFFFFFF);
+    }
+
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo =
+        m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec =
+        m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_key(m_libspdm_use_asym_algo, &data1, &data_size1);
+    spdm_context->local_context.local_public_key_provision = data1;
+    spdm_context->local_context.local_public_key_provision_size = data_size1;
+    libspdm_read_requester_public_key(m_libspdm_use_req_asym_algo, &data2, &data_size2);
+    spdm_context->local_context.peer_public_key_provision = data2;
+    spdm_context->local_context.peer_public_key_provision_size = data_size2;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+
+    ptr = spdm_test_key_exchange_request->exchange_data;
+    dhe_key_size = libspdm_get_dhe_pub_key_size(m_libspdm_use_dhe_algo);
+    dhe_context = libspdm_dhe_new(spdm_context->connection_info.version, m_libspdm_use_dhe_algo,
+                                  false);
+    libspdm_dhe_generate_key(m_libspdm_use_dhe_algo, dhe_context, ptr, &dhe_key_size);
+    ptr += dhe_key_size;
+    libspdm_dhe_free(m_libspdm_use_dhe_algo, dhe_context);
+    opaque_key_exchange_req_size =
+        libspdm_get_opaque_data_supported_version_data_size(spdm_context);
+    *(uint16_t *)ptr = (uint16_t)opaque_key_exchange_req_size;
+    ptr += sizeof(uint16_t);
+    libspdm_build_opaque_data_supported_version_data(spdm_context, &opaque_key_exchange_req_size,
+                                                     ptr);
+    ptr += opaque_key_exchange_req_size;
+    response_size = sizeof(response);
+
+    libspdm_get_response_key_exchange(spdm_context, spdm_test_key_exchange_request_size,
+                                      spdm_test_key_exchange_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+    free(data1);
+    free(data2);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -551,7 +646,14 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_key_exchange_case7(&State);
     libspdm_unit_test_group_teardown(&State);
+
+    /* Request previously provisioned public key, slot 0xFF */
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_key_exchange_case8(&State);
+    libspdm_unit_test_group_teardown(&State);
 }
+
+
 #else
 size_t libspdm_get_max_buffer_size(void)
 {

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -464,6 +464,85 @@ void libspdm_test_responder_psk_exchange_case6(void **State)
     free(data);
 }
 
+void libspdm_test_responder_psk_exchange_case7(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    void *data;
+    size_t data_size;
+    libspdm_psk_exchange_request_mine_t *spdm_test_psk_exchange_request;
+    size_t spdm_test_psk_exchange_request_size;
+    uint8_t *ptr;
+    size_t opaque_psk_exchange_req_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_psk_exchange_request =
+        (libspdm_psk_exchange_request_mine_t *)spdm_test_context->test_buffer;
+    spdm_test_psk_exchange_request_size = spdm_test_context->test_buffer_size;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->connection_info.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size,
+                                                    NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
+
+    libspdm_reset_message_a(spdm_context);
+
+    opaque_psk_exchange_req_size =
+        libspdm_get_opaque_data_supported_version_data_size(spdm_context);
+    ptr = spdm_test_psk_exchange_request->psk_hint;
+    libspdm_copy_mem(ptr, sizeof(spdm_test_psk_exchange_request->psk_hint),
+                     LIBSPDM_TEST_PSK_HINT_STRING,
+                     sizeof(LIBSPDM_TEST_PSK_HINT_STRING));
+    if (spdm_test_psk_exchange_request->psk_hint_length <= LIBSPDM_PSK_MAX_HINT_LENGTH) {
+        ptr += spdm_test_psk_exchange_request->psk_hint_length;
+    } else {
+        ptr += LIBSPDM_PSK_MAX_HINT_LENGTH;
+    }
+    libspdm_get_random_number(LIBSPDM_PSK_CONTEXT_LENGTH, ptr);
+    if (spdm_test_psk_exchange_request->context_length <= LIBSPDM_PSK_CONTEXT_LENGTH) {
+        ptr += spdm_test_psk_exchange_request->context_length;
+    } else {
+        ptr += LIBSPDM_PSK_CONTEXT_LENGTH;
+    }
+    libspdm_build_opaque_data_supported_version_data(spdm_context, &opaque_psk_exchange_req_size,
+                                                     ptr);
+    ptr += opaque_psk_exchange_req_size;
+    response_size = sizeof(response);
+
+    libspdm_get_response_psk_exchange(spdm_context, spdm_test_psk_exchange_request_size,
+                                      spdm_test_psk_exchange_request, &response_size,
+                                      response);
+
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+    free(data);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -502,6 +581,11 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_psk_exchange_case6(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /* capability.flags: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER */
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_psk_exchange_case7(&State);
     libspdm_unit_test_group_teardown(&State);
 }
 #else

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -189,6 +189,95 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
     free(data1);
 }
 
+void libspdm_test_responder_psk_finish_rsp_case3(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_psk_finish_request_mine_t *spdm_test_psk_finish_request;
+    size_t spdm_test_psk_finish_request_size;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    void *data1;
+    size_t data_size1;
+    static uint8_t m_dummy_buffer[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t hash_data[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t request_finished_key[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t *ptr;
+    libspdm_session_info_t *session_info;
+    uint32_t session_id;
+    uint32_t hash_size;
+    uint32_t hmac_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_psk_finish_request =
+        (libspdm_psk_finish_request_mine_t *)spdm_test_context->test_buffer;
+    spdm_test_psk_finish_request_size = spdm_test_context->test_buffer_size;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state |= LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP;
+    spdm_context->handle_error_return_policy =
+        LIBSPDM_DATA_HANDLE_ERROR_RETURN_POLICY_DROP_ON_DECRYPT_ERROR;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo,
+                                                    &data1, &data_size1,
+                                                    NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data1;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
+    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
+    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.mut_auth_requested = 0;
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
+    libspdm_secured_message_set_request_finished_key(session_info->secured_message_context,
+                                                     m_dummy_buffer, hash_size);
+    libspdm_secured_message_set_session_state(session_info->secured_message_context,
+                                              LIBSPDM_SESSION_STATE_HANDSHAKING);
+
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+    ptr = spdm_test_psk_finish_request->verify_data;
+    libspdm_init_managed_buffer(&th_curr, sizeof(th_curr.buffer));
+
+    libspdm_append_managed_buffer(&th_curr, (uint8_t *)spdm_test_psk_finish_request,
+                                  sizeof(spdm_psk_finish_request_t));
+    libspdm_set_mem(request_finished_key, LIBSPDM_MAX_HASH_SIZE, (uint8_t)(0xFF));
+    libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
+                     libspdm_get_managed_buffer_size(&th_curr), hash_data);
+    libspdm_hmac_all(m_libspdm_use_hash_algo, hash_data, hash_size,
+                     request_finished_key, hash_size, ptr);
+    spdm_test_psk_finish_request_size = sizeof(spdm_psk_finish_request_t) + hmac_size;
+    response_size = sizeof(response);
+    libspdm_get_response_psk_finish(spdm_context, spdm_test_psk_finish_request_size,
+                                    spdm_test_psk_finish_request, &response_size, response);
+    if (spdm_context->session_info[0].session_id != INVALID_SESSION_ID) {
+        libspdm_reset_message_f(spdm_context, spdm_context->session_info);
+        libspdm_reset_message_k(spdm_context, spdm_context->session_info);
+    }
+    free(data1);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -206,6 +295,12 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_psk_finish_rsp_case2(&State);
     libspdm_unit_test_group_teardown(&State);
+
+    #if LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_psk_finish_rsp_case3(&State);
+    libspdm_unit_test_group_teardown(&State);
+    #endif /* LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP */
 }
 #else
 size_t libspdm_get_max_buffer_size(void)


### PR DESCRIPTION
Fix : #1994 
Increase object code coverage to 75%

libspdm_req_get_certificate.c	79.9 %
libspdm_req_key_exchange.c	78.9 %
libspdm_req_psk_exchange.c	76.2 %	
libspdm_rsp_key_exchange.c	83.0%
libspdm_rsp_psk_exchange.c	83.1 %
libspdm_rsp_psk_finish.c	82.1%
libspdm_rsp_respond_if_ready.c	84.6 %