### PR TITLE
Add alias cert mode support

### DIFF
--- a/include/hal/library/responder_secretlib.h
+++ b/include/hal/library/responder_secretlib.h
@@ -232,6 +232,9 @@ extern bool libspdm_responder_data_sign(
  *                              On output, csr_pointer is address for stored CSR.
  *                              The csr_pointer address will be changed.
  *
+ * @param[in]       is_device_cert_model  If true, the cert chain is DeviceCert model.
+ *                                        If false, the cert chain is AliasCert model.
+ *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
  **/
@@ -239,7 +242,8 @@ extern bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bo
                             const void *request, size_t request_size,
                             uint8_t *requester_info, size_t requester_info_length,
                             uint8_t *opaque_data, uint16_t opaque_data_length,
-                            size_t *csr_len, uint8_t *csr_pointer);
+                            size_t *csr_len, uint8_t *csr_pointer,
+                            bool is_device_cert_model);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP */
 
 #endif /* RESPONDER_SECRETLIB_H */

--- a/library/spdm_responder_lib/libspdm_rsp_csr.c
+++ b/library/spdm_responder_lib/libspdm_rsp_csr.c
@@ -26,6 +26,7 @@ libspdm_return_t libspdm_get_response_csr(libspdm_context_t *spdm_context,
     uint8_t *opaque_data;
     uint8_t *requester_info;
     bool need_reset;
+    bool is_device_cert_model;
 
     spdm_request = request;
 
@@ -142,6 +143,13 @@ libspdm_return_t libspdm_get_response_csr(libspdm_context_t *spdm_context,
     spdm_response = response;
     libspdm_zero_mem(response, *response_size);
 
+    is_device_cert_model = false;
+
+    if((spdm_context->local_context.capability.flags &
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP) == 0) {
+        is_device_cert_model = true;
+    }
+
     csr_len = *response_size - sizeof(spdm_csr_response_t);
     csr_p = (uint8_t*)(spdm_response + 1);
     result = libspdm_gen_csr(spdm_context->connection_info.algorithm.base_hash_algo,
@@ -149,7 +157,7 @@ libspdm_return_t libspdm_get_response_csr(libspdm_context_t *spdm_context,
                              &need_reset, request, request_size,
                              requester_info, requester_info_length,
                              opaque_data, opaque_data_length,
-                             &csr_len, csr_p);
+                             &csr_len, csr_p, is_device_cert_model);
     if (!result) {
         return libspdm_generate_error_response(
             spdm_context,

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -19,6 +19,7 @@
 #include <mbedtls/x509_csr.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/oid.h>
 #include <string.h>
 
 #if LIBSPDM_CERT_PARSE_SUPPORT
@@ -1702,6 +1703,8 @@ bool libspdm_set_attribute_for_req(mbedtls_x509write_csr *req, uint8_t *req_info
  * @param[in]      requester_info        requester info to gen CSR
  * @param[in]      requester_info_length The len of requester info
  *
+ * @param[in]       is_ca                if true, set basic_constraints: CA:true; Otherwise, set to false.
+ *
  * @param[in]      context               Pointer to asymmetric context
  * @param[in]      subject_name          Subject name: should be break with ',' in the middle
  *                                       example: "C=AA,CN=BB"
@@ -1713,17 +1716,18 @@ bool libspdm_set_attribute_for_req(mbedtls_x509write_csr *req, uint8_t *req_info
  * "SN","givenName","GN", "initials", "pseudonym", "generationQualifier", "domainComponent", "DC"}.
  * Note: The object of C and countryName should be CSR Supported Country Codes
  *
- * @param[in]      csr_len               For input, csr_len is the size of store CSR buffer.
- *                                       For output, csr_len is CSR len for DER format
- * @param[in]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
- *                                       For output, csr_pointer is address for stored CSR.
- *                                       The csr_pointer address will be changed.
+ * @param[in, out]      csr_len               For input, csr_len is the size of store CSR buffer.
+ *                                            For output, csr_len is CSR len for DER format
+ * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
+ *                                            For output, csr_pointer is address for stored CSR.
+ *                                            The csr_pointer address will be changed.
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
  **/
 bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                           uint8_t *requester_info, size_t requester_info_length,
+                          bool is_ca,
                           void *context, char *subject_name,
                           size_t *csr_len, uint8_t *csr_pointer)
 {
@@ -1734,6 +1738,14 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
     mbedtls_x509write_csr req;
     mbedtls_md_type_t md_alg;
     mbedtls_pk_context key;
+
+    /*basic_constraints: CA: false */
+    #define BASIC_CONSTRAINTS_STRING_FALSE {0x30, 0x00}
+    uint8_t basic_constraints_false[] = BASIC_CONSTRAINTS_STRING_FALSE;
+
+    /*basic_constraints: CA: true */
+    #define BASIC_CONSTRAINTS_STRING_TRUE {0x30, 0x03, 0x01, 0x01, 0xFF}
+    uint8_t basic_constraints_true[] = BASIC_CONSTRAINTS_STRING_TRUE;
 
     /* Init */
     mbedtls_x509write_csr_init(&req);
@@ -1824,6 +1836,20 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
 
     /* Set key */
     mbedtls_x509write_csr_set_key(&req, &key);
+
+    /*set basicConstraints*/
+    if (mbedtls_x509write_csr_set_extension(&req, MBEDTLS_OID_BASIC_CONSTRAINTS,
+                                            MBEDTLS_OID_SIZE(MBEDTLS_OID_BASIC_CONSTRAINTS),
+                                            is_ca ? basic_constraints_true : basic_constraints_false,
+                                            is_ca ?
+                                            sizeof(basic_constraints_true) :
+                                            sizeof(basic_constraints_false)
+                                            ) != 0) {
+        ret = 1;
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                       "mbedtls_x509write_csr_set_extension set basicConstraints failed \n"));
+        goto free_all;
+    }
 
     /*csr data is written at the end of the buffer*/
     ret = mbedtls_x509write_csr_der(&req, csr_pointer, csr_buffer_size, libspdm_myrand, NULL);

--- a/os_stub/cryptlib_null/pk/x509.c
+++ b/os_stub/cryptlib_null/pk/x509.c
@@ -748,6 +748,8 @@ int32_t libspdm_x509_compare_date_time(const void *date_time1, const void *date_
  * @param[in]      requester_info        requester info to gen CSR
  * @param[in]      requester_info_length The len of requester info
  *
+ * @param[in]       is_ca                if true, set basic_constraints: CA:true; Otherwise, set to false.
+ *
  * @param[in]      context               Pointer to asymmetric context
  * @param[in]      subject_name          Subject name: should be break with ',' in the middle
  *                                       example: "C=AA,CN=BB"
@@ -759,17 +761,18 @@ int32_t libspdm_x509_compare_date_time(const void *date_time1, const void *date_
  * "SN","givenName","GN", "initials", "pseudonym", "generationQualifier", "domainComponent", "DC"}.
  * Note: The object of C and countryName should be CSR Supported Country Codes
  *
- * @param[in]      csr_len               For input, csr_len is the size of store CSR buffer.
- *                                       For output, csr_len is CSR len for DER format
- * @param[in]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
- *                                       For output, csr_pointer is address for stored CSR.
- *                                       The csr_pointer address will be changed.
+ * @param[in, out]      csr_len               For input, csr_len is the size of store CSR buffer.
+ *                                            For output, csr_len is CSR len for DER format
+ * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
+ *                                            For output, csr_pointer is address for stored CSR.
+ *                                            The csr_pointer address will be changed.
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
  **/
 bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                           uint8_t *requester_info, size_t requester_info_length,
+                          bool is_ca,
                           void *context, char *subject_name,
                           size_t *csr_len, uint8_t *csr_pointer)
 {

--- a/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
+++ b/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
@@ -642,6 +642,8 @@ extern bool libspdm_sm2_dsa_generate_key(void *sm2_context, uint8_t *public_data
  * @param[in]      requester_info        requester info to gen CSR
  * @param[in]      requester_info_length The len of requester info
  *
+ * @param[in]       is_ca                if true, set basic_constraints: CA:true; Otherwise, set to false.
+ *
  * @param[in]      context               Pointer to asymmetric context
  * @param[in]      subject_name          Subject name: should be break with ',' in the middle
  *                                       example: "C=AA,CN=BB"
@@ -654,17 +656,18 @@ extern bool libspdm_sm2_dsa_generate_key(void *sm2_context, uint8_t *public_data
  * "SN","givenName","GN", "initials", "pseudonym", "generationQualifier", "domainComponent", "DC"}.
  * Note: The object of C and countryName should be CSR Supported Country Codes
  *
- * @param[in]      csr_len               For input, csr_len is the size of store CSR buffer.
- *                                       For output, csr_len is CSR len for DER format
- * @param[in]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
- *                                       For output, csr_pointer is address for stored CSR.
- *                                       The csr_pointer address will be changed.
+ * @param[in, out]      csr_len               For input, csr_len is the size of store CSR buffer.
+ *                                            For output, csr_len is CSR len for DER format
+ * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
+ *                                            For output, csr_pointer is address for stored CSR.
+ *                                            The csr_pointer address will be changed.
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
  **/
 extern bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                                  uint8_t *requester_info, size_t requester_info_length,
+                                 bool is_ca,
                                  void *context, char *subject_name,
                                  size_t *csr_len, uint8_t *csr_pointer);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_GET_CSR_CAP */

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -113,7 +113,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
                      const void *request, size_t request_size,
                      uint8_t *requester_info, size_t requester_info_length,
                      uint8_t *opaque_data, uint16_t opaque_data_length,
-                     size_t *csr_len, uint8_t *csr_pointer)
+                     size_t *csr_len, uint8_t *csr_pointer,
+                     bool is_device_cert_model)
 {
     return false;
 }

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1057,7 +1057,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
                      const void *request, size_t request_size,
                      uint8_t *requester_info, size_t requester_info_length,
                      uint8_t *opaque_data, uint16_t opaque_data_length,
-                     size_t *csr_len, uint8_t *csr_pointer)
+                     size_t *csr_len, uint8_t *csr_pointer,
+                     bool is_device_cert_model)
 {
     bool result;
     size_t hash_nid;
@@ -1139,6 +1140,7 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
 
         result = libspdm_gen_x509_csr(hash_nid, asym_nid,
                                       requester_info, requester_info_length,
+                                      !is_device_cert_model,
                                       context, subject_name,
                                       csr_len, csr_pointer);
         libspdm_asym_free(base_asym_algo, context);
@@ -1157,6 +1159,7 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
 
     result = libspdm_gen_x509_csr(hash_nid, asym_nid,
                                   requester_info, requester_info_length,
+                                  !is_device_cert_model,
                                   context, subject_name,
                                   csr_len, csr_pointer);
     libspdm_asym_free(base_asym_algo, context);


### PR DESCRIPTION
Fix: #2056

Add `is_device_cert_model` to set different `basicConstraints`;