### PR TITLE
Fix spelling mistakes across the repository

### DIFF
--- a/doc/api/common_api.md
+++ b/doc/api/common_api.md
@@ -118,7 +118,7 @@ Enumeration value used for the `libspdm_set_data` and/or `libspdm_get_data` func
       timing." and is in units of microseconds. This value is only used by a Requester and is used
       in the following scenarios.
         - It is the value of the `timeout` argument in `libspdm_device_send_message_func`. When
-          sending a message this is a worst-case value, and the implementor of the function is free
+          sending a message this is a worst-case value, and the implementer of the function is free
           to reduce the timeout value based on knowledge of the underlying transport.
         - It is added to the Responder's `CT` or `ST1` value and passed via the `timeout` argument
           in `libspdm_device_receive_message_func`.

--- a/doc/api/secured_message_api.md
+++ b/doc/api/secured_message_api.md
@@ -125,7 +125,7 @@ destination buffer.
 This function should only be called after the session has been fully established and
 `libspdm_secured_message_get_session_state()` returns `LIBSPDM_SESSION_STATE_ESTABLISHED`.
 
-The structure is packed and is layed out as
+The structure is packed and is laid out as
 - Struct Version (4 bytes)
 - AEAD Key Size (4 bytes)
 - AEAD IV Size (4 bytes)

--- a/doc/fips.md
+++ b/doc/fips.md
@@ -77,7 +77,7 @@ If FIPS mode is enabled, then only FIPS-approved algorithms will be enabled, whi
 
 ### Key zeroization
 
