### PR TITLE
Fix the responder chunk checking

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_chunk_get.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_get.c
@@ -33,8 +33,9 @@ libspdm_return_t libspdm_get_response_chunk_get(
                                                response_size, response);
     }
 
-    if ((spdm_context->local_context.capability.flags &
-         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP) == 0) {
+    if (!libspdm_is_capabilities_flag_supported(
+            spdm_context, false, SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
         return libspdm_generate_error_response(
             spdm_context,
             SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -34,8 +34,9 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
                                                response_size, response);
     }
 
-    if ((spdm_context->local_context.capability.flags &
-         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP) == 0) {
+    if (!libspdm_is_capabilities_flag_supported(
+            spdm_context, false, SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
         return libspdm_generate_error_response(
             spdm_context,
             SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -619,7 +619,7 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
          ((context->local_context.capability.sender_data_transfer_size != 0) &&
           (my_response_size > context->local_context.capability.sender_data_transfer_size))) &&
         libspdm_is_capabilities_flag_supported(
-            context, false, 0,
+            context, false, SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP,
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
         #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
@@ -50,6 +50,8 @@ void libspdm_test_responder_chunk_get_case1(void **State)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -118,6 +120,8 @@ void libspdm_test_responder_chunk_get_case2(void **State)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -184,6 +188,8 @@ void libspdm_test_responder_chunk_get_case3(void **State)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -251,6 +257,8 @@ void libspdm_test_responder_chunk_get_case4(void **State)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_send_ack/chunk_send_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_send_ack/chunk_send_ack.c
@@ -55,6 +55,8 @@ void libspdm_test_responder_chunk_send_ack_setup_algo_state(libspdm_context_t *s
 
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 }
 
 void libspdm_test_responder_chunk_send_ack_case1(void **State)

--- a/unit_test/test_spdm_responder/chunk_get.c
+++ b/unit_test/test_spdm_responder/chunk_get.c
@@ -94,6 +94,8 @@ void libspdm_test_responder_chunk_get_rsp_case2(void** state)
 
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     /* Set bad response state */
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
@@ -152,6 +154,8 @@ void libspdm_test_responder_chunk_get_rsp_case3(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
 
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
@@ -208,6 +212,8 @@ void libspdm_test_responder_chunk_get_rsp_case4(void** state)
 
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
     spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_12;
@@ -262,6 +268,8 @@ void libspdm_test_responder_chunk_get_rsp_case5(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
     spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_11; /* Mismatching SPDM version */
@@ -314,6 +322,8 @@ void libspdm_test_responder_chunk_get_rsp_case6(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     /* Set no chunk saved */
     spdm_context->chunk_context.get.chunk_in_use = false;
@@ -373,6 +383,8 @@ void libspdm_test_responder_chunk_get_rsp_case7(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -443,6 +455,8 @@ void libspdm_test_responder_chunk_get_rsp_case8(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -513,6 +527,8 @@ void libspdm_test_responder_chunk_get_rsp_case9(void** state)
         CHUNK_GET_RESPONDER_UNIT_TEST_DATA_TRANSFER_SIZE;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -593,6 +609,8 @@ void libspdm_test_responder_chunk_get_rsp_case10(void** state)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -697,6 +715,8 @@ void libspdm_test_responder_chunk_get_rsp_case11(void** state)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -799,6 +819,8 @@ void libspdm_test_responder_chunk_get_rsp_case12(void** state)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 
@@ -903,6 +925,8 @@ void libspdm_test_responder_chunk_get_rsp_case13(void** state)
     spdm_context->local_context.capability.data_transfer_size = data_transfer_size;
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
 

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -107,7 +107,8 @@ void libspdm_test_responder_chunk_send_ack_setup_algo_state(libspdm_context_t* s
 
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
-
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 }
 
 /* Test sending large NegAlg Request in multiple chunks. */
@@ -257,6 +258,8 @@ void libspdm_test_responder_chunk_send_ack_rsp_case1(void** state)
 
     spdm_context->local_context.capability.flags &=
         ~SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     chunk_num = 0;
     bytes_total = sizeof(m_libspdm_chunk_send_negotiate_algorithm_request1);

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -56,6 +56,8 @@ void libspdm_test_responder_receive_send_rsp_case1(void** state)
     spdm_context->local_context.capability.flags |=
         (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP
          | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP);
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_read_responder_public_certificate_chain(
         m_libspdm_use_hash_algo,
@@ -181,6 +183,8 @@ void libspdm_test_responder_receive_send_rsp_case2(void** state)
     spdm_context->local_context.capability.flags |=
         (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP
          | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP);
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     /* The local Responder transmit buffer size for sending a single and complete SPDM message */
     spdm_context->local_context.capability.sender_data_transfer_size =
@@ -265,6 +269,8 @@ void libspdm_test_responder_receive_send_rsp_case3(void** state)
     spdm_context->local_context.capability.flags |=
         (SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP
          | SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP);
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
 
     libspdm_read_responder_public_certificate_chain(
         m_libspdm_use_hash_algo,


### PR DESCRIPTION
Currently the responder does not check requester's chunk cap.

This patch adds requester's chunk cap.