### PR TITLE
Add "extern C" to library headers 

### DIFF
--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -7,6 +7,10 @@
 #ifndef SPDM_COMMON_LIB_H
 #define SPDM_COMMON_LIB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "internal/libspdm_lib_config.h"
 #include "hal/base.h"
 #include "library/spdm_secured_message_lib.h"
@@ -1001,5 +1005,9 @@ typedef libspdm_return_t (*libspdm_vendor_response_callback_func)(
     void *resp_data);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPDM_COMMON_LIB_H */

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -7,6 +7,10 @@
 #ifndef SPDM_CRYPT_LIB_H
 #define SPDM_CRYPT_LIB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "internal/libspdm_lib_config.h"
 
 #include "hal/base.h"
@@ -1119,6 +1123,10 @@ bool libspdm_verify_req_info(uint8_t *req_info, uint16_t req_info_len);
 #if LIBSPDM_FIPS_MODE
 /*run all of the self-tests and returns the results.*/
 bool libspdm_fips_run_selftest(void *fips_selftest_context);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* SPDM_CRYPT_LIB_H */

--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -7,6 +7,10 @@
 #ifndef SPDM_REQUESTER_LIB_H
 #define SPDM_REQUESTER_LIB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "library/spdm_common_lib.h"
 
 /**
@@ -899,5 +903,9 @@ libspdm_return_t libspdm_vendor_send_request_receive_response(
     void *resp_data);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPDM_REQUESTER_LIB_H */

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -1,11 +1,15 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #ifndef SPDM_RESPONDER_LIB_H
 #define SPDM_RESPONDER_LIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "library/spdm_common_lib.h"
 #include "library/spdm_secured_message_lib.h"
@@ -293,5 +297,9 @@ libspdm_return_t libspdm_register_vendor_callback_func(void *spdm_context,
                                                        libspdm_vendor_response_callback_func resp_callback);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPDM_RESPONDER_LIB_H */

--- a/include/library/spdm_return_status.h
+++ b/include/library/spdm_return_status.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -203,4 +203,4 @@ typedef uint32_t libspdm_return_t;
 #define LIBSPDM_STATUS_LOW_ENTROPY \
     LIBSPDM_STATUS_CONSTRUCT(LIBSPDM_SEVERITY_ERROR, LIBSPDM_SOURCE_RNG, 0x0000)
 
-#endif
+#endif /* SPDM_RETURN_STATUS_H */

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -1,11 +1,15 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2023 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #ifndef SPDM_SECURED_MESSAGE_LIB_H
 #define SPDM_SECURED_MESSAGE_LIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "hal/base.h"
 #include "industry_standard/spdm.h"
@@ -294,5 +298,9 @@ libspdm_return_t libspdm_decode_secured_message(
 void libspdm_secured_message_get_last_spdm_error_struct(
     void *spdm_secured_message_context,
     libspdm_error_struct_t *last_spdm_error);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPDM_SECURED_MESSAGE_LIB_H */

--- a/include/library/spdm_transport_mctp_lib.h
+++ b/include/library/spdm_transport_mctp_lib.h
@@ -1,11 +1,15 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #ifndef SPDM_MCTP_TRANSPORT_LIB_H
 #define SPDM_MCTP_TRANSPORT_LIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "library/spdm_common_lib.h"
 #include "library/spdm_crypt_lib.h"
@@ -137,5 +141,9 @@ uint32_t libspdm_mctp_get_max_random_number_count(void);
  */
 spdm_version_number_t libspdm_mctp_get_secured_spdm_version(
     spdm_version_number_t secured_message_version);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPDM_MCTP_TRANSPORT_LIB_H */

--- a/include/library/spdm_transport_pcidoe_lib.h
+++ b/include/library/spdm_transport_pcidoe_lib.h
@@ -1,11 +1,15 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #ifndef PCI_DOE_TRANSPORT_LIB_H
 #define PCI_DOE_TRANSPORT_LIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "library/spdm_common_lib.h"
 #include "library/spdm_crypt_lib.h"
@@ -197,5 +201,9 @@ uint32_t libspdm_pci_doe_get_max_random_number_count(void);
  */
 spdm_version_number_t libspdm_pci_doe_get_secured_spdm_version(
     spdm_version_number_t secured_message_version);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PCI_DOE_TRANSPORT_LIB_H */


### PR DESCRIPTION
Fix #2704.

In order to support linkage to cpp application, I'm adding "extern C" block to the library headers. 
I've built libspdm successfully into an embedded cpp application with this and some other cmake changes. 