### PR TITLE
Add unit tests for SPDM secured messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,11 @@ jobs:
         run: |
           cd build/bin
           ./test_crypt
+      - name: Test Secured Message
+        if: matrix.toolchain != 'LIBFUZZER' && matrix.toolchain != 'ARM_GNU' && matrix.configurations != '-DDISABLE_TESTS=1'
+        run: |
+          cd build/bin
+          ./test_spdm_secured_message
       - name: Test FIPS
         if: matrix.toolchain != 'LIBFUZZER' && matrix.toolchain != 'ARM_GNU' && matrix.configurations == '-DLIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT=1 -DLIBSPDM_FIPS_MODE=1' && matrix.configurations != '-DDISABLE_TESTS=1'
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,6 +891,7 @@ else()
             ADD_SUBDIRECTORY(unit_test/test_crypt)
             ADD_SUBDIRECTORY(unit_test/test_spdm_crypt)
             ADD_SUBDIRECTORY(unit_test/test_spdm_fips)
+            ADD_SUBDIRECTORY(unit_test/test_spdm_secured_message)
             endif()
 
             if((NOT TOOLCHAIN STREQUAL "ARM_DS2022") AND (NOT TOOLCHAIN STREQUAL "RISCV_XPACK"))

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -224,11 +224,11 @@ typedef enum {
  * SPDM Secured Message version is 1.0 or 1.1.
  * *_LITTLE and *_BIG immediately return an error on decryption failure.
  * *_BOTH tries the opposite endianness on decryption failure.
- * The default endianness is little endian for both encryption and decryption. */
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE 0
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG 1
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH 2
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH 3
+ * The default is LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH. */
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH 0
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE 1
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH 2
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG 3
 
 /*
  * +--------------------------+------------------------------------------+---------+

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -26,7 +26,7 @@ static void generate_iv(uint64_t sequence_number, uint8_t *iv, const uint8_t *sa
         }
         break;
     case LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG:
-    case LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH: {
+    case LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH:
         /* If big-endian then the sequence number is zero-extended to the lower indices.
          * The sequence number ends at the highest index (aead_size - 1). */
         sequence_number = libspdm_le_to_be_64(sequence_number);
@@ -34,12 +34,10 @@ static void generate_iv(uint64_t sequence_number, uint8_t *iv, const uint8_t *sa
                          aead_iv_size,
                          &sequence_number,
                          sizeof(sequence_number));
-        for (index = aead_iv_size - sizeof(sequence_number); index < sizeof(sequence_number);
-             index++) {
+        for (index = aead_iv_size - sizeof(sequence_number); index < aead_iv_size; index++) {
             iv[index] = iv[index] ^ iv_temp[index];
         }
         break;
-    }
     }
 }
 

