### PR TITLE
Fix encapsulated GET_CERTIFICATE bug

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -144,13 +144,16 @@ libspdm_return_t libspdm_process_encap_response_certificate(
                      cert_chain_buffer_max_size - cert_chain_buffer_size,
                      (const void *)(spdm_response + 1), spdm_response->portion_length);
 
+    cert_chain_buffer_size += spdm_response->portion_length;
+    spdm_context->mut_auth_cert_chain_buffer_size = cert_chain_buffer_size;
+
     if (spdm_response->remainder_length != 0) {
         *need_continue = true;
+
         return LIBSPDM_STATUS_SUCCESS;
     }
 
     *need_continue = false;
-    cert_chain_buffer_size += spdm_response->portion_length;
 
     if (spdm_context->local_context.verify_peer_spdm_cert_chain != NULL) {
         result = spdm_context->local_context.verify_peer_spdm_cert_chain (


### PR DESCRIPTION
The `spdm_context` was not being updated after a certificate was received from the Requester, so that the Responder continually requested the first 0x400 or so bytes in an infinite loop.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>