### PR TITLE
Add `session_id` to `libspdm_event_get_types`

### DIFF
--- a/include/hal/library/eventlib.h
+++ b/include/hal/library/eventlib.h
@@ -20,6 +20,7 @@
  *
  * @param  spdm_context  A pointer to the SPDM context.
  * @param  spdm_version  Indicates the negotiated version.
+ * @param  session_id    Secure session identifier.
  * @param  supported_event_groups_list      A pointer to the buffer that holds the list of event.
  *                                          groups.
  * @param  supported_event_groups_list_len  On input, the size, in bytes, of the buffer to hold the
@@ -35,6 +36,7 @@
 extern bool libspdm_event_get_types(
     void *spdm_context,
     spdm_version_number_t spdm_version,
+    uint32_t session_id,
     void *supported_event_groups_list,
     uint32_t *supported_event_groups_list_len,
     uint8_t *event_group_count);

--- a/library/spdm_responder_lib/libspdm_rsp_supported_event_types.c
+++ b/library/spdm_responder_lib/libspdm_rsp_supported_event_types.c
@@ -98,7 +98,7 @@ libspdm_return_t libspdm_get_response_supported_event_types(libspdm_context_t *s
     supported_event_groups_list_len = (uint32_t)response_buffer_size -
                                       sizeof(spdm_supported_event_types_response_t);
 
-    if (!libspdm_event_get_types(spdm_context, spdm_context->connection_info.version,
+    if (!libspdm_event_get_types(spdm_context, spdm_context->connection_info.version, session_id,
                                  (void *)(spdm_response + 1), &supported_event_groups_list_len,
                                  &event_group_count)) {
         return libspdm_generate_error_response(spdm_context,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -229,6 +229,7 @@ bool libspdm_gen_csr_ex(
 bool libspdm_event_get_types(
     void *spdm_context,
     spdm_version_number_t spdm_version,
+    uint32_t session_id,
     void *supported_event_groups_list,
     uint32_t *supported_event_groups_list_len,
     uint8_t *event_group_count)

--- a/os_stub/spdm_device_secret_lib_sample/lib.c
+++ b/os_stub/spdm_device_secret_lib_sample/lib.c
@@ -2236,6 +2236,7 @@ bool libspdm_write_certificate_to_nvm(
 bool libspdm_event_get_types(
     void *spdm_context,
     spdm_version_number_t spdm_version,
+    uint32_t session_id,
     void *supported_event_groups_list,
     uint32_t *supported_event_groups_list_len,
     uint8_t *event_group_count)


### PR DESCRIPTION
Fix #2838.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>