### PR TITLE
Refactor unit tests

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -3950,13 +3950,6 @@ void libspdm_test_requester_challenge_case28(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_challenge_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_challenge_test_send_message,
-    libspdm_requester_challenge_test_receive_message,
-};
-
 int libspdm_requester_challenge_test_main(void)
 {
     const struct CMUnitTest spdm_requester_challenge_tests[] = {
@@ -4012,7 +4005,14 @@ int libspdm_requester_challenge_test_main(void)
         cmocka_unit_test(libspdm_test_requester_challenge_case28),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_challenge_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_challenge_test_send_message,
+        libspdm_requester_challenge_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_challenge_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -832,13 +832,6 @@ void libspdm_test_requester_chunk_get_case4(void** state)
 }
 #endif
 
-libspdm_test_context_t m_libspdm_requester_chunk_get_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_chunk_get_test_send_message,
-    libspdm_requester_chunk_get_test_receive_message,
-};
-
 int libspdm_requester_chunk_get_test_main(void)
 {
     /* Test the CHUNK_GET handlers in various requester handlers */
@@ -861,8 +854,14 @@ int libspdm_requester_chunk_get_test_main(void)
 #endif
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_chunk_get_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_chunk_get_test_send_message,
+        libspdm_requester_chunk_get_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_chunk_get_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -472,13 +472,6 @@ void libspdm_test_requester_chunk_send_case12(void** state)
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
-libspdm_test_context_t m_libspdm_requester_chunk_send_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_chunk_send_test_send_message,
-    libspdm_requester_chunk_send_test_receive_message,
-};
-
 int libspdm_requester_chunk_send_test_main(void)
 {
     /* Test the CHUNK_SEND handlers in various requester handlers */
@@ -509,8 +502,14 @@ int libspdm_requester_chunk_send_test_main(void)
         cmocka_unit_test(libspdm_test_requester_chunk_send_case12),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_chunk_send_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_chunk_send_test_send_message,
+        libspdm_requester_chunk_send_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_chunk_send_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/encap_certificate.c
+++ b/unit_test/test_spdm_requester/encap_certificate.c
@@ -528,11 +528,6 @@ void libspdm_test_requester_encap_certificate_case7(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_encap_certificate_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_requester_encap_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_requester_encap_certificate_tests[] = {
@@ -550,7 +545,12 @@ int libspdm_requester_encap_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_requester_encap_certificate_case7),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_encap_certificate_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_encap_certificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/encap_challenge_auth.c
+++ b/unit_test/test_spdm_requester/encap_challenge_auth.c
@@ -563,11 +563,6 @@ void test_libspdm_requester_encap_challenge_auth_case8(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_spdm_requester_challenge_auth_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_requester_encap_challenge_auth_test_main(void)
 {
     const struct CMUnitTest spdm_requester_challenge_auth_tests[] = {
@@ -587,7 +582,12 @@ int libspdm_requester_encap_challenge_auth_test_main(void)
         cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case8),
     };
 
-    libspdm_setup_test_context(&m_spdm_requester_challenge_auth_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_challenge_auth_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/encap_digests.c
+++ b/unit_test/test_spdm_requester/encap_digests.c
@@ -406,11 +406,6 @@ void test_spdm_requester_encap_get_digests_case6(void **state)
     }
 }
 
-libspdm_test_context_t m_spdm_requester_digests_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_requester_encap_digests_test_main(void)
 {
     const struct CMUnitTest spdm_requester_digests_tests[] = {
@@ -428,7 +423,12 @@ int libspdm_requester_encap_digests_test_main(void)
         cmocka_unit_test(test_spdm_requester_encap_get_digests_case6),
     };
 
-    libspdm_setup_test_context(&m_spdm_requester_digests_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_digests_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/encap_key_update.c
+++ b/unit_test/test_spdm_requester/encap_key_update.c
@@ -1078,13 +1078,6 @@ void test_libspdm_requester_encap_key_update_case14(void **state)
                      0);
 }
 
-
-
-libspdm_test_context_t m_libspdm_requester_encap_key_update_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_requester_encap_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_update_tests[] = {
@@ -1118,7 +1111,12 @@ int libspdm_requester_encap_key_update_test_main(void)
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case14),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_encap_key_update_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_key_update_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/encap_request.c
+++ b/unit_test/test_spdm_requester/encap_request.c
@@ -1071,13 +1071,6 @@ void libspdm_test_requester_encap_request_case10(void **State)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-libspdm_test_context_t m_libspdm_requester_encap_request_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_encap_request_test_send_message,
-    libspdm_requester_encap_request_test_receive_message,
-};
-
 int libspdm_requester_encap_request_test_main(void)
 {
     const struct CMUnitTest spdm_requester_encap_request_tests[] = {
@@ -1106,7 +1099,14 @@ int libspdm_requester_encap_request_test_main(void)
         cmocka_unit_test(libspdm_test_requester_encap_request_case10),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_encap_request_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_encap_request_test_send_message,
+        libspdm_requester_encap_request_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_encap_request_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -1731,13 +1731,6 @@ void libspdm_test_requester_end_session_case12(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_end_session_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_end_session_test_send_message,
-    libspdm_requester_end_session_test_receive_message,
-};
-
 int libspdm_requester_end_session_test_main(void)
 {
     const struct CMUnitTest spdm_requester_end_session_tests[] = {
@@ -1767,7 +1760,14 @@ int libspdm_requester_end_session_test_main(void)
         cmocka_unit_test(libspdm_test_requester_end_session_case12),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_end_session_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_end_session_test_send_message,
+        libspdm_requester_end_session_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_end_session_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -1998,13 +1998,6 @@ static void libspdm_test_requester_get_capabilities_err_case40(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_capabilities_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_capabilities_test_send_message,
-    libspdm_requester_get_capabilities_test_receive_message,
-};
-
 int libspdm_requester_get_capabilities_error_test_main(void)
 {
     const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
@@ -2050,7 +2043,14 @@ int libspdm_requester_get_capabilities_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case40),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_capabilities_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_capabilities_test_send_message,
+        libspdm_requester_get_capabilities_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(m_spdm_requester_get_capabilities_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1586,13 +1586,6 @@ static void libspdm_test_requester_get_digests_err_case25(void **state)
 {
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_digests_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_digests_test_send_message,
-    libspdm_requester_get_digests_test_receive_message,
-};
-
 int libspdm_requester_get_digests_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_digests_tests[] = {
@@ -1623,7 +1616,14 @@ int libspdm_requester_get_digests_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case25),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_digests_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_digests_test_send_message,
+        libspdm_requester_get_digests_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_digests_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_event_types_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_event_types_err.c
@@ -181,20 +181,20 @@ static void libspdm_test_requester_get_event_types_err_case1(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-static libspdm_test_context_t m_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    send_message,
-    receive_message,
-};
-
 int libspdm_requester_get_event_types_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
         cmocka_unit_test(libspdm_test_requester_get_event_types_err_case1)
     };
 
-    libspdm_setup_test_context(&m_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        send_message,
+        receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -4697,13 +4697,6 @@ static void libspdm_test_requester_get_measurements_err_case37(void **state)
 {
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_measurements_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_measurements_test_send_message,
-    libspdm_requester_get_measurements_test_receive_message,
-};
-
 int libspdm_requester_get_measurements_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_measurements_tests[] = {
@@ -4746,7 +4739,14 @@ int libspdm_requester_get_measurements_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_measurements_err_case37),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_measurements_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_measurements_test_send_message,
+        libspdm_requester_get_measurements_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_measurements_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -844,13 +844,6 @@ static void libspdm_test_requester_get_version_err_case18(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_version_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    send_message,
-    receive_message,
-};
-
 int libspdm_requester_get_version_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_version_tests[] = {
@@ -874,7 +867,14 @@ int libspdm_requester_get_version_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_version_err_case18),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_version_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        send_message,
+        receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_version_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -6299,13 +6299,6 @@ static void libspdm_test_requester_key_exchange_err_case31(void **state)
     free(data);
 }
 
-static libspdm_test_context_t m_libspdm_requester_key_exchange_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_key_exchange_test_send_message,
-    libspdm_requester_key_exchange_test_receive_message,
-};
-
 int libspdm_requester_key_exchange_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_exchange_tests[] = {
@@ -6366,7 +6359,14 @@ int libspdm_requester_key_exchange_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_key_exchange_err_case31),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_key_exchange_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_key_exchange_test_send_message,
+        libspdm_requester_key_exchange_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_key_exchange_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
+++ b/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
@@ -3112,13 +3112,6 @@ static void libspdm_test_requester_negotiate_algorithms_error_case43(void** stat
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-libspdm_test_context_t m_libspdm_requester_negotiate_algorithms_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_negotiate_algorithms_test_send_message,
-    libspdm_requester_negotiate_algorithm_test_receive_message,
-};
-
 int libspdm_requester_negotiate_algorithms_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_negotiate_algorithms_tests[] = {
@@ -3170,7 +3163,14 @@ int libspdm_requester_negotiate_algorithms_error_test_main(void)
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case43),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_negotiate_algorithms_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_negotiate_algorithms_test_send_message,
+        libspdm_requester_negotiate_algorithm_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_negotiate_algorithms_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/vendor_request_err.c
+++ b/unit_test/test_spdm_requester/error_test/vendor_request_err.c
@@ -216,25 +216,24 @@ static void libspdm_test_requester_vendor_cmds_err_case1(void **state)
     printf("case 1 %d\n", response.data[0]);
 }
 
-libspdm_test_context_t m_libspdm_requester_vendor_cmds_err_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_vendor_cmds_err_test_send_message,
-    libspdm_requester_vendor_cmds_err_test_receive_message,
-};
-
 int libspdm_requester_vendor_cmds_error_test_main(void)
 {
     const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case1),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_vendor_cmds_err_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_vendor_cmds_err_test_send_message,
+        libspdm_requester_vendor_cmds_err_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }
-
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */

--- a/unit_test/test_spdm_requester/error_test/vendor_request_err.c
+++ b/unit_test/test_spdm_requester/error_test/vendor_request_err.c
@@ -33,7 +33,7 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-libspdm_return_t libspdm_vendor_get_id_func_err_test(
+static libspdm_return_t libspdm_vendor_get_id_func_err_test(
     void *spdm_context,
     uint16_t *resp_standard_id,
     uint8_t *resp_vendor_id_len,
@@ -47,7 +47,7 @@ libspdm_return_t libspdm_vendor_get_id_func_err_test(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-libspdm_return_t libspdm_vendor_response_func_err_test(
+static libspdm_return_t libspdm_vendor_response_func_err_test(
     void *spdm_context,
     uint16_t req_standard_id,
     uint8_t req_vendor_id_len,

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -3827,13 +3827,6 @@ void libspdm_test_requester_finish_case24(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_finish_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_finish_test_send_message,
-    libspdm_requester_finish_test_receive_message,
-};
-
 int libspdm_requester_finish_test_main(void)
 {
     const struct CMUnitTest spdm_requester_finish_tests[] = {
@@ -3882,7 +3875,14 @@ int libspdm_requester_finish_test_main(void)
         cmocka_unit_test(libspdm_test_requester_finish_case24),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_finish_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_finish_test_send_message,
+        libspdm_requester_finish_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_finish_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -1417,13 +1417,6 @@ static void libspdm_test_requester_get_capabilities_case35(void **state)
                      LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_13);
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_capabilities_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_capabilities_test_send_message,
-    libspdm_requester_get_capabilities_test_receive_message,
-};
-
 int libspdm_requester_get_capabilities_test_main(void)
 {
     const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
@@ -1464,8 +1457,14 @@ int libspdm_requester_get_capabilities_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_capabilities_case35),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_get_capabilities_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_capabilities_test_send_message,
+        libspdm_requester_get_capabilities_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(m_spdm_requester_get_capabilities_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -4342,13 +4342,6 @@ void libspdm_test_requester_get_certificate_case30(void **state)
     free(m_libspdm_local_certificate_chain);
 }
 
-libspdm_test_context_t m_libspdm_requester_get_certificate_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_certificate_test_send_message,
-    libspdm_requester_get_certificate_test_receive_message,
-};
-
 int libspdm_requester_get_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_certificate_tests[] = {
@@ -4417,7 +4410,14 @@ int libspdm_requester_get_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_certificate_case30),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_certificate_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_certificate_test_send_message,
+        libspdm_requester_get_certificate_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_certificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -584,13 +584,6 @@ void libspdm_test_requester_get_csr_case7(void **state)
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX */
 }
 
-libspdm_test_context_t m_libspdm_requester_get_csr_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_csr_test_send_message,
-    libspdm_requester_get_csr_test_receive_message,
-};
-
 int libspdm_requester_get_csr_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_csr_tests[] = {
@@ -609,8 +602,14 @@ int libspdm_requester_get_csr_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_csr_case7),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_get_csr_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_csr_test_send_message,
+        libspdm_requester_get_csr_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     /*ensure that cached.csr exists in test_csr at the beginning*/
     libspdm_clear_cached_csr();

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1974,13 +1974,6 @@ static void libspdm_test_requester_get_digests_case29(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-static libspdm_test_context_t m_libspdm_requester_get_digests_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_digests_test_send_message,
-    libspdm_requester_get_digests_test_receive_message,
-};
-
 int libspdm_requester_get_digests_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_digests_tests[] = {
@@ -2015,7 +2008,14 @@ int libspdm_requester_get_digests_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_digests_case29),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_digests_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_digests_test_send_message,
+        libspdm_requester_get_digests_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_digests_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_event_types.c
+++ b/unit_test/test_spdm_requester/get_event_types.c
@@ -181,20 +181,20 @@ static void libspdm_test_requester_get_event_types_case1(void **state)
     assert_int_equal(event_group_count, 1);
 }
 
-static libspdm_test_context_t m_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    send_message,
-    receive_message,
-};
-
 int libspdm_requester_get_event_types_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
         cmocka_unit_test(libspdm_test_requester_get_event_types_case1)
     };
 
