### PR TITLE
library/spdm_responder: Fixup set cert checks

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate.c
@@ -42,7 +42,7 @@ static bool libspdm_set_cert_verify_certchain(const uint8_t *cert_chain, size_t 
     /*verify leaf cert*/
     if (!libspdm_x509_set_cert_certificate_check(leaf_cert_buffer, leaf_cert_buffer_size,
                                                  base_asym_algo, base_hash_algo,
-                                                 false, is_device_cert_model)) {
+                                                 true, is_device_cert_model)) {
         return false;
     }
 


### PR DESCRIPTION
When we run checks against the certificate that the requester set we have the following function calls
 - libspdm_set_cert_verify_certchain()
  - libspdm_x509_set_cert_certificate_check() ...
   - libspdm_verify_leaf_cert_spdm_extension()

At which point libspdm_verify_leaf_cert_spdm_extension() checks to make sure the id-DMTF-hardware-identity OID is not set if it's an AliasCert model.

This ends up being incorrect though. If using an AliasCert the SET_CERTIFICATE CertChain (table 93 - section 770) will "contain a partial certificate chain from the root CA to the Device Certificate CA". This means that the leaf certificate of that chain should set the the id-DMTF-hardware-identity OID as it isn't an alias certificate.

At this point the check in libspdm_verify_leaf_cert_spdm_extension() is incorrect.

The documentation of libspdm_x509_set_cert_certificate_check() states that:
    is_requester_cert     Is the function verifying requester or responder cert.

Although we are a responder, we are verifying a certificate set by the requester, so change the is_requester_cert to true to avoid the incorrect id-DMTF-hardware-identity OID check and match the documentation.