### PR TITLE
Add 1.3 encap Challenge for BasicMutAuth

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -395,6 +395,7 @@ typedef struct {
     spdm_message_header_t last_encap_request_header;
     size_t last_encap_request_size;
     uint16_t cert_chain_total_len;
+    uint8_t req_context[SPDM_REQ_CONTEXT_SIZE];
 } libspdm_encap_context_t;
 
 #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP


### PR DESCRIPTION
This is follow up for https://github.com/DMTF/libspdm/issues/2282 and https://github.com/DMTF/libspdm/pull/2420.


Validated with spdm-emu and spdm-dump https://github.com/DMTF/spdm-dump/pull/90.

