### PR TITLE
Fix "bad" comparison in libspdm_consttime_is_mem_equal

### DIFF
--- a/include/hal/library/memlib.h
+++ b/include/hal/library/memlib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -60,7 +60,7 @@ void libspdm_zero_mem(void *buffer, size_t length);
  * @param  source_buffer       A pointer to the source buffer to compare.
  * @param  length              The number of bytes to compare.
  *
- * @return true   The contents of the two buffers are the same.
+ * @retval true   The contents of the two buffers are the same.
  * @retval false  The contents of the two buffers are not the same.
  **/
 bool libspdm_consttime_is_mem_equal(const void *destination_buffer,

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -487,7 +487,7 @@ libspdm_return_t libspdm_decode_secured_message(
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;
         }
         if (!libspdm_consttime_is_mem_equal(record_header1 + 1, &sequence_num_in_header,
-                                            sequence_num_in_header_size) != 0) {
+                                            sequence_num_in_header_size)) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_FIELD;


### PR DESCRIPTION
Fix #2601.

This also fixes a bug in the doxygen comments

Signed-off-by: Steven Bellock <sbellock@nvidia.com>.