### PR TITLE
Clean up encapsulated send and receive

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -11,31 +11,26 @@
 /**
  * Get the SPDM encapsulated request.
  *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  encap_request_size             size in bytes of the encapsulated request data.
- *                                     On input, it means the size in bytes of encapsulated request data buffer.
- *                                     On output, it means the size in bytes of copied encapsulated request data buffer if RETURN_SUCCESS is returned,
- *                                     and means the size in bytes of desired encapsulated request data buffer if RETURN_BUFFER_TOO_SMALL is returned.
- * @param  encap_request                 A pointer to the encapsulated request data.
- *
- * @retval RETURN_SUCCESS               The encapsulated request is returned.
- * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @param  spdm_context        A pointer to the SPDM context.
+ * @param  encap_request_size  Size, in bytes, of the encapsulated request data.
+ *                             On input, it means the size in bytes of encapsulated request data
+ *                             buffer.
+ *                             On output, it means the size, in bytes, of copied encapsulated
+ *                             request data buffer if LIBSPDM_RETURN_SUCCESS is returned,
+ *                             and means the size in bytes of desired encapsulated request data
+ *                             buffer if LIBSPDM_STATUS_BUFFER_TOO_SMALL is returned.
+ * @param  encap_request       A pointer to the encapsulated request data.
  **/
 typedef libspdm_return_t (*libspdm_get_encap_request_func)(
-    libspdm_context_t *spdm_context, size_t *encap_request_size,
-    void *encap_request);
+    libspdm_context_t *spdm_context, size_t *encap_request_size, void *encap_request);
 
 /**
  * Process the SPDM encapsulated response.
  *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  encap_response_size            size in bytes of the encapsulated response data.
- * @param  encap_response                A pointer to the encapsulated response data.
- * @param  need_continue                     Indicate if encapsulated communication need continue.
- *
- * @retval RETURN_SUCCESS               The encapsulated response is processed.
- * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ * @param  spdm_context         A pointer to the SPDM context.
+ * @param  encap_response_size  Size, in bytes, of the encapsulated response data.
+ * @param  encap_response       A pointer to the encapsulated response data.
+ * @param  need_continue        Indicate if encapsulated communication needs to continue.
  **/
 typedef libspdm_return_t (*libspdm_process_encap_response_func)(
     libspdm_context_t *spdm_context, size_t encap_response_size,
@@ -93,14 +88,11 @@ static void libspdm_encap_move_to_next_op_code(libspdm_context_t *spdm_context)
             spdm_context->encap_context.request_op_code_sequence[0];
         return;
     }
