### PR TITLE
Restrict x86 mnemonic to x86-64

### DIFF
--- a/os_stub/debuglib/debuglib.c
+++ b/os_stub/debuglib/debuglib.c
@@ -37,9 +37,10 @@ void libspdm_debug_assert(const char *file_name, size_t line_number, const char 
 #elif (LIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG == LIBSPDM_DEBUG_LIBSPDM_ASSERT_BREAKPOINT)
 #if defined(_MSC_EXTENSIONS)
     __debugbreak();
-#endif
-#if defined(__GNUC__)
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
     __asm__ __volatile__ ("int $3");
+#else
+#error Breakpoint asserts are not available on this architecture and/or compiler
 #endif
 #elif (LIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG == LIBSPDM_DEBUG_LIBSPDM_ASSERT_EXIT)
     exit(1);


### PR DESCRIPTION
This resolves an issue where setting the assert config to breakpoint on ARM will cause the build to fail with an accurate but unhelpful compiler error.

This restricts the mnemonic to x86-64 architectures, and provides a more explanatory error.

Addresses issue: #2890