### PR TITLE
spdm_crypt_lib: Expose the base_hash_algo

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -81,6 +81,16 @@
 #endif /* LIBSPDM_MAX_AEAD_KEY_SIZE */
 
 /**
+ * This function returns the SPDM base hash algorithm.
+ *
+ * @param  context  A pointer to the SPDM context.
+ *
+ * @return SPDM base hash algorithm
+ *     (spdm_context->connection_info.algorithm.base_hash_algo).
+ **/
+uint32_t libspdm_get_base_hash_algo(void *context);
+
+/**
  * This function returns the SPDM hash algorithm size.
  *
  * @param  base_hash_algo SPDM base_hash_algo

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -877,7 +877,6 @@ bool libspdm_aead_decryption(const spdm_version_number_t secured_message_version
 /**
  * Generates a random byte stream of the specified size.
  *
- * @param  spdm_context  A pointer to the SPDM context.
  * @param  size          Size of random bytes to generate.
  * @param  rand          Pointer to buffer to receive random value.
  **/

--- a/library/spdm_crypt_lib/libspdm_crypt_hash.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_hash.c
@@ -1,10 +1,18 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
+#include "internal/libspdm_common_lib.h"
 #include "internal/libspdm_crypt_lib.h"
+
+uint32_t libspdm_get_base_hash_algo(void *context)
+{
+    libspdm_context_t *spdm_context = context;
+
+    return spdm_context->connection_info.algorithm.base_hash_algo;
+}
 
 uint32_t libspdm_get_hash_size(uint32_t base_hash_algo)
 {


### PR DESCRIPTION
The `base_hash_algo` is useful to know if you are using libspdm as a
library.

Reading it from the `libspdm_context_t` struct isn't ideal as the struct
is private and also doesn't work if using Rust for the implementation.

This commit exposes the `base_hash_algo` publicly using a helper
function.

This PR also fixes the documentation in `include/library/spdm_crypt_lib.h`.