### PR TITLE
Fix openssl build failure for AARCH64_GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
         if(GCOV STREQUAL "ON")
         add_compile_options(--coverage -fprofile-arcs -ftest-coverage)
         endif()
-        set(OPENSSL_FLAGS -include base.h -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -Wno-cast-qual)
+        set(OPENSSL_FLAGS -std=c11 -include base.h -Wno-error=maybe-uninitialized -Wno-error=format -Wno-format -Wno-error=unused-but-set-variable -Wno-cast-qual)
         set(CMOCKA_FLAGS -std=gnu99 -Wpedantic -Wall -Wshadow -Wmissing-prototypes -Wcast-align -Werror=address -Wstrict-prototypes -Werror=strict-prototypes -Wwrite-strings -Werror=write-strings -Werror-implicit-function-declaration -Wpointer-arith -Werror=pointer-arith -Wdeclaration-after-statement -Werror=declaration-after-statement -Wreturn-type -Werror=return-type -Wuninitialized -Werror=uninitialized -Werror=strict-overflow -Wstrict-overflow=2 -Wno-format-zero-length -Wmissing-field-initializers -Wformat-security -Werror=format-security -fno-common -Wformat -fno-common -fstack-protector-strong -Wno-cast-qual)
 
         set(CMAKE_AR aarch64-linux-gnu-gcc-ar)


### PR DESCRIPTION
Trying to compile with toolchain AARCH64_GCC generates the following error:

```bash
$WORKSPACE/libspdm/os_stub/openssllib/openssl/crypto/o_str.c: In function ‘openssl_strerror_r’:
$WORKSPACE/libspdm/os_stub/openssllib/openssl/crypto/o_str.c:329:13: error: implicit declaration of function ‘strerror_r’; did you mean ‘strerror’? [-Werror=implicit-function-declaration]
  329 |     return !strerror_r(errnum, buf, buflen);
      |             ^~~~~~~~~~
```

Fix: just add the flag `-std=c11` in OPENSSL_FLAGS for AARCH64_GCC.