### PR TITLE
library: fix unaligned type casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
     if(TOOLCHAIN STREQUAL "GCC")
         SET(CMAKE_C_COMPILER gcc)
-        ADD_COMPILE_OPTIONS(-std=c99 -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -Wno-address -fpie -fno-asynchronous-unwind-tables -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare -Werror-implicit-function-declaration -Wcast-qual)
+        ADD_COMPILE_OPTIONS(-std=c99 -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -Wno-address -fpie -fno-asynchronous-unwind-tables -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare -Werror-implicit-function-declaration -Wcast-qual -Wcast-align)
         if (ARCH STREQUAL "x64")
             ADD_COMPILE_OPTIONS(-mno-red-zone)
         endif()

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -183,7 +183,7 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
         if (parameter->location != LIBSPDM_DATA_LOCATION_SESSION) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
-        session_id = *(const uint32_t *)parameter->additional_data;
+        session_id = libspdm_read_uint32(parameter->additional_data);
         session_info = libspdm_get_session_info_via_session_id(context, session_id);
         if (session_info == NULL) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
@@ -737,7 +737,7 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
         if (parameter->location != LIBSPDM_DATA_LOCATION_SESSION) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
-        session_id = *(const uint32_t *)parameter->additional_data;
+        session_id = libspdm_read_uint32(parameter->additional_data);
         session_info = libspdm_get_session_info_via_session_id(context, session_id);
         if (session_info == NULL) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -293,9 +293,8 @@ libspdm_return_t libspdm_get_response_key_exchange(libspdm_context_t *spdm_conte
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);
     }
-    opaque_data_length =
-        *(const uint16_t *)((const uint8_t *)request +
-                            sizeof(spdm_key_exchange_request_t) + dhe_key_size);
+    opaque_data_length = libspdm_read_uint16((const uint8_t *)request +
+                                             sizeof(spdm_key_exchange_request_t) + dhe_key_size);
     if (request_size < sizeof(spdm_key_exchange_request_t) + dhe_key_size +
         sizeof(uint16_t) + opaque_data_length) {
         return libspdm_generate_error_response(spdm_context,

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -155,8 +155,8 @@ libspdm_return_t libspdm_mctp_decode_message(uint32_t **session_id,
             sizeof(mctp_message_header_t) + sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_MSG_SIZE;
         }
-        *session_id = (uint32_t *)((uint8_t *)transport_message +
-                                   sizeof(mctp_message_header_t));
+        *session_id = (void *)((uint8_t *)transport_message +
+                               sizeof(mctp_message_header_t));
         break;
     case MCTP_MESSAGE_TYPE_SPDM:
         if (session_id != NULL) {

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -171,8 +171,8 @@ libspdm_return_t libspdm_pci_doe_decode_message(uint32_t **session_id,
             sizeof(pci_doe_data_object_header_t) + sizeof(uint32_t)) {
             return LIBSPDM_STATUS_INVALID_MSG_SIZE;
         }
-        *session_id = (uint32_t *)((uint8_t *)transport_message +
-                                   sizeof(pci_doe_data_object_header_t));
+        *session_id = (void *)((uint8_t *)transport_message +
+                               sizeof(pci_doe_data_object_header_t));
         break;
     case PCI_DOE_DATA_OBJECT_TYPE_SPDM:
         if (session_id != NULL) {


### PR DESCRIPTION
Unaligned access is not supported on some ARCHs. It will trigger CPU load/store fault. This change fixes unaligned access reported by -Wcast-align

Fix https://github.com/DMTF/libspdm/issues/2188