### PR TITLE
Allow Integrator to query the AEAD sequence number

### DIFF
--- a/doc/api/common_api.md
+++ b/doc/api/common_api.md
@@ -324,3 +324,13 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
         - If set then the Responder will clear its negotiated connection state derived from `VCA`.
           If not set then Responder will maintain its negotiated connection state.
         - Only valid if the Responder supports `VCA` caching (`CACHE_CAP` is set).
+- `LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR`
+    - For a given session ID, returns the number of application data messages that have been
+      encrypted / decrypted in the request (Requester to Responder) direction.
+    - This value is only applicable when the local endpoint is in the
+      `LIBSPDM_SESSION_STATE_ESTABLISHED` state.
+- `LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_RSP_DIR`
+    - For a given session ID, returns the number of application data messages that have been
+      encrypted / decrypted in the response (Responder to Requester) direction.
+    - This value is only applicable when the local endpoint is in the
+     `LIBSPDM_SESSION_STATE_ESTABLISHED` state.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -127,17 +127,8 @@ typedef enum {
     LIBSPDM_DATA_MAX_DHE_SESSION_COUNT,
     LIBSPDM_DATA_MAX_PSK_SESSION_COUNT,
 
-    /* DSP0277 defines 64bit sequence number.
-     * The default value is max number 0xFFFFFFFFFFFFFFFFull (64bit).
-     * 0 means the default value.
-     *
-     * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-aead-limits describes
-     * how to limit the use of keys in order to bound the advantage given to an attacker.
-     *
-     * The integrator can override the default value, such as 0xFFFFFFFF (32bit) or 0xFFFFFF (24bit).
-     * If KEY_UPDATE is not sent before the max sequence number is reached,
-     * the SPDM session will be terminated.
-     */
+    LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_RSP_DIR,
+    LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR,
     LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER,
 
     /* MAX */

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -134,6 +134,8 @@ static bool need_session_info_for_data(libspdm_data_type_t data_type)
     case LIBSPDM_DATA_SESSION_MUT_AUTH_REQUESTED:
     case LIBSPDM_DATA_SESSION_END_SESSION_ATTRIBUTES:
     case LIBSPDM_DATA_SESSION_POLICY:
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_RSP_DIR:
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR:
         return true;
     default:
         return false;
@@ -718,6 +720,7 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
                                   void *data, size_t *data_size)
 {
     libspdm_context_t *context;
+    libspdm_secured_message_context_t *secured_context;
     size_t target_data_size;
     void *target_data;
     uint32_t session_id;
@@ -747,6 +750,7 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
         if (session_info == NULL) {
             return LIBSPDM_STATUS_INVALID_PARAMETER;
         }
+        secured_context = session_info->secured_message_context;
     } else {
         session_info = NULL;
     }
@@ -949,6 +953,14 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
     case LIBSPDM_DATA_MAX_PSK_SESSION_COUNT:
         target_data_size = sizeof(uint32_t);
         target_data = &context->max_psk_session_count;
+        break;
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR:
+        target_data_size = sizeof(uint64_t);
+        target_data = &secured_context->application_secret.request_data_sequence_number;
+        break;
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_RSP_DIR:
+        target_data_size = sizeof(uint64_t);
+        target_data = &secured_context->application_secret.response_data_sequence_number;
         break;
     case LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER:
         target_data_size = sizeof(uint64_t);


### PR DESCRIPTION
Fix #2241.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>