### PR TITLE
Add LIBSPDM_MAX_SPDM_SESSION_SEQUENCE_NUMBER

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -21,6 +21,8 @@
 #define LIBSPDM_MAX_CT_EXPONENT 31
 #define LIBSPDM_MAX_RDT_EXPONENT 31
 
+#define LIBSPDM_MAX_SPDM_SESSION_SEQUENCE_NUMBER 0xFFFFFFFFFFFFFFFFull
+
 typedef struct {
     uint8_t spdm_version_count;
     spdm_version_number_t spdm_version[SPDM_MAX_VERSION_COUNT];
@@ -538,6 +540,9 @@ typedef struct {
     /* Current session count for DHE session and PSK session */
     uint32_t current_dhe_session_count;
     uint32_t current_psk_session_count;
+
+    /* see LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER */
+    uint64_t max_spdm_session_sequence_number;
 
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
     /* Chunk specific context */

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -56,6 +56,7 @@ typedef struct {
     size_t aead_key_size;
     size_t aead_iv_size;
     size_t aead_tag_size;
+    uint64_t max_spdm_session_sequence_number;
     bool use_psk;
     libspdm_session_state_t session_state;
     libspdm_session_info_struct_master_secret_t master_secret;
@@ -138,6 +139,16 @@ void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
 void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
                                           const void *psk_hint,
                                           size_t psk_hint_size);
+
+/**
+ * Set the maximum sequence_number to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context      A pointer to the SPDM secured message context.
+ * @param  max_spdm_session_sequence_number  Indicate the maximum sequence_number in SPDM session.
+ */
+void libspdm_secured_message_set_max_spdm_session_sequence_number(
+    void *spdm_secured_message_context,
+    uint64_t max_spdm_session_sequence_number);
 
 /**
  * Allocates and Initializes one Diffie-Hellman Ephemeral (DHE) context for subsequent use,

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -127,6 +127,19 @@ typedef enum {
     LIBSPDM_DATA_MAX_DHE_SESSION_COUNT,
     LIBSPDM_DATA_MAX_PSK_SESSION_COUNT,
 
+    /* DSP0277 defines 64bit sequence number.
+     * The default value is max number 0xFFFFFFFFFFFFFFFFull (64bit).
+     * 0 means the default value.
+     *
+     * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-aead-limits describes
+     * how to limit the use of keys in order to bound the advantage given to an attacker.
+     *
+     * The integrator can override the default value, such as 0xFFFFFFFF (32bit) or 0xFFFFFF (24bit).
+     * If KEY_UPDATE is not sent before the max sequence number is reached,
+     * the SPDM session will be terminated.
+     */
+    LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER,
+
     /* MAX */
     LIBSPDM_DATA_MAX
 } libspdm_data_type_t;

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -615,6 +615,15 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         }
         context->max_psk_session_count = *(uint32_t *)data;
         break;
+    case LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER:
+        if (data_size != sizeof(uint64_t)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        context->max_spdm_session_sequence_number = *(uint64_t *)data;
+        if (context->max_spdm_session_sequence_number == 0) {
+            context->max_spdm_session_sequence_number = LIBSPDM_MAX_SPDM_SESSION_SEQUENCE_NUMBER;
+        }
+        break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;
@@ -850,6 +859,10 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
     case LIBSPDM_DATA_MAX_PSK_SESSION_COUNT:
         target_data_size = sizeof(uint32_t);
         target_data = &context->max_psk_session_count;
+        break;
+    case LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER:
+        target_data_size = sizeof(uint64_t);
+        target_data = &context->max_spdm_session_sequence_number;
         break;
     case LIBSPDM_DATA_VCA_CACHE:
         target_data_size = context->transcript.message_a.buffer_size;
@@ -2502,6 +2515,8 @@ libspdm_return_t libspdm_init_context_with_secured_context(void *spdm_context,
     context->local_context.capability.st1 = SPDM_ST1_VALUE_US;
 
     context->mut_auth_cert_chain_buffer_size = 0;
+
+    context->max_spdm_session_sequence_number = LIBSPDM_MAX_SPDM_SESSION_SEQUENCE_NUMBER;
 
     /* To be updated in libspdm_register_device_buffer_func */
     context->local_context.capability.data_transfer_size = 0;

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -84,6 +84,8 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
     session_info->use_psk = use_psk;
     libspdm_secured_message_set_use_psk(session_info->secured_message_context, use_psk);
     libspdm_secured_message_set_session_type(session_info->secured_message_context, session_type);
+    libspdm_secured_message_set_max_spdm_session_sequence_number(
+        session_info->secured_message_context, spdm_context->max_spdm_session_sequence_number);
     libspdm_secured_message_set_algorithms(
         session_info->secured_message_context,
         spdm_context->connection_info.version,

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -161,6 +161,22 @@ void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
 }
 
 /**
+ * Set the maximum sequence_number to an SPDM secured message context.
+ *
+ * @param  spdm_secured_message_context      A pointer to the SPDM secured message context.
+ * @param  max_spdm_session_sequence_number  Indicate the maximum sequence_number in SPDM session.
+ */
+void libspdm_secured_message_set_max_spdm_session_sequence_number(
+    void *spdm_secured_message_context,
+    uint64_t max_spdm_session_sequence_number)
+{
+    libspdm_secured_message_context_t *secured_message_context;
+
+    secured_message_context = spdm_secured_message_context;
+    secured_message_context->max_spdm_session_sequence_number = max_spdm_session_sequence_number;
+}
+
+/**
  * Import the DHE Secret to an SPDM secured message context.
  *
  * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -121,7 +121,7 @@ libspdm_return_t libspdm_encode_secured_message(
         break;
     }
 
-    if (sequence_number == (uint64_t)-1) {
+    if (sequence_number >= secured_message_context->max_spdm_session_sequence_number) {
         return LIBSPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW;
     }
 
@@ -390,7 +390,7 @@ libspdm_return_t libspdm_decode_secured_message(
         return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
     }
 
-    if (sequence_number == (uint64_t)-1) {
+    if (sequence_number >= secured_message_context->max_spdm_session_sequence_number) {
         libspdm_secured_message_set_last_spdm_error_struct(
             spdm_secured_message_context, &spdm_error);
         return LIBSPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW;


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/2101

Tested in spdm-emu. Setting to small number will cause emu stop communicating.