### PR TITLE
fix responder_chunk_send buffer overflow

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -343,6 +343,10 @@ libspdm_return_t libspdm_handle_error_large_response(
                 break;
             }
             if (large_response_size > spdm_context->local_context.capability.max_spdm_msg_size) {
+                status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+                break;
+            }
+            if (large_response_size <= SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12) {
                 status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
                 break;
             }

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -112,6 +112,7 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
             || spdm_request->chunk_size > calc_max_chunk_size
             || (uint32_t)request_size > spdm_context->local_context.capability.data_transfer_size
             || large_message_size > spdm_context->local_context.capability.max_spdm_msg_size
+            || large_message_size <= SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12
             || (spdm_request->header.param1 & SPDM_CHUNK_SEND_REQUEST_ATTRIBUTE_LAST_CHUNK)
             ) {
             status = LIBSPDM_STATUS_INVALID_MSG_FIELD;

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -92,6 +92,13 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
 
     if (!send_info->chunk_in_use) {
 
+        if (request_size < sizeof(spdm_chunk_send_request_t) + sizeof(uint32_t)) {
+            libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                response_size, response);
+            return LIBSPDM_STATUS_SUCCESS;
+        }
+
         large_message_size = *(const uint32_t*) (spdm_request + 1);
         chunk = (((const uint8_t*) (spdm_request + 1)) + sizeof(uint32_t));
         calc_max_chunk_size =

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -211,12 +211,14 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
         send_info->large_message = NULL;
         send_info->large_message_size = 0;
     } else if (send_info->chunk_bytes_transferred == send_info->large_message_size) {
+        uint8_t opcode;
 
+        opcode = ((spdm_message_header_t*)send_info->large_message)->request_response_code;
         libspdm_get_spdm_response_func response_func =
-            libspdm_get_response_func_via_request_code(
-                ((spdm_message_header_t*)send_info->large_message)->request_response_code);
+            libspdm_get_response_func_via_request_code(opcode);
 
-        if (response_func != NULL) {
+        if ((response_func != NULL) &&
+            (opcode != SPDM_CHUNK_SEND) && (opcode != SPDM_CHUNK_GET)) {
             status = response_func(
                 spdm_context,
                 send_info->large_message_size, send_info->large_message,

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -105,6 +105,10 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
             ((uint32_t)request_size - (uint32_t)(chunk - (const uint8_t*) spdm_request));
 
         if (spdm_request->chunk_seq_no != 0
+            || (spdm_request->chunk_size
+                < SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12
+                - sizeof(spdm_chunk_send_request_t)
+                - sizeof(uint32_t))
             || spdm_request->chunk_size > calc_max_chunk_size
             || (uint32_t)request_size > spdm_context->local_context.capability.data_transfer_size
             || large_message_size > spdm_context->local_context.capability.max_spdm_msg_size
@@ -149,6 +153,9 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
         } else if (!(spdm_request->header.param1 & SPDM_CHUNK_SEND_REQUEST_ATTRIBUTE_LAST_CHUNK)
                    && ((spdm_request->chunk_size + send_info->chunk_bytes_transferred
                         > send_info->large_message_size)
+                       || (spdm_request->chunk_size
+                           < SPDM_MIN_DATA_TRANSFER_SIZE_VERSION_12
+                           - sizeof(spdm_chunk_send_request_t))
                        || ((uint32_t) request_size
                            > spdm_context->local_context.capability.data_transfer_size))) {
             status = LIBSPDM_STATUS_INVALID_MSG_FIELD;

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -102,7 +102,7 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
         large_message_size = *(const uint32_t*) (spdm_request + 1);
         chunk = (((const uint8_t*) (spdm_request + 1)) + sizeof(uint32_t));
         calc_max_chunk_size =
-            ((uint32_t)request_size - (uint32_t)(chunk - (const uint8_t*) spdm_request));
+            (uint32_t)request_size - (sizeof(spdm_chunk_send_request_t) + sizeof(uint32_t));
 
         if (spdm_request->chunk_seq_no != 0
             || (spdm_request->chunk_size
@@ -139,7 +139,7 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
 
         chunk = (const uint8_t*) (spdm_request + 1);
         calc_max_chunk_size =
-            ((uint32_t)request_size - (uint32_t) (chunk - (const uint8_t *) spdm_request));
+            (uint32_t)request_size - sizeof(spdm_chunk_send_request_t);
 
         if (spdm_request->chunk_seq_no != send_info->chunk_seq_no + 1
             || spdm_request->header.param2 != send_info->chunk_handle


### PR DESCRIPTION
Fix https://github.com/DMTF/libspdm/issues/2631

The patch [7dd4c5f](https://github.com/DMTF/libspdm/pull/2640/commits/7dd4c5fd6ed5c05f7de09358fe12a11a349a1ec8) and [3eef8d6](https://github.com/DMTF/libspdm/pull/2640/commits/3eef8d6cdb3ebfe20a069e112964042bcc541fcf) fixed the buffer overflow issue.

The rest is additional enhancement.