### PR TITLE
Added full support for Vendor Defined Requests and Responses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -954,6 +954,7 @@ else()
             ADD_SUBDIRECTORY(unit_test/test_spdm_crypt)
             ADD_SUBDIRECTORY(unit_test/test_spdm_fips)
             ADD_SUBDIRECTORY(unit_test/test_spdm_secured_message)
+            ADD_SUBDIRECTORY(unit_test/test_spdm_vendor_cmds)
             endif()
 
             if((NOT TOOLCHAIN STREQUAL "ARM_DS2022") AND (NOT TOOLCHAIN STREQUAL "RISCV_XPACK"))

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -251,7 +251,10 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
 
    6.1, Use the SPDM vendor defined request.
    ```
-   libspdm_vendor_request (spdm_context, standard_id, vendor_id_len, &vendor_id, &request, request_size, &response, &response_size);
+
+   libspdm_vendor_send_request_receive_response (spdm_context, 
+      req_standard_id, req_vendor_id_len, req_vendor_id, req_size, req_data, 
+      &resp_standard_id, &resp_vendor_id_len, resp_vendor_id, &resp_size, resp_data);
    ```
 
    6.2, Use the transport layer application message.
@@ -455,18 +458,31 @@ Refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF/spdm-e
 
     libspdm_register_get_response_func (spdm_context, libspdm_get_response);
     ```
-    3.2 This callback handles SPDM Vendor Defined Commands
+    3.2 This callbacks handle SPDM Vendor Defined Commands
     ```
