### PR TITLE
Fix default build options for initialize_secured_message_context()

### DIFF
--- a/unit_test/test_spdm_secured_message/encode_decode.c
+++ b/unit_test/test_spdm_secured_message/encode_decode.c
@@ -7,6 +7,8 @@
 #include "spdm_unit_test.h"
 #include "internal/libspdm_secured_message_lib.h"
 
+#if LIBSPDM_AEAD_AES_256_GCM_SUPPORT
+
 static uint8_t m_secured_message[0x1000];
 static uint8_t m_app_message[0x1000];
 static libspdm_secured_message_context_t m_secured_message_context;
@@ -925,3 +927,5 @@ int libspdm_secured_message_encode_decode_test_main(void)
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }
+
+#endif /* LIBSPDM_AEAD_AES_256_GCM_SUPPORT */

--- a/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
+++ b/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
@@ -10,9 +10,11 @@ int main(void)
 {
     int return_value = 0;
 
+#if LIBSPDM_AEAD_AES_256_GCM_SUPPORT
     if (libspdm_secured_message_encode_decode_test_main() != 0) {
         return_value = 1;
     }
+#endif
 
     return return_value;
 }


### PR DESCRIPTION
In initialize_secured_message_context(), two for-loops access two arrays
with LIBSPDM_MAX_AEAD_KEY_SIZE number of elements and with
LIBSPDM_MAX_AEAD_IV_SIZE number of elements separately. Both iterations
go beyond the size of the arrays when the required macro
LIBSPDM_AEAD_AES_256_GCM_SUPPORT for the test is undefined.

Gcc 11.4.0 reports this and aborts the compilation when -DTARGET=Release
is specified with cmake for the build. Check macro define in the unit
test to avoid compile error.