### PR TITLE
Ensure that cached.csr always exists at the beginning

### DIFF
--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -102,6 +102,15 @@ bool libspdm_read_requester_gen_csr(void **csr_data, size_t *csr_len)
     return res;
 }
 
+/*ensure that cached.csr exists in test_csr at the beginning*/
+void libspdm_clear_cached_csr()
+{
+    char *new_name = "test_csr/cached.csr";
+    char *file_name = "test_csr/cached.staging";
+
+    rename(file_name, new_name);
+}
+
 libspdm_return_t libspdm_requester_get_csr_test_send_message(
     void *spdm_context, size_t request_size, const void *request,
     uint64_t timeout)
@@ -555,6 +564,9 @@ int libspdm_requester_get_csr_test_main(void)
 
     libspdm_setup_test_context(
         &m_libspdm_requester_get_csr_test_context);
+
+    /*ensure that cached.csr exists in test_csr at the beginning*/
+    libspdm_clear_cached_csr();
 
     return cmocka_run_group_tests(spdm_requester_get_csr_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -169,6 +169,15 @@ bool libspdm_set_csr_after_reset()
     return true;
 }
 
+/*ensure that cached.csr exists in test_csr at the beginning*/
+void libspdm_clear_cached_csr()
+{
+    char *new_name = "test_csr/cached.csr";
+    char *file_name = "test_csr/cached.staging";
+
+    rename(file_name, new_name);
+}
+
 /*clean the cached last SPDM csr request*/
 void libspdm_test_clear_cached_last_request()
 {
@@ -1928,6 +1937,9 @@ int libspdm_responder_csr_test_main(void)
     };
 
     libspdm_setup_test_context(&m_libspdm_responder_csr_test_context);
+
+    /*ensure that cached.csr exists in test_csr at the beginning*/
+    libspdm_clear_cached_csr();
 
     return cmocka_run_group_tests(spdm_responder_csr_tests,
                                   libspdm_unit_test_group_setup,


### PR DESCRIPTION
Fix: #2632 

The successful unit_test will always make cached.csr name unchanged. But a failed unit_test may change cached.csr to cached.staging, which cause the next unit_test still failing even if the issue is fixed.

Add new api to ensure that cached.csr always exists at the beginning.