### PR TITLE
os_stub/cryptlib_*: x509: Don't copy some NIDs

### DIFF
--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -2110,6 +2110,17 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
             goto free_all;
         }
 
+        if (MBEDTLS_OID_CMP_RAW(MBEDTLS_OID_BASIC_CONSTRAINTS, next_oid->buf.p, oid_tag_len) == 0) {
+            next_oid = next_oid->next;
+            continue;
+        }
+
+        if (MBEDTLS_OID_CMP_RAW(MBEDTLS_OID_AUTHORITY_KEY_IDENTIFIER, next_oid->buf.p,
+                                oid_tag_len) == 0) {
+            next_oid = next_oid->next;
+            continue;
+        }
+
         if (mbedtls_x509write_csr_set_extension(&req, next_oid->buf.p,
                                                 oid_tag_len,
                                                 next_oid->buf.p + oid_tag_len,

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -2635,10 +2635,24 @@ bool libspdm_gen_x509_csr(size_t hash_nid, size_t asym_nid,
     sk_X509_EXTENSION_push(exts, basic_constraints_ext);
 
     if (base_cert != NULL) {
+        const ASN1_OBJECT *basic_constraints_obj = OBJ_nid2obj(NID_basic_constraints);
+        const ASN1_OBJECT *authority_key_identifier_obj = OBJ_nid2obj(NID_authority_key_identifier);
+
         num_exts = X509_get_ext_count(base_cert);
 
         for (int i = 0; i < num_exts; i++) {
-            sk_X509_EXTENSION_push(exts, X509_get_ext(base_cert, i));
+            X509_EXTENSION *extension = X509_get_ext(base_cert, i);
+            ASN1_OBJECT *obj = X509_EXTENSION_get_object(extension);
+
+            if (OBJ_cmp(basic_constraints_obj, obj) == 0) {
+                continue;
+            }
+
+            if (OBJ_cmp(authority_key_identifier_obj, obj) == 0) {
+                continue;
+            }
+
+            sk_X509_EXTENSION_push(exts, extension);
         }
     }
 


### PR DESCRIPTION
Avoid copying the basic_constraints NID as we already set it ourselves
and also avoid copying the authority_key_identifier as it won't be
correct on the CSR.

This PR also fixes the mbedtls NID copying