### PR TITLE
fix default build options for generate_iv()

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -74,9 +74,9 @@
 #define LIBSPDM_MAX_AEAD_IV_SIZE 12
 #define LIBSPDM_MAX_AEAD_TAG_SIZE 16
 #else
-/* set 1 to pass build only */
+/* set 1 or 8 to pass build only */
 #define LIBSPDM_MAX_AEAD_KEY_SIZE 1
-#define LIBSPDM_MAX_AEAD_IV_SIZE 1
+#define LIBSPDM_MAX_AEAD_IV_SIZE 8
 #define LIBSPDM_MAX_AEAD_TAG_SIZE 1
 #endif /* LIBSPDM_MAX_AEAD_KEY_SIZE */
 


### PR DESCRIPTION
generate_iv() iterates over sizeof(uint64_t), accessing an array with LIBSPDM_MAX_AEAD_IV_SIZE number of elements.  With the default build options when no AEAD algorithms are compiled in, this array consists of a single entry.  Gcc 12.2.0 complains about this and aborts the compilation.  Bump the default define to 8 to allow build to succeed.