### PR TITLE
[RFC] crypt_lib: allow partial certchain verification

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -974,20 +974,23 @@ bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const size_t cert_si
 /**
  * This function verifies the integrity of certificate chain data without spdm_cert_chain_t header.
  *
- * @param  cert_chain_data       The certificate chain data without spdm_cert_chain_t header.
- * @param  cert_chain_data_size  Size in bytes of the certificate chain data.
- * @param  base_asym_algo        SPDM base_asym_algo
- * @param  base_hash_algo        SPDM base_hash_algo
- * @param  is_requester_cert     Is the function verifying requester or responder cert.
- * @param  is_device_cert_model  If true, the cert chain is DeviceCert model.
- *                               If false, the cert chain is AliasCert model.
+ * @param  cert_chain_data          The certificate chain data without spdm_cert_chain_t header.
+ * @param  cert_chain_data_size      size in bytes of the certificate chain data.
+ * @param  base_asym_algo            SPDM base_asym_algo
+ * @param  base_hash_algo            SPDM base_hash_algo
+ * @param  is_requester_cert         Is the function verifying requester or responder cert.
+ * @param  is_device_cert_model      If true, the cert chain is DeviceCert model;
+ *                                   If false, the cert chain is AliasCert model;
+ * @param  is_partial_chain          If true, the cert chain does not contain a leaf certificate;
+ *                                   If false, the cert chain is complete;
  *
- * @retval true  Certificate chain data integrity verification pass.
- * @retval false Certificate chain data integrity verification fail.
+ * @retval true  certificate chain data integrity verification pass.
+ * @retval false certificate chain data integrity verification fail.
  **/
 bool libspdm_verify_cert_chain_data(uint8_t *cert_chain_data, size_t cert_chain_data_size,
                                     uint32_t base_asym_algo, uint32_t base_hash_algo,
-                                    bool is_requester_cert, bool is_device_cert_model);
+                                    bool is_requester_cert, bool is_device_cert_model,
+                                    bool is_partial_chain);
 
 /**
  * This function verifies the integrity of certificate chain buffer including

--- a/os_stub/spdm_device_secret_lib_sample/cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/cert.c
@@ -382,8 +382,10 @@ bool libspdm_read_responder_public_certificate_chain(
     size_t digest_size;
     bool is_requester_cert;
     bool is_device_cert_model;
+    bool is_partial_chain;
 
     is_requester_cert = false;
+    is_partial_chain = false;
 
     /*default is true*/
     is_device_cert_model = true;
@@ -454,7 +456,8 @@ bool libspdm_read_responder_public_certificate_chain(
 
     res = libspdm_verify_cert_chain_data(file_data, file_size,
                                          base_asym_algo, base_hash_algo,
-                                         is_requester_cert, is_device_cert_model);
+                                         is_requester_cert, is_device_cert_model,
+                                         is_partial_chain);
     if (!res) {
         free(file_data);
         free(cert_chain);
@@ -658,8 +661,10 @@ bool libspdm_read_responder_public_certificate_chain_per_slot(
     size_t digest_size;
     bool is_requester_cert;
     bool is_device_cert_model;
+    bool is_partial_chain;
 
     is_requester_cert = false;
+    is_partial_chain = false;
 
     /*default is true*/
     is_device_cert_model = true;
@@ -768,7 +773,8 @@ bool libspdm_read_responder_public_certificate_chain_per_slot(
 
     res = libspdm_verify_cert_chain_data(file_data, file_size,
                                          base_asym_algo, base_hash_algo,
-                                         is_requester_cert, is_device_cert_model);
+                                         is_requester_cert, is_device_cert_model,
+                                         is_partial_chain);
     if (!res) {
         free(file_data);
         free(cert_chain);
@@ -826,8 +832,10 @@ bool libspdm_read_requester_public_certificate_chain(
     size_t digest_size;
     bool is_requester_cert;
     bool is_device_cert_model;
+    bool is_partial_chain;
 
     is_requester_cert = false;
+    is_partial_chain = false;
 
     /*default is true*/
     is_device_cert_model = true;
@@ -898,7 +906,8 @@ bool libspdm_read_requester_public_certificate_chain(
 
     res = libspdm_verify_cert_chain_data(file_data, file_size,
                                          req_base_asym_alg, base_hash_algo,
-                                         is_requester_cert, is_device_cert_model);
+                                         is_requester_cert, is_device_cert_model,
+                                         is_partial_chain);
     if (!res) {
         free(file_data);
         free(cert_chain);
@@ -1033,8 +1042,10 @@ bool libspdm_read_responder_public_certificate_chain_by_size(
     size_t digest_size;
     bool is_requester_cert;
     bool is_device_cert_model;
+    bool is_partial_chain;
 
     is_requester_cert = false;
+    is_partial_chain = false;
 
     /*defalut is true*/
     is_device_cert_model = true;
@@ -1083,7 +1094,8 @@ bool libspdm_read_responder_public_certificate_chain_by_size(
 
     res = libspdm_verify_cert_chain_data(file_data, file_size,
                                          base_asym_algo, base_hash_algo,
-                                         is_requester_cert, is_device_cert_model);
+                                         is_requester_cert, is_device_cert_model,
+                                         is_partial_chain);
     if (!res) {
         free(file_data);
         free(cert_chain);


### PR DESCRIPTION
The new addition to the changed api allows us to verify a partial certificate chain, that is, one that does not contain a leaf certificate.

This maybe useful, for example, when the requester is doing a `SET_CERTIFICATE` and is loading in the immutable certificates. If using the AliasCert model, then this chain contains only the rootCA->...->deviceCA (the `immutable` certificates). Composed of only CAs (no leaf). In such a case, we can still use this function to validate most of the chain, but skip the leaf check.