### PR TITLE
Fix `SET_CERTIFICATE` build break

### DIFF
--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -446,7 +446,7 @@
  * This macro will be removed when libspdm 4.0 is released.
  */
 #ifndef LIBSPDM_SET_CERT_CSR_PARAMS
-#define LIBSPDM_SET_CERT_CSR_PARAMS 1
+#define LIBSPDM_SET_CERT_CSR_PARAMS 0
 #endif
 
 #endif /* SPDM_LIB_CONFIG_H */

--- a/os_stub/spdm_device_secret_lib_sample/set_cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/set_cert.c
@@ -50,11 +50,14 @@ bool libspdm_write_certificate_to_nvm(
 #endif /* LIBSPDM_SET_CERT_CSR_PARAMS */
     )
 {
+#if LIBSPDM_SET_CERT_CSR_PARAMS
     if (g_set_cert_is_busy) {
         *is_busy = true;
 
         return false;
-    } else {
+    } else
+#endif /* LIBSPDM_SET_CERT_CSR_PARAMS */
+    {
     #if defined(_WIN32) || (defined(__clang__) && (defined (LIBSPDM_CPU_AARCH64) || \
         defined(LIBSPDM_CPU_ARM)))
         FILE *fp_out;

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1046,6 +1046,7 @@ void libspdm_test_responder_set_certificate_rsp_case12(void **state)
  **/
 void libspdm_test_responder_set_certificate_rsp_case13(void **state)
 {
+#if LIBSPDM_SET_CERT_CSR_PARAMS
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -1111,6 +1112,7 @@ void libspdm_test_responder_set_certificate_rsp_case13(void **state)
 
     free(cert_chain);
     free(m_libspdm_set_certificate_request);
+#endif /* LIBSPDM_SET_CERT_CSR_PARAMS */
 }
 
 int libspdm_responder_set_certificate_rsp_test_main(void)


### PR DESCRIPTION
Fix issues in #2901.

1. Set LIBSPDM_SET_CERT_CSR_PARAMS to 0 by default.
2. Wrap is_busy parameter in sert_cert.c with LIBSPDM_SET_CERT_CSR_PARAMS.