--- a/unit_test/test_spdm_secured_message/CMakeLists.txt
+++ b/unit_test/test_spdm_secured_message/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/test_spdm_requester
+                    ${LIBSPDM_DIR}/include
+                    ${LIBSPDM_DIR}/unit_test/include
+                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
+                    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common
+                    ${LIBSPDM_DIR}/os_stub
+)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    if((TOOLCHAIN STREQUAL "VS2015") OR (TOOLCHAIN STREQUAL "VS2019") OR (TOOLCHAIN STREQUAL "VS2022"))
+        ADD_COMPILE_OPTIONS(/wd4819)
+    endif()
+endif()
+
+SET(src_test_secured_message
+    test_spdm_secured_message.c
+    encode_decode.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c
+)
+
+SET(test_spdm_secured_message_LIBRARY
+    memlib
+    debuglib
+    spdm_responder_lib
+    spdm_requester_lib
+    spdm_common_lib
+    ${CRYPTO_LIB_PATHS}
+    rnglib
+    cryptlib_${CRYPTO}
+    malloclib
+    spdm_crypt_lib
+    spdm_crypt_ext_lib
+    spdm_secured_message_lib
+    spdm_device_secret_lib_sample
+    spdm_transport_test_lib
+    cmockalib
+    platform_lib_null
+)
+
+if(TOOLCHAIN STREQUAL "ARM_DS2022")
+    SET(test_spdm_common_LIBRARY ${test_spdm_common_LIBRARY} armbuild_lib)
+endif()
+
+if(NOT ((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC")))
+    ADD_EXECUTABLE(test_spdm_secured_message ${src_test_secured_message})
+    TARGET_LINK_LIBRARIES(test_spdm_secured_message ${test_spdm_secured_message_LIBRARY})
+endif()

--- a/unit_test/test_spdm_secured_message/encode_decode.c
+++ b/unit_test/test_spdm_secured_message/encode_decode.c
@@ -1,0 +1,511 @@
+#include "spdm_unit_test.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+/*libspdm_return_t libspdm_encode_secured_message(
+    void *spdm_secured_message_context, uint32_t session_id,
+    bool is_request_message, size_t app_message_size,
+    void *app_message, size_t *secured_message_size,
+    void *secured_message,
+    const libspdm_secured_message_callbacks_t *spdm_secured_message_callbacks)*/
+
+static uint8_t m_secured_message[0x1000];
+static uint8_t m_app_message[0x1000];
+static libspdm_secured_message_context_t m_secured_message_context;
+static libspdm_secured_message_callbacks_t m_secured_message_callbacks;
+
+#define PARTIAL_SEQ_NUM_SIZE 8
+
+static uint8_t get_sequence_number(uint64_t sequence_number,
+                                   uint8_t *sequence_number_buffer)
+{
+    libspdm_copy_mem(sequence_number_buffer, (size_t)8,
+                     &sequence_number, (size_t)PARTIAL_SEQ_NUM_SIZE);
+
+    return PARTIAL_SEQ_NUM_SIZE;
+}
+
+static uint32_t get_max_random_number_count(void)
+{
+    return 0;
+}
+
+static spdm_version_number_t get_secured_spdm_version(spdm_version_number_t secured_message_version)
+{
+    return SECURED_SPDM_VERSION_11;
+}
+
+static void initialize_secured_message_context(void)
+{
+    m_secured_message_context.secured_message_version = SECURED_SPDM_VERSION_11;
+    m_secured_message_context.aead_cipher_suite = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM;
+    m_secured_message_context.session_type = LIBSPDM_SESSION_TYPE_ENC_MAC;
+    m_secured_message_context.session_state = LIBSPDM_SESSION_STATE_ESTABLISHED;
+    m_secured_message_context.aead_tag_size = 16;
+    m_secured_message_context.aead_key_size = 32;
+    m_secured_message_context.aead_iv_size = 12;
+    for (uint8_t index = 0; index < 32; index++) {
+        m_secured_message_context.application_secret.request_data_encryption_key[index] = index;
+        m_secured_message_context.application_secret.response_data_encryption_key[index] =
+            32 - index;
+    }
+    for (uint8_t index = 0; index < 12; index++) {
+        m_secured_message_context.application_secret.request_data_salt[index] = index * 2;
+        m_secured_message_context.application_secret.response_data_salt[index] = index * 4;
+    }
+    m_secured_message_context.application_secret.request_data_sequence_number = 0;
+    m_secured_message_context.application_secret.response_data_sequence_number = 0;
+    m_secured_message_context.max_spdm_session_sequence_number = UINT64_MAX;
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH;
+    m_secured_message_callbacks.get_secured_spdm_version = get_secured_spdm_version;
+    m_secured_message_callbacks.get_max_random_number_count = get_max_random_number_count;
+    m_secured_message_callbacks.get_sequence_number = get_sequence_number;
+}
+
+/**
+ * Test 1: Test basic encryption with sequence number set to all zeroes and little endianness.
+ **/
+static void libspdm_test_secured_message_encode_case1(void **state)
+{
+    libspdm_return_t status;
+    uint8_t app_message[16];
+    size_t secured_message_size = sizeof(m_secured_message);
+    const uint32_t session_id = 0x00112233;
+    uint8_t *ptr;
+
+    initialize_secured_message_context();
+
+    for (uint8_t index = 0; index < 16; index++) {
+        app_message[index] = index;
+    }
+
+    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+    assert_memory_equal(&session_id, &m_secured_message, 4);
+
+    /* Sequence number is all zeroes. */
+    for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
+        assert_int_equal(0, m_secured_message[index]);
+    }
+
+    assert_int_equal(0x0022, *(uint16_t*)&m_secured_message[4 + PARTIAL_SEQ_NUM_SIZE]);
+
+    ptr = (uint8_t *)&m_secured_message + 6 + PARTIAL_SEQ_NUM_SIZE;
+
+    /* Expected values generated from https://tinyurl.com/yrx9w78w */
+    uint8_t expected_cipher_text[] = {0x9b, 0xfe, 0xd3, 0xb7, 0x04, 0x3d, 0x32, 0x86, 0x60, 0x3d,
+                                      0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20};
+    uint8_t expected_mac[] = {0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5, 0xa0, 0x27, 0x0a,
+                              0xf6, 0x73, 0xf0, 0xfe, 0x36};
+
+    assert_memory_equal(expected_cipher_text, ptr, sizeof(expected_cipher_text));
+    ptr += sizeof(expected_cipher_text);
+    assert_memory_equal(expected_mac, ptr, sizeof(expected_mac));
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(1, m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 2: Test basic encryption with sequence number set to alternating zeroes and ones and
+ *         little endianness.
+ **/
+static void libspdm_test_secured_message_encode_case2(void **state)
+{
+    libspdm_return_t status;
+    uint8_t app_message[16];
+    size_t secured_message_size = sizeof(m_secured_message);
+    const uint32_t session_id = 0x00112233;
+    uint8_t *ptr;
+
+    initialize_secured_message_context();
+    m_secured_message_context.application_secret.request_data_sequence_number = 0xaa55aa55aa55aa55;
+
+    for (uint8_t index = 0; index < 16; index++) {
+        app_message[index] = index;
+    }
+
+    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+    assert_memory_equal(&session_id, &m_secured_message, 4);
+
+    /* Sequence number is alternating 0x55 and 0xaa. */
+    for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
+        if (index % 2 == 0){
+            assert_int_equal(0x55, m_secured_message[index]);
+        } else {
+            assert_int_equal(0xaa, m_secured_message[index]);
+        }
+    }
+
+    assert_int_equal(0x0022, *(uint16_t*)&m_secured_message[4 + PARTIAL_SEQ_NUM_SIZE]);
+
+    ptr = (uint8_t *)&m_secured_message + 6 + PARTIAL_SEQ_NUM_SIZE;
+
+    /* Expected values generated from https://tinyurl.com/2amhw53e */
+    uint8_t expected_cipher_text[] = {0x0d, 0xea, 0x75, 0xea, 0xc6, 0x91, 0x37, 0x49, 0x94, 0x97,
+                                      0x52, 0x63, 0xf8, 0xc0, 0x8f, 0x6c, 0x1a, 0xa4};
+    uint8_t expected_mac[] = {0x0d, 0xcd, 0xb4, 0x8a, 0xd6, 0xfa, 0x24, 0x04, 0x79, 0xd5, 0xd8,
+                              0xd2, 0xfe, 0x28, 0x19, 0x14};
+
+    assert_memory_equal(expected_cipher_text, ptr, sizeof(expected_cipher_text));
+    ptr += sizeof(expected_cipher_text);
+    assert_memory_equal(expected_mac, ptr, sizeof(expected_mac));
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(0xaa55aa55aa55aa56,
+        m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 3: Test basic encryption with sequence number set to all zeroes and big endianness.
+ *         This has the same result as test 1 since the sequence number is all zeroes.
+ **/
+static void libspdm_test_secured_message_encode_case3(void **state)
+{
+    libspdm_return_t status;
+    uint8_t app_message[16];
+    size_t secured_message_size = sizeof(m_secured_message);
+    const uint32_t session_id = 0x00112233;
+    uint8_t *ptr;
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH;
+
+    for (uint8_t index = 0; index < 16; index++) {
+        app_message[index] = index;
+    }
+
+    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+    assert_memory_equal(&session_id, &m_secured_message, 4);
+
+    /* Sequence number is all zeroes. */
+    for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
+        assert_int_equal(0, m_secured_message[index]);
+    }
+
+    assert_int_equal(0x0022, *(uint16_t*)&m_secured_message[4 + PARTIAL_SEQ_NUM_SIZE]);
+
+    ptr = (uint8_t *)&m_secured_message + 6 + PARTIAL_SEQ_NUM_SIZE;
+
+    /* Expected values generated from https://tinyurl.com/yrx9w78w */
+    uint8_t expected_cipher_text[] = {0x9b, 0xfe, 0xd3, 0xb7, 0x04, 0x3d, 0x32, 0x86, 0x60, 0x3d,
+                                      0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20};
+    uint8_t expected_mac[] = {0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5, 0xa0, 0x27, 0x0a,
+                              0xf6, 0x73, 0xf0, 0xfe, 0x36};
+
+    assert_memory_equal(expected_cipher_text, ptr, sizeof(expected_cipher_text));
+    ptr += sizeof(expected_cipher_text);
+    assert_memory_equal(expected_mac, ptr, sizeof(expected_mac));
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(1, m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 4: Test basic encryption with sequence number set to alternating zeroes and ones and
+ *         big endianness.
+ **/
+static void libspdm_test_secured_message_encode_case4(void **state)
+{
+    libspdm_return_t status;
+    uint8_t app_message[16];
+    size_t secured_message_size = sizeof(m_secured_message);
+    const uint32_t session_id = 0x00112233;
+    uint8_t *ptr;
+
+    initialize_secured_message_context();
+    m_secured_message_context.application_secret.request_data_sequence_number = 0xaa55aa55aa55aa55;
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH;
+
+    for (uint8_t index = 0; index < 16; index++) {
+        app_message[index] = index;
+    }
+
+    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+    assert_memory_equal(&session_id, &m_secured_message, 4);
+
+    /* Sequence number is alternating 0x55 and 0xaa. */
+    for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
+        if (index % 2 == 0){
+            assert_int_equal(0x55, m_secured_message[index]);
+        } else {
+            assert_int_equal(0xaa, m_secured_message[index]);
+        }
+    }
+
+    assert_int_equal(0x0022, *(uint16_t*)&m_secured_message[4 + PARTIAL_SEQ_NUM_SIZE]);
+
+    ptr = (uint8_t *)&m_secured_message + 6 + PARTIAL_SEQ_NUM_SIZE;
+
+    /* Expected values generated from https://tinyurl.com/azaw5bab */
+    uint8_t expected_cipher_text[] = {0xf6, 0x4d, 0x6b, 0x94, 0x37, 0x7a, 0x18, 0x61, 0x01, 0xce,
+                                      0xfe, 0xa0, 0x8d, 0x91, 0x79, 0x8a, 0x89, 0x88};
+    uint8_t expected_mac[] = {0xb6, 0x8e, 0xd3, 0x06, 0x4a, 0x95, 0x70, 0x89, 0xd4, 0xd8, 0xb9,
+                              0x02, 0x9e, 0x9d, 0x72, 0x0b};
+
+    assert_memory_equal(expected_cipher_text, ptr, sizeof(expected_cipher_text));
+    ptr += sizeof(expected_cipher_text);
+    assert_memory_equal(expected_mac, ptr, sizeof(expected_mac));
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(0xaa55aa55aa55aa56,
+        m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 5: Test basic decryption with sequence number set to all zeroes and little endianness.
+ *         This uses the same plaintext as test 1.
+ **/
+static void libspdm_test_secured_message_encode_case5(void **state)
+{
+    libspdm_return_t status;
+    size_t app_message_size = sizeof(m_app_message);
+    void *app_message = m_app_message;
+    const uint32_t session_id = 0x00112233;
+
+    uint8_t secured_message[] = {
+        /* Session id. */
+        0x33, 0x22, 0x11, 0x00,
+        /* Sequence number. */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        /* Total length. */
+        0x22, 0x00,
+        /* Encrypted application data length.*/
+        0x9b, 0xfe,
+        /* Encrypted application data. */
+        0xd3, 0xb7, 0x04, 0x3d, 0x32, 0x86, 0x60, 0x3d,
+        0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20,
+        /* MAC. */
+        0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5,
+        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36};
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE;
+
+    libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
+                     secured_message, sizeof(secured_message));
+
+    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+
+    for (int index = 0; index < 16; index++) {
+        assert_int_equal(index, ((uint8_t *)app_message)[index]);
+    }
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(1, m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 6: Test basic decryption with sequence number set to all zeroes and big endianness.
+ *         This uses the same plaintext as test 1.
+ **/
+static void libspdm_test_secured_message_encode_case6(void **state)
+{
+    libspdm_return_t status;
+    size_t app_message_size = sizeof(m_app_message);
+    void *app_message = m_app_message;
+    const uint32_t session_id = 0x00112233;
+
+    uint8_t secured_message[] = {
+        /* Session id. */
+        0x33, 0x22, 0x11, 0x00,
+        /* Sequence number. */
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        /* Total length. */
+        0x22, 0x00,
+        /* Encrypted application data length.*/
+        0x9b, 0xfe,
+        /* Encrypted application data. */
+        0xd3, 0xb7, 0x04, 0x3d, 0x32, 0x86, 0x60, 0x3d,
+        0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20,
+        /* MAC. */
+        0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5,
+        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36};
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG;
+
+    libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
+                     secured_message, sizeof(secured_message));
+
+    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+
+    for (int index = 0; index < 16; index++) {
+        assert_int_equal(index, ((uint8_t *)app_message)[index]);
+    }
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(1, m_secured_message_context.application_secret.request_data_sequence_number);
+}
+
+/**
+ * Test 7: Test try-fail decryption with sequence number set to alternating zeroes and ones.
+ *         The message is encrypted with big-endian sequence number but decoder is set to try
+ *         little-endian first. This uses the same plaintext as test 1.
+ **/
+static void libspdm_test_secured_message_encode_case7(void **state)
+{
+    libspdm_return_t status;
+    size_t app_message_size = sizeof(m_app_message);
+    void *app_message = m_app_message;
+    const uint32_t session_id = 0x00112233;
+
+    uint8_t secured_message[] = {
+        /* Session id. */
+        0x33, 0x22, 0x11, 0x00,
+        /* Sequence number. */
+        0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa,
+        /* Total length. */
+        0x22, 0x00,
+        /* Encrypted application data length.*/
+        0xf6, 0x4d,
+        /* Encrypted application data. */
+        0x6b, 0x94, 0x37, 0x7a, 0x18, 0x61, 0x01, 0xce,
+        0xfe, 0xa0, 0x8d, 0x91, 0x79, 0x8a, 0x89, 0x88,
+        /* MAC. */
+        0xb6, 0x8e, 0xd3, 0x06, 0x4a, 0x95, 0x70, 0x89,
+        0xd4, 0xd8, 0xb9, 0x02, 0x9e, 0x9d, 0x72, 0x0b};
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH;
+    m_secured_message_context.application_secret.request_data_sequence_number = 0xaa55aa55aa55aa55;
+
+    libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
+                     secured_message, sizeof(secured_message));
+
+    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+
+    for (int index = 0; index < 16; index++) {
+        assert_int_equal(index, ((uint8_t *)app_message)[index]);
+    }
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(0xaa55aa55aa55aa56,
+        m_secured_message_context.application_secret.request_data_sequence_number);
+
+    /* Context should change to big-endian only. */
+    assert_int_equal(LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG,
+                     m_secured_message_context.sequence_number_endian);
+}
+
+/**
+ * Test 8: Test try-fail decryption with sequence number set to alternating zeroes and ones.
+ *         The message is encrypted with little-endian sequence number but decoder is set to try
+ *         big-endian first. This uses the same plaintext as test 1.
+ **/
+static void libspdm_test_secured_message_encode_case8(void **state)
+{
+    libspdm_return_t status;
+    size_t app_message_size = sizeof(m_app_message);
+    void *app_message = m_app_message;
+    const uint32_t session_id = 0x00112233;
+
+    uint8_t secured_message[] = {
+        /* Session id. */
+        0x33, 0x22, 0x11, 0x00,
+        /* Sequence number. */
+        0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa,
+        /* Total length. */
+        0x22, 0x00,
+        /* Encrypted application data length.*/
+        0x0d, 0xea,
+        /* Encrypted application data. */
+        0x75, 0xea, 0xc6, 0x91, 0x37, 0x49, 0x94, 0x97,
+        0x52, 0x63, 0xf8, 0xc0, 0x8f, 0x6c, 0x1a, 0xa4,
+        /* MAC. */
+        0x0d, 0xcd, 0xb4, 0x8a, 0xd6, 0xfa, 0x24, 0x04,
+        0x79, 0xd5, 0xd8, 0xd2, 0xfe, 0x28, 0x19, 0x14};
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH;
+    m_secured_message_context.application_secret.request_data_sequence_number = 0xaa55aa55aa55aa55;
+
+    libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
+                     secured_message, sizeof(secured_message));
+
+    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+        sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
+        &m_secured_message_callbacks);
+
+    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
+    assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
+
+    for (int index = 0; index < 16; index++) {
+        assert_int_equal(index, ((uint8_t *)app_message)[index]);
+    }
+
+    /* Sequence number is incremented by one after operation. */
+    assert_int_equal(0xaa55aa55aa55aa56,
+        m_secured_message_context.application_secret.request_data_sequence_number);
+
+    /* Context should change to little-endian only. */
+    assert_int_equal(LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE,
+                     m_secured_message_context.sequence_number_endian);
+}
+
+static libspdm_test_context_t m_libspdm_common_context_data_test_context = {
+    LIBSPDM_TEST_CONTEXT_VERSION,
+    true,
+    NULL,
+    NULL,
+};
+
+int libspdm_secured_message_encode_decode_test_main(void)
+{
+    const struct CMUnitTest spdm_secured_message_encode_decode_tests[] = {
+        cmocka_unit_test(libspdm_test_secured_message_encode_case1),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case2),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case3),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case4),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case5),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case6),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case7),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case8)
+    };
+
+    libspdm_setup_test_context(&m_libspdm_common_context_data_test_context);
+
+    return cmocka_run_group_tests(spdm_secured_message_encode_decode_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}

