### PR TITLE
libspdm_doe_pcidoe: Add DOE discovery encode/decode helpers

### DIFF
--- a/include/library/spdm_transport_pcidoe_lib.h
+++ b/include/library/spdm_transport_pcidoe_lib.h
@@ -65,6 +65,21 @@ libspdm_return_t libspdm_transport_pci_doe_encode_message(
     size_t *transport_message_size, void **transport_message);
 
 /**
+ * Encode a DOE discovery message.
+ *
+ * @param  message_size                         Size in bytes of the message data buffer.
+ * @param  message                              A pointer to a source buffer to store the message.
+ * @param  transport_message_size               Size in bytes of the transport message data buffer.
+ * @param  transport_message                    A pointer to a destination buffer to store the transport message.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS               The message is encoded successfully.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+ **/
+libspdm_return_t libspdm_pci_doe_encode_discovery(size_t message_size, void *message,
+                                                  size_t *transport_message_size,
+                                                  void **transport_message);
+
+/**
  * Decode an SPDM or APP message from a transport layer message.
  *
  * For normal SPDM message, it removes the transport layer wrapper,

--- a/include/library/spdm_transport_pcidoe_lib.h
+++ b/include/library/spdm_transport_pcidoe_lib.h
@@ -101,6 +101,51 @@ libspdm_return_t libspdm_transport_pci_doe_decode_message(
     size_t *message_size, void **message);
 
 /**
+ * Decode a DOE discovery request message.
+ *
+ * @param  transport_message_size               Size in bytes of the transport message data buffer.
+ * @param  transport_message                    A pointer to a source buffer to store the transport message.
+ * @param  index                                A pointer to a destination to store the index.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS               The message is encoded successfully.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+ **/
+libspdm_return_t libspdm_pci_doe_decode_discovery_request(size_t transport_message_size,
+                                                          const void *transport_message,
+                                                          uint8_t *index);
+/**
+ * Decode a DOE discovery response message.
+ *
+ * @param  transport_message_size               Size in bytes of the transport message data buffer.
+ * @param  transport_message                    A pointer to a source buffer to store the transport message.
+ * @param  vendor_id                            A pointer to a destination to store the vendor_id.
+ * @param  protocol                             A pointer to a destination to store the protocol.
+ * @param  next_index                           A pointer to a destination to store the next_index.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS               The message is encoded successfully.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER     The message is NULL or the message_size is zero.
+ **/
+libspdm_return_t libspdm_pci_doe_decode_discovery_response(size_t transport_message_size,
+                                                           void *transport_message,
+                                                           uint16_t *vendor_id,
+                                                           uint8_t *protocol,
+                                                           uint8_t *next_index);
+
+/**
+ * Return the maximum transport layer message header size.
+ *   Transport Message Header Size + sizeof(spdm_secured_message_cipher_header_t))
+ *
+ *   For MCTP, Transport Message Header Size = sizeof(mctp_message_header_t)
+ *   For PCI_DOE, Transport Message Header Size = sizeof(pci_doe_data_object_header_t)
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ *
+ * @return size of maximum transport layer message header size
+ **/
+uint32_t libspdm_transport_pci_doe_get_header_size(
+    void *spdm_context);
+
+/**
  * Get sequence number in an SPDM secure message.
  *
  * This value is transport layer specific.

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_decode_message/spdm_transport_pci_doe_decode_message.c
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_decode_message/spdm_transport_pci_doe_decode_message.c
@@ -42,6 +42,33 @@ libspdm_test_context_t m_libspdm_transport_pci_doe_test_context = {
     false,
 };
 
+void libspdm_test_transport_pci_doe_decode_discovery(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    bool is_requester;
+
+    spdm_test_context = *State;
+    is_requester = spdm_test_context->is_requester;
+
+    if (is_requester) {
+        uint8_t index = 0;
+
+        libspdm_pci_doe_decode_discovery_request(spdm_test_context->test_buffer_size,
+                                                 spdm_test_context->test_buffer,
+                                                 &index);
+    } else {
+        uint16_t vendor_id = 0;
+        uint8_t protocol = 0;
+        uint8_t next_index = 0;
+
+        libspdm_pci_doe_decode_discovery_response(spdm_test_context->test_buffer_size,
+                                                  spdm_test_context->test_buffer,
+                                                  &vendor_id,
+                                                  &protocol,
+                                                  &next_index);
+    }
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -54,6 +81,8 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_unit_test_group_setup(&State);
 
     libspdm_test_transport_pci_doe_decode_message(&State);
+
+    libspdm_test_transport_pci_doe_decode_discovery(&State);
 
     libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/spdm_transport_pci_doe_encode_message.c
+++ b/unit_test/fuzzing/test_transport/test_spdm_transport_pci_doe_encode_message/spdm_transport_pci_doe_encode_message.c
@@ -54,6 +54,34 @@ libspdm_test_context_t m_libspdm_transport_pci_doe_test_context = {
     false,
 };
 
+void libspdm_test_transport_pci_doe_encode_discovery(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    size_t transport_message_size;
+    uint8_t *transport_message;
+    size_t record_header_max_size;
+
+    spdm_test_context = *State;
+
+    /* limit the encoding buffer to avoid assert, because the input buffer is controlled by the the libspdm consumer. */
+    record_header_max_size = sizeof(pci_doe_data_object_header_t) +
+                             sizeof(spdm_secured_message_a_data_header1_t) +
+                             0 + /* PCI_DOE_SEQUENCE_NUMBER_COUNT */
+                             sizeof(spdm_secured_message_a_data_header2_t) +
+                             sizeof(spdm_secured_message_cipher_header_t) +
+                             0; /* PCI_DOE_MAX_RANDOM_NUMBER_COUNT */
+    LIBSPDM_ASSERT(spdm_test_context->test_buffer_size > record_header_max_size);
+
+    transport_message_size = LIBSPDM_MAX_SENDER_RECEIVER_BUFFER_SIZE;
+    transport_message = spdm_test_context->test_buffer;
+
+    libspdm_pci_doe_encode_discovery(spdm_test_context->test_buffer_size - record_header_max_size,
+                                     (uint8_t *)spdm_test_context->test_buffer + record_header_max_size,
+                                     &transport_message_size,
+                                     (void **)&transport_message);
+}
+
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;


### PR DESCRIPTION
Add helper functions for encoding/decoding the DOE discovery protocol. All DOE requesters and responders must implement this protocol.

There isn't a straight forwrad way to integrate this into libspdm so let's instead implement helper functions that can be used directly by the custom send and receive functions.
