### PR TITLE
Move null implementation of libspdm_event_get_types

### DIFF
--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -222,6 +222,7 @@ bool libspdm_gen_csr_ex(
     return false;
 }
 #endif /*LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX*/
+#endif /* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP */
 
 #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
 bool libspdm_event_get_types(
@@ -234,5 +235,3 @@ bool libspdm_event_get_types(
     return false;
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
-
-#endif /* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP */


### PR DESCRIPTION
Fix #2778.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>