### PR TITLE
Make buffers void instead of uint8_t

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -507,17 +507,15 @@ typedef struct {
 
     /* Cached plain text command
      * If the command is cipher text, decrypt then cache it. */
-    uint8_t *last_spdm_request;
+    void *last_spdm_request;
     size_t last_spdm_request_size;
 
-    /* scratch buffer */
-    uint8_t *scratch_buffer;
+    /* Buffers used for data processing and transport. */
+    void *scratch_buffer;
     size_t scratch_buffer_size;
-    /* sender buffer */
-    uint8_t *sender_buffer;
+    void *sender_buffer;
     size_t sender_buffer_size;
-    /* receiver buffer */
-    uint8_t *receiver_buffer;
+    void *receiver_buffer;
     size_t receiver_buffer_size;
 
     /* Cache session_id in this spdm_message, only valid for secured message. */
@@ -568,7 +566,7 @@ typedef struct {
     /* Cached data for SPDM_ERROR_CODE_RESPONSE_NOT_READY/SPDM_RESPOND_IF_READY */
     spdm_error_data_response_not_ready_t error_data;
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
-    uint8_t *cache_spdm_request;
+    void *cache_spdm_request;
     size_t cache_spdm_request_size;
 #endif
     uint8_t current_token;

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2648,7 +2648,7 @@ libspdm_return_t libspdm_acquire_sender_buffer (
     *max_msg_size = spdm_context->sender_buffer_size;
     #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
     /* it return scratch buffer, because the requester need build message there.*/
-    *msg_buf_ptr = spdm_context->scratch_buffer +
+    *msg_buf_ptr = (uint8_t *)spdm_context->scratch_buffer +
                    libspdm_get_scratch_buffer_large_sender_receiver_offset(spdm_context);
     *max_msg_size = libspdm_get_scratch_buffer_large_sender_receiver_capacity(spdm_context);
     #endif
@@ -2712,7 +2712,7 @@ libspdm_return_t libspdm_acquire_receiver_buffer (
     *max_msg_size = spdm_context->receiver_buffer_size;
     #if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP
     /* it return scratch buffer, because the requester need build message there.*/
-    *msg_buf_ptr = spdm_context->scratch_buffer +
+    *msg_buf_ptr = (uint8_t *)spdm_context->scratch_buffer +
                    libspdm_get_scratch_buffer_large_sender_receiver_offset(spdm_context);
     *max_msg_size = libspdm_get_scratch_buffer_large_sender_receiver_capacity(spdm_context);
     #endif


### PR DESCRIPTION
If pointer arithmetic is needed then they can be cast to the appropriate type.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>