-If a key is not used, then the variable to hold the key must be explictly zeroized. This is done in the libspdm.
+If a key is not used, then the variable to hold the key must be explicitly zeroized. This is done in the libspdm.
 
 The private key for signing is managed by the [requester-asymsignlib](https://github.com/DMTF/libspdm/blob/main/include/hal/library/requester/reqasymsignlib.h) and [responder-asymlib](https://github.com/DMTF/libspdm/blob/main/include/hal/library/responder/asymsignlib.h). The library provider shall guarantee the key is zeroized after use.
 
@@ -132,4 +132,4 @@ The expected step is as follows:
 #endif
 ```
 
-NOTE: If a crypto library does not support a FIPS algorithm, then the algorithm must be disabled explictly. Otherwise `libspdm_fips_run_selftest()` will fail. For example, if the integrator links libspdm with mbedtls, then SHA3 and RdDSA related algorithms must be disabled via `LIBSPDM_SHA3_256_SUPPORT=0`, `LIBSPDM_SHA3_384_SUPPORT=0`, `LIBSPDM_SHA3_512_SUPPORT=0`, `LIBSPDM_EDDSA_ED25519_SUPPORT=0`, `LIBSPDM_EDDSA_ED448_SUPPORT=0`, because they are not supported by mbedtls yet.
+NOTE: If a crypto library does not support a FIPS algorithm, then the algorithm must be disabled explicitly. Otherwise `libspdm_fips_run_selftest()` will fail. For example, if the integrator links libspdm with mbedtls, then SHA3 and RdDSA related algorithms must be disabled via `LIBSPDM_SHA3_256_SUPPORT=0`, `LIBSPDM_SHA3_384_SUPPORT=0`, `LIBSPDM_SHA3_512_SUPPORT=0`, `LIBSPDM_EDDSA_ED25519_SUPPORT=0`, `LIBSPDM_EDDSA_ED448_SUPPORT=0`, because they are not supported by mbedtls yet.

--- a/doc/test.md
+++ b/doc/test.md
@@ -603,7 +603,7 @@ For riscv64 (RISCV64 GCC): `qemu-riscv64 -L /usr/riscv64-linux-gnu <TestBinary>`
 
    The output binary is created by the [goto-cc](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/goto-cc.md).
 
-   For more infomration on how to use [CBMC](https://github.com/diffblue/cbmc/), refer to [CBMC Manual](https://github.com/diffblue/cbmc/tree/develop/doc/cprover-manual), such as [properties](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/properties.md), [modeling-nondeterminism](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/modeling-nondeterminism.md), [api](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/api.md). Example below:
+   For more information on how to use [CBMC](https://github.com/diffblue/cbmc/), refer to [CBMC Manual](https://github.com/diffblue/cbmc/tree/develop/doc/cprover-manual), such as [properties](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/properties.md), [modeling-nondeterminism](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/modeling-nondeterminism.md), [api](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/api.md). Example below:
 
    Using [goto-instrument](https://github.com/diffblue/cbmc/blob/develop/doc/cprover-manual/goto-instrument.md) static analyzer operates on goto-binaries and generate a modified binary:
    `goto-instrument SpdmRequester.exe SpdmRequester.gb <instrumentation-options>`

--- a/os_stub/cryptlib_mbedtls/pk/x509.c
+++ b/os_stub/cryptlib_mbedtls/pk/x509.c
@@ -712,7 +712,7 @@ bool libspdm_x509_verify_cert_chain(const uint8_t *root_cert, size_t root_cert_l
     current_cert = (const unsigned char *)cert_chain;
 
 
-    /* Get Current certificate from certificates buffer and Verify with preciding cert*/
+    /* Get Current certificate from certificates buffer and Verify with preceding cert*/
 
     do {
         tmp_ptr = current_cert;
@@ -1750,7 +1750,7 @@ static bool libspdm_convert_subject_to_string(uint8_t *ptr, size_t obj_len,
         /*move to next SET*/
         ptr += obj_len;
 
-        /*sequece*/
+        /*sequence*/
         ret = libspdm_asn1_get_tag(&internal_p, end, &obj_len,
                                    LIBSPDM_CRYPTO_ASN1_SEQUENCE | LIBSPDM_CRYPTO_ASN1_CONSTRUCTED);
         if (!ret) {
@@ -1855,7 +1855,7 @@ bool libspdm_set_attribute_for_req(mbedtls_x509write_csr *req,
 
     /*integer:version*/
     ret = libspdm_asn1_get_tag(&ptr, end, &obj_len, LIBSPDM_CRYPTO_ASN1_INTEGER);
-    /*check req_info verson. spec PKCS#10: It shall be 0 for this version of the standard.*/
+    /*check req_info version. spec PKCS#10: It shall be 0 for this version of the standard.*/
     if ((obj_len != 1) || (*ptr != 0)) {
         return false;
     }

--- a/os_stub/cryptlib_null/pk/x509.c
+++ b/os_stub/cryptlib_null/pk/x509.c
@@ -313,16 +313,16 @@ bool libspdm_x509_verify_cert(const uint8_t *cert, size_t cert_size,
  *
  * @param[in]      cert_chain         One or more ASN.1 DER-encoded X.509 certificates
  *                                  where the first certificate is signed by the Root
- *                                  Certificate or is the Root Cerificate itself. and
- *                                  subsequent cerificate is signed by the preceding
- *                                  cerificate.
+ *                                  Certificate or is the Root Certificate itself. and
+ *                                  subsequent certificate is signed by the preceding
+ *                                  certificate.
  * @param[in]      cert_chain_length   Total length of the certificate chain, in bytes.
  *
  * @param[in]      root_cert          Trusted Root Certificate buffer
  *
  * @param[in]      root_cert_length    Trusted Root Certificate buffer length
  *
- * @retval  true   All cerificates was issued by the first certificate in X509Certchain.
+ * @retval  true   All certificates was issued by the first certificate in X509Certchain.
  * @retval  false  Invalid certificate or the certificate was not issued by the given
  *                trusted CA.
  **/
@@ -338,9 +338,9 @@ bool libspdm_x509_verify_cert_chain(const uint8_t *root_cert, size_t root_cert_l
  *
  * @param[in]      cert_chain         One or more ASN.1 DER-encoded X.509 certificates
  *                                  where the first certificate is signed by the Root
- *                                  Certificate or is the Root Cerificate itself. and
- *                                  subsequent cerificate is signed by the preceding
- *                                  cerificate.
+ *                                  Certificate or is the Root Certificate itself. and
+ *                                  subsequent certificate is signed by the preceding
+ *                                  certificate.
  * @param[in]      cert_chain_length   Total length of the certificate chain, in bytes.
  *
  * @param[in]      cert_index         index of certificate.

--- a/os_stub/cryptlib_openssl/pk/x509.c
+++ b/os_stub/cryptlib_openssl/pk/x509.c
@@ -417,7 +417,7 @@ libspdm_internal_x509_get_nid_name(X509_NAME *x509_name, const int32_t request_n
     }
 
 
-    /* Retrive the string from X.509 Subject base on the request_nid*/
+    /* Retrieve the string from X.509 Subject base on the request_nid*/
 
     index = X509_NAME_get_index_by_NID(x509_name, request_nid, -1);
     if (index < 0) {
@@ -1996,16 +1996,16 @@ bool libspdm_x509_get_tbs_cert(const uint8_t *cert, size_t cert_size,
  *
  * @param[in]      cert_chain         One or more ASN.1 DER-encoded X.509 certificates
  *                                  where the first certificate is signed by the Root
- *                                  Certificate or is the Root Cerificate itself. and
- *                                  subsequent cerificate is signed by the preceding
- *                                  cerificate.
+ *                                  Certificate or is the Root Certificate itself. and
+ *                                  subsequent certificate is signed by the preceding
+ *                                  certificate.
  * @param[in]      cert_chain_length   Total length of the certificate chain, in bytes.
  *
  * @param[in]      root_cert          Trusted Root Certificate buffer
  *
  * @param[in]      root_cert_length    Trusted Root Certificate buffer length
  *
- * @retval  true   All cerificates was issued by the first certificate in X509Certchain.
+ * @retval  true   All certificates was issued by the first certificate in X509Certchain.
  * @retval  false  Invalid certificate or the certificate was not issued by the given
  *                trusted CA.
  **/
@@ -2113,9 +2113,9 @@ bool libspdm_x509_verify_cert_chain(const uint8_t *root_cert, size_t root_cert_l
  *
  * @param[in]      cert_chain         One or more ASN.1 DER-encoded X.509 certificates
  *                                  where the first certificate is signed by the Root
- *                                  Certificate or is the Root Cerificate itself. and
- *                                  subsequent cerificate is signed by the preceding
- *                                  cerificate.
+ *                                  Certificate or is the Root Certificate itself. and
+ *                                  subsequent certificate is signed by the preceding
+ *                                  certificate.
  * @param[in]      cert_chain_length   Total length of the certificate chain, in bytes.
  *
  * @param[in]      cert_index         index of certificate.
@@ -2354,7 +2354,7 @@ bool libspdm_set_attribute_for_req(X509_REQ *req, uint8_t *req_info, size_t req_
 
     /*integer:version*/
     ret = libspdm_asn1_get_tag(&ptr, end, &obj_len, LIBSPDM_CRYPTO_ASN1_INTEGER);
-    /*check req_info verson. spec PKCS#10: It shall be 0 for this version of the standard.*/
+    /*check req_info version. spec PKCS#10: It shall be 0 for this version of the standard.*/
     if ((obj_len != 1) || (*ptr != 0)) {
         return false;
     }
@@ -2401,7 +2401,7 @@ bool libspdm_set_attribute_for_req(X509_REQ *req, uint8_t *req_info, size_t req_
                                    LIBSPDM_CRYPTO_ASN1_SEQUENCE |
                                    LIBSPDM_CRYPTO_ASN1_CONSTRUCTED);
         if (ret) {
-            /*save old positon*/
+            /*save old position*/
             ptr_old = ptr;
 
             /*move to the next sequence*/

--- a/os_stub/debuglib/debuglib.c
+++ b/os_stub/debuglib/debuglib.c
@@ -73,7 +73,7 @@ void libspdm_debug_print(size_t error_level, const char *format, ...)
     status = vsnprintf(buffer, sizeof(buffer), format, marker);
     va_end(marker);
 
-    /* If status is negative then an encoding error has ocurred. */
+    /* If status is negative then an encoding error has occurred. */
     assert(status >= 0);
     /* If status is greater than or equal to the size of the buffer then the buffer is not
      * large enough to handle the formatted string. */

--- a/os_stub/mbedtlslib/include/mbedtls/libspdm_mbedtls_config.h
+++ b/os_stub/mbedtlslib/include/mbedtls/libspdm_mbedtls_config.h
@@ -1139,7 +1139,7 @@
  *           MBEDTLS_ECP_DP_SECP256R1_ENABLED
  *
  * \warning If SHA-256 is provided only by a PSA driver, you must call
- * psa_crypto_init() before the first hanshake (even if
+ * psa_crypto_init() before the first handshake (even if
  * MBEDTLS_USE_PSA_CRYPTO is disabled).
  *
  * This enables the following ciphersuites (if other requisites are
@@ -1633,7 +1633,7 @@
  * functions mbedtls_ssl_context_save() and mbedtls_ssl_context_load().
  *
  * This pair of functions allows one side of a connection to serialize the
- * context associated with the connection, then free or re-use that context
+ * context associated with the connection, then free or reuse that context
  * while the serialized state is persisted elsewhere, and finally deserialize
  * that state to a live context for resuming read/write operations on the
  * connection. From a protocol perspective, the state of the connection is
@@ -2646,7 +2646,7 @@
  * The CTR_DRBG generator uses AES-256 by default.
  * To use AES-128 instead, enable \c MBEDTLS_CTR_DRBG_USE_128_BIT_KEY above.
  *
- * AES support can either be achived through builtin (MBEDTLS_AES_C) or PSA.
+ * AES support can either be achieved through builtin (MBEDTLS_AES_C) or PSA.
  * Builtin is the default option when MBEDTLS_AES_C is defined otherwise PSA
  * is used.
  *

--- a/os_stub/spdm_device_secret_lib_sample/read_special_cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/read_special_cert.c
@@ -114,7 +114,7 @@ bool libspdm_read_responder_public_certificate_chain_by_size(
 
     is_requester_cert = false;
 
-    /*defalut is true*/
+    /*default is true*/
     is_device_cert_model = true;
 
     *data = NULL;

--- a/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
+++ b/unit_test/fuzzing/test_requester/test_spdm_requester_key_update/key_update.c
@@ -322,7 +322,7 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_requester_key_update_case1(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Sucessful response  update all keys*/
+    /* Successful response  update all keys*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_requester_key_update_case2(&State);
     libspdm_unit_test_group_teardown(&State);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_algorithms/algorithms.c
@@ -476,32 +476,32 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_algorithms_case2(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP*/
+    /* Support capabilities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case3(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag */
+    /* Support capabilities flag */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case4(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP*/
+    /* Support capabilities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case5(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP */
+    /* Support capabilities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case6(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP*/
+    /* Support capabilities flag: SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case7(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Support capablities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP*/
+    /* Support capabilities flag: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP*/
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case8(&State);
     libspdm_unit_test_group_teardown(&State);
@@ -511,7 +511,7 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_algorithms_case9(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* capablities: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP */
+    /* capabilities: SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_algorithms_case10(&State);
     libspdm_unit_test_group_teardown(&State);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_chunk_get/chunk_get.c
@@ -325,7 +325,7 @@ void libspdm_run_test_harness(void *test_buffer, size_t test_buffer_size)
     libspdm_test_responder_chunk_get_case3(&State);
     libspdm_unit_test_group_teardown(&State);
 
-    /* Succesful request of  chunk, where size is exactly max chunk size */
+    /* Successful request of  chunk, where size is exactly max chunk size */
     libspdm_unit_test_group_setup(&State);
     libspdm_test_responder_chunk_get_case4(&State);
     libspdm_unit_test_group_teardown(&State);

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -103,7 +103,7 @@ size_t libspdm_get_multi_element_opaque_data_supported_version_data_size(
  *                                           On input, it means the size in bytes of data_out buffer.
  *                                           On output, it means the size in bytes of copied data_out buffer if RETURN_SUCCESS is returned,
  *                                           and means the size in bytes of desired data_out buffer if RETURN_BUFFER_TOO_SMALL is returned.
- * @param  data_out[in]                      A pointer to the desination buffer to store the opaque data supported version.
+ * @param  data_out[in]                      A pointer to the destination buffer to store the opaque data supported version.
  * @param  element_num[in]                   in this test function, the element number < 9 is right. because element id is changed with element_index
  *
  * @retval RETURN_SUCCESS               The opaque data supported version is built successfully.
@@ -266,7 +266,7 @@ size_t libspdm_get_multi_element_opaque_data_version_selection_data_size(
  *                                           On input, it means the size in bytes of data_out buffer.
  *                                           On output, it means the size in bytes of copied data_out buffer if RETURN_SUCCESS is returned,
  *                                           and means the size in bytes of desired data_out buffer if RETURN_BUFFER_TOO_SMALL is returned.
- * @param  data_out[in]                      A pointer to the desination buffer to store the opaque data selection version.
+ * @param  data_out[in]                      A pointer to the destination buffer to store the opaque data selection version.
  * @param  element_num[in]                   in this test function, the element number < 9 is right. because element id is changed with element_index
  *
  * @retval RETURN_SUCCESS               The opaque data selection version is built successfully.

--- a/unit_test/test_spdm_requester/encap_certificate.c
+++ b/unit_test/test_spdm_requester/encap_certificate.c
@@ -42,7 +42,7 @@ size_t m_spdm_get_certificate_request4_size =
 
 /**
  * Test 1: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the
- * certificate chain Expected Behavior: generate a correctly formed Certficate
+ * certificate chain Expected Behavior: generate a correctly formed Certificate
  * message, including its portion_length and remainder_length fields
  **/
 void libspdm_test_requester_encap_certificate_case1(void **state)
@@ -109,7 +109,7 @@ void libspdm_test_requester_encap_certificate_case2(void **state)
 
 /**
  * Test 3: request length at the boundary of maximum integer values, while
- * keeping offset 0 Expected Behavior: generate correctly formed Certficate
+ * keeping offset 0 Expected Behavior: generate correctly formed Certificate
  * messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_requester_encap_certificate_case3(void **state)
@@ -162,7 +162,7 @@ void libspdm_test_requester_encap_certificate_case3(void **state)
         expected_chunk_size = LIBSPDM_MIN(m_spdm_get_certificate_request3.length,
                                           LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to
+        /* resetting an internal buffer to avoid overflow and prevent tests to
          * succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
@@ -187,7 +187,7 @@ void libspdm_test_requester_encap_certificate_case3(void **state)
 
 /**
  * Test 4: request offset at the boundary of maximum integer values, while
- * keeping length 0 Expected Behavior: generate correctly formed Certficate
+ * keeping length 0 Expected Behavior: generate correctly formed Certificate
  * messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_requester_encap_certificate_case4(void **state)
@@ -243,7 +243,7 @@ void libspdm_test_requester_encap_certificate_case4(void **state)
         TEST_DEBUG_PRINT("i:%d test_offsets[i]:%u\n", i, test_offsets[i]);
         m_spdm_get_certificate_request3.offset = test_offsets[i];
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to
+        /* resetting an internal buffer to avoid overflow and prevent tests to
          * succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
@@ -278,7 +278,7 @@ void libspdm_test_requester_encap_certificate_case4(void **state)
 /**
  * Test 5: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of long certificate
  * chains, with the largest valid offset Expected Behavior: generate correctly
- * formed Certficate messages, including its portion_length and remainder_length
+ * formed Certificate messages, including its portion_length and remainder_length
  * fields
  **/
 void libspdm_test_requester_encap_certificate_case5(void **state)
@@ -331,7 +331,7 @@ void libspdm_test_requester_encap_certificate_case5(void **state)
                          m_spdm_get_certificate_request3.offset +
                          m_spdm_get_certificate_request3.length);
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to
+        /* resetting an internal buffer to avoid overflow and prevent tests to
          * succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
@@ -382,7 +382,7 @@ void libspdm_test_requester_encap_certificate_case5(void **state)
 
 /**
  * Test 6: request a whole certificate chain byte by byte
- * Expected Behavior: generate correctly formed Certficate messages, including
+ * Expected Behavior: generate correctly formed Certificate messages, including
  * its portion_length and remainder_length fields
  **/
 void libspdm_test_requester_encap_certificate_case6(void **state)
@@ -418,7 +418,7 @@ void libspdm_test_requester_encap_certificate_case6(void **state)
     m_spdm_get_certificate_request3.length = 1;
     expected_chunk_size = 1;
 
-    /* reseting an internal buffer to avoid overflow and prevent tests to
+    /* resetting an internal buffer to avoid overflow and prevent tests to
      * succeed*/
     libspdm_reset_message_b(spdm_context);
 
@@ -470,8 +470,8 @@ void libspdm_test_requester_encap_certificate_case6(void **state)
 
 /**
  * Test 7: check request attributes and response attributes , SlotSizeRequested=1b the Offset and Length fields in the
- * GET_CERTIFICATE request shall be ignored by the Responde
- * Expected Behavior: generate a correctly formed Certficate message, including its portion_length and remainder_length fields
+ * GET_CERTIFICATE request shall be ignored by the Responder
+ * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
 void libspdm_test_requester_encap_certificate_case7(void **state)
 {

--- a/unit_test/test_spdm_requester/encap_key_update.c
+++ b/unit_test/test_spdm_requester/encap_key_update.c
@@ -947,7 +947,7 @@ void test_libspdm_requester_encap_key_update_case12(void **state)
 }
 
 
-/* ohter command + UpdateKey: success*/
+/* other command + UpdateKey: success*/
 void test_libspdm_requester_encap_key_update_case13(void **state)
 {
     libspdm_return_t status;
@@ -983,7 +983,7 @@ void test_libspdm_requester_encap_key_update_case13(void **state)
 
     /*request side *not* updated*/
 
-    /*ohter command with cleared last_key_update_request*/
+    /*other command with cleared last_key_update_request*/
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));
 
     /*response side updated */
@@ -1016,7 +1016,7 @@ void test_libspdm_requester_encap_key_update_case13(void **state)
 }
 
 
-/* ohter command + VerifyNewKey: failed*/
+/* other command + VerifyNewKey: failed*/
 void test_libspdm_requester_encap_key_update_case14(void **state)
 {
     libspdm_return_t status;
@@ -1052,7 +1052,7 @@ void test_libspdm_requester_encap_key_update_case14(void **state)
 
     /*request side *not* updated*/
 
-    /*ohter command with cleared last_key_update_request*/
+    /*other command with cleared last_key_update_request*/
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));
 
     /*response side updated */
@@ -1105,9 +1105,9 @@ int libspdm_requester_encap_key_update_test_main(void)
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case11),
         /* VerifyNewKey + VerifyNewKey: failed*/
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case12),
-        /* ohter command + UpdateKey: success*/
+        /* other command + UpdateKey: success*/
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case13),
-        /* ohter command + VerifyNewKey: failed*/
+        /* other command + VerifyNewKey: failed*/
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case14),
     };
 

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1181,7 +1181,7 @@ static void libspdm_test_requester_get_digests_err_case9(void **state)
 }
 
 /**
- * Test 10: flag cert_cap from CAPABILITIES is not setted meaning the Requester does not support DIGESTS and
+ * Test 10: flag cert_cap from CAPABILITIES is not set meaning the Requester does not support DIGESTS and
  * CERTIFICATE response messages
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_UNSUPPORTED_CAP, with no DIGESTS message received
  **/
@@ -1375,7 +1375,7 @@ static void libspdm_test_requester_get_digests_err_case17(void **state)
 /**
  * Test 18: a request message is successfully sent but the number of digests received in the response message is different than
  * the number of bits set in param2 - Slot mask
- * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer is not shrunk)
  **/
 static void libspdm_test_requester_get_digests_err_case18(void **state)
 {
@@ -1441,7 +1441,7 @@ static void libspdm_test_requester_get_digests_err_case19(void **state)
 /**
  * Test 20: a request message is successfully sent but the size of the response message is smaller than the minimum size of a SPDM DIGESTS response,
  * meaning it is an invalid response message.
- * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer is not shrunk)
  **/
 static void libspdm_test_requester_get_digests_err_case20(void **state)
 {
@@ -1476,7 +1476,7 @@ static void libspdm_test_requester_get_digests_err_case20(void **state)
 /**
  * Test 21: a request message is successfully sent but the size of the response message is bigger than the maximum size of a SPDM DIGESTS response,
  * meaning it is an invalid response message.
- * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer not shrinked)
+ * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no successful DIGESTS message received (managed buffer is not shrunk)
  **/
 static void libspdm_test_requester_get_digests_err_case21(void **state)
 {

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -4567,7 +4567,7 @@ static void libspdm_test_requester_get_measurements_err_case30(void **state)
 }
 
 /**
- * Test 31: Error case, reponse contains opaque data larger than the maximum allowed. MAXUINT16 is used
+ * Test 31: Error case, response contains opaque data larger than the maximum allowed. MAXUINT16 is used
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
 static void libspdm_test_requester_get_measurements_err_case31(void **state)

--- a/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
+++ b/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
@@ -2836,7 +2836,7 @@ static void libspdm_test_requester_negotiate_algorithms_error_case37(void **stat
 }
 
 /**
- * Test 38: Reserverd alg_type value.
+ * Test 38: Reserved alg_type value.
  * Expected behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
 static void libspdm_test_requester_negotiate_algorithms_error_case38(void **state)

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -2911,7 +2911,7 @@ void libspdm_test_requester_get_certificate_case11(void **state)
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
 
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
 
@@ -2983,7 +2983,7 @@ void libspdm_test_requester_get_certificate_case12(void **state)
         m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
     spdm_context->local_context.is_requester = true;
@@ -3059,7 +3059,7 @@ void libspdm_test_requester_get_certificate_case13(void **state)
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
     spdm_context->local_context.is_requester = true;
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
 
@@ -3129,7 +3129,7 @@ void libspdm_test_requester_get_certificate_case14(void **state)
         m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
 
@@ -3201,7 +3201,7 @@ void libspdm_test_requester_get_certificate_case15(void **state)
         m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
 
@@ -3450,7 +3450,7 @@ void libspdm_test_requester_get_certificate_case19(void **state)
         m_libspdm_use_asym_algo;
     spdm_context->connection_info.algorithm.req_base_asym_alg =
         m_libspdm_use_req_asym_algo;
-    /* Reseting message buffer*/
+    /* Resetting message buffer*/
     libspdm_reset_message_b(spdm_context);
     /* Calculating expected number of messages received*/
 
@@ -4369,15 +4369,15 @@ int libspdm_requester_get_certificate_test_main(void)
         cmocka_unit_test(libspdm_test_requester_get_certificate_case11),
         /* Fail certificate chain check*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case12),
-        /* Sucessful response: get a certificate chain that fits in one single message*/
+        /* Successful response: get a certificate chain that fits in one single message*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case13),
-        /* Sucessful response: get certificate chain byte by byte*/
+        /* Successful response: get certificate chain byte by byte*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case14),
-        /* Sucessful response: get a long certificate chain*/
+        /* Successful response: get a long certificate chain*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case15),
         /* Unexpected errors*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case16),
-        /* Sucessful response: get a certificate chain not start with root cert.*/
+        /* Successful response: get a certificate chain not start with root cert.*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case17),
         /* Fail response: get a certificate chain not start with root cert but with wrong signature.*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case18),

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -5078,7 +5078,7 @@ static void libspdm_test_requester_get_measurements_case23(void **state)
 }
 
 /**
- * Test 24: Error case, reponse contains opaque data larger than the maximum allowed
+ * Test 24: Error case, response contains opaque data larger than the maximum allowed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
 static void libspdm_test_requester_get_measurements_case24(void **state)

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -5710,7 +5710,7 @@ int libspdm_requester_key_update_test_main(void)
         cmocka_unit_test(libspdm_test_requester_key_update_case25),
         cmocka_unit_test(libspdm_test_requester_key_update_case26),
         /* update all keys
-         * Sucessful response*/
+         * Successful response*/
         cmocka_unit_test(libspdm_test_requester_key_update_case27),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
         cmocka_unit_test(libspdm_test_requester_key_update_case28),

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -45,7 +45,7 @@ spdm_get_certificate_request_t m_libspdm_get_certificate_request5 = {
 size_t m_libspdm_get_certificate_request5_size = sizeof(m_libspdm_get_certificate_request5);
 /**
  * Test 1: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the certificate chain
- * Expected Behavior: generate a correctly formed Certficate message, including its portion_length and remainder_length fields
+ * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case1(void **state)
 {
@@ -321,7 +321,7 @@ void libspdm_test_responder_certificate_case6(void **state)
 
 /**
  * Test 7: request length at the boundary of maximum integer values, while keeping offset 0
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case7(void **state)
 {
@@ -371,7 +371,7 @@ void libspdm_test_responder_certificate_case7(void **state)
         expected_chunk_size = LIBSPDM_MIN(m_libspdm_get_certificate_request3.length,
                                           LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+        /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
         status = libspdm_get_response_certificate(
@@ -396,7 +396,7 @@ void libspdm_test_responder_certificate_case7(void **state)
 
 /**
  * Test 8: request offset at the boundary of maximum integer values, while keeping length 0
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case8(void **state)
 {
@@ -453,7 +453,7 @@ void libspdm_test_responder_certificate_case8(void **state)
         TEST_LIBSPDM_DEBUG_PRINT("i:%d test_offsets[i]:%u\n", i, test_offsets[i]);
         m_libspdm_get_certificate_request3.offset = test_offsets[i];
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+        /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
         status = libspdm_get_response_certificate(
@@ -492,7 +492,7 @@ void libspdm_test_responder_certificate_case8(void **state)
 
 /**
  * Test 9: request offset and length at the boundary of maximum integer values
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case9(void **state)
 {
@@ -562,7 +562,7 @@ void libspdm_test_responder_certificate_case9(void **state)
                                      test_sizes[j]);
             m_libspdm_get_certificate_request3.offset = test_sizes[j];
 
-            /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+            /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
             libspdm_reset_message_b(spdm_context);
             response_size = sizeof(response);
             status = libspdm_get_response_certificate(
@@ -623,7 +623,7 @@ void libspdm_test_responder_certificate_case9(void **state)
 
 /**
  * Test 10: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of long certificate chains, with the largest valid offset
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case10(void **state)
 {
@@ -680,7 +680,7 @@ void libspdm_test_responder_certificate_case10(void **state)
             m_libspdm_get_certificate_request3.offset +
             m_libspdm_get_certificate_request3.length);
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+        /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
         status = libspdm_get_response_certificate(
@@ -739,7 +739,7 @@ void libspdm_test_responder_certificate_case10(void **state)
 
 /**
  * Test 11: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of a short certificate chain (fits in 1 message)
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case11(void **state)
 {
@@ -800,7 +800,7 @@ void libspdm_test_responder_certificate_case11(void **state)
             m_libspdm_get_certificate_request3.offset +
             m_libspdm_get_certificate_request3.length);
 
-        /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+        /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
         libspdm_reset_message_b(spdm_context);
         response_size = sizeof(response);
         status = libspdm_get_response_certificate(
@@ -854,7 +854,7 @@ void libspdm_test_responder_certificate_case11(void **state)
 
 /**
  * Test 12: request a whole certificate chain byte by byte
- * Expected Behavior: generate correctly formed Certficate messages, including its portion_length and remainder_length fields
+ * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case12(void **state)
 {
@@ -894,7 +894,7 @@ void libspdm_test_responder_certificate_case12(void **state)
     expected_chunk_size = 1;
 
 
-    /* reseting an internal buffer to avoid overflow and prevent tests to succeed*/
+    /* resetting an internal buffer to avoid overflow and prevent tests to succeed*/
     libspdm_reset_message_b(spdm_context);
 
     spdm_response = NULL;
@@ -1026,7 +1026,7 @@ void libspdm_test_responder_certificate_case13(void **state)
 
 /**
  * Test 14: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the certificate chain in a session
- * Expected Behavior: generate a correctly formed Certficate message, including its portion_length and remainder_length fields
+ * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case14(void **state)
 {
@@ -1272,8 +1272,8 @@ void libspdm_test_responder_certificate_case17(void **state)
 
 /**
  * Test 18: check request attributes and response attributes , SlotSizeRequested=1b the Offset and Length fields in the
- * GET_CERTIFICATE request shall be ignored by the Responde
- * Expected Behavior: generate a correctly formed Certficate message, including its portion_length and remainder_length fields
+ * GET_CERTIFICATE request shall be ignored by the Responder
+ * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
 void libspdm_test_responder_certificate_case18(void **state)
 {

--- a/unit_test/test_spdm_responder/chunk_get.c
+++ b/unit_test/test_spdm_responder/chunk_get.c
@@ -780,7 +780,7 @@ void libspdm_test_responder_chunk_get_rsp_case11(void** state)
 }
 
 /**
- * Test 12: Succesful request of last chunk where size is exactly max chunk size
+ * Test 12: Successful request of last chunk where size is exactly max chunk size
  **/
 void libspdm_test_responder_chunk_get_rsp_case12(void** state)
 {
@@ -876,7 +876,7 @@ void libspdm_test_responder_chunk_get_rsp_case12(void** state)
     assert_int_equal(spdm_response->chunk_seq_no, chunk_seq_no);
     assert_int_equal(spdm_response->chunk_size, third_chunk_size);
 
-    /* Verify the 3nd chunk is filled with 3 */
+    /* Verify the 3rd chunk is filled with 3 */
     chunk_ptr = (uint8_t*) (spdm_response + 1);
     for (i = 0; i < spdm_response->chunk_size; i++) {
         assert_int_equal(chunk_ptr[i], 3);
@@ -884,7 +884,7 @@ void libspdm_test_responder_chunk_get_rsp_case12(void** state)
 }
 
 /**
- * Test 13: Succesful request of last chunk where size is exactly 1.
+ * Test 13: Successful request of last chunk where size is exactly 1.
  **/
 void libspdm_test_responder_chunk_get_rsp_case13(void** state)
 {
@@ -998,7 +998,7 @@ void libspdm_test_responder_chunk_get_rsp_case13(void** state)
 
 
 /**
- * Test 14: Responder has reponse exceed chunk seq no
+ * Test 14: Responder has response exceed chunk seq no
  **/
 void libspdm_test_responder_chunk_get_rsp_case14(void** state)
 {
@@ -1116,11 +1116,11 @@ int libspdm_responder_chunk_get_rsp_test_main(void)
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case10),
         /* Successful request of middle chunk */
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case11),
-        /* Succesful request of last chunk, where size is exactly max chunk size */
+        /* Successful request of last chunk, where size is exactly max chunk size */
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case12),
         /* Successful request of last chunk where chunk size is exactly 1 byte */
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case13),
-        /* Responder has reponse exceed chunk seq no */
+        /* Responder has response exceed chunk seq no */
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case14),
     };
 

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -1909,7 +1909,7 @@ int libspdm_responder_chunk_send_ack_test_main(void)
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case18),
         /* Request missing LAST_CHUNK when request size != data transfer size. */
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case19),
-        /* Request chunk seq warpped. */
+        /* Request chunk seq wrapped. */
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case20),
         /* Request size exceed max chunk seq no. */
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case21),

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -284,14 +284,14 @@ bool libspdm_check_csr_basic_constraints(uint8_t *csr, uint16_t csr_len, bool is
     if (!result) {
         return false;
     }
-    /*basic constriants oid*/
+    /*basic constraints oid*/
     result = libspdm_asn1_get_tag(&ptr, end, &obj_len, LIBSPDM_CRYPTO_ASN1_OID);
     if (!result) {
         return false;
     }
     ptr += obj_len;
 
-    /*basic constriants*/
+    /*basic constraints*/
     result = libspdm_asn1_get_tag(&ptr, end, &obj_len, LIBSPDM_CRYPTO_ASN1_OCTET_STRING);
     if (!result) {
         return false;
@@ -1483,7 +1483,7 @@ void libspdm_test_responder_csr_case13(void **state)
 /**
  * Test 14: receives a valid GET_CSR request message from Requester with need_reset for SPDM 1.3
  * Expected Behavior: the first get_csr with csr_tracking_tag 0: responder return need reset and available csr_tracking_tag;
- *                    Afer reset, then send get_csr with csr_tracking_tag 0 six times: responder return need reset and available csr_tracking_tag;
+ *                    After reset, then send get_csr with csr_tracking_tag 0 six times: responder return need reset and available csr_tracking_tag;
  *                    Then send get_csr with csr_tracking_tag 0: responder return busy error;
  **/
 void libspdm_test_responder_csr_case14(void **state)

--- a/unit_test/test_spdm_responder/encap_get_digests.c
+++ b/unit_test/test_spdm_responder/encap_get_digests.c
@@ -109,7 +109,7 @@ void test_spdm_responder_encap_get_digests_case2(void **state)
 }
 
 /**
- * Test 3: Error response message with error code busy reponse seize incorrect
+ * Test 3: Error response message with error code busy response seize incorrect
  * Expected Behavior:  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
 void test_spdm_responder_encap_get_digests_case3(void **state)
@@ -198,7 +198,7 @@ void test_spdm_responder_encap_get_digests_case4(void **state)
 }
 
 /**
- * Test 5: flag cert_cap from CAPABILITIES is not setted meaning the Requester does not support DIGESTS and
+ * Test 5: flag cert_cap from CAPABILITIES is not set meaning the Requester does not support DIGESTS and
  * CERTIFICATE response messages
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/

--- a/unit_test/test_spdm_responder/key_update.c
+++ b/unit_test/test_spdm_responder/key_update.c
@@ -1878,7 +1878,7 @@ void libspdm_test_responder_key_update_case23(void **state)
 }
 
 /**
- * Test 24: :other command + UpdateKey, last requeset is not key_update command, current key operation is update key
+ * Test 24: :other command + UpdateKey, last request is not key_update command, current key operation is update key
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
@@ -1922,7 +1922,7 @@ void libspdm_test_responder_key_update_case24(void **state)
                                   secured_message_context->hash_size);
     /*response side *not* updated*/
 
-    /*ohter command with cleared last_key_update_request*/
+    /*other command with cleared last_key_update_request*/
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));
 
     /*updatekey*/
@@ -1950,7 +1950,7 @@ void libspdm_test_responder_key_update_case24(void **state)
 }
 
 /**
- * Test 25: :other command + UpdateAllKeys, last requeset is not key_update command, current key operation is update all key
+ * Test 25: :other command + UpdateAllKeys, last request is not key_update command, current key operation is update all key
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
@@ -1998,7 +1998,7 @@ void libspdm_test_responder_key_update_case25(void **state)
                                   m_rsp_secret_buffer, m_rsp_secret_buffer,
                                   secured_message_context->hash_size);
 
-    /*ohter command with cleared last_key_update_request*/
+    /*other command with cleared last_key_update_request*/
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));
 
     response_size = sizeof(response);
@@ -2025,7 +2025,7 @@ void libspdm_test_responder_key_update_case25(void **state)
 }
 
 /**
- * Test 26: :other command + VerifyNewKey, last requeset is not key_update command, current key operation is verify key
+ * Test 26: :other command + VerifyNewKey, last request is not key_update command, current key operation is verify key
  * Expected behavior: the responder refuses the KEY_UPDATE message and
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
@@ -2074,7 +2074,7 @@ void libspdm_test_responder_key_update_case26(void **state)
                                   m_rsp_secret_buffer, m_rsp_secret_buffer,
                                   secured_message_context->hash_size);
 
-    /*ohter command with cleared last_key_update_request*/
+    /*other command with cleared last_key_update_request*/
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));
 
     /*VerifyNewKey*/
@@ -2207,11 +2207,11 @@ int libspdm_responder_key_update_test_main(void)
         cmocka_unit_test(libspdm_test_responder_key_update_case22),
         /* VerifyNewKey + VerifyNewKey: failed*/
         cmocka_unit_test(libspdm_test_responder_key_update_case23),
-        /* ohter command + UpdateKey: success*/
+        /* other command + UpdateKey: success*/
         cmocka_unit_test(libspdm_test_responder_key_update_case24),
-        /* ohter command + UpdateAllKeys: success*/
+        /* other command + UpdateAllKeys: success*/
         cmocka_unit_test(libspdm_test_responder_key_update_case25),
-        /* ohter command + VerifyNewKey: failed*/
+        /* other command + VerifyNewKey: failed*/
         cmocka_unit_test(libspdm_test_responder_key_update_case26),
         /* Invalid operation,other key_update operation: failed*/
         cmocka_unit_test(libspdm_test_responder_key_update_case27),

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -1256,7 +1256,7 @@ void libspdm_test_responder_measurements_case21(void **state)
 }
 
 /**
- * Test 22: request a large number of measurements before requesting a singed response
+ * Test 22: request a large number of measurements before requesting a signed response
  * Expected Behavior: while transcript.message_m is not full, get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  *                    if transcript.message_m has no more room, an error response is expected
  **/

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -94,7 +94,7 @@ void libspdm_test_responder_set_certificate_rsp_case1(void **state)
     free(cert_chain);
     free(m_libspdm_set_certificate_request);
 
-    /*test overwirte same slot_id cert*/
+    /*test overwrite same slot_id cert*/
 
     /*read a different cert_chain*/
     libspdm_read_responder_public_certificate_chain_per_slot(1, m_libspdm_use_hash_algo,


### PR DESCRIPTION
Spelling mistakes were identified using the following command:

```
$ codespell -w $(find . -type f \( -iname \*.c -o -iname \*.h -o -iname \*.md \))
```

Wherever possible, codespell automatically fixed the errors. For any issues that could not be automatically corrected, those were addressed manually.