### PR TITLE
Fix up for build error in build environment with ARM architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,24 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
         SET(CMAKE_C_LINK_EXECUTABLE "")
 
+    elseif(TOOLCHAIN STREQUAL "NONE")
+        ADD_COMPILE_OPTIONS(-fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -Wno-address -fpie -fno-asynchronous-unwind-tables -flto -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare -Werror-implicit-function-declaration)
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            ADD_COMPILE_OPTIONS(-g)
+        endif()
+        if(GCOV STREQUAL "ON")
+        ADD_COMPILE_OPTIONS(--coverage -fprofile-arcs -ftest-coverage)
+        endif()
+        SET(OPENSSL_FLAGS -include base.h -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -Wno-cast-qual -Wno-error=implicit-function-declaration)
+        SET(CMOCKA_FLAGS -std=gnu99 -Wpedantic -Wall -Wshadow -Wmissing-prototypes -Wcast-align -Werror=address -Wstrict-prototypes -Werror=strict-prototypes -Wwrite-strings -Werror=write-strings -Werror-implicit-function-declaration -Wpointer-arith -Werror=pointer-arith -Wdeclaration-after-statement -Werror=declaration-after-statement -Wreturn-type -Werror=return-type -Wuninitialized -Werror=uninitialized -Werror=strict-overflow -Wstrict-overflow=2 -Wno-format-zero-length -Wmissing-field-initializers -Wformat-security -Werror=format-security -fno-common -Wformat -fno-common -fstack-protector-strong -Wno-cast-qual)
+
+        SET(CMAKE_LINKER ${CMAKE_C_COMPILER})
+        SET(CMAKE_EXE_LINKER_FLAGS "-flto -Wno-error -no-pie" )
+        if(GCOV STREQUAL "ON")
+        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  --coverage -lgcov -fprofile-arcs -ftest-coverage")
+        endif()
+        SET(CMAKE_C_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> -Wl,--start-group <LINK_LIBRARIES> -Wl,--end-group")
+
     endif()
 
     if(NOT TOOLCHAIN STREQUAL "NIOS2_GCC")
@@ -1013,12 +1031,14 @@ else()
         SET(CMAKE_PROJECT_NAME "libspdm")
         SET(CMAKE_PROJECT_DESCRIPTION "libspdm shared library")
 
-        SET(CMAKE_SKIP_BUILD_RPATH FALSE)
-        SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-        SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+        if(NOT TOOLCHAIN STREQUAL "NONE")
+            SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+            SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+            SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+            SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+        endif()
 
-        add_library(${LIB_NAME} SHARED 
+        add_library(${LIB_NAME} SHARED
             $<TARGET_OBJECTS:spdm_common_lib>
             $<TARGET_OBJECTS:spdm_crypt_lib>
             $<TARGET_OBJECTS:spdm_requester_lib>
@@ -1028,7 +1048,7 @@ else()
             $<TARGET_OBJECTS:spdm_transport_pcidoe_lib>
         )
 
-        add_library(${LIB_NAME}_platform SHARED 
+        add_library(${LIB_NAME}_platform SHARED
             $<TARGET_OBJECTS:debuglib>
             $<TARGET_OBJECTS:malloclib>
             $<TARGET_OBJECTS:platform_lib>
@@ -1036,7 +1056,7 @@ else()
             $<TARGET_OBJECTS:memlib>
         )
 
-        add_library(${LIB_NAME}_crypto SHARED 
+        add_library(${LIB_NAME}_crypto SHARED
             $<TARGET_OBJECTS:spdm_crypt_ext_lib>
             $<TARGET_OBJECTS:cryptlib_${CRYPTO}>
         )
@@ -1050,12 +1070,19 @@ else()
             )
         elseif(CRYPTO STREQUAL "openssl")
             SET(CRYPTO_DEPS "-lssl -lcrypto")
-            TARGET_LINK_LIBRARIES(${LIB_NAME}_crypto
-                PUBLIC ssl
-                PUBLIC crypto
-            )
-        endif()  
-        
+            if(TOOLCHAIN STREQUAL "NONE")
+                TARGET_LINK_LIBRARIES(${LIB_NAME}_crypto
+                    PUBLIC openssllib
+                    PUBLIC cryptlib_openssl
+                )
+            else()
+                TARGET_LINK_LIBRARIES(${LIB_NAME}_crypto
+                    PUBLIC ssl
+                    PUBLIC crypto
+                )
+            endif()
+        endif()
+
         TARGET_LINK_LIBRARIES(${LIB_NAME}
             PUBLIC ${LIB_NAME}_platform
             PUBLIC ${LIB_NAME}_crypto

--- a/os_stub/cryptlib_openssl/CMakeLists.txt
+++ b/os_stub/cryptlib_openssl/CMakeLists.txt
@@ -21,6 +21,8 @@ elseif(ARCH STREQUAL "riscv32")
     ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_RISCV32)
 elseif(ARCH STREQUAL "riscv64")
     ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_RISCV64)
+elseif((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
+    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
 else()
     MESSAGE(FATAL_ERROR "Unknown ARCH")
 endif()
@@ -50,10 +52,6 @@ SET(src_cryptlib_openssl
     rand/rand.c
     sys_call/crt_wrapper_host.c
 )
-
-if ((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
-    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
-endif()
 
 ADD_LIBRARY(cryptlib_openssl STATIC ${src_cryptlib_openssl})
 TARGET_COMPILE_OPTIONS(cryptlib_openssl PRIVATE ${OPENSSL_FLAGS})

--- a/os_stub/openssllib/CMakeLists.txt
+++ b/os_stub/openssllib/CMakeLists.txt
@@ -22,6 +22,8 @@ elseif(ARCH STREQUAL "riscv32")
     ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_RISCV32)
 elseif(ARCH STREQUAL "riscv64")
     ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_RISCV64)
+elseif((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
+    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
 else()
     MESSAGE(FATAL_ERROR "Unknown ARCH")
 endif()
@@ -748,9 +750,5 @@ SET(src_openssllib
     rand_pool.c
     ossl_store.c
 )
-
-if ((ARCH STREQUAL "arm") OR (ARCH STREQUAL "aarch64"))
-    ADD_COMPILE_OPTIONS(-DLIBSPDM_CPU_ARM)
-endif()
 
 ADD_LIBRARY(openssllib STATIC ${src_openssllib})


### PR DESCRIPTION
There are couple of problems when I try to build libspdm in a Yocto project with ARM architecture.
This pull request fixes the problems which I've met.
I used following cmake command.
```
EXTRA_OECMAKE = "-DARCH=${TUNE_ARCH} -DTOOLCHAIN=NONE -DTARGET=Release -DCRYPTO=openssl -DBUILD_LINUX_SHARED_LIB=ON"
```

### Fixed problems:
1. openssllib and cryptolib_openssl prints "Unknown ARCH" and stop building, because 'os_stub/openssllib/CMakeLists.txt' and 'os_stub/cryptlib_openssl/CMakeLists.txt' has 2 if statement for 'ARCH' cmake parameter and first one prints "Unknown ARCH" with FATAL_ERROR.

2. Warnings and errors from sub-modules related with compile flags.
For ex, following error needs '-include base.h'.
```
| .../libspdm/os_stub/openssllib/include/openssl/configuration.h:55:9: error: unknown type name 'size_t'
|    55 | typedef size_t UINTN;
|       |         ^~~~~~
```

3. Cannot find -lssl and -lcrypto on linking lib/libspdm_crypto.so
```
.../libspdm/git-r0/recipe-sysroot-native/usr/bin/arm-openbmc-linux-gnueabi/../../libexec/arm-openbmc-linux-gnueabi/gcc/arm-openbmc-linux-gnueabi/11.2.0/ld: cannot find -lssl
.../libspdm/git-r0/recipe-sysroot-native/usr/bin/arm-openbmc-linux-gnueabi/../../libexec/arm-openbmc-linux-gnueabi/gcc/arm-openbmc-linux-gnueabi/11.2.0/ld: cannot find -lcrypto
collect2: error: ld returned 1 exit status
```

4. Redundant RPATH warning by Yocto QA tests
```
libspdm: /usr/lib/libspdm.so contains probably-redundant RPATH /usr/lib [useless-rpaths]
```