### PR TITLE
os_stub: Allow disabling time checks

### DIFF
--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -301,6 +301,8 @@ Refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF/spdm-e
 
    0.5, implement required SPDM device IO functions - `libspdm_device_send_message_func` and `libspdm_device_receive_message_func` according to [spdm_common_lib](https://github.com/DMTF/libspdm/blob/main/include/library/spdm_common_lib.h).
 
+   0.6, if the device does not have access to a real-time clock and if the device uses OpenSSL or Mbed TLS then undefine `OPENSSL_CHECK_TIME` or `MBEDTLS_HAVE_TIME_DATE`.
+
 0. Implement a proper spdm_device_secret_lib.
 
 1. Initialize SPDM context (similar to SPDM Requester)

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1884,9 +1884,13 @@ bool libspdm_x509_verify_cert(const uint8_t *cert, size_t cert_size,
 
 
     /* Allow partial certificate chains, terminated by a non-self-signed but
-     * still trusted intermediate certificate. Also disable time checks.*/
+     * still trusted intermediate certificate.
+     */
 
     X509_STORE_set_flags(cert_store, X509_V_FLAG_PARTIAL_CHAIN);
+#ifndef OPENSSL_CHECK_TIME
+    X509_STORE_set_flags(cert_store, X509_V_FLAG_NO_CHECK_TIME);
+#endif
 
 
     /* Set up X509_STORE_CTX for the subsequent verification operation.*/

--- a/os_stub/openssllib/include/openssl/configuration.h
+++ b/os_stub/openssllib/include/openssl/configuration.h
@@ -12,6 +12,21 @@
 extern "C" {
 # endif
 
+/**
+ * \def X509_V_FLAG_NO_CHECK_TIME
+ *
+ * The X509_V_FLAG_NO_CHECK_TIME flag suppresses checking the
+ * validity period of certificates and CRLs against the current time.
+ *
+ * The time needs to be correct (not necessarily very accurate, but at least
+ * the date should be correct). This is used to verify the validity period of
+ * X.509 certificates.
+ *
+ * Comment if your system does not have a correct clock.
+ *
+ */
+#define OPENSSL_CHECK_TIME
+
 # ifdef OPENSSL_ALGORITHM_DEFINES
 #  error OPENSSL_ALGORITHM_DEFINES no longer supported
 # endif


### PR DESCRIPTION
Some implementations might not have accurate clocks, so allow disabling time checks.