### PR TITLE
rnglib: add support for a nostd target

### DIFF
--- a/os_stub/rnglib/CMakeLists.txt
+++ b/os_stub/rnglib/CMakeLists.txt
@@ -5,7 +5,11 @@ INCLUDE_DIRECTORIES(${LIBSPDM_DIR}/include
                     ${LIBSPDM_DIR}/os_stub/rnglib
 )
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT TOOLCHAIN STREQUAL "ARM_DS2022")
+set (src_rnglib "")
+
+if(TOOLCHAIN STREQUAL "ARM_GNU_BARE_METAL" OR TOOLCHAIN STREQUAL "RISCV_NONE")
+    # The target must provide the required implementation at link time.
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT TOOLCHAIN STREQUAL "ARM_DS2022")
 SET(src_rnglib
     rng_linux.c
 )
@@ -19,4 +23,8 @@ SET(src_rnglib
 )
 endif()
 
-ADD_LIBRARY(rnglib STATIC ${src_rnglib})
+if (NOT src_rnglib STREQUAL "")
+    ADD_LIBRARY(rnglib STATIC ${src_rnglib})
+else ()
+    message(WARNING "An rnglib implementation must be provided at link time")
+endif()

--- a/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
+++ b/os_stub/spdm_crypt_ext_lib/cryptlib_ext.h
@@ -11,6 +11,20 @@
 #include "hal/library/cryptlib.h"
 
 /**
+ * Generates a 64-bit random number.
+ *
+ * An implementation must be provided by the target environment to provide
+ * a cryptographically safe 64-bit random number.
+ *
+ * @param[out] rand_data     buffer pointer to store the 64-bit random value.
+ *
+ * @retval true         Random number generated successfully.
+ * @retval false        Failed to generate the random number.
+ *
+ **/
+extern bool libspdm_get_random_number_64(uint64_t *rand_data);
+
+/**
  * Retrieve the common name (CN) string from one X.509 certificate.
  *
  * @param[in]      cert              Pointer to the DER-encoded X509 certificate.


### PR DESCRIPTION
## Overview

For nostd/baremetal targets, rnglib cannot currently be used. This change allows the integrator to provide a cryptographically safe implementation for `libspdm_get_random_number_64()`. Such that it is abstracted away from libspdm.

It is the integrators responsibility to provide an implementation that is crypto-graphically safe.

