### PR TITLE
CMakeLists: add disabling flto option for NONE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,25 +618,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         SET(CMAKE_EXE_LINKER_FLAGS "")
 
         SET(CMAKE_C_LINK_EXECUTABLE "")
-
-    elseif(TOOLCHAIN STREQUAL "NONE")
-        ADD_COMPILE_OPTIONS(-fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -ffunction-sections -fdata-sections -fno-common -Wno-address -fpie -fno-asynchronous-unwind-tables -flto -DUSING_LTO  -Wno-maybe-uninitialized -Wno-uninitialized  -Wno-builtin-declaration-mismatch -Wno-nonnull-compare -Werror-implicit-function-declaration)
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-            ADD_COMPILE_OPTIONS(-g)
-        endif()
-        if(GCOV STREQUAL "ON")
-        ADD_COMPILE_OPTIONS(--coverage -fprofile-arcs -ftest-coverage)
-        endif()
-        SET(OPENSSL_FLAGS -include base.h -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -Wno-cast-qual -Wno-error=implicit-function-declaration)
-        SET(CMOCKA_FLAGS -std=gnu99 -Wpedantic -Wall -Wshadow -Wmissing-prototypes -Wcast-align -Werror=address -Wstrict-prototypes -Werror=strict-prototypes -Wwrite-strings -Werror=write-strings -Werror-implicit-function-declaration -Wpointer-arith -Werror=pointer-arith -Wdeclaration-after-statement -Werror=declaration-after-statement -Wreturn-type -Werror=return-type -Wuninitialized -Werror=uninitialized -Werror=strict-overflow -Wstrict-overflow=2 -Wno-format-zero-length -Wmissing-field-initializers -Wformat-security -Werror=format-security -fno-common -Wformat -fno-common -fstack-protector-strong -Wno-cast-qual)
-
-        SET(CMAKE_LINKER ${CMAKE_C_COMPILER})
-        SET(CMAKE_EXE_LINKER_FLAGS "-flto -Wno-error -no-pie" )
-        if(GCOV STREQUAL "ON")
-        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  --coverage -lgcov -fprofile-arcs -ftest-coverage")
-        endif()
-        SET(CMAKE_C_LINK_EXECUTABLE "<CMAKE_LINKER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> -Wl,--start-group <LINK_LIBRARIES> -Wl,--end-group")
-
     endif()
 
     if(NOT TOOLCHAIN STREQUAL "NIOS2_GCC")


### PR DESCRIPTION
~Similar to [8071c13](https://github.com/DMTF/libspdm/commit/8071c139a89a0b90cb256e787a603c34f028380d), this adds an option to disable flto for the `NONE` toolchain. This is useful when linking against other libraries with foreign FFIs (rust etc...). @alistair23~ 

"The [point](https://github.com/DMTF/libspdm/blob/main/doc/build.md#linux-builds-inside-build-environments) of the "NONE" option though was to provide none of these compiler options and the build project should provide them instead. It seems like https://github.com/DMTF/libspdm/pull/2464 introduced a bug in setting these." As mentioned by Alistair below.

 However, the changes introduced
in https://github.com/DMTF/libspdm/commit/811f2b596def04b3a36368cf2098546d7907767f set certain compiler/linker
option that does not comply with the definition of the options as
specified in [1]. This change removes those options.

[1] https://github.com/DMTF/libspdm/blob/main/doc/build.md#linux-builds-inside-build-environments