--- a/unit_test/test_spdm_secured_message/encode_decode.c
+++ b/unit_test/test_spdm_secured_message/encode_decode.c
@@ -1,12 +1,11 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2023 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
 #include "spdm_unit_test.h"
 #include "internal/libspdm_secured_message_lib.h"
-
-/*libspdm_return_t libspdm_encode_secured_message(
-    void *spdm_secured_message_context, uint32_t session_id,
-    bool is_request_message, size_t app_message_size,
-    void *app_message, size_t *secured_message_size,
-    void *secured_message,
-    const libspdm_secured_message_callbacks_t *spdm_secured_message_callbacks)*/
 
 static uint8_t m_secured_message[0x1000];
 static uint8_t m_app_message[0x1000];
@@ -79,11 +78,11 @@ static void libspdm_test_secured_message_encode_case1(void **state)
         app_message[index] = index;
     }
 
-    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_encode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
     assert_memory_equal(&session_id, &m_secured_message, 4);
 
@@ -129,17 +128,17 @@ static void libspdm_test_secured_message_encode_case2(void **state)
         app_message[index] = index;
     }
 
-    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_encode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
     assert_memory_equal(&session_id, &m_secured_message, 4);
 
     /* Sequence number is alternating 0x55 and 0xaa. */
     for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
