### PR TITLE
os_stub/cryptlib_openssl: Fixup typo

### DIFF
--- a/os_stub/cryptlib_openssl/CMakeLists.txt
+++ b/os_stub/cryptlib_openssl/CMakeLists.txt
@@ -22,7 +22,7 @@ elseif(ARCH STREQUAL "riscv32")
 elseif(ARCH STREQUAL "riscv64")
     ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_RISCV64)
 else()
-    MESSAGE(FATAL_ERROR "Unknown nARCH")
+    MESSAGE(FATAL_ERROR "Unknown ARCH")
 endif()
 
 SET(src_cryptlib_openssl


### PR DESCRIPTION
Resolves: https://github.com/DMTF/libspdm/issues/2022