### PR TITLE
pass spdm context as cookie to libspdm_*_data_sign()

### DIFF
--- a/include/hal/library/requester/reqasymsignlib.h
+++ b/include/hal/library/requester/reqasymsignlib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023 DMTF. All rights reserved.
+ *  Copyright 2023-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -31,6 +31,7 @@
  * @retval false signing fail.
  **/
 extern bool libspdm_requester_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version,
     uint8_t op_code,
     uint16_t req_base_asym_alg,

--- a/include/hal/library/responder/asymsignlib.h
+++ b/include/hal/library/responder/asymsignlib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2023 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -59,6 +59,7 @@ extern bool libspdm_challenge_opaque_data(
  * @retval false Signing fail.
  **/
 extern bool libspdm_responder_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version,
     uint8_t op_code, uint32_t base_asym_algo,
     uint32_t base_hash_algo, bool is_data_hash,

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -785,12 +785,14 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.algorithm.req_base_asym_alg);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         result = libspdm_requester_data_sign(
+            spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
             false, m1m2_buffer, m1m2_buffer_size, signature, &signature_size);
 #else
         result = libspdm_requester_data_sign(
+            spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.req_base_asym_alg,
             spdm_context->connection_info.algorithm.base_hash_algo,
@@ -804,6 +806,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             spdm_context->connection_info.algorithm.base_asym_algo);
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
         result = libspdm_responder_data_sign(
+            spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,
@@ -811,6 +814,7 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
             &signature_size);
 #else
         result = libspdm_responder_data_sign(
+            spdm_context,
             spdm_context->connection_info.version, SPDM_CHALLENGE_AUTH,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.base_hash_algo,

--- a/library/spdm_requester_lib/libspdm_req_finish.c
+++ b/library/spdm_requester_lib/libspdm_req_finish.c
@@ -300,12 +300,14 @@ bool libspdm_generate_finish_req_signature(libspdm_context_t *spdm_context,
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     result = libspdm_requester_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_requester_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_FINISH,
         spdm_context->connection_info.algorithm.req_base_asym_alg,
         spdm_context->connection_info.algorithm.base_hash_algo,

--- a/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_exchange.c
@@ -149,12 +149,14 @@ bool libspdm_generate_key_exchange_rsp_signature(libspdm_context_t *spdm_context
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
     result = libspdm_responder_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
         false, th_curr_data, th_curr_data_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_KEY_EXCHANGE_RSP,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -40,12 +40,14 @@ bool libspdm_generate_measurement_signature(libspdm_context_t *spdm_context,
     l1l2_buffer_size = libspdm_get_managed_buffer_size(&l1l2);
 
     result = libspdm_responder_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,
         false, l1l2_buffer, l1l2_buffer_size, signature, &signature_size);
 #else
     result = libspdm_responder_data_sign(
+        spdm_context,
         spdm_context->connection_info.version, SPDM_MEASUREMENTS,
         spdm_context->connection_info.algorithm.base_asym_algo,
         spdm_context->connection_info.algorithm.base_hash_algo,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -81,6 +81,7 @@ bool libspdm_generate_measurement_summary_hash(
 
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 bool libspdm_requester_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint16_t req_base_asym_alg,
     uint32_t base_hash_algo, bool is_data_hash,
@@ -92,6 +93,7 @@ bool libspdm_requester_data_sign(
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */
 
 bool libspdm_responder_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo,
     uint32_t base_hash_algo, bool is_data_hash,

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -1600,6 +1600,7 @@ bool libspdm_generate_measurement_summary_hash(
 
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
 bool libspdm_requester_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint16_t req_base_asym_alg,
     uint32_t base_hash_algo, bool is_data_hash,
@@ -1679,6 +1680,7 @@ bool libspdm_requester_data_sign(
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */
 
 bool libspdm_responder_data_sign(
+    void *spdm_context,
     spdm_version_number_t spdm_version, uint8_t op_code,
     uint32_t base_asym_algo,
     uint32_t base_hash_algo, bool is_data_hash,

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_challenge/challenge.c
@@ -101,11 +101,12 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         (((spdm_response->header.spdm_version >> 4) & 0xF) >= 10)) {
         spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
     }
-    libspdm_responder_data_sign(spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+    libspdm_responder_data_sign(spdm_context,
+                                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                                 SPDM_CHALLENGE_AUTH, m_libspdm_use_asym_algo,
                                 m_libspdm_use_hash_algo, false,
-                                m_libspdm_local_buffer, m_libspdm_local_buffer_size, ptr,
-                                &sig_size);
+                                m_libspdm_local_buffer,
+                                m_libspdm_local_buffer_size, ptr, &sig_size);
     ptr += sig_size;
 
     libspdm_transport_test_encode_message(spdm_context, NULL, false, false, spdm_response_size,

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_exchange/key_exchange.c
@@ -200,11 +200,14 @@ libspdm_return_t libspdm_device_receive_message(void *spdm_context, size_t *resp
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false,
-                libspdm_get_managed_buffer(&th_curr), libspdm_get_managed_buffer_size(
-                &th_curr), ptr, &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -465,11 +465,13 @@ void libspdm_test_responder_finish_case8(void **State)
     }
 
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        spdm_test_finish_request->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo, false,
-            libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr), ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                spdm_test_finish_request->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -223,12 +223,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -300,12 +302,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                          m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -448,14 +452,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                              m_libspdm_local_buffer_size, hash_data);
             sig_size =
                 libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_CHALLENGE_AUTH,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer,
-                    m_libspdm_local_buffer_size, ptr,
-                    &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_CHALLENGE_AUTH,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(
@@ -610,14 +614,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                              m_libspdm_local_buffer_size, hash_data);
             sig_size =
                 libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_CHALLENGE_AUTH,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer,
-                    m_libspdm_local_buffer_size, ptr,
-                    &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_CHALLENGE_AUTH,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(
@@ -687,11 +691,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -779,11 +786,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -851,11 +861,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -923,11 +936,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -995,11 +1011,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1070,11 +1089,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1144,11 +1166,13 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, hash_data, libspdm_get_hash_size (
                               m_libspdm_use_hash_algo), hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, hash_data, libspdm_get_hash_size (
-                m_libspdm_use_hash_algo), Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false, hash_data,
+                                    libspdm_get_hash_size(m_libspdm_use_hash_algo),
+                                    Ptr, &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1217,11 +1241,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1323,11 +1350,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
                                                spdm_response, response_size, response);
@@ -1394,12 +1424,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(hash_data, libspdm_get_hash_size(m_libspdm_use_hash_algo));
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(spdm_response->header.spdm_version <<
-                                    SPDM_VERSION_NUMBER_SHIFT_BIT,
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
                                     SPDM_CHALLENGE_AUTH,
-                                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                                    false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                                    ptr, &sig_size);
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1485,12 +1517,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1566,12 +1600,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1646,11 +1682,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
         libspdm_hash_all (m_libspdm_use_hash_algo, m_libspdm_local_buffer,
                           m_libspdm_local_buffer_size, hash_data);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1768,11 +1807,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                          (size_t)Ptr - (size_t)spdm_response);
         m_libspdm_local_buffer_size += ((size_t)Ptr - (size_t)spdm_response);
         sig_size = libspdm_get_asym_signature_size (m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo, false, m_libspdm_local_buffer,
-                m_libspdm_local_buffer_size, Ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, Ptr,
+                                    &sig_size);
         Ptr += sig_size;
 
         libspdm_transport_test_encode_message (spdm_context, NULL, false, false, spdm_response_size,
@@ -1849,12 +1891,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1934,12 +1978,14 @@ libspdm_return_t libspdm_requester_challenge_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_CHALLENGE_AUTH,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_CHALLENGE_AUTH,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -211,12 +211,12 @@ void libspdm_requester_chunk_get_test_case3_build_challenge_response(
                    libspdm_get_hash_size(m_libspdm_use_hash_algo)));
     libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
     sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-    libspdm_responder_data_sign(
-        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-            false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-            ptr, &sig_size);
+    libspdm_responder_data_sign(spdm_context,
+                                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_CHALLENGE_AUTH, m_libspdm_use_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                m_libspdm_local_buffer,
+                                m_libspdm_local_buffer_size, ptr, &sig_size);
     ptr += sig_size;
 }
 

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -505,12 +505,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -595,12 +597,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -754,14 +758,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
             sig_size =
                 libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_MEASUREMENTS,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer,
-                    m_libspdm_local_buffer_size, ptr,
-                    &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_MEASUREMENTS,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(
@@ -1196,12 +1200,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1761,12 +1767,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1860,12 +1868,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1959,12 +1969,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2056,12 +2068,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2444,12 +2458,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         /* For secure message, message is in sender buffer, we need copy it to scratch buffer.
@@ -2605,12 +2621,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -476,13 +476,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -642,13 +643,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -880,13 +882,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                              libspdm_get_managed_buffer_size(&th_curr),
                              hash_data);
             free(data);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                    false, libspdm_get_managed_buffer(&th_curr),
-                    libspdm_get_managed_buffer_size(&th_curr), ptr,
-                    &signature_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_KEY_EXCHANGE_RSP,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        libspdm_get_managed_buffer(&th_curr),
+                                        libspdm_get_managed_buffer_size(&th_curr),
+                                        ptr, &signature_size);
             libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                              sizeof(m_libspdm_local_buffer)
                              - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1136,13 +1139,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                              libspdm_get_managed_buffer_size(&th_curr),
                              hash_data);
             free(data);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                    false, libspdm_get_managed_buffer(&th_curr),
-                    libspdm_get_managed_buffer_size(&th_curr), ptr,
-                    &signature_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_KEY_EXCHANGE_RSP,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        libspdm_get_managed_buffer(&th_curr),
+                                        libspdm_get_managed_buffer_size(&th_curr),
+                                        ptr, &signature_size);
             libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                              sizeof(m_libspdm_local_buffer)
                              - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1343,13 +1347,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1518,13 +1523,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1689,13 +1695,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1863,13 +1870,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2030,13 +2038,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2197,13 +2206,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2373,13 +2383,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2541,13 +2552,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2714,13 +2726,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2870,13 +2883,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3037,13 +3051,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3205,13 +3220,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3373,13 +3389,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3541,13 +3558,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3710,13 +3728,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3879,13 +3898,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4048,13 +4068,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4201,11 +4222,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
                          ptr, signature_size);
@@ -4366,13 +4390,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4534,13 +4559,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -1869,12 +1869,14 @@ libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
                            libspdm_get_hash_size(m_libspdm_use_hash_algo)));
             libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
             sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_CHALLENGE_AUTH,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                    ptr, &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_CHALLENGE_AUTH,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(spdm_context, NULL, false,

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -554,12 +554,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -640,12 +642,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -799,14 +803,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
             sig_size =
                 libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_MEASUREMENTS,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer,
-                    m_libspdm_local_buffer_size, ptr,
-                    &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_MEASUREMENTS,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(
@@ -973,14 +977,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
             libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
             sig_size =
                 libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_MEASUREMENTS,
-                    m_libspdm_use_asym_algo,
-                    m_libspdm_use_hash_algo,
-                    false, m_libspdm_local_buffer,
-                    m_libspdm_local_buffer_size, ptr,
-                    &sig_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_MEASUREMENTS,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        m_libspdm_local_buffer,
+                                        m_libspdm_local_buffer_size, ptr,
+                                        &sig_size);
             ptr += sig_size;
 
             libspdm_transport_test_encode_message(
@@ -1364,12 +1368,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -1454,12 +1460,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2023,12 +2031,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2122,12 +2132,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2221,12 +2233,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2318,12 +2332,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
         LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "HashDataSize (0x%x):\n",
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2706,12 +2722,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         /* For secure message, message is in sender buffer, we need copy it to scratch buffer.
@@ -2864,12 +2882,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -2982,12 +3002,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,
@@ -3119,12 +3141,14 @@ static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
                        libspdm_get_hash_size(m_libspdm_use_hash_algo)));
         libspdm_dump_hex(m_libspdm_local_buffer, m_libspdm_local_buffer_size);
         sig_size = libspdm_get_asym_signature_size(m_libspdm_use_asym_algo);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_MEASUREMENTS,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, m_libspdm_local_buffer, m_libspdm_local_buffer_size,
-                ptr, &sig_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_MEASUREMENTS,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    m_libspdm_local_buffer,
+                                    m_libspdm_local_buffer_size, ptr,
+                                    &sig_size);
         ptr += sig_size;
 
         libspdm_transport_test_encode_message(spdm_context, NULL, false,

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -494,13 +494,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -660,13 +661,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -898,13 +900,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                              libspdm_get_managed_buffer_size(&th_curr),
                              hash_data);
             free(data);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                    false, libspdm_get_managed_buffer(&th_curr),
-                    libspdm_get_managed_buffer_size(&th_curr), ptr,
-                    &signature_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_KEY_EXCHANGE_RSP,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        libspdm_get_managed_buffer(&th_curr),
+                                        libspdm_get_managed_buffer_size(&th_curr),
+                                        ptr, &signature_size);
             libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                              sizeof(m_libspdm_local_buffer)
                              - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1154,13 +1157,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
                              libspdm_get_managed_buffer_size(&th_curr),
                              hash_data);
             free(data);
-            libspdm_responder_data_sign(
-                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                    SPDM_KEY_EXCHANGE_RSP,
-                    m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                    false, libspdm_get_managed_buffer(&th_curr),
-                    libspdm_get_managed_buffer_size(&th_curr), ptr,
-                    &signature_size);
+            libspdm_responder_data_sign(spdm_context,
+                                        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                        SPDM_KEY_EXCHANGE_RSP,
+                                        m_libspdm_use_asym_algo,
+                                        m_libspdm_use_hash_algo, false,
+                                        libspdm_get_managed_buffer(&th_curr),
+                                        libspdm_get_managed_buffer_size(&th_curr),
+                                        ptr, &signature_size);
             libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                              sizeof(m_libspdm_local_buffer)
                              - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1361,13 +1365,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1536,13 +1541,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1711,13 +1717,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -1887,13 +1894,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2054,13 +2062,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2221,13 +2230,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2397,13 +2407,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2565,13 +2576,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2724,13 +2736,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -2860,13 +2873,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3027,13 +3041,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3194,13 +3209,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3362,13 +3378,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3520,13 +3537,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3679,13 +3697,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -3848,13 +3867,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4017,13 +4037,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4186,13 +4207,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4339,11 +4361,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP, m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr, &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer) - m_libspdm_local_buffer_size,
                          ptr, signature_size);
@@ -4504,13 +4529,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4662,13 +4688,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4828,13 +4855,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -
@@ -4995,13 +5023,14 @@ static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
         libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                          libspdm_get_managed_buffer_size(&th_curr), hash_data);
         free(data);
-        libspdm_responder_data_sign(
-            spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-                SPDM_KEY_EXCHANGE_RSP,
-                m_libspdm_use_asym_algo, m_libspdm_use_hash_algo,
-                false, libspdm_get_managed_buffer(&th_curr),
-                libspdm_get_managed_buffer_size(&th_curr), ptr,
-                &signature_size);
+        libspdm_responder_data_sign(spdm_context,
+                                    spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                    SPDM_KEY_EXCHANGE_RSP,
+                                    m_libspdm_use_asym_algo,
+                                    m_libspdm_use_hash_algo, false,
+                                    libspdm_get_managed_buffer(&th_curr),
+                                    libspdm_get_managed_buffer_size(&th_curr),
+                                    ptr, &signature_size);
         libspdm_copy_mem(&m_libspdm_local_buffer[m_libspdm_local_buffer_size],
                          sizeof(m_libspdm_local_buffer)
                          - (&m_libspdm_local_buffer[m_libspdm_local_buffer_size] -

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -80,12 +80,13 @@ void libspdm_test_responder_encap_challenge_case1(void **state)
     *(uint16_t *)ptr = 0;
     ptr += sizeof(uint16_t);
 
-    libspdm_requester_data_sign(
-        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, (uint8_t*)spdm_response, response_size - sig_size,
-            ptr, &sig_size);
+    libspdm_requester_data_sign(spdm_context,
+                                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_CHALLENGE_AUTH,
+                                m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                (uint8_t *)spdm_response,
+                                response_size - sig_size, ptr, &sig_size);
 
     status =  libspdm_process_encap_response_challenge_auth(spdm_context, response_size,
                                                             spdm_response,
@@ -355,12 +356,13 @@ void libspdm_test_responder_encap_challenge_case5(void **state)
     *(uint16_t *)ptr = 0;
     ptr += sizeof(uint16_t);
 
-    libspdm_requester_data_sign(
-        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, (uint8_t*)spdm_response, response_size - sig_size,
-            ptr, &sig_size);
+    libspdm_requester_data_sign(spdm_context,
+                                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_CHALLENGE_AUTH,
+                                m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                (uint8_t *)spdm_response,
+                                response_size - sig_size, ptr, &sig_size);
 
     status = libspdm_process_encap_response_challenge_auth(spdm_context, response_size,
                                                            spdm_response,
@@ -448,12 +450,13 @@ void libspdm_test_responder_encap_challenge_case6(void **state)
     libspdm_set_mem(ptr, SPDM_REQ_CONTEXT_SIZE, 0xAA);
     ptr += SPDM_REQ_CONTEXT_SIZE;
 
-    libspdm_requester_data_sign(
-        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_CHALLENGE_AUTH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, (uint8_t*)spdm_response, response_size - sig_size,
-            ptr, &sig_size);
+    libspdm_requester_data_sign(spdm_context,
+                                spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_CHALLENGE_AUTH,
+                                m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                (uint8_t *)spdm_response,
+                                response_size - sig_size, ptr, &sig_size);
 
     status =  libspdm_process_encap_response_challenge_auth(spdm_context, response_size,
                                                             spdm_response,

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -928,12 +928,13 @@ void libspdm_test_responder_finish_case8(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request3,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -1631,12 +1632,13 @@ void libspdm_test_responder_finish_case15(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request3,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -1788,10 +1790,11 @@ void libspdm_test_responder_finish_case16(void **state)
     libspdm_hash_all(m_libspdm_use_hash_algo, libspdm_get_managed_buffer(&th_curr),
                      libspdm_get_managed_buffer_size(&th_curr), random_buffer);
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, random_buffer, hash_size, ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request3.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false, random_buffer,
+                                hash_size, ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2037,13 +2040,13 @@ void libspdm_test_responder_finish_case18(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request4,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request4.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request4.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2202,12 +2205,13 @@ void libspdm_test_responder_finish_case19(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request5,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request5.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request5.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2369,12 +2373,13 @@ void libspdm_test_responder_finish_case20(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2649,12 +2654,13 @@ void libspdm_test_responder_finish_case22(void **state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t *)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2813,12 +2819,13 @@ void libspdm_test_responder_finish_case23(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -2977,12 +2984,13 @@ void libspdm_test_responder_finish_case24(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -3141,12 +3149,13 @@ void libspdm_test_responder_finish_case25(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 #endif
     libspdm_append_managed_buffer(&th_curr, ptr, req_asym_signature_size);
     ptr += req_asym_signature_size;
@@ -3303,12 +3312,13 @@ void libspdm_test_responder_finish_case26(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 
     /* Switch signature to little endian */
     libspdm_copy_signature_swap_endian(
@@ -3471,12 +3481,13 @@ void libspdm_test_responder_finish_case27(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 
     /* Switch signature to little endian */
     libspdm_copy_signature_swap_endian(
@@ -3639,12 +3650,13 @@ void libspdm_test_responder_finish_case28(void** state)
     libspdm_append_managed_buffer(&th_curr, (uint8_t*)&m_libspdm_finish_request7,
                                   sizeof(spdm_finish_request_t));
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-    libspdm_requester_data_sign(
-        m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT, SPDM_FINISH,
-            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
-            false, libspdm_get_managed_buffer(&th_curr),
-            libspdm_get_managed_buffer_size(&th_curr),
-            ptr, &req_asym_signature_size);
+    libspdm_requester_data_sign(spdm_context,
+                                m_libspdm_finish_request7.header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+                                SPDM_FINISH, m_libspdm_use_req_asym_algo,
+                                m_libspdm_use_hash_algo, false,
+                                libspdm_get_managed_buffer(&th_curr),
+                                libspdm_get_managed_buffer_size(&th_curr),
+                                ptr, &req_asym_signature_size);
 
     /* Switch signature to little endian */
     libspdm_copy_signature_swap_endian(


### PR DESCRIPTION
Hi there,

is there a reason that these two are not being passed the spdm context?

Right now there's no state connected to the signing backend. This means it needs to be hardcoded which credentials are being used. Passing the context allows the backend code to retrieve the app-specific context to access local credentials.

The initial diff passes the context as void *, as the header for the prototypes are included in the common lib before libspdm_context_t is defined. There's probably a way to work around this though.

There might be more crypto wrappers where this might be useful, trying to start the discussion using this PR.

Opinions?

Cheers,
Patrick