### PR TITLE
Fix incorrect use LIBSPDM_DATA_TRANSFER_SIZE and LIBSPDM_MAX_SPDM_MSG…

### DIFF
--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -1045,7 +1045,7 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
         spdm_response->ct_exponent = 0;
         spdm_response->flags = LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_12;
         spdm_response->data_transfer_size = LIBSPDM_DATA_TRANSFER_SIZE;
-        spdm_response->max_spdm_msg_size = LIBSPDM_MAX_SPDM_MSG_SIZE - 1;
+        spdm_response->max_spdm_msg_size = LIBSPDM_DATA_TRANSFER_SIZE - 1;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
                                               false, spdm_response_size,

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -449,7 +449,7 @@ spdm_get_capabilities_request_t m_libspdm_get_capabilities_request26 = {
     (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP|
      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP),
     LIBSPDM_DATA_TRANSFER_SIZE,
-    LIBSPDM_MAX_SPDM_MSG_SIZE - 1,
+    LIBSPDM_DATA_TRANSFER_SIZE - 1,
 };
 size_t m_libspdm_get_capabilities_request26_size = sizeof(m_libspdm_get_capabilities_request26);
 


### PR DESCRIPTION
…_SIZE in unit tests.

Fix: #2071