### PR TITLE
library: Include base_*_algo to libspdm_write_certificate_to_nvm()

### DIFF
--- a/include/hal/library/responder_secretlib.h
+++ b/include/hal/library/responder_secretlib.h
@@ -290,12 +290,15 @@ extern bool libspdm_is_in_trusted_environment();
  * @param[in]  slot_id          The number of slot for the certificate chain.
  * @param[in]  cert_chain       The pointer for the certificate chain to set.
  * @param[in]  cert_chain_size  The size of the certificate chain to set.
+ * @param[in]  base_hash_algo   Indicates the negotiated signing algorithm.
+ * @param[in]  base_asym_algo   Indicates the negotiated hash algorithms.
  *
  * @retval true   The certificate chain was successfully written to non-volatile memory.
  * @retval false  Unable to write certificate chain to non-volatile memory.
  **/
 extern bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
-                                             size_t cert_chain_size);
+                                             size_t cert_chain_size,
+                                             uint32_t base_hash_algo, uint32_t base_asym_algo);
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP */
 

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
@@ -194,7 +194,9 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
 
     /* set certificate to NV*/
     result = libspdm_write_certificate_to_nvm(slot_id, cert_chain,
-                                              cert_chain_size);
+                                              cert_chain_size,
+                                              spdm_context->connection_info.algorithm.base_asym_algo,
+                                              spdm_context->connection_info.algorithm.base_hash_algo);
     if (!result) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -118,7 +118,8 @@ bool libspdm_is_in_trusted_environment()
 }
 
 bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
-                                      size_t cert_chain_size)
+                                      size_t cert_chain_size,
+                                      uint32_t base_hash_algo, uint32_t base_asym_algo)
 {
     return false;
 }

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1588,7 +1588,8 @@ bool libspdm_is_in_trusted_environment()
 }
 
 bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
-                                      size_t cert_chain_size)
+                                      size_t cert_chain_size,
+                                      uint32_t base_hash_algo, uint32_t base_asym_algo)
 {
 #if defined(_MSC_VER) || (defined(__clang__) && (defined (LIBSPDM_CPU_AARCH64) || \
     defined(LIBSPDM_CPU_ARM)))


### PR DESCRIPTION
If the implementor wants to update the certificate without rebooting the device they will need to know the base_hash_algo and base_asym_algo in order to verify and hash the new certificate. Let's pass that information to the libspdm_write_certificate_to_nvm() function so that it can use it.