### PR TITLE
Added shared library and pkg-config support for LibSPDM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 project("libspdm" C)
+SET(LIB_NAME "spdm")
+SET(CMAKE_PROJECT_NAME "LibSPDM")
+SET(CMAKE_PROJECT_DESCRIPTION "LibSPDM Shared Library")
+FILE(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.md CMAKE_INPUT_PROJECT_VERSION)
+string(REPLACE " " "_" CMAKE_PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
 
 #
 # Build Configuration Macro Definition
@@ -16,6 +21,7 @@ SET(CMAKE_BUILD_TYPE ${TARGET} CACHE STRING "Choose the target of build: Debug R
 SET(CRYPTO ${CRYPTO} CACHE STRING "Choose the crypto of build: mbedtls openssl" FORCE)
 SET(GCOV ${GCOV} CACHE STRING "Choose the target of Gcov: ON  OFF, and default is OFF" FORCE)
 SET(STACK_USAGE ${STACK_USAGE} CACHE STRING "Choose the target of STACK_USAGE: ON  OFF, and default is OFF" FORCE)
+SET(BUILD_SHARED_LIB ${BUILD_SHARED_LIB} CACHE STRING "Choose if shared library libspdm.co should be built: ON OFF, and default is OFF" FORCE)
 
 if(NOT GCOV)
     SET(GCOV "OFF")
@@ -23,6 +29,10 @@ endif()
 
 if(NOT STACK_USAGE)
     SET(STACK_USAGE "OFF")
+endif()
+
+if(NOT BUILD_SHARED_LIB)
+    SET(BUILD_SHARED_LIB "OFF")
 endif()
 
 SET(LIBSPDM_DIR ${PROJECT_SOURCE_DIR})
@@ -973,5 +983,54 @@ else()
                 ADD_SUBDIRECTORY(unit_test/test_size/test_size_of_spdm_responder)
             endif()
         endif()
+    endif()
+
+    if (BUILD_SHARED_LIB STREQUAL "ON")
+        if(CRYPTO STREQUAL "mbedtls")
+            SET(CRYPTO_DEPS "-lmbedtls -lmbedx509 -lmbedcrypto")
+            add_library(${LIB_NAME} SHARED 
+                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                                            $<TARGET_OBJECTS:debuglib>
+                                            $<TARGET_OBJECTS:malloclib>
+                                            $<TARGET_OBJECTS:platform_lib>
+                                            $<TARGET_OBJECTS:rnglib>
+                                            $<TARGET_OBJECTS:spdm_common_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_lib>
+                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
+                                            $<TARGET_OBJECTS:spdm_requester_lib>
+                                            $<TARGET_OBJECTS:spdm_responder_lib>
+                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                                            $<TARGET_OBJECTS:memlib>
+                                            )
+            
+        elseif(CRYPTO STREQUAL "openssl")
+            SET(CRYPTO_DEPS "-lssl -lcrypto")
+            add_library(${LIB_NAME} SHARED 
+                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                                            $<TARGET_OBJECTS:debuglib>
+                                            $<TARGET_OBJECTS:malloclib>
+                                            $<TARGET_OBJECTS:platform_lib>
+                                            $<TARGET_OBJECTS:rnglib>
+                                            $<TARGET_OBJECTS:spdm_common_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_lib>
+                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
+                                            $<TARGET_OBJECTS:spdm_requester_lib>
+                                            $<TARGET_OBJECTS:spdm_responder_lib>
+                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                                            $<TARGET_OBJECTS:memlib>
+                                            )
+        endif()        
+
+        install(DIRECTORY include DESTINATION include/libspdm)
+        configure_file(libspdm.pc.in lib/pkgconfig/libspdm.pc @ONLY)
+        install(FILES ${CMAKE_BINARY_DIR}/lib/pkgconfig/libspdm.pc DESTINATION lib/pkgconfig/)
+        install(TARGETS ${LIB_NAME}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 endif()

--- a/libspdm.pc.in
+++ b/libspdm.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/lib
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/include/lib@PROJECT_NAME@
+
+Name: @CMAKE_PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @CMAKE_PROJECT_VERSION@
+
+Requires:
+Cflags: -I${includedir} -I${includedir}/include
+Libs: -L${libdir} -l@PROJECT_NAME@ @CRYPTO_DEPS@

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1495,6 +1495,15 @@ uint8_t m_libspdm_bin_str0[0x11] = {
     0x64, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64,
 };
 
+void libspdm_dump_hex_str_sample(const uint8_t *buffer, size_t buffer_size)
+{
+    size_t index;
+
+    for (index = 0; index < buffer_size; index++) {
+        printf("%02x", buffer[index]);
+    }
+}
+
 bool libspdm_psk_handshake_secret_hkdf_expand(
     spdm_version_number_t spdm_version,
     uint32_t base_hash_algo,
@@ -1522,7 +1531,7 @@ bool libspdm_psk_handshake_secret_hkdf_expand(
         return false;
     }
     printf("[PSK]: ");
-    libspdm_dump_hex_str(psk, psk_size);
+    libspdm_dump_hex_str_sample(psk, psk_size);
     printf("\n");
 
     hash_size = libspdm_get_hash_size(base_hash_algo);


### PR DESCRIPTION
Changes:
- spdm_device_secret_lib_sample has its own dump_hex_str_sample method
- added pkg-config libspdm.pc.in file for cmake to use as template

CMakeLists.txt changes:
- added BUILD_SHARED_LIB cmake parameter (ON/OFF) to enable/disable building of libspdm.so in addition to the static libraries
- added two build paths for libspdm.so that generate distinct pkg-config pc files, for runtime linking with either mbedtls or openssl

Signed-off-by: Ionut Ursachi <viursachi@google.com>