### PR TITLE
Add runtime support for signing as little endian and dual endian verification.

### DIFF
--- a/include/hal/library/requester/reqasymsignlib.h
+++ b/include/hal/library/requester/reqasymsignlib.h
@@ -34,7 +34,9 @@ extern bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version,
     uint8_t op_code,
     uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size);
 

--- a/include/hal/library/responder/asymsignlib.h
+++ b/include/hal/library/responder/asymsignlib.h
@@ -61,7 +61,9 @@ extern bool libspdm_challenge_opaque_data(
 extern bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version,
     uint8_t op_code, uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size);
 

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -565,6 +565,11 @@ typedef struct {
 #if LIBSPDM_FIPS_MODE
     libspdm_fips_selftest_context fips_selftest_context;
 #endif /* LIBSPDM_FIPS_MODE */
+
+    /* Endianness to use for asymmetric algorithms signing and verification on SPDM 1.0 and 1.1 */
+    uint32_t spdm_10_11_asym_algo_sign_little_endian;
+    uint32_t spdm_10_11_asym_algo_verify_dual_endian;
+
 } libspdm_context_t;
 
 #define LIBSPDM_CONTEXT_SIZE_WITHOUT_SECURED_CONTEXT (sizeof(libspdm_context_t))

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -131,6 +131,13 @@ typedef enum {
     LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR,
     LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER,
 
+    /* For SPDM 1.0 and 1.1:
+     * 1) Allow signing in little-endian for specified asymmetric algorithms.
+     * 2) Allow signature verification for both endians for specified asymmetric algorithms.
+     **/
+    LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_SIGN_LITTLE_ENDIAN,
+    LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_VERIFY_DUAL_ENDIAN,
+
     /* MAX */
     LIBSPDM_DATA_MAX
 } libspdm_data_type_t;

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -31,22 +31,30 @@
 
 #if ((LIBSPDM_RSA_SSA_4096_SUPPORT) || (LIBSPDM_RSA_PSS_4096_SUPPORT))
 #define LIBSPDM_MAX_ASYM_KEY_SIZE 512
+#define LIBSPDM_MAX_ASYM_SIG_SIZE 512
 #elif ((LIBSPDM_RSA_SSA_3072_SUPPORT) || (LIBSPDM_RSA_PSS_3072_SUPPORT))
 #define LIBSPDM_MAX_ASYM_KEY_SIZE 384
+#define LIBSPDM_MAX_ASYM_SIG_SIZE 384
 #elif ((LIBSPDM_RSA_SSA_2048_SUPPORT) || (LIBSPDM_RSA_PSS_2048_SUPPORT))
 #define LIBSPDM_MAX_ASYM_KEY_SIZE 256
+#define LIBSPDM_MAX_ASYM_SIG_SIZE 256
 #elif (LIBSPDM_ECDSA_P521_SUPPORT)
 #define LIBSPDM_MAX_ASYM_KEY_SIZE (66 * 2)
+#define LIBSPDM_MAX_ASYM_SIG_SIZE (66 * 2)
 #elif (LIBSPDM_EDDSA_ED448_SUPPORT)
 #define LIBSPDM_MAX_ASYM_KEY_SIZE (57 * 2)
+#define LIBSPDM_MAX_ASYM_SIG_SIZE (57 * 2)
 #elif (LIBSPDM_ECDSA_P384_SUPPORT)
 #define LIBSPDM_MAX_ASYM_KEY_SIZE (48 * 2)
+#define LIBSPDM_MAX_ASYM_SIG_SIZE (48 * 2)
 #elif ((LIBSPDM_ECDSA_P256_SUPPORT) || (LIBSPDM_SM2_DSA_P256_SUPPORT) || \
     (LIBSPDM_EDDSA_ED25519_SUPPORT))
 #define LIBSPDM_MAX_ASYM_KEY_SIZE (32 * 2)
+#define LIBSPDM_MAX_ASYM_SIG_SIZE (32 * 2)
 #else
 /* set 1 to pass build only */
 #define LIBSPDM_MAX_ASYM_KEY_SIZE 1
+#define LIBSPDM_MAX_ASYM_SIG_SIZE 1
 #endif /* LIBSPDM_MAX_ASYM_KEY_SIZE */
 
 #if ((LIBSPDM_SHA512_SUPPORT) || (LIBSPDM_SHA3_512_SUPPORT))
