### PR TITLE
cryptlib_openssl: Remove internal OpenSSL crypto include

### DIFF
--- a/os_stub/cryptlib_openssl/pk/ecd.c
+++ b/os_stub/cryptlib_openssl/pk/ecd.c
@@ -13,7 +13,6 @@
 
 #include "internal_crypt_lib.h"
 #include <openssl/evp.h>
-#include <crypto/evp.h>
 
 /**
  * Allocates and Initializes one Edwards-Curve context for subsequent use
@@ -95,7 +94,6 @@ bool libspdm_ecd_set_pub_key(void *ecd_context, const uint8_t *public_key,
 {
     uint32_t final_pub_key_size;
     EVP_PKEY *evp_key;
-    EVP_PKEY *new_evp_key;
 
     if ((ecd_context == NULL) || (public_key == NULL)) {
         return false;
@@ -118,19 +116,13 @@ bool libspdm_ecd_set_pub_key(void *ecd_context, const uint8_t *public_key,
         return false;
     }
 
-    new_evp_key = EVP_PKEY_new_raw_public_key(EVP_PKEY_id(evp_key), NULL,
-                                              public_key, public_key_size);
+    evp_key = EVP_PKEY_new_raw_public_key(EVP_PKEY_id(evp_key), NULL,
+                                          public_key, public_key_size);
 
-    if (new_evp_key == NULL) {
+    if (evp_key == NULL) {
         return false;
     }
 
-    if (evp_pkey_copy_downgraded(&evp_key, new_evp_key) != 1) {
-        EVP_PKEY_free(new_evp_key);
-        return false;
-    }
-
-    EVP_PKEY_free(new_evp_key);
     return true;
 }
 
@@ -153,7 +145,6 @@ bool libspdm_ecd_set_pri_key(void *ecd_context, const uint8_t *private_key,
 {
     uint32_t final_pri_key_size;
     EVP_PKEY *evp_key;
-    EVP_PKEY *new_evp_key;
 
     if ((ecd_context == NULL) || (private_key == NULL)) {
         return false;
@@ -176,18 +167,12 @@ bool libspdm_ecd_set_pri_key(void *ecd_context, const uint8_t *private_key,
         return false;
     }
 
-    new_evp_key = EVP_PKEY_new_raw_private_key(EVP_PKEY_id(evp_key), NULL,
-                                               private_key, private_key_size);
-    if (new_evp_key == NULL) {
+    evp_key = EVP_PKEY_new_raw_private_key(EVP_PKEY_id(evp_key), NULL,
+                                           private_key, private_key_size);
+    if (evp_key == NULL) {
         return false;
     }
 
-    if (evp_pkey_copy_downgraded(&evp_key, new_evp_key) != 1) {
-        EVP_PKEY_free(new_evp_key);
-        return false;
-    }
-
-    EVP_PKEY_free(new_evp_key);
     return true;
 }
 

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -17,7 +17,6 @@
 #include <openssl/bn.h>
 #include <openssl/pem.h>
 #include <openssl/bio.h>
-#include <crypto/x509.h>
 
 #if LIBSPDM_CERT_PARSE_SUPPORT
 
@@ -2300,9 +2299,9 @@ bool libspdm_set_attribute_for_req(X509_REQ *req, uint8_t *req_info, size_t req_
     size_t pubkey_info_len;
     uint8_t *der_data;
     int32_t der_len;
-    X509_REQ_INFO *x509_req_info;
+    X509_NAME *x509_req_name;
 
-    x509_req_info = NULL;
+    x509_req_name = NULL;
     der_data = NULL;
     der_len = 0;
     length = (int32_t)req_info_len;
@@ -2316,10 +2315,10 @@ bool libspdm_set_attribute_for_req(X509_REQ *req, uint8_t *req_info, size_t req_
     }
 
     /*get subject name from req_info and set it to CSR*/
-    x509_req_info = d2i_X509_REQ_INFO(NULL, (const unsigned char **)(&req_info), req_info_len);
-    if (x509_req_info) {
-        X509_REQ_set_subject_name(req, x509_req_info->subject);
-        X509_REQ_INFO_free(x509_req_info);
+    x509_req_name = d2i_X509_NAME(NULL, (const unsigned char **)(&req_info), req_info_len);
+    if (x509_req_name) {
+        X509_REQ_set_subject_name(req, x509_req_name);
+        X509_NAME_free(x509_req_name);
     } else {
         return false;
     }


### PR DESCRIPTION
The OpenSSL source code describes the crypto include as:
"Internal EC functions for other submodules: not for application use"
 - https://github.com/openssl/openssl/blob/master/include/crypto/ec.h

Using the internal APIs makes it difficult to use libspdm as a library
with other packages. So let's remove the uses of the internal API and
instead use the public API.

We can also assume that the internal APIs don't provide backwards
compatible guarantees