### PR TITLE
os_stub: mbedtlslib: allow skipping time checks

### DIFF
--- a/os_stub/mbedtlslib/include/mbedtls/config.h
+++ b/os_stub/mbedtlslib/include/mbedtls/config.h
@@ -140,7 +140,9 @@
  *
  * Comment if your system does not support time functions
  */
+#ifndef MBEDTLS_SKIP_TIME_CHECK
 #define MBEDTLS_HAVE_TIME
+#endif
 
 /**
  * \def MBEDTLS_HAVE_TIME_DATE
@@ -161,7 +163,9 @@
  * mbedtls_platform_gmtime_r() at compile-time by using the macro
  * MBEDTLS_PLATFORM_GMTIME_R_ALT.
  */
+#ifndef MBEDTLS_SKIP_TIME_CHECK
 #define MBEDTLS_HAVE_TIME_DATE
+#endif
 
 /**
  * \def MBEDTLS_PLATFORM_MEMORY


### PR DESCRIPTION
## Overview

This allows the user to compile libspdm with
`-DCMAKE_C_FLAGS="-DMBEDTLS_SKIP_TIME_CHECK"` for a target that does not support the `time()`/`gmtime()` functions from `time.h`.

Useful for developing/testing on embedded targets without having to create changes locally to comment these macros out.