### PR TITLE
Don't require PSK macros if PSK is not enabled

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -816,16 +816,18 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
                                libspdm_session_info_t *session_info,
                                uint32_t session_id, bool use_psk);
 
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 /**
  * Set the psk_hint to a session info.
  *
- * @param  session_info                  A pointer to a session info.
- * @param  psk_hint                      Indicate the PSK hint.
- * @param  psk_hint_size                  The size in bytes of the PSK hint.
+ * @param  session_info   A pointer to a session info.
+ * @param  psk_hint       Indicate the PSK hint.
+ * @param  psk_hint_size  The size in bytes of the PSK hint.
  */
 void libspdm_session_info_set_psk_hint(libspdm_session_info_t *session_info,
                                        const void *psk_hint,
                                        size_t psk_hint_size);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 /**
  * This function returns if a given version is supported based upon the GET_VERSION/VERSION.

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -66,7 +66,9 @@ typedef struct {
     bool requester_backup_valid;
     bool responder_backup_valid;
     size_t psk_hint_size;
+    #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
     uint8_t psk_hint[LIBSPDM_PSK_MAX_HINT_LENGTH];
+    #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
     uint8_t export_master_secret[LIBSPDM_MAX_HASH_SIZE];
     uint8_t sequence_number_endian;
 
@@ -130,16 +132,18 @@ void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
                                             uint16_t aead_cipher_suite,
                                             uint16_t key_schedule);
 
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 /**
  * Set the psk_hint to an SPDM secured message context.
  *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
+ * @param  spdm_secured_message_context  A pointer to the SPDM secured message context.
  * @param  psk_hint                      Indicate the PSK hint.
- * @param  psk_hint_size                  The size in bytes of the PSK hint.
+ * @param  psk_hint_size                 The size in bytes of the PSK hint.
  */
 void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
                                           const void *psk_hint,
                                           size_t psk_hint_size);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 /**
  * Set the maximum sequence_number to an SPDM secured message context.

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -7,6 +7,121 @@
 #ifndef SPDM_LIB_CONFIG_H
 #define SPDM_LIB_CONFIG_H
 
+/* Code space optimization for optional messages.
+ *
+ * An Integrator of libspdm may not need all of the optional SPDM messages. The
+ * LIBSPDM_ENABLE_CAPABILITY_***_CAP compile time switches allow the Integrator to enable or disable
+ * capabilities and messages.
+ */
+
+/* SPDM 1.0 capabilities and messages. */
+#ifndef LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_CERT_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
+#define LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES 1
+#endif
+
+/* SPDM 1.1 capabilities. */
+#ifndef LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_PSK_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP 1
+#endif
+
+/* SPDM 1.2 capabilities. */
+#ifndef LIBSPDM_ENABLE_CAPABILITY_CSR_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_CSR_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP 1
+#endif
+
+/* SPDM 1.3 capabilities. */
+#ifndef LIBSPDM_ENABLE_CAPABILITY_MEL_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_MEL_CAP 1
+#endif
+
+#ifndef LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
+#define LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP 1
+#endif
+
+/* Includes SPDM 1.3 features for CSR messages. If enabled then LIBSPDM_ENABLE_CAPABILITY_CSR_CAP
+ * must also be enabled.
+ */
+#ifndef LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX
+#define LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX 1
+#endif
+
+/* If 1 then endpoint supports sending GET_CERTIFICATE and GET_DIGESTS requests.
+ * If enabled and endpoint is a Responder then LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
+ * must also be enabled.
+ */
+#ifndef LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
+#define LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT 1
+#endif
+
+/* If 1 then endpoint supports sending CHALLENGE request.
+ * If enabled and endpoint is a Responder then LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
+ * must also be enabled.
+ */
+#ifndef LIBSPDM_SEND_CHALLENGE_SUPPORT
+#define LIBSPDM_SEND_CHALLENGE_SUPPORT 1
+#endif
+
+/* If 1 then endpoint supports sending the GET_SUPPORTED_EVENT_TYPES, SUBSCRIBE_EVENT_TYPES, and
+ * encapsulated EVENT_ACK messages. In addition, LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP must also be
+ * 1.
+ */
+#ifndef LIBSPDM_EVENT_RECIPIENT_SUPPORT
+#define LIBSPDM_EVENT_RECIPIENT_SUPPORT 1
+#endif
+
+/* When LIBSPDM_RESPOND_IF_READY_SUPPORT is 0 then
+ *      - For a Requester, if the Responder sends a ResponseNotReady ERROR response then the error
+ *        is immediately returned to the Integrator. The Requester cannot send a RESPOND_IF_READY
+ *        request.
+ *      - For a Responder, it cannot send a RESPOND_IF_READY ERROR response and does not support
+ *        RESPOND_IF_READY.
+ * When LIBSPDM_RESPOND_IF_READY_SUPPORT is 1 then
+ *      - For a Requester, if the Responder sends a ResponseNotReady ERROR response then libspdm
+ *        waits an amount of time, as specified by the RDTExponent parameter, before sending
+ *        RESPOND_IF_READY.
+ *      - For a Responder, if its response state is NOT_READY then it will send a ResponseNotReady
+ *        ERROR response to the Requester, and will accept a subsequent RESPOND_IF_READY request.
+ */
+#ifndef LIBSPDM_RESPOND_IF_READY_SUPPORT
+#define LIBSPDM_RESPOND_IF_READY_SUPPORT 1
+#endif
+
 /* Enables FIPS 140-3 mode. */
 #ifndef LIBSPDM_FIPS_MODE
 #define LIBSPDM_FIPS_MODE 0
