### PR TITLE
Added shared library and pkg-config support for libspdm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 project("libspdm" C)
-SET(LIB_NAME "spdm")
-SET(CMAKE_PROJECT_NAME "LibSPDM")
-SET(CMAKE_PROJECT_DESCRIPTION "LibSPDM Shared Library")
 FILE(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.md CMAKE_INPUT_PROJECT_VERSION)
 string(REPLACE " " "_" CMAKE_PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
 
@@ -21,7 +18,7 @@ SET(CMAKE_BUILD_TYPE ${TARGET} CACHE STRING "Choose the target of build: Debug R
 SET(CRYPTO ${CRYPTO} CACHE STRING "Choose the crypto of build: mbedtls openssl" FORCE)
 SET(GCOV ${GCOV} CACHE STRING "Choose the target of Gcov: ON  OFF, and default is OFF" FORCE)
 SET(STACK_USAGE ${STACK_USAGE} CACHE STRING "Choose the target of STACK_USAGE: ON  OFF, and default is OFF" FORCE)
-SET(BUILD_SHARED_LIB ${BUILD_SHARED_LIB} CACHE STRING "Choose if shared library libspdm.co should be built: ON OFF, and default is OFF" FORCE)
+SET(BUILD_LINUX_SHARED_LIB ${BUILD_LINUX_SHARED_LIB} CACHE STRING "Choose if libspdm shared library should be built for linux: ON OFF, and default is OFF" FORCE)
 
 if(NOT GCOV)
     SET(GCOV "OFF")
@@ -31,8 +28,8 @@ if(NOT STACK_USAGE)
     SET(STACK_USAGE "OFF")
 endif()
 
-if(NOT BUILD_SHARED_LIB)
-    SET(BUILD_SHARED_LIB "OFF")
+if(NOT BUILD_LINUX_SHARED_LIB)
+    SET(BUILD_LINUX_SHARED_LIB "OFF")
 endif()
 
 SET(LIBSPDM_DIR ${PROJECT_SOURCE_DIR})
@@ -985,7 +982,11 @@ else()
         endif()
     endif()
 
-    if (BUILD_SHARED_LIB STREQUAL "ON")
+    if ((BUILD_LINUX_SHARED_LIB STREQUAL "ON") AND (CMAKE_SYSTEM_NAME MATCHES "Linux"))
+        SET(LIB_NAME "spdm")
+        SET(CMAKE_PROJECT_NAME "libspdm")
+        SET(CMAKE_PROJECT_DESCRIPTION "libspdm shared library")
+
         if(CRYPTO STREQUAL "mbedtls")
             SET(CRYPTO_DEPS "-lmbedtls -lmbedx509 -lmbedcrypto")
             add_library(${LIB_NAME} SHARED 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -987,51 +987,59 @@ else()
         SET(CMAKE_PROJECT_NAME "libspdm")
         SET(CMAKE_PROJECT_DESCRIPTION "libspdm shared library")
 
+        SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+        SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+        SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+        add_library(${LIB_NAME} SHARED 
+            $<TARGET_OBJECTS:spdm_common_lib>
+            $<TARGET_OBJECTS:spdm_crypt_lib>
+            $<TARGET_OBJECTS:spdm_requester_lib>
+            $<TARGET_OBJECTS:spdm_responder_lib>
+            $<TARGET_OBJECTS:spdm_secured_message_lib>
+            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+        )
+
+        add_library(${LIB_NAME}_platform SHARED 
+            $<TARGET_OBJECTS:debuglib>
+            $<TARGET_OBJECTS:malloclib>
+            $<TARGET_OBJECTS:platform_lib>
+            $<TARGET_OBJECTS:rnglib>
+            $<TARGET_OBJECTS:memlib>
+        )
+
+        add_library(${LIB_NAME}_crypto SHARED 
+            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
+            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+        )
+
         if(CRYPTO STREQUAL "mbedtls")
             SET(CRYPTO_DEPS "-lmbedtls -lmbedx509 -lmbedcrypto")
-            add_library(${LIB_NAME} SHARED 
-                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                                            $<TARGET_OBJECTS:debuglib>
-                                            $<TARGET_OBJECTS:malloclib>
-                                            $<TARGET_OBJECTS:platform_lib>
-                                            $<TARGET_OBJECTS:rnglib>
-                                            $<TARGET_OBJECTS:spdm_common_lib>
-                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
-                                            $<TARGET_OBJECTS:spdm_crypt_lib>
-                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
-                                            $<TARGET_OBJECTS:spdm_requester_lib>
-                                            $<TARGET_OBJECTS:spdm_responder_lib>
-                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
-                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                                            $<TARGET_OBJECTS:memlib>
-                                            )
-            
+            TARGET_LINK_LIBRARIES(${LIB_NAME}_crypto
+                PUBLIC mbedtls
+                PUBLIC mbedx509
+                PUBLIC mbedcrypto
+            )
         elseif(CRYPTO STREQUAL "openssl")
             SET(CRYPTO_DEPS "-lssl -lcrypto")
-            add_library(${LIB_NAME} SHARED 
-                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
-                                            $<TARGET_OBJECTS:debuglib>
-                                            $<TARGET_OBJECTS:malloclib>
-                                            $<TARGET_OBJECTS:platform_lib>
-                                            $<TARGET_OBJECTS:rnglib>
-                                            $<TARGET_OBJECTS:spdm_common_lib>
-                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
-                                            $<TARGET_OBJECTS:spdm_crypt_lib>
-                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
-                                            $<TARGET_OBJECTS:spdm_requester_lib>
-                                            $<TARGET_OBJECTS:spdm_responder_lib>
-                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
-                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
-                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
-                                            $<TARGET_OBJECTS:memlib>
-                                            )
-        endif()        
+            TARGET_LINK_LIBRARIES(${LIB_NAME}_crypto
+                PUBLIC ssl
+                PUBLIC crypto
+            )
+        endif()  
+        
+        TARGET_LINK_LIBRARIES(${LIB_NAME}
+            PUBLIC ${LIB_NAME}_platform
+            PUBLIC ${LIB_NAME}_crypto
+        )
 
         install(DIRECTORY include DESTINATION include/libspdm)
         configure_file(libspdm.pc.in lib/pkgconfig/libspdm.pc @ONLY)
         install(FILES ${CMAKE_BINARY_DIR}/lib/pkgconfig/libspdm.pc DESTINATION lib/pkgconfig/)
-        install(TARGETS ${LIB_NAME}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(TARGETS ${LIB_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(TARGETS ${LIB_NAME}_platform LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(TARGETS ${LIB_NAME}_crypto LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 project("libspdm" C)
+SET(LIB_NAME "spdm")
+SET(CMAKE_PROJECT_NAME "LibSPDM")
+SET(CMAKE_PROJECT_DESCRIPTION "LibSPDM Shared Library")
+FILE(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.md CMAKE_INPUT_PROJECT_VERSION)
+string(REPLACE " " "_" CMAKE_PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
 
 #
 # Build Configuration Macro Definition
@@ -16,6 +21,7 @@ SET(CMAKE_BUILD_TYPE ${TARGET} CACHE STRING "Choose the target of build: Debug R
 SET(CRYPTO ${CRYPTO} CACHE STRING "Choose the crypto of build: mbedtls openssl" FORCE)
 SET(GCOV ${GCOV} CACHE STRING "Choose the target of Gcov: ON  OFF, and default is OFF" FORCE)
 SET(STACK_USAGE ${STACK_USAGE} CACHE STRING "Choose the target of STACK_USAGE: ON  OFF, and default is OFF" FORCE)
+SET(BUILD_SHARED_LIB ${BUILD_SHARED_LIB} CACHE STRING "Choose if shared library libspdm.co should be built: ON OFF, and default is OFF" FORCE)
 
 if(NOT GCOV)
     SET(GCOV "OFF")
@@ -23,6 +29,10 @@ endif()
 
 if(NOT STACK_USAGE)
     SET(STACK_USAGE "OFF")
+endif()
+
+if(NOT BUILD_SHARED_LIB)
+    SET(BUILD_SHARED_LIB "OFF")
 endif()
 
 SET(LIBSPDM_DIR ${PROJECT_SOURCE_DIR})
@@ -973,5 +983,54 @@ else()
                 ADD_SUBDIRECTORY(unit_test/test_size/test_size_of_spdm_responder)
             endif()
         endif()
+    endif()
+
+    if (BUILD_SHARED_LIB STREQUAL "ON")
+        if(CRYPTO STREQUAL "mbedtls")
+            SET(CRYPTO_DEPS "-lmbedtls -lmbedx509 -lmbedcrypto")
+            add_library(${LIB_NAME} SHARED 
+                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                                            $<TARGET_OBJECTS:debuglib>
+                                            $<TARGET_OBJECTS:malloclib>
+                                            $<TARGET_OBJECTS:platform_lib>
+                                            $<TARGET_OBJECTS:rnglib>
+                                            $<TARGET_OBJECTS:spdm_common_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_lib>
+                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
+                                            $<TARGET_OBJECTS:spdm_requester_lib>
+                                            $<TARGET_OBJECTS:spdm_responder_lib>
+                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                                            $<TARGET_OBJECTS:memlib>
+                                            )
+            
+        elseif(CRYPTO STREQUAL "openssl")
+            SET(CRYPTO_DEPS "-lssl -lcrypto")
+            add_library(${LIB_NAME} SHARED 
+                                            $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                                            $<TARGET_OBJECTS:debuglib>
+                                            $<TARGET_OBJECTS:malloclib>
+                                            $<TARGET_OBJECTS:platform_lib>
+                                            $<TARGET_OBJECTS:rnglib>
+                                            $<TARGET_OBJECTS:spdm_common_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_ext_lib>
+                                            $<TARGET_OBJECTS:spdm_crypt_lib>
+                                            $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
+                                            $<TARGET_OBJECTS:spdm_requester_lib>
+                                            $<TARGET_OBJECTS:spdm_responder_lib>
+                                            $<TARGET_OBJECTS:spdm_secured_message_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_mctp_lib>
+                                            $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
+                                            $<TARGET_OBJECTS:memlib>
+                                            )
+        endif()        
+
+        install(DIRECTORY include DESTINATION include/libspdm)
+        configure_file(libspdm.pc.in lib/pkgconfig/libspdm.pc @ONLY)
+        install(FILES ${CMAKE_BINARY_DIR}/lib/pkgconfig/libspdm.pc DESTINATION lib/pkgconfig/)
+        install(TARGETS ${LIB_NAME}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 endif()

--- a/doc/build.md
+++ b/doc/build.md
@@ -269,9 +269,9 @@ Supports shared libraries building and pkg-config '.pc' file generation and inst
 Will generate:
  - libspdm.so - main library code, all subprojects from "library" folder
  - libspdm_platform.so - subprojects in the "os_stub" folder related to platform code, like memory allocation, random number generator, etc.
-  - libspdm_crypto.so - cryptography related code for libspdm linking to either mbedtls or openssl libraries
-All three libraries are required for an application that uses libspdm, but the developer is free to implement their own versions of libspdm_platform or libspdm_crypto libraries and link with their implementations.
-Will install pc file and all required headers and shared libraries (except for spdm_device_secret_lib_sample which developer has to implement), so application developers can use 'pkg-config --libs libspdm' and 'pkg-config --cflags libspdm' to link with libspdm
+  - libspdm_crypto.so - cryptography related code for libspdm to dynamically link to either Mbed TLS or OpenSSL shared libraries.
+All three libraries are required for an application that uses libspdm, but the integrator is free to implement their own versions of libspdm_platform or libspdm_crypto libraries and link with their implementations.
+Will install pc file and all required headers and shared libraries (except for spdm_device_secret_lib_sample which the integrator has to implement), so application developers can use 'pkg-config --libs libspdm' and 'pkg-config --cflags libspdm' to link with libspdm
 
 To build with shared library support:
 ```

--- a/doc/build.md
+++ b/doc/build.md
@@ -263,6 +263,27 @@ cmake -DARCH=<arch> -DTOOLCHAIN=NONE -DTARGET=<Debug|Release> -DCRYPTO=<mbedtls|
 make
 ```
 
+### Linux Shared Library Builds
+
+Supports shared libraries building and pkg-config '.pc' file generation and installation.
+Will generate:
+ - libspdm.so - main library code, all subprojects from "library" folder
+ - libspdm_platform.so - subprojects in the "os_stub" folder related to platform code, like memory allocation, random number generator, etc.
+  - libspdm_crypto.so - cryptography related code for libspdm linking to either mbedtls or openssl libraries
+All three libraries are required for an application that uses libspdm, but the developer is free to implement their own versions of libspdm_platform or libspdm_crypto libraries and link with their implementations.
+Will install pc file and all required headers and shared libraries (except for spdm_device_secret_lib_sample which developer has to implement), so application developers can use 'pkg-config --libs libspdm' and 'pkg-config --cflags libspdm' to link with libspdm
+
+To build with shared library support:
+```
+cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Release -DCRYPTO=mbedtls -DBUILD_LINUX_SHARED_LIB=ON ..
+```
+
+To compile and link with libspdm:
+```
+gcc `pkg-config --cflags libspdm` -c libspdm_app.c -o libspdm_app.o
+gcc libspdm_app.o `pkg-config --libs libspdm` libspdm_app
+```
+
 ### Disabling unit and fuzz tests
 
 Unit tests can be disable by adding -DDISABLE_TESTS=1 to CMake.

--- a/libspdm.pc.in
+++ b/libspdm.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/lib
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/include/lib@LIB_NAME@
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/lib@LIB_NAME@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
@@ -9,4 +9,4 @@ Version: @CMAKE_PROJECT_VERSION@
 
 Requires:
 Cflags: -I${includedir} -I${includedir}/include
-Libs: -L${libdir} -l@LIB_NAME@ @CRYPTO_DEPS@
+Libs: -L${libdir} -l@LIB_NAME@ -l@LIB_NAME@_platform -l@LIB_NAME@_crypto @CRYPTO_DEPS@

--- a/libspdm.pc.in
+++ b/libspdm.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/lib
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/include/lib@PROJECT_NAME@
+
+Name: @CMAKE_PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @CMAKE_PROJECT_VERSION@
+
+Requires:
+Cflags: -I${includedir} -I${includedir}/include
+Libs: -L${libdir} -l@PROJECT_NAME@ @CRYPTO_DEPS@

--- a/libspdm.pc.in
+++ b/libspdm.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/lib
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/include/lib@PROJECT_NAME@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/include/lib@LIB_NAME@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
@@ -9,4 +9,4 @@ Version: @CMAKE_PROJECT_VERSION@
 
 Requires:
 Cflags: -I${includedir} -I${includedir}/include
-Libs: -L${libdir} -l@PROJECT_NAME@ @CRYPTO_DEPS@
+Libs: -L${libdir} -l@LIB_NAME@ @CRYPTO_DEPS@

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1495,15 +1495,6 @@ uint8_t m_libspdm_bin_str0[0x11] = {
     0x64, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64,
 };
 
-void libspdm_dump_hex_str_sample(const uint8_t *buffer, size_t buffer_size)
-{
-    size_t index;
-
-    for (index = 0; index < buffer_size; index++) {
-        printf("%02x", buffer[index]);
-    }
-}
-
 bool libspdm_psk_handshake_secret_hkdf_expand(
     spdm_version_number_t spdm_version,
     uint32_t base_hash_algo,
@@ -1531,7 +1522,7 @@ bool libspdm_psk_handshake_secret_hkdf_expand(
         return false;
     }
     printf("[PSK]: ");
-    libspdm_dump_hex_str_sample(psk, psk_size);
+    libspdm_dump_hex_str(psk, psk_size);
     printf("\n");
 
     hash_size = libspdm_get_hash_size(base_hash_algo);

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1495,6 +1495,15 @@ uint8_t m_libspdm_bin_str0[0x11] = {
     0x64, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64,
 };
 
+void libspdm_dump_hex_str_sample(const uint8_t *buffer, size_t buffer_size)
+{
+    size_t index;
+
+    for (index = 0; index < buffer_size; index++) {
+        printf("%02x", buffer[index]);
+    }
+}
+
 bool libspdm_psk_handshake_secret_hkdf_expand(
     spdm_version_number_t spdm_version,
     uint32_t base_hash_algo,
@@ -1522,7 +1531,7 @@ bool libspdm_psk_handshake_secret_hkdf_expand(
         return false;
     }
     printf("[PSK]: ");
-    libspdm_dump_hex_str(psk, psk_size);
+    libspdm_dump_hex_str_sample(psk, psk_size);
     printf("\n");
 
     hash_size = libspdm_get_hash_size(base_hash_algo);


### PR DESCRIPTION
Changes:
- added pkg-config libspdm.pc.in file for cmake to use as template

CMakeLists.txt changes:
- added BUILD_SHARED_LIB cmake parameter (ON/OFF) to enable/disable building of libspdm.so in addition to the static libraries
- added two build paths for libspdm.so that generate distinct pkg-config pc files, for runtime linking with either mbedtls or openssl