-    libspdm_setup_test_context(&m_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        send_message,
+        receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_measurement_extension_log.c
+++ b/unit_test/test_spdm_requester/get_measurement_extension_log.c
@@ -1071,13 +1071,6 @@ void libspdm_test_requester_get_measurement_extension_log_case9(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-libspdm_test_context_t m_libspdm_requester_get_measurement_extension_log_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_measurement_extension_log_test_send_message,
-    libspdm_requester_get_measurement_extension_log_test_receive_message,
-};
-
 int libspdm_requester_get_measurement_extension_log_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_measurement_extension_log_tests[] = {
@@ -1102,7 +1095,14 @@ int libspdm_requester_get_measurement_extension_log_test_main(void)
 
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_measurement_extension_log_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_measurement_extension_log_test_send_message,
+        libspdm_requester_get_measurement_extension_log_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_measurement_extension_log_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -6388,12 +6388,6 @@ static void libspdm_test_requester_get_measurements_case41(void **state)
 #endif
     free(data);
 }
-libspdm_test_context_t m_libspdm_requester_get_measurements_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_measurements_test_send_message,
-    libspdm_requester_get_measurements_test_receive_message,
-};
 
 int libspdm_requester_get_measurements_test_main(void)
 {
@@ -6441,7 +6435,14 @@ int libspdm_requester_get_measurements_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_measurements_case41),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_measurements_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_measurements_test_send_message,
+        libspdm_requester_get_measurements_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_measurements_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -787,13 +787,6 @@ static void libspdm_test_requester_get_version_case16(void **state)
  * }
  */
 
