### PR TITLE
Add libspdm_get_data enum for accessing the request

### DIFF
--- a/doc/api/common_api.md
+++ b/doc/api/common_api.md
@@ -401,3 +401,8 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
             - The endianness of the sequence number is little-endian.
         - `LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_BIG_DEC_BIG`
             - The endianness of the sequence number is big-endian.
+- `LIBSPDM_DATA_REQUEST_AND_SIZE`
+    - Returns a pointer to the raw command buffer and the size of the command in bytes.
+    - This pointer is valid after libspdm_set_scratch_buffer is called, but the command itself is
+      not valid unless the size returned is greater than zero. The command and its size will
+      persist until the next command is received or the libspdm context is reset.

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -107,6 +107,9 @@ typedef enum {
     /* VCA cached for CACHE_CAP in 1.2 for transcript. */
     LIBSPDM_DATA_VCA_CACHE,
 
+    /* Raw request buffer and size */
+    LIBSPDM_DATA_REQUEST_AND_SIZE,
+
     /* if the context is for a requester. It only needs to be set in VCA cache.
      * In normal flow, the value is set in GET_VERSION or VERSION automatically.
      * false means responder

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1128,6 +1128,10 @@ libspdm_return_t libspdm_get_data(void *spdm_context, libspdm_data_type_t data_t
         target_data_size = context->transcript.message_a.buffer_size;
         target_data = context->transcript.message_a.buffer;
         break;
+    case LIBSPDM_DATA_REQUEST_AND_SIZE:
+        target_data_size = context->last_spdm_request_size;
+        target_data = context->last_spdm_request;
+        break;
     case LIBSPDM_DATA_SPDM_VERSION_10_11_VERIFY_SIGNATURE_ENDIAN:
         target_data_size = sizeof(uint8_t);
         target_data = &context->spdm_10_11_verify_signature_endian;


### PR DESCRIPTION
Provide an enum to allow libspdm_get_data to return the current request and its size from the tracking pointer in the context.