### PR TITLE
Change spdm_test_context to spdm_context in unit test

### DIFF
--- a/unit_test/test_spdm_requester/error_test/vendor_request_err.c
+++ b/unit_test/test_spdm_requester/error_test/vendor_request_err.c
@@ -116,7 +116,7 @@ static libspdm_return_t libspdm_requester_vendor_cmds_err_test_receive_message(
         libspdm_vendor_response_test *spdm_response;
         libspdm_vendor_request_test* spdm_request = NULL;
         status = libspdm_transport_test_decode_message(
-            spdm_test_context, &session_id, &is_app_message, true,
+            spdm_context, &session_id, &is_app_message, true,
             m_libspdm_local_buffer_size, m_libspdm_local_buffer,
             &transport_message_size, (void **)(&spdm_request));
         assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);

--- a/unit_test/test_spdm_requester/vendor_request.c
+++ b/unit_test/test_spdm_requester/vendor_request.c
@@ -128,7 +128,7 @@ static libspdm_return_t libspdm_requester_vendor_cmds_test_receive_message(
         size_t spdm_response_size;
         size_t transport_header_size;
         status = libspdm_transport_test_decode_message(
-            spdm_test_context, &session_id, &is_app_message, true,
+            spdm_context, &session_id, &is_app_message, true,
             m_libspdm_local_buffer_size, m_libspdm_local_buffer,
             &transport_message_size, (void **)(&spdm_request));
         assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);


### PR DESCRIPTION
Fix #2780.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>