-        if (index % 2 == 0){
+        if (index % 2 == 0) {
             assert_int_equal(0x55, m_secured_message[index]);
         } else {
             assert_int_equal(0xaa, m_secured_message[index]);
@@ -162,7 +161,7 @@ static void libspdm_test_secured_message_encode_case2(void **state)
 
     /* Sequence number is incremented by one after operation. */
     assert_int_equal(0xaa55aa55aa55aa56,
-        m_secured_message_context.application_secret.request_data_sequence_number);
+                     m_secured_message_context.application_secret.request_data_sequence_number);
 }
 
 /**
@@ -185,11 +184,11 @@ static void libspdm_test_secured_message_encode_case3(void **state)
         app_message[index] = index;
     }
 
-    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_encode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
     assert_memory_equal(&session_id, &m_secured_message, 4);
 
@@ -237,17 +236,17 @@ static void libspdm_test_secured_message_encode_case4(void **state)
         app_message[index] = index;
     }
 
-    status = libspdm_encode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_encode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(app_message), app_message, &secured_message_size, &m_secured_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
     assert_memory_equal(&session_id, &m_secured_message, 4);
 
     /* Sequence number is alternating 0x55 and 0xaa. */
     for (int index = 4; index < 4 + PARTIAL_SEQ_NUM_SIZE; index++) {
-        if (index % 2 == 0){
+        if (index % 2 == 0) {
             assert_int_equal(0x55, m_secured_message[index]);
         } else {
             assert_int_equal(0xaa, m_secured_message[index]);
@@ -270,7 +269,7 @@ static void libspdm_test_secured_message_encode_case4(void **state)
 
     /* Sequence number is incremented by one after operation. */
     assert_int_equal(0xaa55aa55aa55aa56,
-        m_secured_message_context.application_secret.request_data_sequence_number);
+                     m_secured_message_context.application_secret.request_data_sequence_number);
 }
 
 /**
@@ -298,7 +297,8 @@ static void libspdm_test_secured_message_encode_case5(void **state)
         0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20,
         /* MAC. */
         0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5,
-        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36};
+        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36
+    };
 
     initialize_secured_message_context();
     m_secured_message_context.sequence_number_endian =
