### PR TITLE
Add SESSION_SEQUENCE_NUMBER_ENDIAN

### DIFF
--- a/doc/api/common_api.md
+++ b/doc/api/common_api.md
@@ -297,7 +297,7 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
       `LIBSPDM_DATA_MAX_SPDM_SESSION_SEQUENCE_NUMBER` is set to `0` then the default value is used.
 - `LIBSPDM_DATA_SPDM_VERSION_10_11_VERIFY_SIGNATURE_ENDIAN`
     - Specifies how verification of asymmetric signatures is handled when the negotiated SPDM
-      version is 1.0 or 1.1. Its value can be one of
+      version is 1.0 or 1.1. Its value is one of
         - `LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_BIG_ONLY`
             - The endianness of the signature is only interpreted as big-endian.
         - `LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_LITTLE_ONLY`
@@ -306,8 +306,8 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
             - The endianness of the signature is first interpreted as big-endian. If verification
               fails then little-endian is tried.
 - `LIBSPDM_DATA_SEQUENCE_NUMBER_ENDIAN`
-    - Specifies the endianness of the sequence number used in secured message encryption and
-      decryption. Its value can be one of
+    - Specifies the endianness of the AEAD sequence number used in secured message encryption and
+      decryption. Its value is one of
         - `LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH`
             - Data is encrypted with a little-endian sequence number and data is initially decrypted
               with a little-endian sequence number. If decryption fails then a big-endian sequence
@@ -321,10 +321,12 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
         - `LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG`
             - Data is both encrypted and decrypted with a big-endian sequence number.
     - For practical purposes `*_BOTH` only applies to Responder endpoints. In the scenario where
-      Requester and Responder only support different endianness encodings, the Responder may return
-      a `DecryptError` to the Requester or it may not return anything and terminate the session. In
-      such a situation the Requester Integrator may change the sequence number endianness to the
-      opposite value and try again with session establishment.
+      Requester and Responder exclusively support different endianness encodings, the Responder may
+      return a `DecryptError` to the Requester or it may not return an error and terminate the
+      session. In such a situation the Requester Integrator may change the sequence number
+      endianness to the opposite value and try again with session establishment. Once a session has
+      been successfully established, the correct endianness can be queried from
+      `LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_ENDIAN`.
 
 ### Values that can only be `get`.
 
@@ -364,3 +366,10 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
       encrypted / decrypted in the response (Responder to Requester) direction.
     - This value is only applicable when the local endpoint is in the
      `LIBSPDM_SESSION_STATE_ESTABLISHED` state.
+- `LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_ENDIAN`
+    - For a given session ID, returns the endianness of the AEAD sequence number. Its value is one
+      of
+        - `LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE`
+            - The endianness of the sequence number is little-endian.
+        - `LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH`
+            - The endianness of the sequence number is big-endian.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -119,7 +119,7 @@ typedef enum {
      * When set a new value, below rule is applied:
      *     new MaxDheSessionCount <= LIBSPDM_MAX_SESSION_COUNT - current MaxPskSessionCount
      *     new MaxPskSessionCount <= LIBSPDM_MAX_SESSION_COUNT - current MaxDheSessionCount
-     * 0 means no limiation for the specific DHE or PSK session, as long as
+     * 0 means no limitation for the specific DHE or PSK session, as long as
      *     PskSessionCount + DheSessionCount <= LIBSPDM_MAX_SESSION_COUNT.
      * If these values are modified while there are active sessions then the active sessions
      * aren't terminated.
@@ -135,6 +135,7 @@ typedef enum {
     LIBSPDM_DATA_SPDM_VERSION_10_11_VERIFY_SIGNATURE_ENDIAN,
 
     LIBSPDM_DATA_SEQUENCE_NUMBER_ENDIAN,
+    LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_ENDIAN,
 
     /* MAX */
     LIBSPDM_DATA_MAX
@@ -224,11 +225,11 @@ typedef enum {
  * SPDM Secured Message version is 1.0 or 1.1.
  * *_LITTLE and *_BIG immediately return an error on decryption failure.
  * *_BOTH tries the opposite endianness on decryption failure.
- * The default is LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH. */
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH 0
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE 1
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH 2
-#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG 3
+ * The default is LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE. */
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE 0
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_BOTH 1
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG 2
+#define LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BOTH 3
 
 /*
  * +--------------------------+------------------------------------------+---------+

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -136,6 +136,7 @@ static bool need_session_info_for_data(libspdm_data_type_t data_type)
     case LIBSPDM_DATA_SESSION_POLICY:
     case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_RSP_DIR:
     case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR:
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_ENDIAN:
         return true;
     default:
         return false;
@@ -993,6 +994,9 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
     case LIBSPDM_DATA_SEQUENCE_NUMBER_ENDIAN:
         target_data_size = sizeof(uint8_t);
         target_data = &context->sequence_number_endian;
+    case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_ENDIAN:
+        target_data_size = sizeof(uint8_t);
+        target_data = &secured_context->sequence_number_endian;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         break;


### PR DESCRIPTION
And revert the default value back to little-endian only.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>