-    for (index = 0;
-         index < spdm_context->encap_context.request_op_code_count;
-         index++) {
+    for (index = 0; index < spdm_context->encap_context.request_op_code_count; index++) {
         if (spdm_context->encap_context.current_request_op_code ==
             spdm_context->encap_context.request_op_code_sequence[index]) {
             spdm_context->encap_context.current_request_op_code =
-                spdm_context->encap_context
-                .request_op_code_sequence[index + 1];
+                spdm_context->encap_context.request_op_code_sequence[index + 1];
             return;
         }
     }
@@ -110,25 +102,21 @@ static void libspdm_encap_move_to_next_op_code(libspdm_context_t *spdm_context)
 /**
  * Process a SPDM encapsulated response.
  *
- * @param  spdm_context                  The SPDM context for the device.
- * @param  encap_response_size            size in bytes of the request data.
- * @param  encap_response                A pointer to the request data.
- * @param  encap_request_size             size in bytes of the response data.
- * @param  encap_request                 A pointer to the response data.
- *
- * @retval RETURN_SUCCESS               The SPDM encapsulated request is generated successfully.
- * @retval RETURN_UNSUPPORTED           Do not know how to process the request.
+ * @param  spdm_context         The SPDM context for the device.
+ * @param  encap_response_size  Size, in bytes, of the request data.
+ * @param  encap_response       A pointer to the request data.
+ * @param  encap_request_size   Size, in bytes, of the response data.
+ * @param  encap_request        A pointer to the response data.
  **/
 static libspdm_return_t libspdm_process_encapsulated_response(
     libspdm_context_t *spdm_context, size_t encap_response_size,
-    const void *encap_response, size_t *encap_request_size,
-    void *encap_request)
+    const void *encap_response, size_t *encap_request_size, void *encap_request)
 {
     libspdm_return_t status;
     bool need_continue;
     libspdm_encap_response_struct_t encap_response_struct;
 
-    /* Process previous response*/
+    /* Process previous response. */
     need_continue = false;
 
     if (spdm_context->encap_context.current_request_op_code != 0) {
@@ -143,8 +131,7 @@ static libspdm_return_t libspdm_process_encapsulated_response(
             return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         }
         status = encap_response_struct.process_encap_response(
-            spdm_context, encap_response_size, encap_response,
-            &need_continue);
+            spdm_context, encap_response_size, encap_response, &need_continue);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             /* If the Requester delivers an encapsulated ERROR message with a ResponseNotReady error code,
              * the Responder shall terminate the encapsulated request flow by setting Param2 in
@@ -161,19 +148,19 @@ static libspdm_return_t libspdm_process_encapsulated_response(
 
     spdm_context->encap_context.request_id += 1;
 
-    /* Move to next request*/
+    /* Move to next request. */
     if (!need_continue) {
         libspdm_encap_move_to_next_op_code(spdm_context);
     }
 
     if (spdm_context->encap_context.current_request_op_code == 0) {
-        /* No more work to do - stop*/
+        /* No more work to do - stop. */
         *encap_request_size = 0;
         spdm_context->encap_context.current_request_op_code = 0;
         return LIBSPDM_STATUS_SUCCESS;
     }
 
-    /* Process the next request*/
+    /* Process the next request. */
     status = libspdm_get_encap_struct_via_op_code(
         spdm_context->encap_context.current_request_op_code, &encap_response_struct);
     LIBSPDM_ASSERT(status == LIBSPDM_STATUS_SUCCESS);
@@ -266,8 +253,7 @@ libspdm_return_t libspdm_get_response_encapsulated_request(
     spdm_response->header.param1 = 0;
     spdm_response->header.param2 = 0;
 
-    encap_request_size =
-        *response_size - sizeof(spdm_encapsulated_request_response_t);
+    encap_request_size = *response_size - sizeof(spdm_encapsulated_request_response_t);
     encap_request = spdm_response + 1;
 
     status = libspdm_process_encapsulated_response(
@@ -278,8 +264,7 @@ libspdm_return_t libspdm_get_response_encapsulated_request(
             spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
             response_size, response);
     }
-    *response_size = sizeof(spdm_encapsulated_request_response_t) +
-                     encap_request_size;
+    *response_size = sizeof(spdm_encapsulated_request_response_t) + encap_request_size;
     spdm_response->header.param1 = spdm_context->encap_context.request_id;
 
     if (encap_request_size == 0) {
@@ -318,26 +303,21 @@ libspdm_return_t libspdm_get_response_encapsulated_response_ack(
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP)) {
         return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-            SPDM_DELIVER_ENCAPSULATED_RESPONSE, response_size,
-            response);
+            SPDM_DELIVER_ENCAPSULATED_RESPONSE, response_size, response);
     }