@@ -307,11 +307,11 @@ static void libspdm_test_secured_message_encode_case5(void **state)
     libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
                      secured_message, sizeof(secured_message));
 
-    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_decode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
 
     for (int index = 0; index < 16; index++) {
@@ -347,7 +347,8 @@ static void libspdm_test_secured_message_encode_case6(void **state)
         0x86, 0x17, 0x33, 0xd6, 0x7f, 0x95, 0x9a, 0x20,
         /* MAC. */
         0x3d, 0x4f, 0xac, 0x58, 0xcb, 0x70, 0x6c, 0xf5,
-        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36};
+        0xa0, 0x27, 0x0a, 0xf6, 0x73, 0xf0, 0xfe, 0x36
+    };
 
     initialize_secured_message_context();
     m_secured_message_context.sequence_number_endian =
@@ -356,11 +357,11 @@ static void libspdm_test_secured_message_encode_case6(void **state)
     libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
                      secured_message, sizeof(secured_message));
 
-    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_decode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
 
     for (int index = 0; index < 16; index++) {
@@ -397,7 +398,8 @@ static void libspdm_test_secured_message_encode_case7(void **state)
         0xfe, 0xa0, 0x8d, 0x91, 0x79, 0x8a, 0x89, 0x88,
         /* MAC. */
         0xb6, 0x8e, 0xd3, 0x06, 0x4a, 0x95, 0x70, 0x89,
-        0xd4, 0xd8, 0xb9, 0x02, 0x9e, 0x9d, 0x72, 0x0b};
+        0xd4, 0xd8, 0xb9, 0x02, 0x9e, 0x9d, 0x72, 0x0b
+    };
 
     initialize_secured_message_context();
     m_secured_message_context.sequence_number_endian =
