### PR TITLE
Initialize variable to quiet compiler finding

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -818,7 +818,7 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
                                   void *data, size_t *data_size)
 {
     libspdm_context_t *context;
-    libspdm_secured_message_context_t *secured_context;
+    libspdm_secured_message_context_t *secured_context = NULL;
     size_t target_data_size;
     void *target_data;
     uint32_t session_id;


### PR DESCRIPTION
The compiler believes that the variable secured_context might be used in the switch-case LIBSPDM_DATA_SESSION_SEQUENCE_NUMBER_REQ_DIR without being initialized.  This though does not happen because in that case need_session_info_for_data() will return true and secured_context will be set.