### PR TITLE
Add new fuzzing test cases for SPDM 1.3.0

### DIFF
--- a/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_get_capabilities/get_capabilities.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -9,6 +9,13 @@
 #include "toolchain_harness.h"
 
 uint8_t temp_buf[LIBSPDM_RECEIVER_BUFFER_SIZE];
+
+spdm_version_number_t m_version[] = {
+    SPDM_MESSAGE_VERSION_10,
+    SPDM_MESSAGE_VERSION_11,
+    SPDM_MESSAGE_VERSION_12,
+    SPDM_MESSAGE_VERSION_13,
+};
 
 size_t libspdm_get_max_buffer_size(void)
 {
@@ -55,15 +62,19 @@ void libspdm_test_requester_get_capabilities(void **State)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
+    uint8_t index;
 
     spdm_test_context = *State;
     spdm_context = spdm_test_context->spdm_context;
 
-    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
-                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
-    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+    for (index = 0; index < sizeof(m_version)/sizeof(spdm_version_number_t); index++) {
+        spdm_context->connection_info.version = m_version[index] <<
+                                                SPDM_VERSION_NUMBER_SHIFT_BIT;
+        spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_VERSION;
+        libspdm_reset_message_a(spdm_context);
 
-    libspdm_get_capabilities(spdm_context);
+        libspdm_get_capabilities(spdm_context);
+    }
 }
 
 libspdm_test_context_t m_libspdm_test_requester_context = {

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_negotiate_algorithms/negotiate_algorithms.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -61,6 +61,8 @@ void libspdm_test_requester_negotiate_algorithms_case1(void **State)
         m_libspdm_use_measurement_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
     spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+    spdm_context->local_context.algorithm.measurement_spec = SPDM_MEASUREMENT_SPECIFICATION_DMTF;
     libspdm_reset_message_a(spdm_context);
 
     libspdm_negotiate_algorithms(spdm_context);
@@ -79,6 +81,8 @@ void libspdm_test_requester_negotiate_algorithms_case2(void **State)
         m_libspdm_use_measurement_hash_algo;
     spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
     spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP;
+    spdm_context->local_context.algorithm.measurement_spec = SPDM_MEASUREMENT_SPECIFICATION_DMTF;
     libspdm_reset_message_a(spdm_context);
 
     libspdm_negotiate_algorithms(spdm_context);
@@ -161,6 +165,98 @@ void libspdm_test_requester_negotiate_algorithms_case4(void **State)
     libspdm_negotiate_algorithms(spdm_context);
 }
 
+void libspdm_test_requester_negotiate_algorithms_case5(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_test_context = *State;
+    uint32_t connection_capability_flags;
+
+    spdm_context = spdm_test_context->spdm_context;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+    spdm_context->local_context.algorithm.other_params_support = 0;
+
+    spdm_context->local_context.capability.flags = SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
+                                                   SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP|
+                                                   SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP|
+                                                   SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP|
+                                                   SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    connection_capability_flags =
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+
+    spdm_context->connection_info.capability.flags = connection_capability_flags;
+
+    /* Sub Case 0: Initially*/
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 1: MEL_CAP set 1,mel_specification set SPDM_MEL_SPECIFICATION_DMTF*/
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEL_CAP;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.algorithm.mel_spec = SPDM_MEL_SPECIFICATION_DMTF;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 2: MEL_CAP set 1, mel_specification set 0*/
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEL_CAP;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.mel_spec = 0;
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 3:MEL_CAP set 0, mel_specification set SPDM_MEL_SPECIFICATION_DMTF*/
+    spdm_context->connection_info.capability.flags = connection_capability_flags;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->local_context.algorithm.mel_spec = SPDM_MEL_SPECIFICATION_DMTF;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 4: MEL_CAP set 0, mel_specification set 0*/
+    spdm_context->connection_info.capability.flags = connection_capability_flags;
+    libspdm_reset_message_a(spdm_context);
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.mel_spec = 0;
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 5: MULTI_KEY_CAP set 01b*/
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP_ONLY;
+    spdm_context->local_context.capability.flags =
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_ONLY;
+    spdm_context->local_context.algorithm.other_params_support = SPDM_ALGORITHMS_MULTI_KEY_CONN;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    libspdm_negotiate_algorithms(spdm_context);
+
+    /* Sub Case 6: MULTI_KEY_CAP set 10b*/
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP_NEG;
+    spdm_context->local_context.capability.flags =
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP_NEG;
+    spdm_context->local_context.algorithm.other_params_support = SPDM_ALGORITHMS_MULTI_KEY_CONN;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    libspdm_negotiate_algorithms(spdm_context);
+}
+
 libspdm_test_context_t m_libspdm_test_requester_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     true,