@@ -409,6 +417,7 @@ void libspdm_asym_free(uint32_t base_asym_algo, void *context);
  *
  * @param  base_asym_algo  SPDM base_asym_algo
  * @param  base_hash_algo  SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algos_verify_dual_endian Algos to verify dual endian.
  * @param  context         Pointer to asymmetric context for signature verification.
  * @param  message         Pointer to octet message to be checked (before hash).
  * @param  message_size    Size of the message in bytes.
@@ -421,6 +430,7 @@ void libspdm_asym_free(uint32_t base_asym_algo, void *context);
 bool libspdm_asym_verify(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_verify_dual_endian,
     void *context, const uint8_t *message,
     size_t message_size, const uint8_t *signature,
     size_t sig_size);
@@ -430,6 +440,7 @@ bool libspdm_asym_verify(
  *
  * @param  base_asym_algo  SPDM base_asym_algo
  * @param  base_hash_algo  SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algos_verify_dual_endian Algos to verify dual endian.
  * @param  context         Pointer to asymmetric context for signature verification.
  * @param  message_hash    Pointer to octet message hash to be checked (after hash).
  * @param  hash_size       Size of the hash in bytes.
@@ -442,6 +453,7 @@ bool libspdm_asym_verify(
 bool libspdm_asym_verify_hash(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_verify_dual_endian,
     void *context, const uint8_t *message_hash,
     size_t hash_size, const uint8_t *signature,
     size_t sig_size);
@@ -454,6 +466,7 @@ bool libspdm_asym_verify_hash(
  *
  * @param  base_asym_algo  SPDM base_asym_algo
  * @param  base_hash_algo  SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algos_sign_little_endian Algos to sign in little endian.
  * @param  context         Pointer to asymmetric context for signature generation.
  * @param  message         Pointer to octet message to be signed (before hash).
  * @param  message_size    Size of the message in bytes.
@@ -468,6 +481,7 @@ bool libspdm_asym_verify_hash(
 bool libspdm_asym_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
     void *context, const uint8_t *message,
     size_t message_size, uint8_t *signature,
     size_t *sig_size);
@@ -480,6 +494,7 @@ bool libspdm_asym_sign(
  *
  * @param  base_asym_algo  SPDM base_asym_algo
  * @param  base_hash_algo  SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algos_sign_little_endian Algos to sign in little endian.
  * @param  context         Pointer to asymmetric context for signature generation.
  * @param  message_hash    Pointer to octet message hash to be signed (after hash).
  * @param  hash_size       Size of the hash in bytes.
@@ -494,6 +509,7 @@ bool libspdm_asym_sign(
 bool libspdm_asym_sign_hash(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
     void *context, const uint8_t *message_hash,
     size_t hash_size, uint8_t *signature,
     size_t *sig_size);
@@ -558,6 +574,7 @@ void libspdm_req_asym_free(uint16_t req_base_asym_alg, void *context);
  *
  * @param  req_base_asym_alg  SPDM req_base_asym_alg
  * @param  base_hash_algo     SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algo_verify_dual_endian Verify in both endians for some algos.
  * @param  context            Pointer to asymmetric context for signature verification.
  * @param  message            Pointer to octet message to be checked (before hash).
  * @param  message_size       Size of the message in bytes.
@@ -569,8 +586,9 @@ void libspdm_req_asym_free(uint16_t req_base_asym_alg, void *context);
  **/
 bool libspdm_req_asym_verify(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, void *context,
+    uint16_t req_base_asym_alg, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_verify_dual_endian,
+    void *context,
     const uint8_t *message, size_t message_size,
     const uint8_t *signature, size_t sig_size);
 
@@ -579,6 +597,7 @@ bool libspdm_req_asym_verify(
  *
  * @param  req_base_asym_alg  SPDM req_base_asym_alg
  * @param  base_hash_algo     SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algo_verify_dual_endian Verify in both endians for some algos.
  * @param  context            Pointer to asymmetric context for signature verification.
  * @param  message_hash       Pointer to octet message hash to be checked (after hash).
  * @param  hash_size          Size of the hash in bytes.
@@ -590,8 +609,9 @@ bool libspdm_req_asym_verify(
  **/
 bool libspdm_req_asym_verify_hash(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, void *context,
+    uint16_t req_base_asym_alg, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_verify_dual_endian,
+    void *context,
     const uint8_t *message_hash, size_t hash_size,
     const uint8_t *signature, size_t sig_size);
 
@@ -603,6 +623,7 @@ bool libspdm_req_asym_verify_hash(
  *
  * @param  req_base_asym_alg  SPDM req_base_asym_alg
  * @param  base_hash_algo     SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algo_sign_little_endian Sign in little endian for some algos.
  * @param  context            Pointer to asymmetric context for signature generation.
  * @param  message            Pointer to octet message to be signed (before hash).
  * @param  message_size       Size of the message in bytes.
@@ -616,8 +637,9 @@ bool libspdm_req_asym_verify_hash(
  **/
 bool libspdm_req_asym_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, void *context,
+    uint16_t req_base_asym_alg, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_sign_little_endian,
+    void *context,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size);
 
@@ -629,6 +651,7 @@ bool libspdm_req_asym_sign(
  *
  * @param  req_base_asym_alg  SPDM req_base_asym_alg
  * @param  base_hash_algo     SPDM base_hash_algo
+ * @param  spdm_10_11_asym_algo_sign_little_endian Sign in little endian for some algos.
  * @param  context            Pointer to asymmetric context for signature generation.
  * @param  message_hash       Pointer to octet message hash to be signed (after hash).
  * @param  hash_size          Size of the hash in bytes.
@@ -642,8 +665,9 @@ bool libspdm_req_asym_sign(
  **/
 bool libspdm_req_asym_sign_hash(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, void *context,
+    uint16_t req_base_asym_alg, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_sign_little_endian,
+    void *context,
     const uint8_t *message_hash, size_t hash_size,
     uint8_t *signature, size_t *sig_size);
 

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -688,6 +688,18 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
             context->max_spdm_session_sequence_number = LIBSPDM_MAX_SPDM_SESSION_SEQUENCE_NUMBER;
         }
         break;
+    case LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_SIGN_LITTLE_ENDIAN:
+        if (data_size != sizeof(uint32_t)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        context->spdm_10_11_asym_algo_sign_little_endian = *(uint32_t*)data;
+        break;
+    case LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_VERIFY_DUAL_ENDIAN:
+        if (data_size != sizeof(uint32_t)) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+        context->spdm_10_11_asym_algo_verify_dual_endian = *(uint32_t*)data;
+        break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;
@@ -969,6 +981,14 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
     case LIBSPDM_DATA_VCA_CACHE:
         target_data_size = context->transcript.message_a.buffer_size;
         target_data = context->transcript.message_a.buffer;
+        break;
+    case LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_SIGN_LITTLE_ENDIAN:
+        target_data_size = sizeof(uint32_t);
+        target_data = &context->spdm_10_11_asym_algo_sign_little_endian;
+        break;
+    case LIBSPDM_DATA_SPDM_VERSION_10_11_ASYM_ALGO_VERIFY_DUAL_ENDIAN:
+        target_data_size = sizeof(uint32_t);
+        target_data = &context->spdm_10_11_asym_algo_verify_dual_endian;
         break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -788,12 +788,14 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_sign_little_endian,
             false, m1m2_buffer, m1m2_buffer_size, signature, &signature_size);
 #else
         result = libspdm_requester_data_sign(
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_sign_little_endian,
             true, m1m2_hash, m1m2_hash_size, signature, &signature_size);
 #endif
 #else /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */
@@ -807,6 +809,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_sign_little_endian,
             false, m1m2_buffer, m1m2_buffer_size, signature,
             &signature_size);
 #else
@@ -814,6 +817,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_sign_little_endian,
             true, m1m2_hash, m1m2_hash_size, signature,
             &signature_size);
 #endif
@@ -1052,6 +1056,7 @@ bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
             context, m1m2_buffer, m1m2_buffer_size, sign_data, sign_data_size);
         libspdm_asym_free(
             spdm_context->connection_info.algorithm.base_asym_algo, context);
@@ -1060,6 +1065,7 @@ bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
             context, m1m2_hash, m1m2_hash_size, sign_data, sign_data_size);
         if (slot_id == 0xFF) {
             libspdm_asym_free(
@@ -1072,6 +1078,7 @@ bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
             context, m1m2_buffer, m1m2_buffer_size, sign_data, sign_data_size);
         libspdm_req_asym_free(
             spdm_context->connection_info.algorithm.req_base_asym_alg, context);
@@ -1080,6 +1087,7 @@ bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
             context, m1m2_hash, m1m2_hash_size, sign_data, sign_data_size);
         if (slot_id == 0xFF) {
             libspdm_req_asym_free(

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -303,12 +303,14 @@ bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_requester_data_sign(
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         true, hash_data, hash_size, signature, &signature_size);
 #endif
     if (result) {

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -87,6 +87,7 @@ bool libspdm_verify_measurement_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, l1l2_buffer, l1l2_buffer_size, sign_data, sign_data_size);
     libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo, context);
 #else
@@ -94,6 +95,7 @@ bool libspdm_verify_measurement_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, l1l2_hash, l1l2_hash_size, sign_data, sign_data_size);
     if (slot_id == 0xF) {
         libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo, context);

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -224,6 +224,7 @@ bool libspdm_verify_key_exchange_rsp_signature(
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, th_curr_data, th_curr_data_size, sign_data, sign_data_size);
     libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo, context);
 #else
@@ -231,6 +232,7 @@ bool libspdm_verify_key_exchange_rsp_signature(
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, hash_data, hash_size, sign_data, sign_data_size);
     if (slot_id == 0xFF) {
         libspdm_asym_free(spdm_context->connection_info.algorithm.base_asym_algo, context);

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -243,6 +243,7 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, th_curr_data, th_curr_data_size, sign_data, sign_data_size);
     libspdm_req_asym_free(spdm_context->connection_info.algorithm.req_base_asym_alg, context);
 #else
@@ -250,6 +251,7 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_verify_dual_endian,
         context, hash_data, hash_size, sign_data, sign_data_size);
     if (slot_id == 0xFF) {
         libspdm_req_asym_free(spdm_context->connection_info.algorithm.req_base_asym_alg, context);

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -152,12 +152,14 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         true, hash_data, hash_size, signature, &signature_size);
 #endif
     if (result) {

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -43,12 +43,14 @@ bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         false, l1l2_buffer, l1l2_buffer_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->spdm_10_11_asym_algo_sign_little_endian,
         true, l1l2_hash, l1l2_hash_size, signature, &signature_size);
 #endif
     return result;

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -83,7 +83,9 @@ bool libspdm_generate_measurement_summary_hash(
 bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {
@@ -94,7 +96,9 @@ bool libspdm_requester_data_sign(
 bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algo_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1332,8 +1332,9 @@ bool libspdm_generate_measurement_summary_hash(
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 bool libspdm_requester_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint16_t req_base_asym_alg,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint16_t req_base_asym_alg, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {
@@ -1363,11 +1364,13 @@ bool libspdm_requester_data_sign(
 
         if (is_data_hash) {
             result = libspdm_req_asym_sign_hash(spdm_version, op_code, req_base_asym_alg,
-                                                base_hash_algo, context,
+                                                base_hash_algo,
+                                                spdm_10_11_asym_algos_sign_little_endian, context,
                                                 message, message_size, signature, sig_size);
         } else {
             result = libspdm_req_asym_sign(spdm_version, op_code, req_base_asym_alg,
-                                           base_hash_algo, context,
+                                           base_hash_algo,
+                                           spdm_10_11_asym_algos_sign_little_endian, context,
                                            message, message_size,
                                            signature, sig_size);
         }
@@ -1383,11 +1386,13 @@ bool libspdm_requester_data_sign(
 
     if (is_data_hash) {
         result = libspdm_req_asym_sign_hash(spdm_version, op_code, req_base_asym_alg,
-                                            base_hash_algo, context,
+                                            base_hash_algo,
+                                            spdm_10_11_asym_algos_sign_little_endian, context,
                                             message, message_size, signature, sig_size);
     } else {
         result = libspdm_req_asym_sign(spdm_version, op_code, req_base_asym_alg,
-                                       base_hash_algo, context,
+                                       base_hash_algo,
+                                       spdm_10_11_asym_algos_sign_little_endian, context,
                                        message, message_size,
                                        signature, sig_size);
     }
@@ -1402,8 +1407,9 @@ bool libspdm_requester_data_sign(
 
 bool libspdm_responder_data_sign(
     spdm_version_number_t spdm_version, uint8_t op_code,
-    uint32_t base_asym_algo,
-    uint32_t base_hash_algo, bool is_data_hash,
+    uint32_t base_asym_algo, uint32_t base_hash_algo,
+    uint32_t spdm_10_11_asym_algos_sign_little_endian,
+    bool is_data_hash,
     const uint8_t *message, size_t message_size,
     uint8_t *signature, size_t *sig_size)
 {
@@ -1430,11 +1436,11 @@ bool libspdm_responder_data_sign(
 
         if (is_data_hash) {
             result = libspdm_asym_sign_hash(spdm_version, op_code, base_asym_algo, base_hash_algo,
-                                            context,
+                                            spdm_10_11_asym_algos_sign_little_endian, context,
                                             message, message_size, signature, sig_size);
         } else {
-            result = libspdm_asym_sign(spdm_version, op_code, base_asym_algo,
-                                       base_hash_algo, context,
+            result = libspdm_asym_sign(spdm_version, op_code, base_asym_algo, base_hash_algo,
+                                       spdm_10_11_asym_algos_sign_little_endian, context,
                                        message, message_size,
                                        signature, sig_size);
         }
@@ -1450,13 +1456,12 @@ bool libspdm_responder_data_sign(
 
     if (is_data_hash) {
         result = libspdm_asym_sign_hash(spdm_version, op_code, base_asym_algo, base_hash_algo,
-                                        context,
+                                        spdm_10_11_asym_algos_sign_little_endian, context,
                                         message, message_size, signature, sig_size);
     } else {
-        result = libspdm_asym_sign(spdm_version, op_code, base_asym_algo,
-                                   base_hash_algo, context,
-                                   message, message_size,
-                                   signature, sig_size);
+        result = libspdm_asym_sign(spdm_version, op_code, base_asym_algo, base_hash_algo,
+                                   spdm_10_11_asym_algos_sign_little_endian, context,
+                                   message, message_size, signature, sig_size);
     }
     libspdm_asym_free(base_asym_algo, context);
 #if !LIBSPDM_PRIVATE_KEY_MODE_RAW_KEY_ONLY

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -102,8 +102,9 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
     }
     libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                                SPDM_CHALLENGE_AUTH, m_libspdm_use_asym_algo,
-                                m_libspdm_use_hash_algo, false,
+                                SPDM_CHALLENGE_AUTH,
+                                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
+                                false,
                                 m_libspdm_local_buffer, m_libspdm_local_buffer_size, ptr,
                                 &sig_size);
     ptr += sig_size;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -202,7 +202,7 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         free(data);
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false,
+                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false,
                 libspdm_get_managed_buffer(&th_curr), libspdm_get_managed_buffer_size(
                 &th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -467,7 +467,7 @@ void libspdm_test_responder_finish_case8(void **State)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         spdm_test_finish_request->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, false,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0, false,
             libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr), ptr, &req_asym_signature_size);
 #endif

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -217,7 +217,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -294,7 +294,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -444,6 +444,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                     SPDM_CHALLENGE_AUTH,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -606,6 +607,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                     SPDM_CHALLENGE_AUTH,
                     m_libspdm_use_asym_algo,
                     m_libspdm_use_hash_algo,
+                    0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -681,7 +683,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -773,7 +775,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -845,7 +847,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -917,7 +919,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -989,7 +991,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1064,7 +1066,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1138,7 +1140,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, hash_data, libspdm_get_hash_size (
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, hash_data, libspdm_get_hash_size (
                 m_libspdm_use_hash_algo), Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1211,7 +1213,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1317,7 +1319,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, ptr, &sig_size);
         ptr += sig_size;
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1388,7 +1390,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(spdm_response->header.spdm_version <<
                                     SPDM_VERSION_NUMBER_SHIFT_BIT,
                                     SPDM_CHALLENGE_AUTH,
-                                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                                     false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                                     ptr, &sig_size);
         ptr += sig_size;
@@ -1479,7 +1481,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1560,7 +1562,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1640,7 +1642,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 
@@ -1762,7 +1764,7 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0, false, m_libspdm_local_buffer,
                 m_libspdm_local_buffer_size, Ptr, &sig_size);
         Ptr += sig_size;
 

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -195,7 +195,7 @@ void libspdm_requester_chunk_get_test_case3_build_challenge_response(
     libspdm_responder_data_sign(
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
             false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
             ptr, &sig_size);
     ptr += sig_size;

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -508,7 +508,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -598,7 +598,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -757,8 +757,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_MEASUREMENTS,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -1199,7 +1198,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1764,7 +1763,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1863,7 +1862,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1962,7 +1961,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2059,7 +2058,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2447,7 +2446,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2608,7 +2607,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -479,7 +479,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -645,7 +645,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -883,7 +883,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1139,7 +1139,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1346,7 +1346,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1521,7 +1521,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1692,7 +1692,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1866,7 +1866,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2033,7 +2033,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2200,7 +2200,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2376,7 +2376,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2544,7 +2544,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2717,7 +2717,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2873,7 +2873,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3040,7 +3040,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3208,7 +3208,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3376,7 +3376,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3544,7 +3544,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3713,7 +3713,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3882,7 +3882,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4051,7 +4051,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4203,7 +4203,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         free(data);
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
@@ -4369,7 +4369,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4537,7 +4537,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1860,7 +1860,7 @@ libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_CHALLENGE_AUTH,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                     ptr, &sig_size);
             ptr += sig_size;

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -545,7 +545,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -631,7 +631,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -791,7 +791,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_MEASUREMENTS,
                     m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
+                    m_libspdm_use_hash_algo, 0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -965,7 +965,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_MEASUREMENTS,
                     m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
+                    m_libspdm_use_hash_algo, 0,
                     false, m_libspdm_local_buffer,
                     m_libspdm_local_buffer_size, ptr,
                     &sig_size);
@@ -1355,7 +1355,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -1445,7 +1445,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2014,7 +2014,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2113,7 +2113,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2212,7 +2212,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2309,7 +2309,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2697,7 +2697,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2855,7 +2855,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -2973,7 +2973,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;
@@ -3110,7 +3110,7 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
                 ptr, &sig_size);
         ptr += sig_size;

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -497,7 +497,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -663,7 +663,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -901,7 +901,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1157,7 +1157,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
             libspdm_responder_data_sign(
                 spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                     SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                     false, libspdm_get_managed_buffer(&th_curr),
                     libspdm_get_managed_buffer_size(&th_curr), ptr,
                     &signature_size);
@@ -1364,7 +1364,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1539,7 +1539,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1714,7 +1714,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -1890,7 +1890,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2057,7 +2057,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2224,7 +2224,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2400,7 +2400,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2568,7 +2568,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2727,7 +2727,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -2863,7 +2863,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3030,7 +3030,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3197,7 +3197,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3365,7 +3365,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3523,7 +3523,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3682,7 +3682,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -3851,7 +3851,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4020,7 +4020,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4189,7 +4189,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4341,7 +4341,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         free(data);
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
@@ -4507,7 +4507,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4665,7 +4665,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4831,7 +4831,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);
@@ -4998,7 +4998,7 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_responder_data_sign(
             spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                 SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
+                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, 0,
                 false, libspdm_get_managed_buffer(&th_curr),
                 libspdm_get_managed_buffer_size(&th_curr), ptr,
                 &signature_size);

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -81,7 +81,7 @@ void libspdm_test_responder_encap_challenge_case1(void **state)
     libspdm_requester_data_sign(
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, (uint8_t*)spdm_response, response_size - sig_size,
             ptr, &sig_size);
 
@@ -356,7 +356,7 @@ void libspdm_test_responder_encap_challenge_case5(void **state)
     libspdm_requester_data_sign(
         spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, (uint8_t*)spdm_response, response_size - sig_size,
             ptr, &sig_size);
 

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -930,7 +930,7 @@ void libspdm_test_responder_finish_case8(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -1633,7 +1633,7 @@ void libspdm_test_responder_finish_case15(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -1790,7 +1790,7 @@ void libspdm_test_responder_finish_case16(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, random_buffer, hash_size, ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
@@ -2040,7 +2040,7 @@ void libspdm_test_responder_finish_case18(void **state)
     libspdm_requester_data_sign(
         m_libspdm_finish_request4.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
             SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2204,7 +2204,7 @@ void libspdm_test_responder_finish_case19(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request5.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2371,7 +2371,7 @@ void libspdm_test_responder_finish_case20(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);
@@ -2651,7 +2651,7 @@ void libspdm_test_responder_finish_case22(void **state)
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_requester_data_sign(
         m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, 0,
             false, libspdm_get_managed_buffer(&th_curr),
             libspdm_get_managed_buffer_size(&th_curr),
             ptr, &req_asym_signature_size);


### PR DESCRIPTION
@jyao1 @steven-bellock 

Looking for feedback on this runtime mechanism for supporting endian changes in spdm versions 1.0/11.  Not really excited about this, but I pass a "spdm_10_11_asym_algos_sign_little_endian" and "spdm_10_11_asym_algos_verify_dual_endian" fields around (retrieved from spdm_context) which are bitfields to indicate the asymmetric algorithms we should apply the endian changes too.  

I could have made it more generic (removing the spdm_10_11 from the name and allowing it to be applied for all versions). It might look less specific in that case and give a cleaner look and more flexibility to the integrator, but may be against specs if it applied to non 1.0/1.1 algorithms. 

Looking for your guys thoughts.

I'll add tests after we bottom out on a design.