@@ -407,11 +409,11 @@ static void libspdm_test_secured_message_encode_case7(void **state)
     libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
                      secured_message, sizeof(secured_message));
 
-    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_decode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
 
     for (int index = 0; index < 16; index++) {
@@ -420,7 +422,7 @@ static void libspdm_test_secured_message_encode_case7(void **state)
 
     /* Sequence number is incremented by one after operation. */
     assert_int_equal(0xaa55aa55aa55aa56,
-        m_secured_message_context.application_secret.request_data_sequence_number);
+                     m_secured_message_context.application_secret.request_data_sequence_number);
 
     /* Context should change to big-endian only. */
     assert_int_equal(LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG,
@@ -453,7 +455,8 @@ static void libspdm_test_secured_message_encode_case8(void **state)
         0x52, 0x63, 0xf8, 0xc0, 0x8f, 0x6c, 0x1a, 0xa4,
         /* MAC. */
         0x0d, 0xcd, 0xb4, 0x8a, 0xd6, 0xfa, 0x24, 0x04,
-        0x79, 0xd5, 0xd8, 0xd2, 0xfe, 0x28, 0x19, 0x14};
+        0x79, 0xd5, 0xd8, 0xd2, 0xfe, 0x28, 0x19, 0x14
+    };
 
     initialize_secured_message_context();
     m_secured_message_context.sequence_number_endian =
