### PR TITLE
Supply slot_id to libspdm_*_data_sign()

### DIFF
--- a/include/hal/library/requester_secretlib.h
+++ b/include/hal/library/requester_secretlib.h
@@ -16,6 +16,7 @@
  *
  * @param  req_base_asym_alg Indicates the signing algorithm.
  * @param  base_hash_algo    Indicates the hash algorithm.
+ * @param  slot_id           The number of slot for the certificate chain.
  * @param  is_data_hash      Indicates the message type.
  *                           If true, raw message before hash.
  *                           If false, message hash.
@@ -34,7 +35,8 @@ extern bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version,
     uint8_t op_code,
     uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */

--- a/include/hal/library/responder_secretlib.h
+++ b/include/hal/library/responder_secretlib.h
@@ -216,6 +216,7 @@ extern bool libspdm_psk_master_secret_hkdf_expand(
  *
  * @param  base_asym_algo  Indicates the signing algorithm.
  * @param  base_hash_algo  Indicates the hash algorithm.
+ * @param  slot_id         The number of slot for the certificate chain.
  * @param  is_data_hash    Indicate the message type.
  *                         If true, raw message before hash.
  *                         If false, message hash.
@@ -232,7 +233,8 @@ extern bool libspdm_psk_master_secret_hkdf_expand(
 extern bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version,
     uint8_t op_code, uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size);
 

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -873,6 +873,7 @@ bool libspdm_verify_peer_cert_chain_buffer(libspdm_context_t *spdm_context,
  **/
 bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
                                                bool is_requester,
+                                               uint8_t slot_id,
                                                uint8_t *signature);
 
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -863,6 +863,7 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
  **/
 bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
                                             libspdm_session_info_t *session_info,
+                                            uint8_t slot_id,
                                             uint8_t *signature);
 
 #endif /* SPDM_RESPONDER_LIB_INTERNAL_H */

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -785,6 +785,7 @@ bool libspdm_verify_peer_cert_chain_buffer(libspdm_context_t *spdm_context,
  **/
 bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
                                                bool is_requester,
+                                               uint8_t slot_id,
                                                uint8_t *signature)
 {
     bool result;
@@ -826,12 +827,14 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            slot_id,
             false, m1m2_buffer, m1m2_buffer_size, signature, &signature_size);
 #else
         result = libspdm_requester_data_sign(
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            slot_id,
             true, m1m2_hash, m1m2_hash_size, signature, &signature_size);
 #endif
 #else /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */
@@ -845,6 +848,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            slot_id,
             false, m1m2_buffer, m1m2_buffer_size, signature,
             &signature_size);
 #else
@@ -852,6 +856,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            slot_id,
             true, m1m2_hash, m1m2_hash_size, signature,
             &signature_size);
 #endif

--- a/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_challenge_auth.c
@@ -177,7 +177,7 @@ libspdm_return_t libspdm_get_encap_response_challenge_auth(
             response_size, response);
     }
     result =
-        libspdm_generate_challenge_auth_signature(context, true, ptr);
+        libspdm_generate_challenge_auth_signature(context, true, slot_id, ptr);
     if (!result) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_UNSPECIFIED,

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -303,12 +303,14 @@ bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.peer_used_cert_chain_slot_id,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_requester_data_sign(
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.peer_used_cert_chain_slot_id,
         true, hash_data, hash_size, signature, &signature_size);
 #endif
     if (result) {

--- a/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
+++ b/library/spdm_responder_lib/libspdm_rsp_challenge_auth.c
@@ -271,7 +271,7 @@ libspdm_return_t libspdm_get_response_challenge_auth(libspdm_context_t *spdm_con
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,
                                                response_size, response);
     }
