### PR TITLE
277 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
    [DSP0274](https://www.dmtf.org/dsp/DSP0274)  Security Protocol and Data Model (SPDM) Specification (version [1.0.2](https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.0.2.pdf), version [1.1.3](https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.1.3.pdf), version [1.2.2](https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.2.2.pdf) and version [1.3.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0274_1.3.0.pdf))
 
-   [DSP0277](https://www.dmtf.org/dsp/DSP0277)  Secured Messages using SPDM Specification (version [1.1.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0277_1.1.0.pdf))
+   [DSP0277](https://www.dmtf.org/dsp/DSP0277)  Secured Messages using SPDM Specification (version [1.0.1](https://www.dmtf.org/sites/default/files/standards/documents/DSP0277_1.0.1.pdf), version [1.1.1](https://www.dmtf.org/sites/default/files/standards/documents/DSP0277_1.1.1.pdf), version [1.2.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0277_1.2.0.pdf))
 
    MCTP and secured MCTP follow :
 

--- a/doc/crypto_endianness.md
+++ b/doc/crypto_endianness.md
@@ -25,6 +25,11 @@ libspdm follows that for SPDM 1.1+. Because the definition aligns with existing 
 
 ## Endianness of AEAD IV
 
+Versions 1.2 of the Secured Messages using SPDM specification describes:
+* The sequence number shall be encoded as little endian in memory.
+
+When the negotiated Secured Messages using SPDM version is 1.2 or later libspdm follows this definition.
+
 Versions 1.0 and 1.1 of the Secured Messages using SPDM specification do not explicitly specify how
 the AEAD IV is formed. In particular the endianness of the sequence number is either missing (1.0)
 or ill-defined (1.1). libspdm allows an Integrator to specify the endianness encoding of the

--- a/include/industry_standard/spdm_secured_message.h
+++ b/include/industry_standard/spdm_secured_message.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -51,11 +51,12 @@
  *                AssociatedData           AeadTag
  */
 
-/* 2 means SPDM secured message version 1.0, 1.1 */
-#define SECURED_SPDM_MAX_VERSION_COUNT 2
+/* 3 means SPDM secured message version 1.0, 1.1, 1.2 */
+#define SECURED_SPDM_MAX_VERSION_COUNT 3
 /* the DSP0277 specification version */
 #define SECURED_SPDM_VERSION_10 0x10
 #define SECURED_SPDM_VERSION_11 0x11
+#define SECURED_SPDM_VERSION_12 0x12
 
 typedef struct {
     uint32_t session_id;

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2947,11 +2947,14 @@ libspdm_return_t libspdm_init_context_with_secured_context(void *spdm_context,
                                                      SPDM_VERSION_NUMBER_SHIFT_BIT;
     context->local_context.version.spdm_version[3] = SPDM_MESSAGE_VERSION_13 <<
                                                      SPDM_VERSION_NUMBER_SHIFT_BIT;
-    context->local_context.secured_message_version.spdm_version_count = 2;
+    context->local_context.secured_message_version.spdm_version_count =
+        SECURED_SPDM_MAX_VERSION_COUNT;
     context->local_context.secured_message_version.spdm_version[0] =
-        SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        SECURED_SPDM_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     context->local_context.secured_message_version.spdm_version[1] =
-        SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+        SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    context->local_context.secured_message_version.spdm_version[2] =
+        SECURED_SPDM_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
     context->local_context.capability.st1 = SPDM_ST1_VALUE_US;
 
     context->mut_auth_cert_chain_buffer_size = 0;

--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -120,7 +120,7 @@ libspdm_return_t libspdm_encode_secured_message(
     secured_spdm_version = spdm_secured_message_callbacks->get_secured_spdm_version(
         secured_message_context->secured_message_version);
     version = (uint8_t)(secured_spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT);
-    if (version > SECURED_SPDM_VERSION_11) {
+    if (version > SECURED_SPDM_VERSION_12) {
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
     }
 
@@ -381,7 +381,7 @@ libspdm_return_t libspdm_decode_secured_message(
     secured_spdm_version = spdm_secured_message_callbacks->get_secured_spdm_version(
         secured_message_context->secured_message_version);
     version = (uint8_t)(secured_spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT);
-    if (version > SECURED_SPDM_VERSION_11) {
+    if (version > SECURED_SPDM_VERSION_12) {
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
     }
 


### PR DESCRIPTION
Add DSP0277 1.2 version support definition.

The endianness enforcement will be done at https://github.com/DMTF/libspdm/issues/2735. It is NOT covered in this patch set.