### PR TITLE
Use Ubuntu 22.04 for uncrustify

### DIFF
--- a/.github/workflows/compliance-checks.yml
+++ b/.github/workflows/compliance-checks.yml
@@ -25,7 +25,7 @@ jobs:
 
   uncrustify:
     name: Style Compliance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install uncrustify
         run: |


### PR DESCRIPTION
Fix #2931.

Later on this can be changed back to ubuntu-latest once the configuration file is updated.