### PR TITLE
os_stub: cryptlib: CSR: Allow copying attributes from an existing cert

### DIFF
--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -1931,6 +1931,8 @@ bool libspdm_set_attribute_for_req(mbedtls_x509write_csr *req,
  * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
  *                                            For output, csr_pointer is address for stored CSR.
  *                                            The csr_pointer address will be changed.
+ * @param[in]           base_cert             An optional leaf certificate whose
+ *                                            extensions should be copied to the CSR
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
@@ -1939,7 +1941,8 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                           uint8_t *requester_info, size_t requester_info_length,
                           bool is_ca,
                           void *context, char *subject_name,
-                          size_t *csr_len, uint8_t *csr_pointer)
+                          size_t *csr_len, uint8_t *csr_pointer,
+                          void *base_cert)
 {
     int ret;
     bool result;
@@ -1947,11 +1950,16 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
 
     mbedtls_x509write_csr req;
     mbedtls_md_type_t md_alg;
+    mbedtls_asn1_sequence extns;
+    mbedtls_asn1_sequence *next;
+    mbedtls_x509_buf buf;
+    mbedtls_x509_crt *cert;
     mbedtls_pk_context key;
 
     uint8_t pubkey_buffer[LIBSPDM_MAX_PUBKEY_DER_BUFFER_SIZE];
     uint8_t *pubkey_der_data;
     size_t pubkey_der_len;
+    size_t tag_len;
 
     /*basic_constraints: CA: false */
     #define BASIC_CONSTRAINTS_STRING_FALSE {0x30, 0x00}
@@ -1965,6 +1973,7 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
     mbedtls_x509write_csr_init(&req);
     mbedtls_pk_init(&key);
     csr_buffer_size = *csr_len;
+    next = NULL;
 
     ret = 1;
     switch (asym_nid)
@@ -2063,6 +2072,43 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
 
     /* Set key */
     mbedtls_x509write_csr_set_key(&req, &key);
+
+    if (base_cert != NULL) {
+        cert = base_cert;
+        buf = cert->v3_ext;
+        if (mbedtls_asn1_get_sequence_of(&buf.p, buf.p + buf.len, &extns,
+                                         MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) {
+            ret = 1;
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                           "mbedtls_x509write_csr_set_extension unable to get tag\n"));
+            goto free_all;
+        }
+
+        next = &extns;
+    }
+
+    while (next) {
+        if (mbedtls_asn1_get_tag(&(next->buf.p), next->buf.p + next->buf.len, &tag_len,
+                                 MBEDTLS_ASN1_OID)) {
+            ret = 1;
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                           "mbedtls_x509write_csr_set_extension unable to get tag\n"));
+            goto free_all;
+        }
+
+        if (mbedtls_x509write_csr_set_extension(&req, MBEDTLS_OID_BASIC_CONSTRAINTS,
+                                                MBEDTLS_OID_SIZE(MBEDTLS_OID_BASIC_CONSTRAINTS),
+                                                next->buf.p,
+                                                tag_len
+                                                ) != 0) {
+            ret = 1;
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO,
+                           "mbedtls_x509write_csr_set_extension set custom OID failed \n"));
+            goto free_all;
+        }
+
+        next = next->next;
+    }
 
     /*set basicConstraints*/
     if (mbedtls_x509write_csr_set_extension(&req, MBEDTLS_OID_BASIC_CONSTRAINTS,

--- a/os_stub/cryptlib_null/pk/x509.c
+++ b/os_stub/cryptlib_null/pk/x509.c
@@ -766,6 +766,8 @@ int32_t libspdm_x509_compare_date_time(const void *date_time1, const void *date_
  * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
  *                                            For output, csr_pointer is address for stored CSR.
  *                                            The csr_pointer address will be changed.
+ * @param[in]           base_cert             An optional leaf certificate whose
+ *                                            extensions should be copied to the CSR
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
@@ -774,7 +776,8 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                           uint8_t *requester_info, size_t requester_info_length,
                           bool is_ca,
                           void *context, char *subject_name,
-                          size_t *csr_len, uint8_t *csr_pointer)
+                          size_t *csr_len, uint8_t *csr_pointer,
+                          void *base_cert)
 {
     LIBSPDM_ASSERT(false);
     return false;

--- a/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
+++ b/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
@@ -739,6 +739,8 @@ extern bool libspdm_sm2_dsa_generate_key(void *sm2_context, uint8_t *public_data
  * @param[in, out]      csr_pointer           For input, csr_pointer is buffer address to store CSR.
  *                                            For output, csr_pointer is address for stored CSR.
  *                                            The csr_pointer address will be changed.
+ * @param[in]           base_cert             An optional leaf certificate whose
+ *                                            extensions should be copied to the CSR
  *
  * @retval  true   Success.
  * @retval  false  Failed to gen CSR.
@@ -747,7 +749,8 @@ extern bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
                                  uint8_t *requester_info, size_t requester_info_length,
                                  bool is_ca,
                                  void *context, char *subject_name,
-                                 size_t *csr_len, uint8_t *csr_pointer);
+                                 size_t *csr_len, uint8_t *csr_pointer,
+                                 void *base_cert);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP */
 
 #endif /* CRYPTLIB_EXT_H */

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -688,7 +688,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
                                       requester_info, requester_info_length,
                                       !is_device_cert_model,
                                       context, subject_name,
-                                      csr_len, csr_pointer);
+                                      csr_len, csr_pointer,
+                                      NULL);
         libspdm_asym_free(base_asym_algo, context);
         libspdm_zero_mem(prikey, prikey_size);
         free(prikey);
@@ -707,7 +708,8 @@ bool libspdm_gen_csr(uint32_t base_hash_algo, uint32_t base_asym_algo, bool *nee
                                   requester_info, requester_info_length,
                                   !is_device_cert_model,
                                   context, subject_name,
-                                  csr_len, csr_pointer);
+                                  csr_len, csr_pointer,
+                                  NULL);
     libspdm_asym_free(base_asym_algo, context);
 #if !LIBSPDM_PRIVATE_KEY_MODE_RAW_KEY_ONLY
 }


### PR DESCRIPTION
Section 754 of SPDM 1.3 states that:

```
    The CSR shall be populated with a combination of attributes
    provided by the Requester via the RequesterInfo field and other
    attributes contributed by the Responder itself.
```

libspdm currently supports populating the CSR based on the RequesterInfo, but we don't allow the Responder to add custom attributes.

This patch updates libspdm_gen_x509_csr() to pass in a base certificate that is used to provide CSR attributes. libspdm_gen_x509_csr() will copy the extensions from `base_cert` to the CSR.

This way devices can choose to apply the same extensions from a leaf certificate (or other certificate already on the device) or create a new cert just to pass the extensions in.

By copying the extensions from an existing cert the API should be generic between OpenSSL and MBedTLS implementations.