@@ -33,6 +148,7 @@
 #define LIBSPDM_MAX_VERSION_COUNT 5
 #endif
 
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 /* This value specifies the maximum size, in bytes, of the `PSK_EXCHANGE.RequesterContext` and,
  * if supported by the Responder, `PSK_EXCHANGE_RSP.ResponderContext` fields. The fields are
  * typically random or monotonically increasing numbers.
@@ -40,10 +156,12 @@
 #ifndef LIBSPDM_PSK_CONTEXT_LENGTH
 #define LIBSPDM_PSK_CONTEXT_LENGTH LIBSPDM_MAX_HASH_SIZE
 #endif
+
 /* This value specifies the maximum size, in bytes, of the `PSK_EXCHANGE.PSKHint` field. */
 #ifndef LIBSPDM_PSK_MAX_HINT_LENGTH
 #define LIBSPDM_PSK_MAX_HINT_LENGTH 16
 #endif
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 /* libspdm allows an Integrator to specify multiple root certificates as trust anchors when
  * verifying certificate chains from an endpoint. This value specifies the maximum number of root
@@ -215,140 +333,7 @@
 #define LIBSPDM_CERT_PARSE_SUPPORT 1
 #endif
 
-/* Code space optimization for Optional request/response messages.*/
 
-/* Consumers of libspdm may wish to not fully implement all of the optional
- * SPDM request/response messages. Therefore we have provided these
- * SPDM_ENABLE_CAPABILITY_***_CAP compile time switches as an optimization
- * disable the code (#if 0) related to said optional capability, thereby
- * reducing the code space used in the image.*/
-
-/* A single switch may enable/disable a single capability or group of related
- * capabilities.*/
-
-/* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP - Enable/Disable single CERT capability.
- * LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP - Enable/Disable single CHAL capability.
- * LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP - Enable/Disables multiple MEAS capabilities:
- *                                  (MEAS_CAP_NO_SIG, MEAS_CAP_SIG, MEAS_FRESH_CAP)*/
-
-/* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP - Enable/Disable single Key Exchange capability.
- * LIBSPDM_ENABLE_CAPABILITY_PSK_CAP - Enable/Disable PSK_EX and PSK_FINISH.*/
-
-/* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP - Enable/Disable mutual authentication.
-* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP    - Enable/Disable encapsulated message.*/
-
-/* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP - Enable/Disable get csr capability.
- * LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP - Enable/Disable set certificate capability. */
-
-/* LIBSPDM_ENABLE_CAPABILITY_MEL_CAP - Enable/Disable MEL capability.*/
-
-/* SPDM 1.0 capabilities and messages. */
-#ifndef LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_CERT_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
-#define LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES 1
-#endif
-
-/* SPDM 1.1 capabilities. */
-#ifndef LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_PSK_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_HBEAT_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP 1
-#endif
-
-/* SPDM 1.2 capabilities. */
-#ifndef LIBSPDM_ENABLE_CAPABILITY_CSR_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_CSR_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP 1
-#endif
-
-/* SPDM 1.3 capabilities. */
-#ifndef LIBSPDM_ENABLE_CAPABILITY_MEL_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_MEL_CAP 1
-#endif
-
-#ifndef LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
-#define LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP 1
-#endif
-
-/* Includes SPDM 1.3 features for CSR messages. If enabled then LIBSPDM_ENABLE_CAPABILITY_CSR_CAP
- * must also be enabled.
- */
-#ifndef LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX
-#define LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX 1
-#endif
-
-/* If 1 then endpoint supports sending GET_CERTIFICATE and GET_DIGESTS requests.
- * If enabled and endpoint is a Responder then LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
- * must also be enabled.
- */
-#ifndef LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
-#define LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT 1
-#endif
-
-/* If 1 then endpoint supports sending CHALLENGE request.
- * If enabled and endpoint is a Responder then LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
- * must also be enabled.
- */
-#ifndef LIBSPDM_SEND_CHALLENGE_SUPPORT
-#define LIBSPDM_SEND_CHALLENGE_SUPPORT 1
-#endif
-
-/* If 1 then endpoint supports sending the GET_SUPPORTED_EVENT_TYPES, SUBSCRIBE_EVENT_TYPES, and
- * encapsulated EVENT_ACK messages. In addition, LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP must also be
- * 1.
- */
-#ifndef LIBSPDM_EVENT_RECIPIENT_SUPPORT
-#define LIBSPDM_EVENT_RECIPIENT_SUPPORT 1
-#endif
-
-/* When LIBSPDM_RESPOND_IF_READY_SUPPORT is 0 then
- *      - For a Requester, if the Responder sends a ResponseNotReady ERROR response then the error
- *        is immediately returned to the Integrator. The Requester cannot send a RESPOND_IF_READY
- *        request.
- *      - For a Responder, it cannot send a RESPOND_IF_READY ERROR response and does not support
- *        RESPOND_IF_READY.
- * When LIBSPDM_RESPOND_IF_READY_SUPPORT is 1 then
- *      - For a Requester, if the Responder sends a ResponseNotReady ERROR response then libspdm
- *        waits an amount of time, as specified by the RDTExponent parameter, before sending
- *        RESPOND_IF_READY.
- *      - For a Responder, if its response state is NOT_READY then it will send a ResponseNotReady
- *        ERROR response to the Requester, and will accept a subsequent RESPOND_IF_READY request.
- */
-#ifndef LIBSPDM_RESPOND_IF_READY_SUPPORT
-#define LIBSPDM_RESPOND_IF_READY_SUPPORT 1
-#endif
 
 /*
  * MinDataTransferSize = 42

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -119,13 +119,7 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
 #endif
 }
 
-/**
- * Set the psk_hint to a session info.
- *
- * @param  session_info                  A pointer to a session info.
- * @param  psk_hint                      Indicate the PSK hint.
- * @param  psk_hint_size                  The size in bytes of the PSK hint.
- */
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 void libspdm_session_info_set_psk_hint(libspdm_session_info_t *session_info,
                                        const void *psk_hint,
                                        size_t psk_hint_size)
