### PR TITLE
Update cmocka submodule to gitlab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
     url = https://github.com/ARMmbed/mbedtls
 [submodule "unit_test/cmockalib/cmocka"]
     path = unit_test/cmockalib/cmocka
-    url = https://git.cryptomilk.org/projects/cmocka.git
+	url = https://gitlab.com/cmocka/cmocka.git


### PR DESCRIPTION
Resolves #2707 

The previous host for the cmocka submodule (https://git.cryptomilk.org/projects/cmocka.git) has been unreliable so this switches to the gitlab mirror at https://gitlab.com/cmocka/cmocka.git.

The submodule itself points to the same commit hash in the mirror.