@@ -191,7 +287,13 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_requester_negotiate_algorithms_case3(&State);
     libspdm_unit_test_group_teardown(&State);
 
+    /* V1.2 response*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_requester_negotiate_algorithms_case4(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /* V1.3 response*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_requester_negotiate_algorithms_case5(&State);
     libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -358,6 +358,94 @@ void libspdm_test_responder_algorithms_case11(void **State)
                                     spdm_test_context->test_buffer, &response_size, response);
 }
 
+void libspdm_test_responder_algorithms_case12(void **State)
+{
+    libspdm_test_context_t    *spdm_test_context;
+    libspdm_context_t  *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.measurement_hash_algo = 0;
+    spdm_context->local_context.algorithm.measurement_spec = 0;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.algorithm.other_params_support = 0;
+    spdm_context->local_context.algorithm.mel_spec = SPDM_MEL_SPECIFICATION_DMTF;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->connection_info.algorithm.other_params_support = SPDM_ALGORITHMS_MULTI_KEY_CONN;
+
+    /* Sub Case 1: MEL_CAP set 1*/
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEL_CAP;
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+    /* Sub Case 2: MEL_CAP set 0*/
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.algorithm.other_params_support = 0;
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_ONLY;
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.algorithm.other_params_support = SPDM_ALGORITHMS_MULTI_KEY_CONN;
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_ONLY;
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.algorithm.other_params_support = 0;
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_NEG;
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.algorithm.other_params_support = SPDM_ALGORITHMS_MULTI_KEY_CONN;
+    spdm_context->connection_info.capability.flags =
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_NEG;
+
+    response_size = sizeof(response);
+    libspdm_get_response_algorithms(spdm_context, spdm_test_context->test_buffer_size,
+                                    spdm_test_context->test_buffer, &response_size, response);
+
+}
+
 libspdm_test_context_t libspdm_test_responder_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     false,
@@ -425,4 +513,8 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_algorithms_case11(&State);
     libspdm_unit_test_group_teardown(&State);
 
+    /* V1.3 requester*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_algorithms_case12(&State);
+    libspdm_unit_test_group_teardown(&State);
 }

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_challenge_auth/challenge_auth.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -267,6 +267,94 @@ void libspdm_test_responder_challenge_case6(void **State)
     free(data);
 }
 
+void libspdm_test_responder_challenge_case7(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size,
+                                                    NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+
+    libspdm_secret_lib_challenge_opaque_data_size = 0;
+    libspdm_reset_message_c(spdm_context);
+
+    response_size = sizeof(response);
+
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
+    free(data);
+}
+
+void libspdm_test_responder_challenge_case8(void **State)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *State;
+    spdm_context = spdm_test_context->spdm_context;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+
+    libspdm_secret_lib_challenge_opaque_data_size = 0;
+    libspdm_reset_message_c(spdm_context);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->transcript.message_m.buffer_size =
+        spdm_context->transcript.message_m.max_buffer_size;
+#endif
+
+    for (uint8_t i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_key_usage_bit_mask[i] =
+            SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE |
+            SPDM_KEY_USAGE_BIT_MASK_MEASUREMENT_USE;
+    }
+
+    response_size = sizeof(response);
+    libspdm_get_response_challenge_auth(spdm_context, spdm_test_context->test_buffer_size,
+                                        spdm_test_context->test_buffer, &response_size, response);
+    free(data);
+}
+
 void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
 {
     void *State;
@@ -306,6 +394,15 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_challenge_case6(&State);
     libspdm_unit_test_group_teardown(&State);
 
+    /* V1.2 requester*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_challenge_case7(&State);
+    libspdm_unit_test_group_teardown(&State);
+
+    /* V1.3 requester*/
+    libspdm_unit_test_group_setup(&State);
+    libspdm_test_responder_challenge_case8(&State);
+    libspdm_unit_test_group_teardown(&State);
 }
 #else
 size_t libspdm_get_max_buffer_size(void)


### PR DESCRIPTION
Code coverage has been improved as follows:
```
libspdm_req_negotiate_algorithms.c          81.8% -> 95.3%       
libspdm_req_get_capabilities.c              75.5% -> 94.3%          
libspdm_rsp_algorithms.c                    61.6% -> 74.7%     
libspdm_rsp_challenge_auth.c                81.0% -> 84.1%
```	