### PR TITLE
Enforce DSP0277 capabilities

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -74,7 +74,10 @@ static bool validate_responder_capability(uint32_t capabilities_flag, uint8_t ve
 
         /* Checks that originate from key exchange capabilities. */
         if ((key_ex_cap == 1) || (psk_cap != 0)) {
-            if ((mac_cap == 0) && (encrypt_cap == 0)) {
+            /* While clearing MAC_CAP and setting ENCRYPT_CAP is legal according to DSP0274, libspdm
+             * also implements DSP0277 secure messages, which requires at least MAC_CAP to be set.
+             */
+            if (mac_cap == 0) {
                 return false;
             }
         } else {

--- a/library/spdm_responder_lib/libspdm_rsp_capabilities.c
+++ b/library/spdm_responder_lib/libspdm_rsp_capabilities.c
@@ -69,7 +69,10 @@ static bool libspdm_check_request_flag_compatibility(uint32_t capabilities_flag,
 
         /* Checks that originate from key exchange capabilities. */
         if ((key_ex_cap == 1) || (psk_cap == 1)) {
-            if ((mac_cap == 0) && (encrypt_cap == 0)) {
+            /* While clearing MAC_CAP and setting ENCRYPT_CAP is legal according to DSP0274, libspdm
+             * also implements DSP0277 secure messages, which requires at least MAC_CAP to be set.
+             */
+            if (mac_cap == 0) {
                 return false;
             }
         } else {


### PR DESCRIPTION
Fix #1986.

Note that this code path is already covered in a unit test that sets `ENC_CAP=0` and `MAC_CAP=0`.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>