### PR TITLE
library: Pass spdm_context to libspdm_write_certificate_to_nvm()

### DIFF
--- a/include/hal/library/responder_secretlib.h
+++ b/include/hal/library/responder_secretlib.h
@@ -287,6 +287,7 @@ extern bool libspdm_is_in_trusted_environment();
  * Stores a certificate chain in non-volatile memory.
  *
  *
+ * @param[in]  spdm_context                  A pointer to the SPDM context.
  * @param[in]  slot_id          The number of slot for the certificate chain.
  * @param[in]  cert_chain       The pointer for the certificate chain to set.
  * @param[in]  cert_chain_size  The size of the certificate chain to set.
@@ -296,7 +297,8 @@ extern bool libspdm_is_in_trusted_environment();
  * @retval true   The certificate chain was successfully written to non-volatile memory.
  * @retval false  Unable to write certificate chain to non-volatile memory.
  **/
-extern bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
+extern bool libspdm_write_certificate_to_nvm(void *spdm_context,
+                                             uint8_t slot_id, const void * cert_chain,
                                              size_t cert_chain_size,
                                              uint32_t base_hash_algo, uint32_t base_asym_algo);
 

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
@@ -193,7 +193,7 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
 #endif /*LIBSPDM_CERT_PARSE_SUPPORT*/
 
     /* set certificate to NV*/
-    result = libspdm_write_certificate_to_nvm(slot_id, cert_chain,
+    result = libspdm_write_certificate_to_nvm(spdm_context, slot_id, cert_chain,
                                               cert_chain_size,
                                               spdm_context->connection_info.algorithm.base_asym_algo,
                                               spdm_context->connection_info.algorithm.base_hash_algo);

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -117,7 +117,8 @@ bool libspdm_is_in_trusted_environment()
     return false;
 }
 
-bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
+bool libspdm_write_certificate_to_nvm(void *spdm_context,
+                                      uint8_t slot_id, const void * cert_chain,
                                       size_t cert_chain_size,
                                       uint32_t base_hash_algo, uint32_t base_asym_algo)
 {

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1587,7 +1587,8 @@ bool libspdm_is_in_trusted_environment()
     return g_in_trusted_environment;
 }
 
-bool libspdm_write_certificate_to_nvm(uint8_t slot_id, const void * cert_chain,
+bool libspdm_write_certificate_to_nvm(void *spdm_context,
+                                      uint8_t slot_id, const void * cert_chain,
                                       size_t cert_chain_size,
                                       uint32_t base_hash_algo, uint32_t base_asym_algo)
 {


### PR DESCRIPTION
If the implementor wants to update the certificate without rebooting the device they will need to know the spdm_context in order to modify the stored certificates. Let's pass that information to the libspdm_write_certificate_to_nvm() function so that it can use it.