-libspdm_test_context_t m_libspdm_requester_get_version_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_version_test_send_message,
-    libspdm_requester_get_version_test_receive_message,
-};
-
 int libspdm_requester_get_version_test_main(void)
 {
     const struct CMUnitTest spdm_requester_get_version_tests[] = {
@@ -817,7 +810,14 @@ int libspdm_requester_get_version_test_main(void)
          * cmocka_unit_test(libspdm_test_requester_get_version_case18), */
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_get_version_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_get_version_test_send_message,
+        libspdm_requester_get_version_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_version_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -1806,13 +1806,6 @@ void libspdm_test_requester_heartbeat_case13(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_heartbeat_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_heartbeat_test_send_message,
-    libspdm_requester_heartbeat_test_receive_message,
-};
-
 int libspdm_requester_heartbeat_test_main(void)
 {
     const struct CMUnitTest spdm_requester_heartbeat_tests[] = {
@@ -1843,7 +1836,14 @@ int libspdm_requester_heartbeat_test_main(void)
         cmocka_unit_test(libspdm_test_requester_heartbeat_case13),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_heartbeat_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_heartbeat_test_send_message,
+        libspdm_requester_heartbeat_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_heartbeat_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -8143,13 +8143,6 @@ static void libspdm_test_requester_key_exchange_case34(void **state)
     free(data);
 }
 
-static libspdm_test_context_t m_libspdm_requester_key_exchange_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_key_exchange_test_send_message,
-    libspdm_requester_key_exchange_test_receive_message,
-};
-
 int libspdm_requester_key_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_exchange_tests[] = {
@@ -8221,7 +8214,14 @@ int libspdm_requester_key_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_requester_key_exchange_case34),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_key_exchange_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_key_exchange_test_send_message,
+        libspdm_requester_key_exchange_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_key_exchange_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -5656,13 +5656,6 @@ void libspdm_test_requester_key_update_case35(void **state)
     assert_int_equal(spdm_context->session_info->session_id, INVALID_SESSION_ID);
 }
 
-libspdm_test_context_t m_libspdm_requester_key_update_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_key_update_test_send_message,
-    libspdm_requester_key_update_test_receive_message,
-};
-
 int libspdm_requester_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_requester_key_update_tests[] = {
@@ -5737,7 +5730,14 @@ int libspdm_requester_key_update_test_main(void)
         cmocka_unit_test(libspdm_test_requester_key_update_case35),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_key_update_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_key_update_test_send_message,
+        libspdm_requester_key_update_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_key_update_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -2177,13 +2177,6 @@ static void libspdm_test_requester_negotiate_algorithms_case36(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-static libspdm_test_context_t m_libspdm_requester_negotiate_algorithms_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_negotiate_algorithms_test_send_message,
-    libspdm_requester_negotiate_algorithm_test_receive_message,
-};
-
 int libspdm_requester_negotiate_algorithms_test_main(void)
 {
     const struct CMUnitTest spdm_requester_negotiate_algorithms_tests[] = {
@@ -2225,7 +2218,14 @@ int libspdm_requester_negotiate_algorithms_test_main(void)
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case36),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_negotiate_algorithms_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_negotiate_algorithms_test_send_message,
+        libspdm_requester_negotiate_algorithm_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_negotiate_algorithms_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -5020,13 +5020,6 @@ void libspdm_test_requester_psk_exchange_case27(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_psk_exchange_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_psk_exchange_test_send_message,
-    libspdm_requester_psk_exchange_test_receive_message,
-};
-
 int libspdm_requester_psk_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_requester_psk_exchange_tests[] = {
@@ -5084,7 +5077,14 @@ int libspdm_requester_psk_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case27),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_psk_exchange_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_psk_exchange_test_send_message,
+        libspdm_requester_psk_exchange_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_psk_exchange_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -2467,13 +2467,6 @@ void libspdm_test_requester_psk_finish_case16(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_requester_psk_finish_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_psk_finish_test_send_message,
-    libspdm_requester_psk_finish_test_receive_message,
-};
-
 int libspdm_requester_psk_finish_test_main(void)
 {
     const struct CMUnitTest spdm_requester_psk_finish_tests[] = {
@@ -2511,7 +2504,14 @@ int libspdm_requester_psk_finish_test_main(void)
         cmocka_unit_test(libspdm_test_requester_psk_finish_case16),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_psk_finish_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_psk_finish_test_send_message,
+        libspdm_requester_psk_finish_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_psk_finish_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -598,13 +598,6 @@ void libspdm_test_requester_set_certificate_case9(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-libspdm_test_context_t m_libspdm_requester_set_certificate_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_set_certificate_test_send_message,
-    libspdm_requester_set_certificate_test_receive_message,
-};
-
 int libspdm_requester_set_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_requester_set_certificate_tests[] = {
@@ -624,7 +617,14 @@ int libspdm_requester_set_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_requester_set_certificate_case9),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_set_certificate_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_set_certificate_test_send_message,
+        libspdm_requester_set_certificate_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_set_certificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/vendor_request.c
+++ b/unit_test/test_spdm_requester/vendor_request.c
@@ -219,20 +219,20 @@ static void libspdm_test_requester_vendor_cmds_case1(void **state)
     printf("case 1 %d\n", response.data[0]);
 }
 
-libspdm_test_context_t m_libspdm_requester_vendor_cmds_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_vendor_cmds_test_send_message,
-    libspdm_requester_vendor_cmds_test_receive_message,
-};
-
 int libspdm_requester_vendor_cmds_test_main(void)
 {
     const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_case1),
     };
 
-    libspdm_setup_test_context(&m_libspdm_requester_vendor_cmds_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        libspdm_requester_vendor_cmds_test_send_message,
+        libspdm_requester_vendor_cmds_test_receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/vendor_request.c
+++ b/unit_test/test_spdm_requester/vendor_request.c
@@ -33,7 +33,7 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-libspdm_return_t libspdm_vendor_get_id_func_test(
+static libspdm_return_t libspdm_vendor_get_id_func_test(
     void *spdm_context,
     uint16_t *resp_standard_id,
     uint8_t *resp_vendor_id_len,
@@ -57,7 +57,7 @@ libspdm_return_t libspdm_vendor_get_id_func_test(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-libspdm_return_t libspdm_vendor_response_func_test(
+static libspdm_return_t libspdm_vendor_response_func_test(
     void *spdm_context,
     uint16_t req_standard_id,
     uint8_t req_vendor_id_len,

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -2946,11 +2946,6 @@ void libspdm_test_responder_algorithms_case32(void **state)
     assert_int_equal(spdm_context->connection_info.algorithm.measurement_spec, 0);
 }
 
-libspdm_test_context_t m_libspdm_responder_algorithms_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_algorithms_test_main(void)
 {
     const struct CMUnitTest spdm_responder_algorithms_tests[] = {
@@ -3094,7 +3089,13 @@ int libspdm_responder_algorithms_test_main(void)
         m_libspdm_use_asym_algo;
     m_libspdm_negotiate_algorithm_request24.spdm_request_version10.base_asym_algo =
         m_libspdm_use_asym_algo;
-    libspdm_setup_test_context(&m_libspdm_responder_algorithms_test_context);
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_algorithms_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -1223,11 +1223,6 @@ void libspdm_test_responder_capabilities_case27(void **state)
                      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_ONLY);
 }
 
-libspdm_test_context_t m_libspdm_responder_capabilities_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_capabilities_test_main(void)
 {
     const struct CMUnitTest spdm_responder_capabilities_tests[] = {
@@ -1285,7 +1280,12 @@ int libspdm_responder_capabilities_test_main(void)
         cmocka_unit_test(libspdm_test_responder_capabilities_case27),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_capabilities_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_capabilities_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -1325,11 +1325,6 @@ void libspdm_test_responder_certificate_case18(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_responder_certificate_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_responder_certificate_tests[] = {
@@ -1372,7 +1367,12 @@ int libspdm_responder_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_responder_certificate_case18),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_certificate_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_certificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -1214,10 +1214,6 @@ void libspdm_test_responder_challenge_auth_case19(void **state)
     assert_int_equal (spdm_response->header.param2, 0);
     free(data1);
 }
-libspdm_test_context_t m_libspdm_responder_challenge_auth_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
 
 int libspdm_responder_challenge_auth_test_main(void)
 {
@@ -1256,7 +1252,12 @@ int libspdm_responder_challenge_auth_test_main(void)
 
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_challenge_auth_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_challenge_auth_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/chunk_get.c
+++ b/unit_test/test_spdm_responder/chunk_get.c
@@ -996,12 +996,6 @@ void libspdm_test_responder_chunk_get_rsp_case13(void** state)
     }
 }
 
-
-libspdm_test_context_t m_libspdm_responder_chunk_get_rsp_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_chunk_get_rsp_test_main(void)
 {
     const struct CMUnitTest spdm_responder_chunk_get_tests[] = {
@@ -1033,7 +1027,12 @@ int libspdm_responder_chunk_get_rsp_test_main(void)
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case13),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_chunk_get_rsp_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_chunk_get_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -1705,11 +1705,6 @@ void libspdm_test_responder_chunk_send_ack_rsp_case19(void** state)
     libspdm_test_responder_chunk_send_ack_reset_send_state(spdm_context);
 }
 
-libspdm_test_context_t m_libspdm_responder_chunk_send_ack_rsp_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_chunk_send_ack_test_main(void)
 {
     const struct CMUnitTest spdm_responder_chunk_send_ack_tests[] = {
@@ -1757,7 +1752,12 @@ int libspdm_responder_chunk_send_ack_test_main(void)
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case19),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_chunk_send_ack_rsp_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_chunk_send_ack_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -1984,11 +1984,6 @@ void libspdm_test_responder_csr_case16(void **state)
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX */
 }
 
-libspdm_test_context_t m_libspdm_responder_csr_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_csr_test_main(void)
 {
     const struct CMUnitTest spdm_responder_csr_tests[] = {
@@ -2025,7 +2020,12 @@ int libspdm_responder_csr_test_main(void)
         cmocka_unit_test(libspdm_test_responder_csr_case16),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_csr_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     /*ensure that cached.csr exists in test_csr at the beginning*/
     libspdm_clear_cached_csr();

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -595,11 +595,6 @@ void libspdm_test_responder_digests_case10(void **state)
     }
 }
 
-libspdm_test_context_t m_libspdm_responder_digests_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_digests_test_main(void)
 {
     const struct CMUnitTest spdm_responder_digests_tests[] = {
@@ -627,7 +622,12 @@ int libspdm_responder_digests_test_main(void)
         cmocka_unit_test(libspdm_test_responder_digests_case10),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_digests_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_digests_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -477,11 +477,6 @@ void libspdm_test_responder_encap_challenge_case6(void **state)
     free(data);
 }
 
-libspdm_test_context_t m_libspdm_responder_encap_challenge_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_encap_challenge_auth_test_main(void)
 {
     const struct CMUnitTest spdm_responder_challenge_tests[] = {
@@ -498,7 +493,12 @@ int libspdm_responder_encap_challenge_auth_test_main(void)
         cmocka_unit_test(libspdm_test_responder_encap_challenge_case6),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_encap_challenge_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_challenge_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/encap_get_certificate.c
+++ b/unit_test/test_spdm_responder/encap_get_certificate.c
@@ -571,11 +571,6 @@ void test_spdm_responder_encap_get_certificate_case5(void **state)
     m_libspdm_local_certificate_chain_size = 0;
 }
 
-libspdm_test_context_t m_spdm_responder_encap_get_certificate_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int spdm_responder_encap_get_certificate_test_main(void)
 {
     const struct CMUnitTest spdm_responder_certificate_tests[] = {
@@ -594,7 +589,12 @@ int spdm_responder_encap_get_certificate_test_main(void)
         cmocka_unit_test(test_spdm_responder_encap_get_certificate_case5),
     };
 
-    libspdm_setup_test_context(&m_spdm_responder_encap_get_certificate_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_certificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/encap_get_digests.c
+++ b/unit_test/test_spdm_responder/encap_get_digests.c
@@ -473,11 +473,6 @@ void test_spdm_responder_encap_get_digests_case7(void **state)
     }
 }
 
-libspdm_test_context_t m_spdm_responder_encap_get_digests_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int spdm_responder_encap_get_digests_test_main(void)
 {
     const struct CMUnitTest spdm_responder_digests_tests[] = {
@@ -497,7 +492,12 @@ int spdm_responder_encap_get_digests_test_main(void)
         cmocka_unit_test(test_spdm_responder_encap_get_digests_case7),
     };
 
-    libspdm_setup_test_context(&m_spdm_responder_encap_get_digests_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_digests_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/encap_key_update.c
+++ b/unit_test/test_spdm_responder/encap_key_update.c
@@ -244,11 +244,6 @@ void libspdm_test_responder_encap_key_update_case5(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-libspdm_test_context_t m_libspdm_responder_encap_key_update_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_encap_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_responder_key_update_tests[] = {
@@ -264,7 +259,12 @@ int libspdm_responder_encap_key_update_test_main(void)
         cmocka_unit_test(libspdm_test_responder_encap_key_update_case5),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_encap_key_update_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_key_update_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/encap_response.c
+++ b/unit_test/test_spdm_responder/encap_response.c
@@ -1039,14 +1039,8 @@ void libspdm_test_get_response_encapsulated_response_ack_case9(void **State)
                      m_libspdm_m_deliver_encapsulated_response_request_t2.header.param1);
 }
 
-libspdm_test_context_t m_libspdm_response_encapsulated_request_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_encapsulated_response_test_main(void)
 {
-
     const struct CMUnitTest spdm_responder_encapsulated_response_tests[] = {
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT)
         /*Success Case request_op_code_sequence: SPDM_GET_DIGESTS*/
@@ -1088,7 +1082,12 @@ int libspdm_responder_encapsulated_response_test_main(void)
         cmocka_unit_test(libspdm_test_get_response_encapsulated_response_ack_case9),
     };
 
-    libspdm_setup_test_context(&m_libspdm_response_encapsulated_request_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_encapsulated_response_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/end_session.c
+++ b/unit_test/test_spdm_responder/end_session.c
@@ -634,11 +634,6 @@ void libspdm_test_responder_end_session_case8(void **state)
     free(data1);
 }
 
-libspdm_test_context_t m_libspdm_responder_end_session_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_end_session_test_main(void)
 {
     const struct CMUnitTest spdm_responder_end_session_tests[] = {
@@ -662,7 +657,12 @@ int libspdm_responder_end_session_test_main(void)
         cmocka_unit_test(libspdm_test_responder_end_session_case8),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_end_session_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_end_session_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
+++ b/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
@@ -96,7 +96,7 @@ static void libspdm_test_responder_supported_event_types_err_case1(void **state)
 
 int libspdm_responder_supported_event_types_error_test_main(void)
 {
-    libspdm_test_context_t m_test_context = {
+    libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         false,
     };
@@ -105,7 +105,7 @@ int libspdm_responder_supported_event_types_error_test_main(void)
         cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case1),
     };
 
-    libspdm_setup_test_context(&m_test_context);
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_supported_event_types_err_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/error_test/vendor_response_err.c
+++ b/unit_test/test_spdm_responder/error_test/vendor_response_err.c
@@ -119,18 +119,18 @@ static void libspdm_test_responder_vendor_cmds_err_case1(void **state)
     response.data_len = (uint16_t)response_len;
 }
 
-libspdm_test_context_t m_libspdm_responder_vendor_cmds_err_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-};
-
 int libspdm_responder_vendor_cmds_error_test_main(void)
 {
     const struct CMUnitTest spdm_responder_vendor_cmds_tests[] = {
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_err_case1),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_vendor_cmds_err_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_vendor_cmds_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/finish.c
+++ b/unit_test/test_spdm_responder/finish.c
@@ -3834,11 +3834,6 @@ void libspdm_test_responder_finish_case29(void **state)
     free(data1);
 }
 
-libspdm_test_context_t m_libspdm_responder_finish_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_finish_test_main(void)
 {
     const struct CMUnitTest spdm_responder_finish_tests[] = {
@@ -3900,7 +3895,12 @@ int libspdm_responder_finish_test_main(void)
         cmocka_unit_test(libspdm_test_responder_finish_case29),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_finish_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_finish_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/heartbeat.c
+++ b/unit_test/test_spdm_responder/heartbeat.c
@@ -625,11 +625,6 @@ void libspdm_test_responder_heartbeat_case8(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-libspdm_test_context_t m_libspdm_responder_heartbeat_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_heartbeat_test_main(void)
 {
     const struct CMUnitTest spdm_responder_heartbeat_tests[] = {
@@ -652,7 +647,12 @@ int libspdm_responder_heartbeat_test_main(void)
         cmocka_unit_test(libspdm_test_responder_heartbeat_case8),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_heartbeat_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_heartbeat_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/key_exchange.c
+++ b/unit_test/test_spdm_responder/key_exchange.c
@@ -1998,11 +1998,6 @@ static void libspdm_test_responder_key_exchange_case22(void **state)
 #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 }
 
-libspdm_test_context_t m_libspdm_responder_key_exchange_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_key_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_responder_key_exchange_tests[] = {
@@ -2049,7 +2044,12 @@ int libspdm_responder_key_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_responder_key_exchange_case22),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_key_exchange_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_key_exchange_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/key_update.c
+++ b/unit_test/test_spdm_responder/key_update.c
@@ -2156,11 +2156,6 @@ void libspdm_test_responder_key_update_case27(void **state)
                         m_rsp_secret_buffer, secured_message_context->hash_size);
 }
 
-libspdm_test_context_t m_libspdm_responder_key_update_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_key_update_test_main(void)
 {
     const struct CMUnitTest spdm_responder_key_update_tests[] = {
@@ -2222,7 +2217,12 @@ int libspdm_responder_key_update_test_main(void)
         cmocka_unit_test(libspdm_test_responder_key_update_case27),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_key_update_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_key_update_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/measurement_extension_log.c
+++ b/unit_test/test_spdm_responder/measurement_extension_log.c
@@ -355,11 +355,6 @@ void libspdm_test_responder_measurement_extension_log_case5(void **state)
                         response_size - sizeof(spdm_measurement_extension_log_response_t));
 }
 
-libspdm_test_context_t m_libspdm_responder_measurement_extension_log_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_measurement_extension_log_test_main(void)
 {
     const struct CMUnitTest spdm_responder_measurement_extension_log_tests[] = {
@@ -375,7 +370,12 @@ int libspdm_responder_measurement_extension_log_test_main(void)
         cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case5),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_measurement_extension_log_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_measurement_extension_log_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -2730,11 +2730,6 @@ void libspdm_test_responder_measurements_case36(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-libspdm_test_context_t m_libspdm_responder_measurements_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_measurements_test_main(void)
 {
     m_libspdm_get_measurements_request11.slot_id_param = SPDM_MAX_SLOT_COUNT - 1;
@@ -2815,7 +2810,12 @@ int libspdm_responder_measurements_test_main(void)
         cmocka_unit_test(libspdm_test_responder_measurements_case36),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_measurements_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_measurements_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/psk_exchange.c
+++ b/unit_test/test_spdm_responder/psk_exchange.c
@@ -1722,11 +1722,6 @@ void libspdm_test_responder_psk_exchange_case17(void **state)
     free(data1);
 }
 
-libspdm_test_context_t m_libspdm_responder_psk_exchange_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_psk_exchange_test_main(void)
 {
     const struct CMUnitTest spdm_responder_psk_exchange_tests[] = {
@@ -1768,7 +1763,12 @@ int libspdm_responder_psk_exchange_test_main(void)
         cmocka_unit_test(libspdm_test_responder_psk_exchange_case17),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_psk_exchange_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_psk_exchange_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/psk_finish.c
+++ b/unit_test/test_spdm_responder/psk_finish.c
@@ -1572,11 +1572,6 @@ void libspdm_test_responder_psk_finish_case14(void **state)
     free(data1);
 }
 
-libspdm_test_context_t m_libspdm_responder_psk_finish_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_psk_finish_test_main(void)
 {
     const struct CMUnitTest spdm_responder_psk_finish_tests[] = {
@@ -1610,7 +1605,12 @@ int libspdm_responder_psk_finish_test_main(void)
         cmocka_unit_test(libspdm_test_responder_psk_finish_case14),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_psk_finish_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_psk_finish_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -491,12 +491,6 @@ void libspdm_test_responder_receive_send_rsp_case4(void** state)
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP */
 }
 
-
-libspdm_test_context_t m_libspdm_responder_receive_send_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_receive_send_test_main(void)
 {
     const struct CMUnitTest spdm_responder_receive_send_tests[] = {
@@ -514,7 +508,12 @@ int libspdm_responder_receive_send_test_main(void)
                                libspdm_unit_test_group_setup),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_receive_send_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_receive_send_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -1359,11 +1359,6 @@ void libspdm_test_responder_respond_if_ready_case14(void **state) {
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
-libspdm_test_context_t m_libspdm_responder_respond_if_ready_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_respond_if_ready_test_main(void) {
     const struct CMUnitTest spdm_responder_respond_if_ready_tests[] = {
         /* Success Case*/
@@ -1401,7 +1396,12 @@ int libspdm_responder_respond_if_ready_test_main(void) {
 
     };
 
-    libspdm_setup_test_context (&m_libspdm_responder_respond_if_ready_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context (&test_context);
 
     return cmocka_run_group_tests(spdm_responder_respond_if_ready_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1039,11 +1039,6 @@ void libspdm_test_responder_set_certificate_rsp_case12(void **state)
     free(m_libspdm_set_certificate_request);
 }
 
-libspdm_test_context_t m_libspdm_responder_set_certificate_rsp_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_set_certificate_rsp_test_main(void)
 {
     const struct CMUnitTest spdm_responder_set_cetificate_tests[] = {
@@ -1072,7 +1067,12 @@ int libspdm_responder_set_certificate_rsp_test_main(void)
         cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case12),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_set_certificate_rsp_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_set_cetificate_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/supported_event_types.c
+++ b/unit_test/test_spdm_responder/supported_event_types.c
@@ -105,16 +105,16 @@ static void libspdm_test_responder_supported_event_types_case1(void **state)
 
 int libspdm_responder_supported_event_types_test_main(void)
 {
-    libspdm_test_context_t m_test_context = {
-        LIBSPDM_TEST_CONTEXT_VERSION,
-        false,
-    };
-
     const struct CMUnitTest spdm_responder_supported_event_types_tests[] = {
         cmocka_unit_test(libspdm_test_responder_supported_event_types_case1),
     };
 
-    libspdm_setup_test_context(&m_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_supported_event_types_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/vendor_response.c
+++ b/unit_test/test_spdm_responder/vendor_response.c
@@ -156,18 +156,18 @@ static void libspdm_test_responder_vendor_cmds_case1(void **state)
         SPDM_MESSAGE_VERSION_10);
 }
 
-libspdm_test_context_t m_libspdm_responder_vendor_cmds_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-};
-
 int libspdm_responder_vendor_cmds_test_main(void)
 {
     const struct CMUnitTest spdm_responder_vendor_cmds_tests[] = {
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_case1),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_vendor_cmds_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_vendor_cmds_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_responder/vendor_response.c
+++ b/unit_test/test_spdm_responder/vendor_response.c
@@ -30,7 +30,7 @@ typedef struct {
 #pragma pack()
 
 
-libspdm_return_t libspdm_vendor_get_id_func_test(
+static libspdm_return_t libspdm_vendor_get_id_func_test(
     void *spdm_context,
     uint16_t *resp_standard_id,
     uint8_t *resp_vendor_id_len,
@@ -54,7 +54,7 @@ libspdm_return_t libspdm_vendor_get_id_func_test(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-libspdm_return_t libspdm_vendor_response_func_test(
+static libspdm_return_t libspdm_vendor_response_func_test(
     void *spdm_context,
     uint16_t req_standard_id,
     uint8_t req_vendor_id_len,

--- a/unit_test/test_spdm_responder/version.c
+++ b/unit_test/test_spdm_responder/version.c
@@ -256,11 +256,6 @@ void libspdm_test_responder_version_case8(void **state)
 #endif
 }
 
-libspdm_test_context_t m_libspdm_responder_version_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    false,
-};
-
 int libspdm_responder_version_test_main(void)
 {
     const struct CMUnitTest spdm_responder_version_tests[] = {
@@ -279,7 +274,12 @@ int libspdm_responder_version_test_main(void)
         cmocka_unit_test(libspdm_test_responder_version_case8),
     };
 
-    libspdm_setup_test_context(&m_libspdm_responder_version_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_responder_version_tests,
                                   libspdm_unit_test_group_setup,


### PR DESCRIPTION
1. Move the test context inside the _main function, as it is not needed outside the function.
2. Make functions static where appropriate.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>