### PR TITLE
Check the whole last SPDM CSR request data

### DIFF
--- a/include/hal/library/responder_secretlib.h
+++ b/include/hal/library/responder_secretlib.h
@@ -217,6 +217,9 @@ extern bool libspdm_responder_data_sign(
  * @param[in]      need_reset            If true, then device needs to be reset to complete the CSR.
  *                                       If false
  *
+ * @param[in]      request                A pointer to the SPDM request data.
+ * @param[in]      request_size           The size of SPDM request data.
+ *
  * @param[in]      requester_info         Requester info to generate the CSR.
  * @param[in]      requester_info_length  The length of requester info.
  *
@@ -233,6 +236,7 @@ extern bool libspdm_responder_data_sign(
  * @retval  false  Failed to gen CSR.
  **/
 extern bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *need_reset,
+                            const void *request, size_t request_size,
                             uint8_t *requester_info, size_t requester_info_length,
                             uint8_t *opaque_data, uint16_t opaque_data_length,
                             size_t *csr_len, uint8_t *csr_pointer);

--- a/library/spdm_responder_lib/libspdm_rsp_csr.c
+++ b/library/spdm_responder_lib/libspdm_rsp_csr.c
@@ -137,7 +137,8 @@ libspdm_return_t libspdm_get_response_csr(libspdm_context_t *spdm_context,
     csr_p = (uint8_t*)(spdm_response + 1);
     result = libspdm_gen_csr(spdm_context->connection_info.algorithm.base_hash_algo,
                              spdm_context->connection_info.algorithm.base_asym_algo,
-                             &need_reset, requester_info, requester_info_length,
+                             &need_reset, request, request_size,
+                             requester_info, requester_info_length,
                              opaque_data, opaque_data_length,
                              &csr_len, csr_p);
     if (!result) {

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -110,6 +110,7 @@ bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
 
 #if LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP
 bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *need_reset,
+                     const void *request, size_t request_size,
                      uint8_t *requester_info, size_t requester_info_length,
                      uint8_t *opaque_data, uint16_t opaque_data_length,
                      size_t *csr_len, uint8_t *csr_pointer)

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -134,34 +134,12 @@ bool libspdm_test_read_cached_csr(uint32_t base_asym_algo, uint8_t **csr_pointer
     return res;
 }
 
-/*clean the cached req_info*/
-void libspdm_test_clear_cached_req_info(uint32_t base_asym_algo)
+/*clean the cached last SPDM csr request*/
+void libspdm_test_clear_cached_last_request()
 {
     char *file;
 
-    switch (base_asym_algo) {
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_2048:
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_2048:
-        file = "rsa2048_req_info";
-        break;
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_3072:
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_3072:
-        file = "rsa3072_req_info";
-        break;
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSASSA_4096:
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_RSAPSS_4096:
-        file = "rsa4096_req_info";
-        break;
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P256:
-        file = "ecp256_req_info";
-        break;
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384:
-        file = "ecp384_req_info";
-        break;
-    case SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P521:
-        file = "ecp521_req_info";
-        break;
-    }
+    file = "cached_last_csr_request";
 
     libspdm_write_output_file(file, NULL, 0);
 }
@@ -602,7 +580,7 @@ void libspdm_test_responder_csr_case6(void **state)
     assert_memory_equal(spdm_response + 1, cached_csr, spdm_response->csr_length);
 
     /*clear cached req_info*/
-    libspdm_test_clear_cached_req_info(m_libspdm_use_asym_algo);
+    libspdm_test_clear_cached_last_request();
     free(m_libspdm_get_csr_request);
 }
 


### PR DESCRIPTION
Fix: #2051

**Commit1:**
Cache the last last SPDM CSR request data;
Add `request` and `request_size` as `libspdm_gen_csr` input;

**The old parameters `requester_info `and `opaque_data` are also saved as input. Because the `spdm_get_csr_request` structure 
should not be known in `os_stub`.  The `requester_info `and `opaque_data` are only got in `library`.**

**Commit2:**
clear last SPDM CSR request data in unit_test;

