### PR TITLE
Mask the multi-key bit in connection_info.

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -733,7 +733,9 @@ libspdm_return_t libspdm_get_response_algorithms(libspdm_context_t *spdm_context
         }
         if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
             spdm_context->connection_info.algorithm.other_params_support =
-                spdm_response->other_params_selection;
+                (spdm_context->connection_info.algorithm.other_params_support &
+                 SPDM_ALGORITHMS_MULTI_KEY_CONN) |
+                (spdm_response->other_params_selection & SPDM_ALGORITHMS_OPAQUE_DATA_FORMAT_MASK);
             if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_13) {
                 spdm_context->connection_info.algorithm.mel_spec =
                     spdm_response->mel_specification_sel;


### PR DESCRIPTION
The reason is the bit in req msg is different from the bit in rsp msg.

Fix https://github.com/DMTF/libspdm/issues/2474

Pass test at https://github.com/DMTF/libspdm/pull/2472