@@ -135,6 +129,7 @@ void libspdm_session_info_set_psk_hint(libspdm_session_info_t *session_info,
         psk_hint,
         psk_hint_size);
 }
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 /**
  * This function gets the session info via session ID.

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2024 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -137,13 +137,7 @@ void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
         secured_message_context->aead_cipher_suite);
 }
 
-/**
- * Set the psk_hint to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  psk_hint                      Indicate the PSK hint.
- * @param  psk_hint_size                  The size in bytes of the PSK hint.
- */
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
                                           const void *psk_hint,
                                           size_t psk_hint_size)
@@ -159,6 +153,7 @@ void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
                          psk_hint_size);
     }
 }
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 /**
  * Set the maximum sequence_number to an SPDM secured message context.

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -192,6 +192,7 @@ typedef struct {
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
 } libspdm_finish_request_mine_t;
 
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 typedef struct {
     spdm_message_header_t header;
     uint16_t req_session_id;
@@ -207,6 +208,7 @@ typedef struct {
     spdm_message_header_t header;
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
 } libspdm_psk_finish_request_mine_t;
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 #pragma pack()
 
@@ -230,6 +232,7 @@ libspdm_finish_request_mine_t m_libspdm_finish_request = {
 };
 size_t m_libspdm_finish_request_size = sizeof(m_libspdm_finish_request);
 
+#if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 libspdm_psk_exchange_request_mine_t m_libspdm_psk_exchange_request = {
     {
         SPDM_MESSAGE_VERSION_11,
@@ -249,6 +252,7 @@ libspdm_psk_finish_request_mine_t m_libspdm_psk_finish_request = {
     },
 };
 size_t m_libspdm_psk_finish_request_size = sizeof(m_libspdm_psk_finish_request);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
 spdm_end_session_request_t m_libspdm_end_session_request = {
     {


### PR DESCRIPTION
If `LIBSPDM_ENABLE_CAPABILITY_PSK_EX_CAP` is not enabled then `LIBSPDM_PSK_CONTEXT_LENGTH` and `LIBSPDM_PSK_MAX_HINT_LENGTH` are still required for a successful build. This pull request fixes that as a subtask of #1211.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>