### PR TITLE
Update cmocka version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ For other architectures, refer to [build](https://github.com/DMTF/libspdm/blob/m
 
 ### Unit Test framework
 
-1) [cmocka](https://cmocka.org/). Version 1.1.5.
+1) [cmocka](https://cmocka.org/). Version 1.1.7.
 
 ## Build
 


### PR DESCRIPTION
#2570 updated cmocka to version 1.1.7. This also updates the documentation to 1.1.7.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>