-    result = libspdm_generate_challenge_auth_signature(spdm_context, false, ptr);
+    result = libspdm_generate_challenge_auth_signature(spdm_context, false, slot_id, ptr);
     if (!result) {
         libspdm_reset_message_c(spdm_context);
         return libspdm_generate_error_response(

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -84,8 +84,8 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
 {
     bool result;
     size_t signature_size;
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     uint8_t slot_id;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     uint8_t *th_curr_data;
     size_t th_curr_data_size;
     libspdm_th_managed_buffer_t th_curr;
@@ -105,9 +105,10 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);
 
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     if (slot_id == 0xFF) {
         result = libspdm_get_local_public_key_buffer(
             spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
@@ -152,12 +153,14 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        slot_id,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        slot_id,
         true, hash_data, hash_size, signature, &signature_size);
 #endif
     if (result) {

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -9,6 +9,7 @@
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
 bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
                                             libspdm_session_info_t *session_info,
+                                            uint8_t slot_id,
                                             uint8_t *signature)
 {
     size_t signature_size;
@@ -43,12 +44,14 @@ bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        slot_id
         false, l1l2_buffer, l1l2_buffer_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        slot_id,
         true, l1l2_hash, l1l2_hash_size, signature, &signature_size);
 #endif
     return result;
@@ -379,7 +382,7 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
 
         fill_response_ptr += opaque_data_size;
 
-        ret = libspdm_generate_measurement_signature(spdm_context, session_info, fill_response_ptr);
+        ret = libspdm_generate_measurement_signature(spdm_context, session_info, slot_id_param, fill_response_ptr);
 
         if (!ret) {
             status = libspdm_generate_error_response(

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -67,7 +67,8 @@ bool libspdm_generate_measurement_summary_hash(
 bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {
@@ -78,7 +79,8 @@ bool libspdm_requester_data_sign(
 bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1764,7 +1764,8 @@ bool libspdm_generate_measurement_summary_hash(
 bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {
@@ -1834,7 +1835,8 @@ bool libspdm_requester_data_sign(
 bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint8_t slot_id, bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -103,7 +103,7 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
     }
     libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                                 SPDM_CHALLENGE_AUTH, m_libspdm_use_asym_algo,
-                                m_libspdm_use_hash_algo, false,
+                                m_libspdm_use_hash_algo, 0, false,
                                 m_libspdm_local_buffer, m_libspdm_local_buffer_size, ptr,
                                 &sig_size);
     ptr += sig_size;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -202,7 +202,8 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         free(data);
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false,
+                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false,
                 libspdm_get_managed_buffer(&th_curr), libspdm_get_managed_buffer_size(
                 &th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -467,7 +467,7 @@ void libspdm_test_responder_finish_case8(void **State)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         spdm_test_finish_request->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, false,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0, false,
             libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr), ptr, &req_asym_signature_size);
 #endif

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -218,6 +218,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -295,6 +296,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -444,6 +446,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                     SPDM_CHALLENGE_AUTH,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -606,6 +609,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                     SPDM_CHALLENGE_AUTH,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -681,7 +685,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -773,7 +778,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -845,7 +851,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -917,7 +924,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -989,7 +997,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1064,7 +1073,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1138,7 +1148,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, hash_data, libspdm_get_hash_size (
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, hash_data, libspdm_get_hash_size (
                 m_libspdm_use_hash_algo), Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1211,7 +1222,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1317,7 +1329,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, ptr, &sig_size);
         ptr += sig_size;
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1389,6 +1402,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                                     SPDM_VERSION_NUMBER_SHIFT_BIT,
                                     SPDM_CHALLENGE_AUTH,
                                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                                    0,
                                     false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                                     ptr, &sig_size);
         ptr += sig_size;
@@ -1480,6 +1494,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                slot_id,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1561,6 +1576,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1640,7 +1656,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1765,7 +1782,8 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -196,6 +196,7 @@ void libspdm_requester_chunk_get_test_case3_build_challenge_response(
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
             m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
             ptr, &sig_size);
     ptr += sig_size;

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -509,6 +509,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -599,6 +600,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -759,6 +761,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                     SPDM_MEASUREMENTS,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -1200,6 +1203,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1765,6 +1769,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1864,6 +1869,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1963,6 +1969,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2060,6 +2067,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2448,6 +2456,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2609,6 +2618,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -480,6 +480,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -646,6 +647,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -884,6 +886,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1140,6 +1143,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1347,6 +1351,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1522,6 +1527,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1693,6 +1699,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1867,6 +1874,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2034,6 +2042,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2201,6 +2210,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2377,6 +2387,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2545,6 +2556,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2718,6 +2730,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2874,6 +2887,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3041,6 +3055,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3209,6 +3224,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3377,6 +3393,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3545,6 +3562,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3714,6 +3732,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3883,6 +3902,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4052,6 +4072,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4204,6 +4225,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
@@ -4370,6 +4392,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4538,6 +4561,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1861,6 +1861,7 @@ libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_CHALLENGE_AUTH,
                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    slot_id,
                     false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                     ptr, &sig_size);
             ptr += sig_size;

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -546,6 +546,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -632,6 +633,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -792,6 +794,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                     SPDM_MEASUREMENTS,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -966,6 +969,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                     SPDM_MEASUREMENTS,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -1356,6 +1360,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1446,6 +1451,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2015,6 +2021,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2114,6 +2121,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2213,6 +2221,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2310,6 +2319,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2698,6 +2708,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2856,6 +2867,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2974,6 +2986,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -3111,6 +3124,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -498,6 +498,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -664,6 +665,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -902,6 +904,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1158,6 +1161,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
                     m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1365,6 +1369,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1540,6 +1545,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1715,6 +1721,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1891,6 +1898,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2058,6 +2066,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2225,6 +2234,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2401,6 +2411,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2569,6 +2580,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2728,6 +2740,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2864,6 +2877,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3031,6 +3045,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3198,6 +3213,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3366,6 +3382,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3524,6 +3541,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3683,6 +3701,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3852,6 +3871,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4021,6 +4041,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4190,6 +4211,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4342,6 +4364,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
@@ -4508,6 +4531,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4666,6 +4690,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4832,6 +4857,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4999,6 +5025,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
                 m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -80,6 +80,7 @@ void libspdm_test_responder_encap_challenge_case1(void **state)
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, (uint8_t*)spdm_response, response_size - sig_size,
             ptr, &sig_size);
 
@@ -349,6 +350,7 @@ void libspdm_test_responder_encap_challenge_case5(void **state)
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, (uint8_t*)spdm_response, response_size - sig_size,
             ptr, &sig_size);
 

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -931,6 +931,7 @@ void libspdm_test_responder_finish_case8(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -1634,6 +1635,7 @@ void libspdm_test_responder_finish_case15(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -1791,6 +1793,7 @@ void libspdm_test_responder_finish_case16(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, random_buffer, hash_size, ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
@@ -2041,6 +2044,7 @@ void libspdm_test_responder_finish_case18(void **state)
         m_libspdm_finish_request4.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2205,6 +2209,7 @@ void libspdm_test_responder_finish_case19(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request5.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2372,6 +2377,7 @@ void libspdm_test_responder_finish_case20(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2652,6 +2658,7 @@ void libspdm_test_responder_finish_case22(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
             m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);


### PR DESCRIPTION
Supply the slot_id to libspdm_responder_data_sign() and libspdm_requester_data_sign(). These functions use certificates to sign an SPDM message so they need to know what slot is being used to sign the data.

For CHALLENGE_AUTH for example the slot_id is sent as part of Param1 and section 365 of spec version 1.2.1 specifies that that slot leaf certificate should be used for signing. Currently there is no way to know which leaf certificate should be used when generating signatures, this patch ensures that we know what slot certificate should be used.