### PR TITLE
Fix logic error when use libspdm_consttime_is_mem_equal

### DIFF
--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -85,7 +85,7 @@ bool libspdm_find_buffer(char *src, size_t src_len, char *dst, size_t dst_len)
 
     for (index = 0; index < src_len - dst_len; index++) {
         if ((*(src + index) == *dst) &&
-            (libspdm_consttime_is_mem_equal(src + index, dst, dst_len) == 0)) {
+            libspdm_consttime_is_mem_equal(src + index, dst, dst_len)) {
             return true;
         }
     }


### PR DESCRIPTION
The logic is wrong when use `libspdm_consttime_is_mem_equal`.