### PR TITLE
CMakeLists.txt: Support x86_64 ARCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ message("CMAKE_GENERATOR = ${CMAKE_GENERATOR}")
 
 if(ARCH STREQUAL "x64")
     message("ARCH = x64")
+elseif(ARCH STREQUAL "x86_64")
+    message("ARCH = x64")
 elseif(ARCH STREQUAL "ia32")
     message("ARCH = ia32")
 elseif(ARCH STREQUAL "arm")


### PR DESCRIPTION
Yocto/OpenEmbedded usses "x86_64" for the 64-bit x86 architecture, which currently isn't supported by libspdm. As it's a common name for the architecture let's add support for "x86_64" as the ARCH.