### PR TITLE
cryptlib_openssl: x509: fixup return value usage

### DIFF
--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -1904,8 +1904,7 @@ bool libspdm_x509_verify_cert(const uint8_t *cert, size_t cert_size,
 
 
     /* X509 Certificate Verification.*/
-
-    res = (bool)X509_verify_cert(cert_ctx);
+    res = (X509_verify_cert(cert_ctx) <= 0) ? false : true;
     X509_STORE_CTX_cleanup(cert_ctx);
 
 done:


### PR DESCRIPTION
X509_verify_cert() returns 1 if a complete chain can be built and validated, otherwise 0, and in exceptional circumstances (such as malloc failure and internal errors) it can also return a negative code [1].

By casting an `int` return value to a `bool`, a negative error code can be treated as `true`. This change fixes that.

[1] https://www.openssl.org/docs/man3.0/man3/X509_verify_cert.html