### PR TITLE
Handle GET_VERSION request receive ResponseNotReady response.

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_get_version.c
+++ b/library/spdm_requester_lib/libspdm_req_get_version.c
@@ -110,6 +110,12 @@ static libspdm_return_t libspdm_try_get_version(libspdm_context_t *spdm_context,
         goto receive_done;
     }
     if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        /* Responder shall not respond to the GET_VERSION request message with ErrorCode=ResponseNotReady.*/
+        if (spdm_response->header.param1 == SPDM_ERROR_CODE_RESPONSE_NOT_READY) {
+            /* Received an unexpected error message. */
+            status = LIBSPDM_STATUS_ERROR_PEER;
+            goto receive_done;
+        }
         status = libspdm_handle_simple_error_response(spdm_context, spdm_response->header.param1);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -644,8 +644,10 @@ static void libspdm_test_requester_get_version_err_case7(void **state)
 }
 
 /**
- * Test 8: receiving a ResponseNotReady ERROR message from the responder.
- * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
+ * Test 8: receiving a ResponseNotReady ERROR message from the responder,
+ * but Responder shall not respond to the GET_VERSION request message with ErrorCode=ResponseNotReady.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER,
+ * Received an unexpected error message.
  **/
 static void libspdm_test_requester_get_version_err_case8(void **state)
 {
@@ -658,7 +660,7 @@ static void libspdm_test_requester_get_version_err_case8(void **state)
     spdm_test_context->case_id = 0x8;
 
     status = libspdm_get_version(spdm_context, NULL, NULL);
-    assert_int_equal(status, LIBSPDM_STATUS_NOT_READY_PEER);
+    assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
 /**


### PR DESCRIPTION
Fix: #2187
If the Responder respond to the GET_VERSION request message with ErrorCode=ResponseNotReady, It is more accurate that the requester return LIBSPDM_STATUS_ERROR_PEER, received an unexpected error message.

due to A Responder shall not respond to the GET_VERSION request message with ErrorCode=ResponseNotReady.