-    if (spdm_context->response_state !=
-        LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
-        if (spdm_context->response_state ==
-            LIBSPDM_RESPONSE_STATE_NORMAL) {
+    if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP) {
+        if (spdm_context->response_state == LIBSPDM_RESPONSE_STATE_NORMAL) {
             return libspdm_generate_error_response(
                 spdm_context,
                 SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                 response_size, response);
         }
-        return libspdm_responder_handle_response_state(
-            spdm_context,
-            spdm_request->header.request_response_code,
-            response_size, response);
+        return libspdm_responder_handle_response_state(spdm_context,
+                                                       spdm_request->header.request_response_code,
+                                                       response_size, response);
     }
 
-    if (request_size <=
-        sizeof(spdm_deliver_encapsulated_response_request_t)) {
+    if (request_size <= sizeof(spdm_deliver_encapsulated_response_request_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);
@@ -345,17 +325,14 @@ libspdm_return_t libspdm_get_response_encapsulated_response_ack(
 
     spdm_request_size = request_size;
 
-    if (spdm_request->header.param1 !=
-        spdm_context->encap_context.request_id) {
+    if (spdm_request->header.param1 != spdm_context->encap_context.request_id) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);
     }
 
     encap_response = (spdm_request + 1);
-    encap_response_size =
-        spdm_request_size -
-        sizeof(spdm_deliver_encapsulated_response_request_t);
+    encap_response_size = spdm_request_size - sizeof(spdm_deliver_encapsulated_response_request_t);
 
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_12) {
         ack_header_size = sizeof(spdm_encapsulated_response_ack_response_t);
@@ -389,8 +366,7 @@ libspdm_return_t libspdm_get_response_encapsulated_response_ack(
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
         return libspdm_generate_error_response(
-            spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0,
-            response_size, response);
+            spdm_context, SPDM_ERROR_CODE_INVALID_RESPONSE_CODE, 0, response_size, response);
     }
 
     *response_size = ack_header_size + encap_request_size;
@@ -402,15 +378,13 @@ libspdm_return_t libspdm_get_response_encapsulated_response_ack(
 
     if (encap_request_size == 0) {
         spdm_response->header.param1 = 0;
-        spdm_response->header.param2 =
-            SPDM_ENCAPSULATED_RESPONSE_ACK_RESPONSE_PAYLOAD_TYPE_ABSENT;
+        spdm_response->header.param2 = SPDM_ENCAPSULATED_RESPONSE_ACK_RESPONSE_PAYLOAD_TYPE_ABSENT;
         if ((spdm_context->encap_context.req_slot_id != 0) &&
             (spdm_context->encap_context.req_slot_id != 0xFF)) {
             spdm_response->header.param2 =
                 SPDM_ENCAPSULATED_RESPONSE_ACK_RESPONSE_PAYLOAD_TYPE_REQ_SLOT_NUMBER;
             *response_size = ack_header_size + 1;
-            *(uint8_t *)(spdm_response + 1) =
-                spdm_context->encap_context.req_slot_id;
+            *(uint8_t *)(spdm_response + 1) = spdm_context->encap_context.req_slot_id;
         }
         spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
     }
@@ -427,7 +401,6 @@ libspdm_return_t libspdm_handle_encap_error_response_main(
 
     return LIBSPDM_STATUS_UNSUPPORTED_CAP;
 }
-
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
@@ -441,15 +414,14 @@ void libspdm_init_basic_mut_auth_encap_state(libspdm_context_t *spdm_context)
                      sizeof(spdm_context->encap_context.last_encap_request_header));
     spdm_context->mut_auth_cert_chain_buffer_size = 0;
 
-    /* Clear Cache*/
+    /* Clear Cache. */
     libspdm_reset_message_mut_b(spdm_context);
     libspdm_reset_message_mut_c(spdm_context);
 
     /* Possible Sequence:
      * 1. Basic Mutual Auth:
      *    1.1 GET_DIGEST/GET_CERTIFICATE/CHALLENGE (encap_context.req_slot_id must not be 0xFF)
-     *    1.2 CHALLENGE (REQUEST_FLAGS_PUB_KEY_ID_CAP, encap_context req_slot_id must be 0xFF)*/
-
+     *    1.2 CHALLENGE (REQUEST_FLAGS_PUB_KEY_ID_CAP, encap_context req_slot_id must be 0xFF) */
     libspdm_zero_mem(spdm_context->encap_context.request_op_code_sequence,
                      sizeof(spdm_context->encap_context.request_op_code_sequence));
     /* Basic Mutual Auth*/
@@ -487,18 +459,22 @@ void libspdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context, uint8_t 
                      sizeof(spdm_context->encap_context.last_encap_request_header));
     spdm_context->mut_auth_cert_chain_buffer_size = 0;
 
-    /* Clear Cache */
+    /* Clear cache. */
     libspdm_reset_message_mut_b(spdm_context);
     libspdm_reset_message_mut_c(spdm_context);
 
     /* Possible Sequence:
      * 2. Session Mutual Auth: (spdm_context->last_spdm_request_session_id_valid)
-     *    2.1 GET_DIGEST/GET_CERTIFICATE (MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST or MUT_AUTH_REQUESTED_WITH_GET_DIGESTS, encap_context.req_slot_id must not be 0xFF)
-     *    2.2 N/A (REQUEST_FLAGS_PUB_KEY_ID_CAP, MUT_AUTH_REQUESTED, encap_context.req_slot_id may or may not be 0xFF)*/
+     *    2.1 GET_DIGEST/GET_CERTIFICATE
+     *        (MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST or MUT_AUTH_REQUESTED_WITH_GET_DIGESTS,
+     *         encap_context.req_slot_id must not be 0xFF)
+     *    2.2 N/A (REQUEST_FLAGS_PUB_KEY_ID_CAP, MUT_AUTH_REQUESTED, encap_context.req_slot_id may
+     *             or may not be 0xFF)*/
 
     libspdm_zero_mem(spdm_context->encap_context.request_op_code_sequence,
                      sizeof(spdm_context->encap_context.request_op_code_sequence));
-    /* Session Mutual Auth*/
+
+    /* Session mutual authentication. */
     if (libspdm_is_capabilities_flag_supported(
             spdm_context, false,
             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PUB_KEY_ID_CAP, 0)) {
@@ -511,7 +487,7 @@ void libspdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context, uint8_t 
 
     switch (mut_auth_requested) {
     case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED:
-        /* no encap is required*/
+        /* No encapsulation is required. */
         spdm_context->encap_context.request_op_code_count = 0;
         break;
     case SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST:
@@ -528,7 +504,7 @@ void libspdm_init_mut_auth_encap_state(libspdm_context_t *spdm_context, uint8_t 
     }
 
     if (spdm_context->encap_context.request_op_code_count != 0) {
-        /* change state only if ENCAP is required */
+        /* Change state only if encapsulation is required. */
         spdm_context->response_state = LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP;
     }
 }


### PR DESCRIPTION
In preparation for encapsulated event messages, this commit cleans up encapsulated send and receive routines for both the Requester and Responder.