### PR TITLE
Update error code for unsupported RequesterInfo in CSR requests

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_csr.c
+++ b/library/spdm_responder_lib/libspdm_rsp_csr.c
@@ -245,7 +245,7 @@ libspdm_return_t libspdm_get_response_csr(libspdm_context_t *spdm_context,
         } else {
             return libspdm_generate_error_response(
                 spdm_context,
-                SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                 response_size, response);
         }
     }

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -1767,7 +1767,7 @@ void libspdm_test_responder_csr_case15(void **state)
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
     assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
     assert_int_equal(spdm_response->header.param2, 0);
 
     /*matched csr_tracking_tag without overwrite*/
@@ -1857,7 +1857,7 @@ void libspdm_test_responder_csr_case15(void **state)
     assert_int_equal(spdm_response->header.request_response_code,
                      SPDM_ERROR);
     assert_int_equal(spdm_response->header.param1,
-                     SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
     assert_int_equal(spdm_response->header.param2, 0);
 
     /*csr_tracking_tag 0 and overwrite*/


### PR DESCRIPTION
Fix #2893