### PR TITLE
spdm_crypt_lib: add new api for partial certificate chain verification

### DIFF
--- a/doc/api/requester_api.md
+++ b/doc/api/requester_api.md
@@ -392,7 +392,9 @@ TBD
 ---
 
 ### Description
-Sends `SET_CERTIFICATE` to deposit a certificate chain into a Responder.
+Sends `SET_CERTIFICATE` to deposit a certificate chain into a Responder. It is recommended that the certificate chain be 
+validated by `libspdm_verify_cert_chain_data_ex` prior to invoking `libspdm_set_certificate`. This ensures that the
+certificate chain is validated locally first.
 
 ### Parameters
 

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -990,6 +990,32 @@ bool libspdm_verify_cert_chain_data(uint8_t *cert_chain_data, size_t cert_chain_
                                     bool is_requester_cert, bool is_device_cert_model);
 
 /**
+ * This function verifies the integrity of certificate chain data without spdm_cert_chain_t header for a
+ * SET_CERTIFICATE
+ *
+ * This function also allows for not-validating the leaf certificate in the chain. This maybe useful for a
+ * requester to validate the immutable certificates ahead of a `SET_CERTIFICATE` request
+ * (i.e using the AliasCertificate model).
+ *
+ * @param  cert_chain_data          The certificate chain data without spdm_cert_chain_t header.
+ * @param  cert_chain_data_size      size in bytes of the certificate chain data.
+ * @param  base_asym_algo            SPDM base_asym_algo
+ * @param  base_hash_algo            SPDM base_hash_algo
+ * @param  is_requester_cert         Is the function verifying requester or responder cert.
+ * @param  is_device_cert_model      If true, the cert chain is DeviceCert model;
+ *                                   If false, the cert chain is AliasCert model;
+ * @param  check_leaf_cert           If true, verify the entire certificate chain;
+ *                                   If false, skip leaf certificate validation;
+ *
+ * @retval true  certificate chain data integrity verification pass.
+ * @retval false certificate chain data integrity verification fail.
+ **/
+bool libspdm_verify_cert_chain_data_ex(const uint8_t *cert_chain_data, size_t cert_chain_data_size,
+                                       uint32_t base_asym_algo, uint32_t base_hash_algo,
+                                       bool is_requester_cert, bool is_device_cert_model,
+                                       bool check_leaf_cert);
+
+/**
  * This function verifies the integrity of certificate chain buffer including
  * spdm_cert_chain_t header.
  *

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
@@ -14,39 +14,13 @@ static bool libspdm_set_cert_verify_certchain(const uint8_t *cert_chain, size_t 
                                               uint32_t base_asym_algo, uint32_t base_hash_algo,
                                               bool is_device_cert_model)
 {
-    const uint8_t *root_cert_buffer;
-    size_t root_cert_buffer_size;
-    const uint8_t *leaf_cert_buffer;
-    size_t leaf_cert_buffer_size;
+    bool is_requester_cert = false;
+    bool check_leaf_cert = true;
 
-    /*get root cert*/
-    if (!libspdm_x509_get_cert_from_cert_chain(
-            cert_chain, cert_chain_size, 0, &root_cert_buffer,
-            &root_cert_buffer_size)) {
-        return false;
-    }
-
-    /*verify cert_chain*/
-    if (!libspdm_x509_verify_cert_chain(root_cert_buffer, root_cert_buffer_size,
-                                        cert_chain, cert_chain_size)) {
-        return false;
-    }
-
-    /*get leaf cert*/
-    if (!libspdm_x509_get_cert_from_cert_chain(
-            cert_chain, cert_chain_size, -1, &leaf_cert_buffer,
-            &leaf_cert_buffer_size)) {
-        return false;
-    }
-
-    /*verify leaf cert*/
-    if (!libspdm_x509_set_cert_certificate_check(leaf_cert_buffer, leaf_cert_buffer_size,
-                                                 base_asym_algo, base_hash_algo,
-                                                 false, is_device_cert_model)) {
-        return false;
-    }
-
-    return true;
+    return libspdm_verify_cert_chain_data_ex(cert_chain, cert_chain_size,
+                                             base_asym_algo, base_hash_algo,
+                                             is_requester_cert, is_device_cert_model,
+                                             check_leaf_cert);
 }
 #endif /*LIBSPDM_CERT_PARSE_SUPPORT*/
 


### PR DESCRIPTION
## Overview:

This addresses the issues discussed in https://github.com/DMTF/libspdm/pull/2369 and https://github.com/DMTF/libspdm/issues/2372

## Testing:

Tested by running responder/requester unit tests locally. Tested the new function by connecting it to a libspdm requester, parsing the certificate chain with the new function, then attempting to do a SET_CERTIFICATE. 