### PR TITLE
Fix unused value Coverity types

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -3102,9 +3102,7 @@ void libspdm_deinit_context(void *spdm_context)
                     context->connection_info.algorithm.req_base_asym_alg, pubkey_context);
             }
 
-            pubkey_context = NULL;
-            context->connection_info.peer_used_cert_chain[slot_index].
-            leaf_cert_public_key = NULL;
+            context->connection_info.peer_used_cert_chain[slot_index].leaf_cert_public_key = NULL;
         }
     }
 #endif

--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -285,8 +285,7 @@ libspdm_return_t libspdm_handle_error_large_response(
 
         status = libspdm_send_spdm_request(spdm_context, session_id,
                                            spdm_request_size, spdm_request);
-        spdm_request = NULL;
-        spdm_request_size = 0;
+
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             break;
         }

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -417,9 +417,6 @@ libspdm_return_t libspdm_handle_large_request(
             spdm_context, session_id, false,
             spdm_request_size, spdm_request);
 
-        spdm_request = NULL;
-        spdm_request_size = 0;
-
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             break;
         }


### PR DESCRIPTION
This commit fixes the following Coverity CIDs:
- 467406
- 467274
- 467469
- 467313
- 467400

They are all of type `unused value`.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>