### PR TITLE
Run code coverage weekly

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -2,7 +2,7 @@ name: Code Coverage
 
 on:
   schedule:
-    - cron:  '00 8 * * *'
+    - cron:  '0 8 * * 0'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Run code coverage weekly instead of nightly. Once a day is too frequent.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>