@@ -463,11 +466,11 @@ static void libspdm_test_secured_message_encode_case8(void **state)
     libspdm_copy_mem(m_secured_message, sizeof(m_secured_message),
                      secured_message, sizeof(secured_message));
 
-    status = libspdm_decode_secured_message(&m_secured_message_context, session_id, true,
+    status = libspdm_decode_secured_message(
+        &m_secured_message_context, session_id, true,
         sizeof(m_secured_message), m_secured_message, &app_message_size, &app_message,
         &m_secured_message_callbacks);
 
-    libspdm_internal_dump_hex((const uint8_t*)&m_secured_message, 100);
     assert_int_equal(LIBSPDM_STATUS_SUCCESS, status);
 
     for (int index = 0; index < 16; index++) {
@@ -476,7 +479,7 @@ static void libspdm_test_secured_message_encode_case8(void **state)
 
     /* Sequence number is incremented by one after operation. */
     assert_int_equal(0xaa55aa55aa55aa56,
-        m_secured_message_context.application_secret.request_data_sequence_number);
+                     m_secured_message_context.application_secret.request_data_sequence_number);
 
     /* Context should change to little-endian only. */
     assert_int_equal(LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE,

--- a/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
+++ b/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
@@ -1,0 +1,18 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2023 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+extern int libspdm_secured_message_encode_decode_test_main(void);
+
+int main(void)
+{
+    int return_value = 0;
+
+    if (libspdm_secured_message_encode_decode_test_main() != 0) {
+        return_value = 1;
+    }
+
+    return return_value;
+}


### PR DESCRIPTION
This also fixes a bug that was caught by these unit tests.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>