+    libspdm_return_t libspdm_vendor_get_id_func(
+      void *spdm_context,
+      uint16_t *resp_standard_id,
+      uint8_t *resp_vendor_id_len,
+      void *resp_vendor_id)
+    {
+      // return responder vendor id
+      ...
+
+      return LIBSPDM_STATUS_SUCCESS;
+    }
+
+    vendor_response_get_id
     libspdm_return_t libspdm_vendor_response_func(
       void *spdm_context,
-      uint16_t standard_id,
-      uint8_t vendor_id_len,
-      const void *vendor_id,
-      const void *request,
-      size_t request_len,
-      void *resp,
-      size_t *resp_len)
-    {
+      uint16_t req_standard_id,
+      uint8_t req_vendor_id_len,
+      const void *req_vendor_id,
+      uint16_t req_size,
+      const void *req_data,
+      uint16_t *resp_size,
+      void *resp_data)
+      {
       // process request and create response
       ...
       // populate response header and payload
@@ -475,6 +491,7 @@ Refer to spdm_server_init() in [spdm_responder.c](https://github.com/DMTF/spdm-e
       return LIBSPDM_STATUS_SUCCESS;
     }
 
+    libspdm_register_vendor_get_id_callback_func(spdm_context, libspdm_vendor_get_id_func);
     libspdm_register_vendor_callback_func(spdm_context, libspdm_vendor_response_func);
     ```
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -249,10 +249,9 @@ Refer to spdm_client_init() in [spdm_requester.c](https://github.com/DMTF/spdm-e
 
 6. Send and receive message in an SPDM session
 
-   6.1, Use the SPDM vendor defined request.
+   6.1, Use the SPDM vendor defined request. In libspdm, libspdm_init_connection call is needed first, so NEGOTIATE_ALGORITHMS step is done before sending a vendor defined request. Also, for each VENDOR_DEFINED_REQUEST, a VENDOR_DEFINED_RESPONSE message is expected, even if it has a data payload field of size zero.
    ```
-
-   libspdm_vendor_send_request_receive_response (spdm_context, 
+   libspdm_vendor_send_request_receive_response (spdm_context, session_id,
       req_standard_id, req_vendor_id_len, req_vendor_id, req_size, req_data, 
       &resp_standard_id, &resp_vendor_id_len, resp_vendor_id, &resp_size, resp_data);
    ```

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -783,10 +783,10 @@ typedef struct {
 
 /* Maximum size of a vendor defined message data length
  * limited by the length field size which is 2 bytes */
-#define LIBSPDM_MAX_VENDOR_DEFINED_DATA_LEN 65535
+#define SPDM_MAX_VENDOR_DEFINED_DATA_LEN 65535
 /* Maximum size of a vendor defined vendor id length
  * limited by the length field size which is 1 byte */
-#define LIBSPDM_MAX_VENDOR_ID_LENGTH 255
+#define SPDM_MAX_VENDOR_ID_LENGTH 255
 
 /* SPDM VENDOR_DEFINED request */
 typedef struct {

--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -781,6 +781,13 @@ typedef struct {
      * param2 == token*/
 } spdm_response_if_ready_request_t;
 
+/* Maximum size of a vendor defined message data length
+ * limited by the length field size which is 2 bytes */
+#define LIBSPDM_MAX_VENDOR_DEFINED_DATA_LEN 65535
+/* Maximum size of a vendor defined vendor id length
+ * limited by the length field size which is 1 byte */
+#define LIBSPDM_MAX_VENDOR_ID_LENGTH 255
+
 /* SPDM VENDOR_DEFINED request */
 typedef struct {
     spdm_message_header_t header;

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -615,6 +615,9 @@ typedef struct {
      * This field is ignored for other SPDM versions */
     uint8_t spdm_10_11_verify_signature_endian;
 
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+    libspdm_vendor_response_callback_func vendor_response_callback;
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 } libspdm_context_t;
 
 #define LIBSPDM_CONTEXT_SIZE_WITHOUT_SECURED_CONTEXT (sizeof(libspdm_context_t))

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -617,6 +617,7 @@ typedef struct {
 
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
     libspdm_vendor_response_callback_func vendor_response_callback;
+    libspdm_vendor_get_id_callback_func vendor_response_get_id;
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 } libspdm_context_t;
 

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -743,6 +743,31 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
 
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+/**
+ * Process the SPDM VENDOR_DEFINED_REQUEST request and return the response.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  request_size                  size in bytes of the request data.
+ * @param  request                      A pointer to the request data.
+ * @param  response_size                 size in bytes of the response data.
+ *                                     On input, it means the size in bytes of response data buffer.
+ *                                     On output, it means the size in bytes of copied response data
+ * @param  response                     A pointer to the response data.
+ *
+ * @retval RETURN_SUCCESS               The request is processed and the response is returned.
+ * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+
+libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_context,
+                                                     size_t request_size,
+                                                     const void *request,
+                                                     size_t *response_size,
+                                                     void *response);
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
 /**
  * This function allocates half of session ID for a responder.
  *

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -755,10 +755,6 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
  *                                     On output, it means the size in bytes of copied response data
  * @param  response                     A pointer to the response data.
  *
- * @retval RETURN_SUCCESS               The request is processed and the response is returned.
- * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
 
 libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_context,

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -955,4 +955,34 @@ uint32_t libspdm_module_version(void);
 /*true: FIPS enabled, false: FIPS disabled*/
 bool libspdm_get_fips_mode(void);
 
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+/**
+ * Vendor Response Callback Prototype.
+ * First 2 bytes are the response length, followed by the actual response
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ * @param  standard_id      Registry or Standards body used
+ * @param  vendor_id_len    Length in bytes of the vendor id field
+ * @param  vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ * @param  request          The vendor defined request
+ * @param  request_len      Length of the request
+ * @param  response         The vendor defined response (including response length as first 2 bytes)
+ * @param  response_len     Length of the vendor response
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS Success
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
+ **/
+typedef libspdm_return_t (*libspdm_vendor_response_callback_func)(
+    void *spdm_context,
+    uint16_t standard_id,
+    uint8_t vendor_id_len,
+    const void *vendor_id,
+    const void *request,
+    size_t request_len,
+    void *response,
+    size_t *response_len);
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
 #endif /* SPDM_COMMON_LIB_H */

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -957,31 +957,55 @@ bool libspdm_get_fips_mode(void);
 
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
 
+/* Maximum size of a vendor defined message data length
+ * limited by length field length which is 2 bytes */
+#define LIBSPDM_MAX_VENDOR_DEFINED_DATA_LEN 65535
+/* Maximum size of a vendor defined vendor id length
+ * limited by length field length which is 1 byte */
+#define LIBSPDM_MAX_VENDOR_ID_LENGTH 255
+
 /**
- * Vendor Response Callback Prototype.
- * First 2 bytes are the response length, followed by the actual response
+ * Vendor Response Get Vendor ID Callback Function Pointer.
+ * Required to be able to compose the Vendor Defined Response correctly
  *
- * @param  spdm_context  A pointer to the SPDM context.
- * @param  standard_id      Registry or Standards body used
- * @param  vendor_id_len    Length in bytes of the vendor id field
- * @param  vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
- * @param  request          The vendor defined request
- * @param  request_len      Length of the request
- * @param  response         The vendor defined response (including response length as first 2 bytes)
- * @param  response_len     Length of the vendor response
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  resp_standard_id     Registry or Standards body used for response
+ * @param  resp_vendor_id_len   Length in bytes of the vendor id field for the response
+ * @param  resp_vendor_id       Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS Success
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
+ **/
+typedef libspdm_return_t (*libspdm_vendor_get_id_callback_func)(
+    void *spdm_context,
+    uint16_t *resp_standard_id,
+    uint8_t *resp_vendor_id_len,
+    void *resp_vendor_id);
+
+/**
+ * Vendor Response Callback Function Pointer.
+ *
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  req_standard_id      Registry or Standards body used for request
+ * @param  req_vendor_id_len    Length in bytes of the vendor id field for the request
+ * @param  req_vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ * @param  req_size             Length of the request
+ * @param  req_data             The vendor defined request
+ * @param  resp_size            Length of the response
+ * @param  resp_data            The vendor defined response
  *
  * @retval LIBSPDM_STATUS_SUCCESS Success
  * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
  **/
 typedef libspdm_return_t (*libspdm_vendor_response_callback_func)(
     void *spdm_context,
-    uint16_t standard_id,
-    uint8_t vendor_id_len,
-    const void *vendor_id,
-    const void *request,
-    size_t request_len,
-    void *response,
-    size_t *response_len);
+    uint16_t req_standard_id,
+    uint8_t req_vendor_id_len,
+    const void *req_vendor_id,
+    uint16_t req_size,
+    const void *req_data,
+    uint16_t *resp_size,
+    void *resp_data);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -957,13 +957,6 @@ bool libspdm_get_fips_mode(void);
 
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
 
-/* Maximum size of a vendor defined message data length
- * limited by length field length which is 2 bytes */
-#define LIBSPDM_MAX_VENDOR_DEFINED_DATA_LEN 65535
-/* Maximum size of a vendor defined vendor id length
- * limited by length field length which is 1 byte */
-#define LIBSPDM_MAX_VENDOR_ID_LENGTH 255
-
 /**
  * Vendor Response Get Vendor ID Callback Function Pointer.
  * Required to be able to compose the Vendor Defined Response correctly

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -76,11 +76,6 @@
 #define LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN 1024
 #endif
 
-/* Maximum size of a vendor defined response message */
-#ifndef LIBSPDM_MAX_VENDOR_DEFINED_RESPONSE_LEN
-#define LIBSPDM_MAX_VENDOR_DEFINED_RESPONSE_LEN 1024
-#endif
-
 /* To ensure integrity in communication between the Requester and the Responder libspdm calculates
  * cryptographic digests and signatures over multiple requests and responses. This value specifies
  * whether libspdm will use a running calculation over the transcript, where requests and responses

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -76,6 +76,11 @@
 #define LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN 1024
 #endif
 
+/* Maximum size of a vendor defined response message */
+#ifndef LIBSPDM_MAX_VENDOR_DEFINED_RESPONSE_LEN
+#define LIBSPDM_MAX_VENDOR_DEFINED_RESPONSE_LEN 1024
+#endif
+
 /* To ensure integrity in communication between the Requester and the Responder libspdm calculates
  * cryptographic digests and signatures over multiple requests and responses. This value specifies
  * whether libspdm will use a running calculation over the transcript, where requests and responses
@@ -266,6 +271,10 @@
 
 #ifndef LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
 #define LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+#define LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES 1
 #endif
 
 /* If 1 then endpoint supports sending GET_CERTIFICATE and GET_DIGESTS requests.

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -766,14 +766,20 @@ void libspdm_reset_msg_log (void *spdm_context);
  *
  * This is useful for creating unique requests/responses to devices.
  *
- * @param  spdm_context     A pointer to the SPDM context.
- * @param  standard_id      Registry or Standards body used
- * @param  vendor_id_len    Length in bytes of the vendor id field
- * @param  vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
- * @param  request          The vendor defined request
- * @param  request_len      Length of the request
- * @param  response         The vendor defined response
- * @param  response_len     Length of the vendor response
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  session_id           Indicates if it is a secured message protected via SPDM session.
+ *                              If session_id is NULL, it is a normal message.
+ *                              If session_id is NOT NULL, it is a secured message.
+ * @param  req_standard_id      Registry or Standards body used for request
+ * @param  req_vendor_id_len    Length in bytes of the vendor id field for the request
+ * @param  req_vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ * @param  req_size             Length of the request
+ * @param  req_data             The vendor defined request
+ * @param  resp_standard_id     Registry or Standards body used for response
+ * @param  resp_vendor_id_len   Length in bytes of the vendor id field for the response
+ * @param  resp_vendor_id       Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ * @param  resp_size            Length of the response
+ * @param  resp_data            The vendor defined response
  *
  * @retval LIBSPDM_STATUS_SUCCESS
  *         VENDOR_DEFINED_REQUEST was sent and VENDOR_DEFINED_RESPONSE was received.
@@ -788,14 +794,19 @@ void libspdm_reset_msg_log (void *spdm_context);
  * @retval LIBSPDM_STATUS_BUFFER_FULL
  *         The buffer used to store transcripts is exhausted.
  **/
-libspdm_return_t libspdm_vendor_request(void *spdm_context,
-                                        uint16_t standard_id,
-                                        uint8_t vendor_id_len,
-                                        void *vendor_id,
-                                        void *request,
-                                        size_t request_len,
-                                        void *response,
-                                        size_t *response_len);
+libspdm_return_t libspdm_vendor_send_request_receive_response(
+    void *spdm_context,
+    const uint32_t *session_id,
+    uint16_t req_standard_id,
+    uint8_t req_vendor_id_len,
+    const void *req_vendor_id,
+    uint16_t req_size,
+    const void *req_data,
+    uint16_t *resp_standard_id,
+    uint8_t *resp_vendor_id_len,
+    void *resp_vendor_id,
+    uint16_t *resp_size,
+    void *resp_data);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -759,4 +759,44 @@ size_t libspdm_get_msg_log_size (void *spdm_context);
 void libspdm_reset_msg_log (void *spdm_context);
 #endif /* LIBSPDM_ENABLE_MSG_LOG */
 
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+/**
+ * This function sends VENDOR_DEFINED_REQUEST to the device and gets back a VENDOR_DEFINED_RESPONSE.
+ *
+ * This is useful for creating unique requests/responses to devices.
+ *
+ * @param  spdm_context     A pointer to the SPDM context.
+ * @param  standard_id      Registry or Standards body used
+ * @param  vendor_id_len    Length in bytes of the vendor id field
+ * @param  vendor_id        Vendor ID assigned by the Registry or Standards Body. Little-endian format
+ * @param  request          The vendor defined request
+ * @param  request_len      Length of the request
+ * @param  response         The vendor defined response
+ * @param  response_len     Length of the vendor response
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS
+ *         VENDOR_DEFINED_REQUEST was sent and VENDOR_DEFINED_RESPONSE was received.
+ * @retval LIBSPDM_STATUS_INVALID_STATE_LOCAL
+ *         Cannot send VENDOR_DEFINED_REQUEST due to Requester's state.
+ * @retval LIBSPDM_STATUS_ERROR_PEER
+ *         The Responder returned an unexpected error.
+ * @retval LIBSPDM_STATUS_BUSY_PEER
+ *         The Responder continually returned Busy error messages.
+ * @retval LIBSPDM_STATUS_RESYNCH_PEER
+ *         The Responder returned a RequestResynch error message.
+ * @retval LIBSPDM_STATUS_BUFFER_FULL
+ *         The buffer used to store transcripts is exhausted.
+ **/
+libspdm_return_t libspdm_vendor_request(void *spdm_context,
+                                        uint16_t standard_id,
+                                        uint8_t vendor_id_len,
+                                        void *vendor_id,
+                                        void *request,
+                                        size_t request_len,
+                                        void *response,
+                                        size_t *response_len);
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
 #endif /* SPDM_REQUESTER_LIB_H */

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -765,6 +765,9 @@ void libspdm_reset_msg_log (void *spdm_context);
  * This function sends VENDOR_DEFINED_REQUEST to the device and gets back a VENDOR_DEFINED_RESPONSE.
  *
  * This is useful for creating unique requests/responses to devices.
+ * In libspdm, libspdm_init_connection call is needed first, so NEGOTIATE_ALGORITHMS step is done before
+ * sending a vendor defined request
+ * For each VENDOR_DEFINED_REQUEST, a VENDOR_DEFINED_RESPONSE is expected, even if it has a data payload field of size zero.
  *
  * @param  spdm_context         A pointer to the SPDM context.
  * @param  session_id           Indicates if it is a secured message protected via SPDM session.

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -262,4 +262,22 @@ void libspdm_register_cert_chain_buffer(
     void *spdm_context, void *cert_chain_buffer, size_t cert_chain_buffer_max_size);
 #endif
 
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+/**
+ * This function registers the callback function for doing a VENDOR_DEFINED_RESPONSE to the device.
+ *
+ * This is useful for creating unique requests to devices.
+ *
+ * @param  spdm_context     A pointer to the SPDM context.
+ * @param  resp_callback_func   Response callback function
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS Success
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
+ **/
+libspdm_return_t libspdm_register_vendor_callback_func(void *spdm_context,
+                                                       libspdm_vendor_response_callback_func resp_callback);
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
 #endif /* SPDM_RESPONDER_LIB_H */

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -265,9 +265,23 @@ void libspdm_register_cert_chain_buffer(
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
 
 /**
+ * This function registers the callback function for getting the Vendor ID for a VENDOR_DEFINED_RESPONSE to the device.
+ *
+ * This is useful for creating unique responses to devices.
+ *
+ * @param  spdm_context     A pointer to the SPDM context.
+ * @param  resp_callback_func   Response callback function
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS Success
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
+ **/
+libspdm_return_t libspdm_register_vendor_get_id_callback_func(void *spdm_context,
+                                                              libspdm_vendor_get_id_callback_func resp_callback);
+
+/**
  * This function registers the callback function for doing a VENDOR_DEFINED_RESPONSE to the device.
  *
- * This is useful for creating unique requests to devices.
+ * This is useful for creating unique responses to devices.
  *
  * @param  spdm_context     A pointer to the SPDM context.
  * @param  resp_callback_func   Response callback function

--- a/library/spdm_requester_lib/CMakeLists.txt
+++ b/library/spdm_requester_lib/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(src_spdm_requester_lib
     libspdm_req_send_receive.c
     libspdm_req_set_certificate.c
     libspdm_req_get_csr.c
+    libspdm_req_vendor_request.c
 )
 
 ADD_LIBRARY(spdm_requester_lib STATIC ${src_spdm_requester_lib})

--- a/library/spdm_requester_lib/libspdm_req_vendor_request.c
+++ b/library/spdm_requester_lib/libspdm_req_vendor_request.c
@@ -7,8 +7,8 @@
 
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
 
-#define SPDM_MAX_VENDOR_PAYLOAD_LEN (LIBSPDM_MAX_VENDOR_ID_LENGTH + 2 + \
-                                     LIBSPDM_MAX_VENDOR_DEFINED_DATA_LEN)
+#define SPDM_MAX_VENDOR_PAYLOAD_LEN (SPDM_MAX_VENDOR_ID_LENGTH + 2 + \
+                                     SPDM_MAX_VENDOR_DEFINED_DATA_LEN)
 
 #pragma pack(1)
 typedef struct {

--- a/library/spdm_requester_lib/libspdm_req_vendor_request.c
+++ b/library/spdm_requester_lib/libspdm_req_vendor_request.c
@@ -217,7 +217,7 @@ libspdm_return_t libspdm_vendor_request(void *spdm_context,
         status = libspdm_try_vendor_request(context,
                                             standard_id,
                                             vendor_id_len, (uint8_t *)vendor_id,
-                                            (uint8_t *)request, request_len,
+                                            (uint8_t *)request, (uint16_t)request_len,
                                             (uint8_t *)response, response_len);
         if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
             return status;

--- a/library/spdm_requester_lib/libspdm_req_vendor_request.c
+++ b/library/spdm_requester_lib/libspdm_req_vendor_request.c
@@ -1,6 +1,5 @@
 /**
- *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2023 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -42,6 +41,10 @@ libspdm_return_t libspdm_try_vendor_send_request_receive_response(
     uint8_t *message;
     size_t message_size = 0;
     size_t transport_header_size;
+    size_t max_payload = 0;
+    uint8_t* vendor_request = NULL;
+    uint8_t *response_ptr = NULL;
+    uint16_t response_size = 0;
 
     /* -=[Check Parameters Phase]=- */
     if (spdm_context == NULL ||
@@ -72,9 +75,9 @@ libspdm_return_t libspdm_try_vendor_send_request_receive_response(
      * removing all protocol, spdm and vendor defined message headers
      * -3 bytes is for the standard_id and vendor_id_len fields in the vendor header
      * -2 bytes is for the payload length field */
-    size_t max_payload = message_size - transport_header_size -
-                         spdm_context->local_context.capability.transport_tail_size
-                         - sizeof(spdm_request->header) - 3 - req_vendor_id_len - 2;
+    max_payload = message_size - transport_header_size -
+                  spdm_context->local_context.capability.transport_tail_size
+                  - sizeof(spdm_request->header) - 3 - req_vendor_id_len - 2;
 
     LIBSPDM_ASSERT (message_size >= transport_header_size +
                     spdm_context->local_context.capability.transport_tail_size);
@@ -95,7 +98,7 @@ libspdm_return_t libspdm_try_vendor_send_request_receive_response(
     spdm_request->len = req_vendor_id_len;
 
     /* Copy Vendor id */
-    uint8_t* vendor_request = ((uint8_t *)spdm_request) + sizeof(spdm_vendor_defined_request_msg_t);
+    vendor_request = ((uint8_t *)spdm_request) + sizeof(spdm_vendor_defined_request_msg_t);
     if (req_vendor_id_len != 0) {
         libspdm_copy_mem(vendor_request, req_vendor_id_len, req_vendor_id, req_vendor_id_len);
         vendor_request += req_vendor_id_len;
@@ -181,8 +184,8 @@ libspdm_return_t libspdm_try_vendor_send_request_receive_response(
     }
 
     /* -=[Process Response Phase]=- */
-    uint8_t *response_ptr = spdm_response->vendor_plus_request + spdm_response->vendor_id_len;
-    uint16_t response_size = *((uint16_t*)response_ptr);
+    response_ptr = spdm_response->vendor_plus_request + spdm_response->vendor_id_len;
+    response_size = *((uint16_t*)response_ptr);
     if (spdm_response_size < response_size +
         sizeof(spdm_vendor_defined_response_msg_t) +
         spdm_response->vendor_id_len + sizeof(uint16_t)) {

--- a/library/spdm_requester_lib/libspdm_req_vendor_request.c
+++ b/library/spdm_requester_lib/libspdm_req_vendor_request.c
@@ -1,0 +1,232 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_requester_lib.h"
+
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+#define SPDM_VENDOR_PAYLOAD_LEN (LIBSPDM_MAX_VENDOR_DEFINED_RESPONSE_LEN - \
+                                 sizeof(spdm_vendor_defined_response_msg_t))
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    uint16_t standard_id;
+    uint8_t vendor_id_len;
+    uint8_t vendor_plus_request[SPDM_VENDOR_PAYLOAD_LEN];
+} libspdm_vendor_defined_response_msg_max_t;
+#pragma pack()
+
+libspdm_return_t libspdm_try_vendor_request(libspdm_context_t *spdm_context,
+                                            uint16_t standard_id,
+                                            uint8_t vendor_id_len,
+                                            uint8_t *vendor_id,
+                                            uint8_t *request,
+                                            uint16_t request_len,
+                                            uint8_t *response,
+                                            size_t *response_len)
+{
+    int i;
+    libspdm_return_t status;
+    spdm_vendor_defined_request_msg_t *spdm_request;
+    size_t spdm_request_size;
+    libspdm_vendor_defined_response_msg_max_t *spdm_response;
+    size_t spdm_response_size;
+    uint8_t *message;
+    size_t message_size;
+    size_t transport_header_size;
+    const uint32_t* session_id = NULL;
+
+    /* -=[Check Parameters Phase]=- */
+    if (vendor_id == NULL ||
+        request == NULL ||
+        response == NULL ||
+        response_len == NULL) {
+        status = LIBSPDM_STATUS_INVALID_PARAMETER;
+        goto done;
+    }
+
+    if (spdm_context->connection_info.connection_state < LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+        return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+    }
+
+    /* do not accept requests exceeding maximum allowed payload */
+    if (request_len > SPDM_VENDOR_PAYLOAD_LEN) {
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
+    transport_header_size = spdm_context->local_context.capability.transport_header_size;
+
+    /* -=[Construct Request Phase]=- */
+    status = libspdm_acquire_sender_buffer (spdm_context, &message_size, (void **)&message);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        return status;
+    }
+    LIBSPDM_ASSERT (message_size >= transport_header_size +
+                    spdm_context->local_context.capability.transport_tail_size);
+    spdm_request = (void *)(message + transport_header_size);
+
+    spdm_request->header.spdm_version = libspdm_get_connection_version (spdm_context);
+    spdm_request->header.request_response_code = SPDM_VENDOR_DEFINED_REQUEST;
+    spdm_request->header.param1 = 0;
+    spdm_request->header.param2 = 0;
+    /* Message header here */
+    spdm_request->standard_id = standard_id;
+    spdm_request->len = vendor_id_len;
+
+    /* Copy Vendor id */
+    uint8_t* vendor_request = ((uint8_t *)spdm_request) + sizeof(spdm_vendor_defined_request_msg_t);
+    libspdm_copy_mem(vendor_request, vendor_id_len, vendor_id, vendor_id_len);
+    vendor_request += vendor_id_len;
+
+    /* Copy request_len */
+    libspdm_copy_mem(vendor_request, sizeof(uint16_t), &request_len, sizeof(uint16_t));
+    vendor_request += sizeof(uint16_t);
+
+    /* Copy payload */
+    size_t vendor_request_len = SPDM_VENDOR_PAYLOAD_LEN - sizeof(uint16_t);
+    libspdm_copy_mem(vendor_request, vendor_request_len, request, request_len);
+
+    spdm_request_size = sizeof(spdm_vendor_defined_request_msg_t) +
+                        vendor_id_len + sizeof(uint16_t) + request_len;
+
+    /* -=[Send Request Phase]=- */
+    status =
+        libspdm_send_spdm_request(spdm_context, session_id, spdm_request_size, spdm_request);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        libspdm_release_sender_buffer (spdm_context);
+        status = LIBSPDM_STATUS_SEND_FAIL;
+        goto done;
+    }
+    libspdm_release_sender_buffer (spdm_context);
+    spdm_request = (void *)spdm_context->last_spdm_request;
+
+    /* -=[Receive Response Phase]=- */
+    status = libspdm_acquire_receiver_buffer (spdm_context, &message_size, (void **)&message);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        return status;
+    }
+    LIBSPDM_ASSERT (message_size >= transport_header_size);
+    spdm_response = (void *)(message);
+    spdm_response_size = message_size;
+
+    libspdm_zero_mem(spdm_response, spdm_response_size);
+    status = libspdm_receive_spdm_response(spdm_context, session_id,
+                                           &spdm_response_size,
+                                           (void **)&spdm_response);
+
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        status = LIBSPDM_STATUS_RECEIVE_FAIL;
+        goto done;
+    }
+
+    /* -=[Validate Response Phase]=- */
+    /* check response buffer size at least spdm response default header plus
+     * number of bytes required by vendor id and 2 bytes for response payload size */
+    if (spdm_response_size < sizeof(spdm_vendor_defined_response_msg_t) +
+        spdm_response->vendor_id_len + sizeof(uint16_t)) {
+        status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        goto done;
+    }
+    if (spdm_response->header.spdm_version != spdm_request->header.spdm_version) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto done;
+    }
+    if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        status = libspdm_handle_error_response_main(
+            spdm_context, session_id,
+            &spdm_response_size,
+            (void **)&spdm_response, SPDM_VENDOR_DEFINED_REQUEST,
+            SPDM_VENDOR_DEFINED_RESPONSE);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            goto done;
+        }
+    } else if (spdm_response->header.request_response_code != SPDM_VENDOR_DEFINED_RESPONSE) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto done;
+    }
+    if (spdm_response->standard_id != spdm_request->standard_id) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto done;
+    }
+    if (spdm_response->vendor_id_len != spdm_request->len) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto done;
+    }
+    vendor_request = ((uint8_t *)spdm_request) + sizeof(spdm_vendor_defined_request_msg_t);
+    uint8_t* vendor_response = spdm_response->vendor_plus_request;
+    for (i = 0; i < spdm_response->vendor_id_len; i++) {
+        if (*vendor_request != *vendor_response) {
+            status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+            goto done;
+        }
+        vendor_request++;
+        vendor_response++;
+    }
+
+    /* -=[Process Response Phase]=- */
+    uint8_t *response_ptr = spdm_response->vendor_plus_request + spdm_response->vendor_id_len;
+    uint16_t response_size = *((uint16_t*)response_ptr);
+    if (spdm_response_size < response_size +
+        sizeof(spdm_vendor_defined_response_msg_t) +
+        spdm_response->vendor_id_len + sizeof(uint16_t)) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto done;
+    }
+    response_ptr += sizeof(uint16_t);
+    if (*response_len < response_size) {
+        status = LIBSPDM_STATUS_BUFFER_TOO_SMALL;
+        goto done;
+    }
+    libspdm_copy_mem(response, *response_len, response_ptr, response_size);
+    *response_len = response_size;
+
+    /* -=[Log Message Phase]=- */
+    #if LIBSPDM_ENABLE_MSG_LOG
+    libspdm_append_msg_log(spdm_context, spdm_response, spdm_response_size);
+    #endif /* LIBSPDM_ENABLE_MSG_LOG */
+
+    status = LIBSPDM_STATUS_SUCCESS;
+done:
+    libspdm_release_receiver_buffer (spdm_context);
+    return status;
+}
+
+libspdm_return_t libspdm_vendor_request(void *spdm_context,
+                                        uint16_t standard_id,
+                                        uint8_t vendor_id_len,
+                                        void *vendor_id,
+                                        void *request,
+                                        size_t request_len,
+                                        void *response,
+                                        size_t *response_len)
+{
+    libspdm_context_t *context;
+    size_t retry;
+    uint64_t retry_delay_time;
+    libspdm_return_t status;
+
+    context = spdm_context;
+    context->crypto_request = true;
+    retry = context->retry_times;
+    retry_delay_time = context->retry_delay_time;
+    do {
+        status = libspdm_try_vendor_request(context,
+                                            standard_id,
+                                            vendor_id_len, (uint8_t *)vendor_id,
+                                            (uint8_t *)request, request_len,
+                                            (uint8_t *)response, response_len);
+        if ((status != LIBSPDM_STATUS_BUSY_PEER) || (retry == 0)) {
+            return status;
+        }
+
+        libspdm_sleep(retry_delay_time);
+    } while (retry-- != 0);
+
+    return status;
+}
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */

--- a/library/spdm_responder_lib/CMakeLists.txt
+++ b/library/spdm_responder_lib/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(src_spdm_responder_lib
     libspdm_rsp_csr.c
     libspdm_rsp_chunk_send_ack.c
     libspdm_rsp_chunk_get.c
+    libspdm_rsp_vendor_response.c
 )
 
 ADD_LIBRARY(spdm_responder_lib STATIC ${src_spdm_responder_lib})

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -84,6 +84,10 @@ libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_
         { SPDM_CHUNK_GET, libspdm_get_response_chunk_get},
         { SPDM_CHUNK_SEND, libspdm_get_response_chunk_send},
         #endif /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
+
+        #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+        { SPDM_VENDOR_DEFINED_REQUEST, libspdm_get_vendor_defined_response },
+        #endif /*LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES*/
     };
 
     for (index = 0; index < sizeof(get_response_struct) / sizeof(get_response_struct[0]); index++) {

--- a/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
@@ -1,0 +1,139 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_responder_lib.h"
+
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+/* expected number of bytes for VENDOR MESSAGE HEADERS */
+#define SPDM_VENDOR_DEFINED_FIXED_HEADER_LEN 7
+
+libspdm_return_t libspdm_register_vendor_callback_func(void *spdm_context,
+                                                       libspdm_vendor_response_callback_func resp_callback)
+{
+
+    libspdm_context_t *context = (libspdm_context_t *)spdm_context;
+    context->vendor_response_callback = resp_callback;
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_context,
+                                                     size_t request_size,
+                                                     const void *request,
+                                                     size_t *response_size,
+                                                     void *response)
+{
+    const spdm_vendor_defined_request_msg_t *spdm_request;
+    spdm_vendor_defined_response_msg_t *spdm_response;
+    uint16_t header_length;
+    size_t response_capacity;
+    libspdm_return_t status = LIBSPDM_STATUS_SUCCESS;
+    int i;
+
+    /* -=[Check Parameters Phase]=- */
+    if (request == NULL ||
+        response == NULL ||
+        response_size == NULL) {
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
+    spdm_request = request;
+
+    if (spdm_request->header.spdm_version != libspdm_get_connection_version(spdm_context)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_VERSION_MISMATCH, 0,
+                                               response_size, response);
+    }
+    if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
+        return libspdm_responder_handle_response_state(
+            spdm_context,
+            spdm_request->header.request_response_code,
+            response_size, response);
+    }
+    if (spdm_context->connection_info.connection_state < LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
+                                               0, response_size, response);
+    }
+
+    if (request_size < sizeof(spdm_vendor_defined_request_msg_t)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
+                                                  spdm_request->header.request_response_code);
+
+    /* length of spdm request/response header before payload start */
+    header_length = sizeof(spdm_vendor_defined_response_msg_t) + spdm_request->len +
+                    sizeof(uint16_t);
+
+    LIBSPDM_ASSERT(*response_size >= header_length);
+    LIBSPDM_ASSERT(
+        sizeof(spdm_vendor_defined_response_msg_t) == SPDM_VENDOR_DEFINED_FIXED_HEADER_LEN);
+    response_capacity = *response_size - header_length;
+    libspdm_zero_mem(response, header_length);
+    spdm_response = response;
+
+    spdm_response->header.spdm_version = spdm_request->header.spdm_version;
+    spdm_response->header.request_response_code = SPDM_VENDOR_DEFINED_RESPONSE;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = 0;
+    spdm_response->standard_id = spdm_request->standard_id;
+    spdm_response->len = spdm_request->len;
+
+    const uint8_t *req_data = ((const uint8_t *)request) +
+                              sizeof(spdm_vendor_defined_request_msg_t);
+    LIBSPDM_ASSERT(sizeof(spdm_vendor_defined_request_msg_t) ==
+                   SPDM_VENDOR_DEFINED_FIXED_HEADER_LEN);
+    uint8_t *resp_data = ((uint8_t *)response) + sizeof(spdm_vendor_defined_response_msg_t);
+    uint8_t *vendor_id = resp_data;
+    resp_data += spdm_response->len;
+
+    /* SPDM Response format
+     *  1 byte SPDMVersion
+     *  1 byte RequestResponseCode
+     *  2 bytes Reserved
+     *  2 bytes StandardID
+     *  1 bytes VendorID Length Len1, based on StandardID
+     *  Len1 bytes VendorID
+     *  2 bytes Response Length Len2
+     *  Len2 bytes Response Payload
+     */
+
+    /* assign vendors from request
+     * req_data advances by spdm_response->len */
+    for (i = 0; i < spdm_response->len; i++) {
+        *vendor_id++ = *req_data++;
+    }
+
+    /* advance by payload length, so callback gets actual payload */
+    req_data += sizeof(uint16_t);
+    resp_data += sizeof(uint16_t);
+
+    /* request_size will hold actual payload size */
+    request_size -= sizeof(spdm_vendor_defined_request_msg_t) + spdm_response->len +
+                    sizeof(uint16_t);
+
+    /* replace capacity with size */
+    status = spdm_context->vendor_response_callback(spdm_context,
+                                                    spdm_request->standard_id,
+                                                    spdm_request->len,
+                                                    vendor_id, req_data, request_size,
+                                                    resp_data, &response_capacity);
+
+    /* store back the response payload size */
+    *((uint16_t*)(resp_data - sizeof(uint16_t))) = response_capacity;
+    *response_size = response_capacity + header_length;
+
+    /* We are not caching request and response with libspdm_append_message_b
+     * as these are used for secure sessions, so out of scope for us */
+
+    return status;
+}
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */

--- a/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
@@ -65,6 +65,12 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
                                                response_size, response);
     }
 
+    if (spdm_context->vendor_response_callback == NULL) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
     libspdm_reset_message_buffer_via_request_code(spdm_context, NULL,
                                                   spdm_request->header.request_response_code);
 
@@ -107,8 +113,9 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
 
     /* assign vendors from request
      * req_data advances by spdm_response->len */
+    uint8_t* temp_vendor_ptr = vendor_id;
     for (i = 0; i < spdm_response->len; i++) {
-        *vendor_id++ = *req_data++;
+        *temp_vendor_ptr++ = *req_data++;
     }
 
     /* advance by payload length, so callback gets actual payload */
@@ -127,8 +134,8 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
                                                     resp_data, &response_capacity);
 
     /* store back the response payload size */
-    *((uint16_t*)(resp_data - sizeof(uint16_t))) = response_capacity;
-    *response_size = response_capacity + header_length;
+    *((uint16_t*)(resp_data - sizeof(uint16_t))) = (uint16_t)response_capacity;
+    *response_size = response_capacity + (size_t)header_length;
 
     /* We are not caching request and response with libspdm_append_message_b
      * as these are used for secure sessions, so out of scope for us */

--- a/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
@@ -142,7 +142,7 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
      */
 
     /* replace capacity with size */
-    spdm_response->len = LIBSPDM_MAX_VENDOR_ID_LENGTH;
+    spdm_response->len = SPDM_MAX_VENDOR_ID_LENGTH;
     resp_data = ((uint8_t *)response) + sizeof(spdm_vendor_defined_response_msg_t);
 
     req_vendor_id = ((const uint8_t *)request) +

--- a/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_vendor_response.c
@@ -1,6 +1,5 @@
 /**
- *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2023 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -43,6 +42,10 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
 
     libspdm_session_info_t *session_info = NULL;
     libspdm_session_state_t session_state = 0;
+    uint8_t *resp_data = NULL;
+    const uint8_t *req_vendor_id;
+    const uint8_t *req_data;
+    uint16_t resp_size = 0;
 
     /* -=[Check Parameters Phase]=- */
     if (request == NULL ||
@@ -140,14 +143,14 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
 
     /* replace capacity with size */
     spdm_response->len = LIBSPDM_MAX_VENDOR_ID_LENGTH;
-    uint8_t *resp_data = ((uint8_t *)response) + sizeof(spdm_vendor_defined_response_msg_t);
+    resp_data = ((uint8_t *)response) + sizeof(spdm_vendor_defined_response_msg_t);
 
-    const uint8_t *req_vendor_id = ((const uint8_t *)request) +
-                                   sizeof(spdm_vendor_defined_response_msg_t);
-    const uint8_t *req_data = ((const uint8_t *)request) +
-                              sizeof(spdm_vendor_defined_request_msg_t) +
-                              ((const spdm_vendor_defined_response_msg_t*)request)->len +
-                              sizeof(uint16_t);
+    req_vendor_id = ((const uint8_t *)request) +
+                    sizeof(spdm_vendor_defined_response_msg_t);
+    req_data = ((const uint8_t *)request) +
+               sizeof(spdm_vendor_defined_request_msg_t) +
+               ((const spdm_vendor_defined_response_msg_t*)request)->len +
+               sizeof(uint16_t);
 
     status = spdm_context->vendor_response_get_id(
         spdm_context,
@@ -158,7 +161,7 @@ libspdm_return_t libspdm_get_vendor_defined_response(libspdm_context_t *spdm_con
     /* move pointer and adjust buffer size */
     resp_data += spdm_response->len + sizeof(uint16_t);
     response_capacity -= spdm_response->len + sizeof(uint16_t);
-    uint16_t resp_size = (uint16_t)response_capacity;
+    resp_size = (uint16_t)response_capacity;
 
     status = spdm_context->vendor_response_callback(spdm_context,
                                                     spdm_request->standard_id,

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -11,18 +11,32 @@
 
 #define CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE (64)
 
+libspdm_return_t my_test_get_vendor_id_func(
+    void *spdm_context,
+    uint16_t *resp_standard_id,
+    uint8_t *resp_vendor_id_len,
+    void *resp_vendor_id)
+{
+    *resp_standard_id = 6;
+    *resp_vendor_id_len = 2;
+    ((uint8_t*)resp_vendor_id)[0] = 0xAA;
+    ((uint8_t*)resp_vendor_id)[1] = 0xAA;
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
 libspdm_return_t my_test_get_response_func(
     void *spdm_context,
-    uint16_t standard_id,
-    uint8_t vendor_id_len,
-    const void *vendor_id,
-    const void *request,
-    size_t request_len,
-    void *resp,
-    size_t *resp_len)
+    uint16_t req_standard_id,
+    uint8_t req_vendor_id_len,
+    const void *req_vendor_id,
+    uint16_t req_size,
+    const void *req_data,
+    uint16_t *resp_size,
+    void *resp_data)
 {
     /* response message size is greater than the sending transmit buffer size of responder */
-    *resp_len = CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE + 1;
+    *resp_size = CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE + 1;
     return LIBSPDM_STATUS_SUCCESS;
 }
 
@@ -218,6 +232,7 @@ void libspdm_test_responder_receive_send_rsp_case2(void** state)
     libspdm_zero_mem(response, response_size);
 
     /* Make response message size greater than the sending transmit buffer size of responder */
+    libspdm_register_vendor_get_id_callback_func(spdm_context, my_test_get_vendor_id_func);
     libspdm_register_vendor_callback_func(spdm_context, my_test_get_response_func);
 
     status = libspdm_build_response(spdm_context, NULL, false,

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -12,12 +12,17 @@
 #define CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE (64)
 
 libspdm_return_t my_test_get_response_func(
-    void *spdm_context, const uint32_t *session_id, bool is_app_message,
-    size_t request_size, const void *request, size_t *response_size,
-    void *response)
+    void *spdm_context,
+    uint16_t standard_id,
+    uint8_t vendor_id_len,
+    const void *vendor_id,
+    const void *request,
+    size_t request_len,
+    void *resp,
+    size_t *resp_len)
 {
     /* response message size is greater than the sending transmit buffer size of responder */
-    *response_size = CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE + 1;
+    *resp_len = CHUNK_GET_UNIT_TEST_OVERRIDE_DATA_TRANSFER_SIZE + 1;
     return LIBSPDM_STATUS_SUCCESS;
 }
 
@@ -213,7 +218,7 @@ void libspdm_test_responder_receive_send_rsp_case2(void** state)
     libspdm_zero_mem(response, response_size);
 
     /* Make response message size greater than the sending transmit buffer size of responder */
-    spdm_context->get_response_func = (void *)my_test_get_response_func;
+    libspdm_register_vendor_callback_func(spdm_context, my_test_get_response_func);
 
     status = libspdm_build_response(spdm_context, NULL, false,
                                     &response_size, (void**)&response);

--- a/unit_test/test_spdm_vendor_cmds/CMakeLists.txt
+++ b/unit_test/test_spdm_vendor_cmds/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/unit_test/test_spdm_vendor_cmds
+                    ${LIBSPDM_DIR}/include
+                    ${LIBSPDM_DIR}/unit_test/include
+                    ${LIBSPDM_DIR}/os_stub/spdm_device_secret_lib_sample
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include
+                    ${LIBSPDM_DIR}/unit_test/cmockalib/cmocka/include/cmockery
+                    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common
+                    ${LIBSPDM_DIR}/os_stub
+)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    if((TOOLCHAIN STREQUAL "VS2015") OR (TOOLCHAIN STREQUAL "VS2019") OR (TOOLCHAIN STREQUAL "VS2022"))
+        ADD_COMPILE_OPTIONS(/wd4819)
+    endif()
+endif()
+
+SET(src_test_spdm_vendor_cmds
+    test_spdm_vendor_cmds.c
+    vendor_cmds.c
+    error_test/vendor_cmds_err.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
+    ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c
+)
+
+SET(test_spdm_vendor_cmds_LIBRARY
+    memlib
+    debuglib
+    spdm_responder_lib
+    spdm_requester_lib
+    spdm_common_lib
+    ${CRYPTO_LIB_PATHS}
+    rnglib
+    cryptlib_${CRYPTO}
+    malloclib
+    spdm_crypt_lib
+    spdm_crypt_ext_lib
+    spdm_secured_message_lib
+    spdm_device_secret_lib_sample
+    spdm_transport_test_lib
+    cmockalib
+    platform_lib
+)
+
+if(TOOLCHAIN STREQUAL "ARM_DS2022")
+    SET(test_spdm_vendor_cmds_LIBRARY ${test_spdm_vendor_cmds_LIBRARY} armbuild_lib)
+endif()
+
+if((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC"))
+    ADD_EXECUTABLE(test_spdm_vendor_cmds
+                   ${src_test_spdm_vendor_cmds}
+                   $<TARGET_OBJECTS:memlib>
+                   $<TARGET_OBJECTS:debuglib>
+                   $<TARGET_OBJECTS:spdm_requester_lib>
+                   $<TARGET_OBJECTS:spdm_common_lib>
+                   $<TARGET_OBJECTS:${CRYPTO_LIB_PATHS}>
+                   $<TARGET_OBJECTS:rnglib>
+                   $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
+                   $<TARGET_OBJECTS:malloclib>
+                   $<TARGET_OBJECTS:spdm_crypt_lib>
+                   $<TARGET_OBJECTS:spdm_secured_message_lib>
+                   $<TARGET_OBJECTS:spdm_device_secret_lib_sample>
+                   $<TARGET_OBJECTS:spdm_transport_test_lib>
+                   $<TARGET_OBJECTS:cmockalib>
+                   $<TARGET_OBJECTS:platform_lib>
+    )
+else()
+    ADD_EXECUTABLE(test_spdm_vendor_cmds ${src_test_spdm_vendor_cmds})
+    TARGET_LINK_LIBRARIES(test_spdm_vendor_cmds ${test_spdm_vendor_cmds_LIBRARY})
+endif()

--- a/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
+++ b/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
@@ -1,6 +1,5 @@
 /**
- *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2023 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -58,10 +57,10 @@ libspdm_return_t libspdm_vendor_response_func_err_test(
     void *resp_data)
 {
     libspdm_vendor_response_test test_response;
-    /* get pointer to response length and populate */
-    *resp_size = sizeof(test_response.data);
     /* get pointer to response data payload and populate */
     uint8_t *resp_payload = (uint8_t *)resp_data;
+    /* get pointer to response length and populate */
+    *resp_size = sizeof(test_response.data);
     /* store length of response */
     libspdm_set_mem(resp_payload, *resp_size, 0xFF);
 
@@ -232,6 +231,7 @@ static void libspdm_test_requester_vendor_cmds_err_case2(void **state)
     libspdm_vendor_response_test response = {0};
     response.vendor_id_len = sizeof(response.vendor_id);
     response.data_len = sizeof(response.data);
+    size_t response_len = 0;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -256,7 +256,7 @@ static void libspdm_test_requester_vendor_cmds_err_case2(void **state)
     request.data_len = sizeof(request.data);
     libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
 
-    size_t response_len = sizeof(response);
+    response_len = sizeof(response);
 
     /* copy header of request structure to buffer */
     libspdm_copy_mem(request_buffer, 255, &request,

--- a/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
+++ b/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
@@ -15,7 +15,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint16_t vendor_id;
+    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[16];
 } libspdm_vendor_request_test;
@@ -24,7 +24,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint16_t vendor_id;
+    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[64];
 } libspdm_vendor_response_test;
@@ -33,30 +33,45 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
+libspdm_return_t libspdm_vendor_get_id_func_err_test(
+    void *spdm_context,
+    uint16_t *resp_standard_id,
+    uint8_t *resp_vendor_id_len,
+    void *resp_vendor_id)
+{
+    *resp_standard_id = 6;
+    *resp_vendor_id_len = 2;
+    ((uint8_t*)resp_vendor_id)[0] = 0xAA;
+    ((uint8_t*)resp_vendor_id)[1] = 0xAA;
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
 libspdm_return_t libspdm_vendor_response_func_err_test(
     void *spdm_context,
-    uint16_t standard_id,
-    uint8_t vendor_id_len,
-    const void *vendor_id,
-    const void *request,
-    size_t request_len,
-    void *resp,
-    size_t *resp_len)
+    uint16_t req_standard_id,
+    uint8_t req_vendor_id_len,
+    const void *req_vendor_id,
+    uint16_t req_size,
+    const void *req_data,
+    uint16_t *resp_size,
+    void *resp_data)
 {
     libspdm_vendor_response_test test_response;
     /* get pointer to response length and populate */
-    uint16_t *response_len = (uint16_t *)resp;
-    *response_len = sizeof(test_response.data);
-    *resp_len = *response_len; /* for output */
+    *resp_size = sizeof(test_response.data);
     /* get pointer to response data payload and populate */
-    uint8_t *resp_payload = (uint8_t *)resp;
+    uint8_t *resp_payload = (uint8_t *)resp_data;
     /* store length of response */
-    libspdm_set_mem(resp_payload, *response_len, 0xFF);
+    libspdm_set_mem(resp_payload, *resp_size, 0xFF);
 
-    *response_len = 65000;
+    if (resp_size == NULL || *resp_size == 0)
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+
+    /* TBD make an error here, like response len 65000, but different this time. */
 
     printf("Got request 0x%x, sent response 0x%x\n",
-           ((const uint8_t*)request)[0], ((uint8_t*)resp)[0]);
+           ((const uint8_t*)req_data)[0], ((uint8_t*)resp_data)[0]);
 
     return LIBSPDM_STATUS_SUCCESS;
 }
@@ -124,8 +139,13 @@ static libspdm_return_t libspdm_requester_vendor_cmds_err_test_receive_message(
         spdm_response->vendor_id_len = spdm_request->vendor_id_len;
         /* usually 2 bytes for vendor id */
         assert_int_equal(spdm_response->vendor_id_len, sizeof(uint16_t));
-        spdm_response->vendor_id = spdm_request->vendor_id;
-        spdm_response->data_len = sizeof(spdm_response->data) + 65000;
+        libspdm_copy_mem(spdm_response->vendor_id, spdm_request->vendor_id_len,
+                         spdm_request->vendor_id, spdm_request->vendor_id_len);
+
+        if (spdm_response->data_len < sizeof(spdm_response->data))
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+
+        spdm_response->data_len = sizeof(spdm_response->data);
         libspdm_set_mem(spdm_response->data, sizeof(spdm_response->data), 0xff);
 
         status = libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -143,7 +163,7 @@ static libspdm_return_t libspdm_requester_vendor_cmds_err_test_receive_message(
 
 /**
  * Test 1: Sending a vendor defined request
- * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_PARAMETER
  * due to invalid length of data field in the response
  **/
 static void libspdm_test_requester_vendor_cmds_err_case1(void **state)
@@ -152,7 +172,9 @@ static void libspdm_test_requester_vendor_cmds_err_case1(void **state)
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
     libspdm_vendor_request_test request;
-    libspdm_vendor_response_test response;
+    libspdm_vendor_response_test response = {0};
+    response.vendor_id_len = sizeof(response.vendor_id);
+    response.data_len = sizeof(response.data);
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -163,25 +185,32 @@ static void libspdm_test_requester_vendor_cmds_err_case1(void **state)
         LIBSPDM_CONNECTION_STATE_NEGOTIATED;
     spdm_context->local_context.is_requester = true;
 
+    status = libspdm_register_vendor_get_id_callback_func(spdm_context,
+                                                          libspdm_vendor_get_id_func_err_test);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     status = libspdm_register_vendor_callback_func(spdm_context,
                                                    libspdm_vendor_response_func_err_test);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     request.standard_id = 6;
     request.vendor_id_len = 2;
-    request.vendor_id = 0xAAAA;
+    request.vendor_id[0] = 0xAA;
+    request.vendor_id[1] = 0xAA;
     request.data_len = sizeof(request.data);
     libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
 
-    size_t response_len = sizeof(response.data);
+    response.data_len = 0; /* will generate error */
 
-    status = libspdm_vendor_request(spdm_context,
-                                    request.standard_id, request.vendor_id_len,
-                                    &request.vendor_id, &(request.data),
-                                    request.data_len,
-                                    &response.data, &response_len
-                                    );
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    status = libspdm_vendor_send_request_receive_response(spdm_context, NULL,
+                                                          request.standard_id,
+                                                          request.vendor_id_len,
+                                                          request.vendor_id, request.data_len,
+                                                          request.data,
+                                                          &response.standard_id,
+                                                          &response.vendor_id_len,
+                                                          response.vendor_id, &response.data_len,
+                                                          response.data);
+    assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
     assert_int_equal(
         spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT,
         SPDM_MESSAGE_VERSION_10);
@@ -198,8 +227,11 @@ static void libspdm_test_requester_vendor_cmds_err_case2(void **state)
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
+    uint8_t request_buffer[255] = {0};
     libspdm_vendor_request_test request;
-    libspdm_vendor_response_test response;
+    libspdm_vendor_response_test response = {0};
+    response.vendor_id_len = sizeof(response.vendor_id);
+    response.data_len = sizeof(response.data);
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -219,14 +251,23 @@ static void libspdm_test_requester_vendor_cmds_err_case2(void **state)
 
     request.standard_id = 6;
     request.vendor_id_len = 2;
-    request.vendor_id = 0xAAAA;
+    request.vendor_id[0] = 0xAA;
+    request.vendor_id[1] = 0xAA;
     request.data_len = sizeof(request.data);
     libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
 
     size_t response_len = sizeof(response);
 
+    /* copy header of request structure to buffer */
+    libspdm_copy_mem(request_buffer, 255, &request,
+                     sizeof(request.header) + 3 + request.vendor_id_len);
+    /* copy the request data to the correct offset in the request_buffer */
+    libspdm_copy_mem(request_buffer + sizeof(request.header) + 3 + request.vendor_id_len,
+                     request.data_len + 2, &request.data_len, request.data_len + 2);
+
+    /* requires correctly encoded spdm vendor request message */
     status = libspdm_get_vendor_defined_response(spdm_context, sizeof(request),
-                                                 &request, &response_len, NULL);
+                                                 request_buffer, &response_len, NULL);
 
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
     assert_int_equal(

--- a/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
+++ b/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
@@ -14,7 +14,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
+    uint8_t vendor_id[SPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[16];
 } libspdm_vendor_request_test;
@@ -23,7 +23,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
+    uint8_t vendor_id[SPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[64];
 } libspdm_vendor_response_test;

--- a/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
+++ b/unit_test/test_spdm_vendor_cmds/error_test/vendor_cmds_err.c
@@ -1,0 +1,261 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_responder_lib.h"
+
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    uint16_t standard_id;
+    uint8_t vendor_id_len;
+    uint16_t vendor_id;
+    uint16_t data_len;
+    uint8_t data[16];
+} libspdm_vendor_request_test;
+
+typedef struct {
+    spdm_message_header_t header;
+    uint16_t standard_id;
+    uint8_t vendor_id_len;
+    uint16_t vendor_id;
+    uint16_t data_len;
+    uint8_t data[64];
+} libspdm_vendor_response_test;
+#pragma pack()
+
+static size_t m_libspdm_local_buffer_size;
+static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
+
+libspdm_return_t libspdm_vendor_response_func_err_test(
+    void *spdm_context,
+    uint16_t standard_id,
+    uint8_t vendor_id_len,
+    const void *vendor_id,
+    const void *request,
+    size_t request_len,
+    void *resp,
+    size_t *resp_len)
+{
+    libspdm_vendor_response_test test_response;
+    /* get pointer to response length and populate */
+    uint16_t *response_len = (uint16_t *)resp;
+    *response_len = sizeof(test_response.data);
+    *resp_len = *response_len; /* for output */
+    /* get pointer to response data payload and populate */
+    uint8_t *resp_payload = (uint8_t *)resp;
+    /* store length of response */
+    libspdm_set_mem(resp_payload, *response_len, 0xFF);
+
+    *response_len = 65000;
+
+    printf("Got request 0x%x, sent response 0x%x\n",
+           ((const uint8_t*)request)[0], ((uint8_t*)resp)[0]);
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+static libspdm_return_t libspdm_requester_vendor_cmds_err_test_send_message(
+    void *spdm_context, size_t request_size, const void *request,
+    uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1: {
+        const uint8_t *ptr = (const uint8_t *)request;
+
+        m_libspdm_local_buffer_size = 0;
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         ptr, request_size);
+        m_libspdm_local_buffer_size += request_size;
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x2:
+        return LIBSPDM_STATUS_SUCCESS;
+    default:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
+}
+
+/* Acts as the Responder Integration */
+static libspdm_return_t libspdm_requester_vendor_cmds_err_test_receive_message(
+    void *spdm_context, size_t *response_size,
+    void **response, uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_return_t status = LIBSPDM_STATUS_SUCCESS;
+
+    uint32_t* session_id = NULL;
+    bool is_app_message = false;
+    size_t transport_message_size = sizeof(libspdm_vendor_request_test);
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1: {
+        libspdm_vendor_response_test *spdm_response;
+        libspdm_vendor_request_test* spdm_request = NULL;
+        status = libspdm_transport_test_decode_message(
+            spdm_test_context, &session_id, &is_app_message, true,
+            m_libspdm_local_buffer_size, m_libspdm_local_buffer,
+            &transport_message_size, (void **)(&spdm_request));
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(libspdm_vendor_response_test);
+        transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.request_response_code = SPDM_VENDOR_DEFINED_RESPONSE;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+
+        spdm_response->standard_id = spdm_request->standard_id;
+        spdm_response->vendor_id_len = spdm_request->vendor_id_len;
+        /* usually 2 bytes for vendor id */
+        assert_int_equal(spdm_response->vendor_id_len, sizeof(uint16_t));
+        spdm_response->vendor_id = spdm_request->vendor_id;
+        spdm_response->data_len = sizeof(spdm_response->data) + 65000;
+        libspdm_set_mem(spdm_response->data, sizeof(spdm_response->data), 0xff);
+
+        status = libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                                       false, spdm_response_size,
+                                                       spdm_response,
+                                                       response_size, response);
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    default:
+        return LIBSPDM_STATUS_RECEIVE_FAIL;
+    }
+}
+
+/**
+ * Test 1: Sending a vendor defined request
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD
+ * due to invalid length of data field in the response
+ **/
+static void libspdm_test_requester_vendor_cmds_err_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_vendor_request_test request;
+    libspdm_vendor_response_test response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.is_requester = true;
+
+    status = libspdm_register_vendor_callback_func(spdm_context,
+                                                   libspdm_vendor_response_func_err_test);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    request.standard_id = 6;
+    request.vendor_id_len = 2;
+    request.vendor_id = 0xAAAA;
+    request.data_len = sizeof(request.data);
+    libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
+
+    size_t response_len = sizeof(response.data);
+
+    status = libspdm_vendor_request(spdm_context,
+                                    request.standard_id, request.vendor_id_len,
+                                    &request.vendor_id, &(request.data),
+                                    request.data_len,
+                                    &response.data, &response_len
+                                    );
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(
+        spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT,
+        SPDM_MESSAGE_VERSION_10);
+
+    printf("case 1 %d\n", response.data[0]);
+}
+
+/**
+ * Test 2: Sending a vendor defined request with one parameter NULL
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_INVALID_PARAMETER
+ **/
+static void libspdm_test_requester_vendor_cmds_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_vendor_request_test request;
+    libspdm_vendor_response_test response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
+    request.header.spdm_version = SPDM_MESSAGE_VERSION_10;
+    spdm_context->connection_info.version = request.header.spdm_version <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.is_requester = true;
+
+    status = libspdm_register_vendor_callback_func(spdm_context,
+                                                   libspdm_vendor_response_func_err_test);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    request.standard_id = 6;
+    request.vendor_id_len = 2;
+    request.vendor_id = 0xAAAA;
+    request.data_len = sizeof(request.data);
+    libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
+
+    size_t response_len = sizeof(response);
+
+    status = libspdm_get_vendor_defined_response(spdm_context, sizeof(request),
+                                                 &request, &response_len, NULL);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+    assert_int_equal(
+        spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT,
+        SPDM_MESSAGE_VERSION_10);
+
+    response.data_len = (uint16_t)response_len;
+}
+
+libspdm_test_context_t m_libspdm_requester_vendor_cmds_err_test_context = {
+    LIBSPDM_TEST_CONTEXT_VERSION,
+    true,
+    libspdm_requester_vendor_cmds_err_test_send_message,
+    libspdm_requester_vendor_cmds_err_test_receive_message,
+};
+
+int libspdm_requester_vendor_cmds_error_test_main(void)
+{
+    const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
+        cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case1),
+        cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case2)
+    };
+
+    libspdm_setup_test_context(&m_libspdm_requester_vendor_cmds_err_test_context);
+
+    return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */

--- a/unit_test/test_spdm_vendor_cmds/test_spdm_vendor_cmds.c
+++ b/unit_test/test_spdm_vendor_cmds/test_spdm_vendor_cmds.c
@@ -1,6 +1,5 @@
 /**
- *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2023 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 

--- a/unit_test/test_spdm_vendor_cmds/test_spdm_vendor_cmds.c
+++ b/unit_test/test_spdm_vendor_cmds/test_spdm_vendor_cmds.c
@@ -1,0 +1,29 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+int libspdm_requester_vendor_cmds_test_main(void);
+int libspdm_requester_vendor_cmds_error_test_main(void);
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+int main(void)
+{
+    int return_value = 0;
+
+    #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+    if (libspdm_requester_vendor_cmds_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_vendor_cmds_error_test_main() != 0) {
+        return_value = 1;
+    }
+    #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+    return return_value;
+}

--- a/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
+++ b/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
@@ -1,0 +1,258 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+#include "internal/libspdm_responder_lib.h"
+
+#if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    uint16_t standard_id;
+    uint8_t vendor_id_len;
+    uint16_t vendor_id;
+    uint16_t data_len;
+    uint8_t data[16];
+} libspdm_vendor_request_test;
+
+typedef struct {
+    spdm_message_header_t header;
+    uint16_t standard_id;
+    uint8_t vendor_id_len;
+    uint16_t vendor_id;
+    uint16_t data_len;
+    uint8_t data[64];
+} libspdm_vendor_response_test;
+#pragma pack()
+
+static size_t m_libspdm_local_buffer_size;
+static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
+
+libspdm_return_t libspdm_vendor_response_func_test(
+    void *spdm_context,
+    uint16_t standard_id,
+    uint8_t vendor_id_len,
+    const void *vendor_id,
+    const void *request,
+    size_t request_len,
+    void *resp,
+    size_t *resp_len)
+{
+    libspdm_vendor_response_test test_response;
+    /* get pointer to response length and populate */
+    uint16_t *response_len = (uint16_t *)resp;
+    *response_len = sizeof(test_response.data);
+    *resp_len = *response_len; /* for output */
+    /* get pointer to response data payload and populate */
+    uint8_t *resp_payload = (uint8_t *)resp;
+    /* store length of response */
+    libspdm_set_mem(resp_payload, *response_len, 0xFF);
+
+    printf("Got request 0x%x, sent response 0x%x\n",
+           ((const uint8_t*)request)[0], ((uint8_t*)resp)[0]);
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+static libspdm_return_t libspdm_requester_vendor_cmds_test_send_message(
+    void *spdm_context, size_t request_size, const void *request,
+    uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1: {
+        const uint8_t *ptr = (const uint8_t *)request;
+
+        m_libspdm_local_buffer_size = 0;
+        libspdm_copy_mem(m_libspdm_local_buffer, sizeof(m_libspdm_local_buffer),
+                         ptr, request_size);
+        m_libspdm_local_buffer_size += request_size;
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x2:
+        return LIBSPDM_STATUS_SUCCESS;
+    default:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
+}
+
+/* Acts as the Responder Integration */
+static libspdm_return_t libspdm_requester_vendor_cmds_test_receive_message(
+    void *spdm_context, size_t *response_size,
+    void **response, uint64_t timeout)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_return_t status = LIBSPDM_STATUS_SUCCESS;
+
+    uint32_t* session_id = NULL;
+    bool is_app_message = false;
+    size_t transport_message_size = sizeof(libspdm_vendor_request_test);
+
+    spdm_test_context = libspdm_get_test_context();
+    switch (spdm_test_context->case_id) {
+    case 0x1: {
+        libspdm_vendor_response_test *spdm_response;
+        libspdm_vendor_request_test* spdm_request = NULL;
+        status = libspdm_transport_test_decode_message(
+            spdm_test_context, &session_id, &is_app_message, true,
+            m_libspdm_local_buffer_size, m_libspdm_local_buffer,
+            &transport_message_size, (void **)(&spdm_request));
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(libspdm_vendor_response_test);
+        transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_10;
+        spdm_response->header.request_response_code = SPDM_VENDOR_DEFINED_RESPONSE;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+
+        spdm_response->standard_id = spdm_request->standard_id;
+        spdm_response->vendor_id_len = spdm_request->vendor_id_len;
+        /* usually 2 bytes for vendor id */
+        assert_int_equal(spdm_response->vendor_id_len, sizeof(uint16_t));
+        spdm_response->vendor_id = spdm_request->vendor_id;
+        spdm_response->data_len = sizeof(spdm_response->data);
+        libspdm_set_mem(spdm_response->data, sizeof(spdm_response->data), 0xff);
+
+        status = libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                                       false, spdm_response_size,
+                                                       spdm_response,
+                                                       response_size, response);
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
+    default:
+        return LIBSPDM_STATUS_RECEIVE_FAIL;
+    }
+}
+
+/**
+ * Test 1: Sending a vendor defined request
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
+ **/
+static void libspdm_test_requester_vendor_cmds_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_vendor_request_test request;
+    libspdm_vendor_response_test response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_10 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.is_requester = true;
+
+    status = libspdm_register_vendor_callback_func(spdm_context,
+                                                   libspdm_vendor_response_func_test);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    request.standard_id = 6;
+    request.vendor_id_len = 2;
+    request.vendor_id = 0xAAAA;
+    request.data_len = sizeof(request.data);
+    libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
+
+    size_t response_len = sizeof(response.data);
+
+    status = libspdm_vendor_request(spdm_context,
+                                    request.standard_id, request.vendor_id_len,
+                                    &request.vendor_id, &(request.data),
+                                    request.data_len,
+                                    &response.data, &response_len
+                                    );
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(
+        spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT,
+        SPDM_MESSAGE_VERSION_10);
+
+    printf("case 1 %d\n", response.data[0]);
+}
+
+/**
+ * Test 2: Sending a vendor defined request using the internal response handler
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
+ **/
+static void libspdm_test_requester_vendor_cmds_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_vendor_request_test request;
+    libspdm_vendor_response_test response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
+    request.header.spdm_version = SPDM_MESSAGE_VERSION_10;
+    spdm_context->connection_info.version = request.header.spdm_version <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.is_requester = true;
+
+    status = libspdm_register_vendor_callback_func(spdm_context,
+                                                   libspdm_vendor_response_func_test);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    request.standard_id = 6;
+    request.vendor_id_len = 2;
+    request.vendor_id = 0xAAAA;
+    request.data_len = sizeof(request.data);
+    libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
+
+    size_t response_len = sizeof(response);
+
+    status = libspdm_get_vendor_defined_response(spdm_context, sizeof(request),
+                                                 &request, &response_len, &response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(
+        spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT,
+        SPDM_MESSAGE_VERSION_10);
+
+    response.data_len = (uint16_t)response_len;
+}
+
+libspdm_test_context_t m_libspdm_requester_vendor_cmds_test_context = {
+    LIBSPDM_TEST_CONTEXT_VERSION,
+    true,
+    libspdm_requester_vendor_cmds_test_send_message,
+    libspdm_requester_vendor_cmds_test_receive_message,
+};
+
+int libspdm_requester_vendor_cmds_test_main(void)
+{
+    const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
+        cmocka_unit_test(libspdm_test_requester_vendor_cmds_case1),
+        cmocka_unit_test(libspdm_test_requester_vendor_cmds_case2)
+    };
+
+    libspdm_setup_test_context(&m_libspdm_requester_vendor_cmds_test_context);
+
+    return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+
+#endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */

--- a/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
+++ b/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
@@ -14,7 +14,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
+    uint8_t vendor_id[SPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[16];
 } libspdm_vendor_request_test;
@@ -23,7 +23,7 @@ typedef struct {
     spdm_message_header_t header;
     uint16_t standard_id;
     uint8_t vendor_id_len;
-    uint8_t vendor_id[LIBSPDM_MAX_VENDOR_ID_LENGTH];
+    uint8_t vendor_id[SPDM_MAX_VENDOR_ID_LENGTH];
     uint16_t data_len;
     uint8_t data[64];
 } libspdm_vendor_response_test;

--- a/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
+++ b/unit_test/test_spdm_vendor_cmds/vendor_cmds.c
@@ -1,6 +1,5 @@
 /**
- *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2023 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -73,10 +72,10 @@ libspdm_return_t libspdm_vendor_response_func_test(
         return LIBSPDM_STATUS_INVALID_PARAMETER;
 
     libspdm_vendor_response_test test_response;
-    /* get pointer to response length and populate */
-    *resp_size = sizeof(test_response.data);
     /* get pointer to response data payload and populate */
     uint8_t *resp_payload = (uint8_t *)resp_data;
+    /* get pointer to response length and populate */
+    *resp_size = sizeof(test_response.data);
     /* store length of response */
     libspdm_set_mem(resp_payload, *resp_size, 0xFF);
 
@@ -127,13 +126,13 @@ static libspdm_return_t libspdm_requester_vendor_cmds_test_receive_message(
     case 0x1: {
         libspdm_vendor_response_test *spdm_response;
         libspdm_vendor_request_test* spdm_request = NULL;
+        size_t spdm_response_size;
+        size_t transport_header_size;
         status = libspdm_transport_test_decode_message(
             spdm_test_context, &session_id, &is_app_message, true,
             m_libspdm_local_buffer_size, m_libspdm_local_buffer,
             &transport_message_size, (void **)(&spdm_request));
         assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-        size_t spdm_response_size;
-        size_t transport_header_size;
 
         spdm_response_size = sizeof(libspdm_vendor_response_test);
         transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
@@ -234,6 +233,7 @@ static void libspdm_test_requester_vendor_cmds_case2(void **state)
     uint8_t response_buffer[255] = {0};
     libspdm_vendor_request_test request = {0};
     libspdm_vendor_response_test response = {0};
+    size_t response_len = 0;
     response.vendor_id_len = sizeof(response.vendor_id);
     response.data_len = sizeof(response.data);
 
@@ -263,7 +263,7 @@ static void libspdm_test_requester_vendor_cmds_case2(void **state)
     request.data_len = sizeof(request.data);
     libspdm_set_mem(request.data, sizeof(request.data), 0xAA);
 
-    size_t response_len = sizeof(response);
+    response_len = sizeof(response);
 
     /* copy header of request structure to buffer */
     libspdm_copy_mem(request_buffer, 255, &request,


### PR DESCRIPTION
Hello,

I have created a new pull request that implements support for Vendor Defined Requests and Responses.
The changes allow responder integrator to register a callback that will process any SPDM Vendor Defined Requests and issue Vendor Defined Responses. It also implements a dedicated method for a Requester to issue a Vendor Defined Request. I added a few tests as well to validate the code.

New public API methods:
Responder:
libspdm_vendor_response_callback_func response_callback;
libspdm_register_vendor_callback_func( ... response_callback);
Requester:
libspdm_vendor_request(... request ... response ...);

Please take a look and let me know any feedback. Thank you.
