### PR TITLE
cryptlib_openssl: ecd: Remove internal OpenSSL crypto include

### DIFF
--- a/os_stub/cryptlib_openssl/pk/ecd.c
+++ b/os_stub/cryptlib_openssl/pk/ecd.c
@@ -12,6 +12,9 @@
  **/
 
 #include "internal_crypt_lib.h"
+
+#if (LIBSPDM_EDDSA_ED25519_SUPPORT) || (LIBSPDM_EDDSA_ED448_SUPPORT)
+
 #include <openssl/evp.h>
 #include <crypto/evp.h>
 
@@ -471,3 +474,4 @@ bool libspdm_eddsa_verify(const void *ecd_context, size_t hash_nid,
     EVP_MD_CTX_free(ctx);
     return true;
 }
+#endif /* (LIBSPDM_EDDSA_ED25519_SUPPORT) || (LIBSPDM_EDDSA_ED448_SUPPORT) */


### PR DESCRIPTION
The OpenSSL source code describes the crypto include as:
"Internal EC functions for other submodules: not for application use"
 - https://github.com/openssl/openssl/blob/master/include/crypto/ec.h

Using the internal APIS makes it difficult to use libspdm as a library
with other packages. So let's remove the uses of the internal API and
instead use the public API.

The current ECD code uses internal APIs, making it unsuitable for use in
production code or libraries.

The supported way to do this is via OSSL params, either with
EVP_PKEY_fromdata() [1] or using EVP_PKEY_set_octet_string_param().

Unfortunately this isn't supported in OpenSSL and ed25519_set_params()
and ed448_set_params() will always return 1, indicating no support.

As there doesn't appear to be a supported method in OpenSSL to set the
public and private keys, let's instead allow users to disable this
support so the library can be used with the regular OpenSSL libraries.

1: https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_fromdata.html