### PR TITLE
Add SPDM 1.3 feature encapsulate GET_ENDPOINT_INFO

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -468,7 +468,7 @@ typedef struct {
 
 #define LIBSPDM_MAX_ENCAP_REQUEST_OP_CODE_SEQUENCE_COUNT 3
 typedef struct {
-    /* Valid OpCode: GET_DIGEST/GET_CERTIFICATE/CHALLENGE/KEY_UPDATE
+    /* Valid OpCode: GET_DIGEST/GET_CERTIFICATE/CHALLENGE/KEY_UPDATE/GET_ENDPOINT_INFO
      * The last one is 0x00, as terminator.*/
     uint8_t request_op_code_sequence[LIBSPDM_MAX_ENCAP_REQUEST_OP_CODE_SEQUENCE_COUNT + 1];
     uint8_t request_op_code_count;
@@ -666,6 +666,10 @@ typedef struct {
 #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
     libspdm_process_event_func process_event;
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+    libspdm_get_endpoint_info_callback_func get_endpoint_info_callback;
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT) */
 } libspdm_context_t;
 
 #define LIBSPDM_CONTEXT_SIZE_WITHOUT_SECURED_CONTEXT (sizeof(libspdm_context_t))

--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -481,6 +481,13 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
                                                       size_t *response_size,
                                                       void *response);
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+#if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
+libspdm_return_t libspdm_get_encap_response_endpoint_info(void *spdm_context,
+                                                          size_t request_size,
+                                                          void *request,
+                                                          size_t *response_size,
+                                                          void *response);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -607,6 +607,44 @@ libspdm_return_t libspdm_get_encap_request_key_update(libspdm_context_t *spdm_co
 libspdm_return_t libspdm_process_encap_response_key_update(
     libspdm_context_t *spdm_context, size_t encap_response_size,
     const void *encap_response, bool *need_continue);
+
+#if LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
+/**
+ * Get the SPDM encapsulated GET_ENDPOINT_INFO request.
+ *
+ * @param  spdm_context                 A pointer to the SPDM context.
+ * @param  encap_request_size           size in bytes of the encapsulated request data.
+ *                                      On input, it means the size in bytes of encapsulated request data buffer.
+ *                                      On output, it means the size in bytes of copied encapsulated request data buffer if RETURN_SUCCESS is returned,
+ *                                      and means the size in bytes of desired encapsulated request data buffer if RETURN_BUFFER_TOO_SMALL is returned.
+ * @param  encap_request                A pointer to the encapsulated request data.
+ *
+ * @retval RETURN_SUCCESS               The encapsulated request is returned.
+ * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ **/
+libspdm_return_t libspdm_get_encap_request_get_endpoint_info(
+    libspdm_context_t *spdm_context,
+    size_t *encap_request_size,
+    void *encap_request);
+
+/**
+ * Process the SPDM encapsulated GET_ENDPOINT_INFO response.
+ *
+ * @param  spdm_context                 A pointer to the SPDM context.
+ * @param  encap_response_size          size in bytes of the encapsulated response data.
+ * @param  encap_response               A pointer to the encapsulated response data.
+ * @param  need_continue                Indicate if encapsulated communication need continue.
+ *
+ * @retval RETURN_SUCCESS               The encapsulated response is processed.
+ * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
+ **/
+libspdm_return_t libspdm_process_encap_response_endpoint_info(
+    libspdm_context_t *spdm_context, size_t encap_response_size,
+    const void *encap_response, bool *need_continue);
+
+#endif /* LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
+
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
 /**

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -1051,6 +1051,27 @@ void libspdm_register_event_callback(void *spdm_context,
                                      libspdm_process_event_func process_event_func);
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+/**
+ * Encapsulate Get Endpoint Info Callback Function Pointer.
+ *
+ * @param spdm_context       A pointer to the SPDM context.
+ * @param subcode            The subcode of the GET_ENDPOINT_INFO request.
+ * @param param2             Bit [7:4]. Reserved.
+ *                           Bit [3:0]. SlotID.
+ * @param request_attributes The request attributes of the GET_ENDPOINT_INFO request.
+ * @param endpoint_info_size The size in bytes of the endpoint_info buffer.
+ * @param endpoint_info      A pointer to the buffer to store the endpoint information.
+ */
+typedef libspdm_return_t (*libspdm_get_endpoint_info_callback_func)(
+    void *spdm_context,
+    uint8_t subcode,
+    uint8_t param2,
+    uint8_t request_attributes,
+    uint32_t endpoint_info_size,
+    const void *endpoint_info);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP && LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -117,7 +117,10 @@
 #define LIBSPDM_EVENT_RECIPIENT_SUPPORT 1
 #endif
 
-/* If 1 then endpoint supports sending the GET_ENDPOINT_INFO request. */
+/* If 1 then endpoint supports sending the GET_ENDPOINT_INFO request.
+ * If enabled and endpoint is a Responder then LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP
+ * must also be enabled.
+ */
 #ifndef LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
 #define LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT 1
 #endif

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2024 DMTF. All rights reserved.
+ *  Copyright 2021-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -250,6 +250,15 @@ void libspdm_register_key_update_callback_func(
  **/
 void libspdm_init_key_update_encap_state(void *spdm_context);
 
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+/**
+ * This function initializes the get_endpoint_info encapsulated state.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ **/
+void libspdm_init_get_endpoint_info_encap_state(void *spdm_context);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP && LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
+
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && \
     (LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT)
 /**
@@ -297,6 +306,21 @@ libspdm_return_t libspdm_register_vendor_callback_func(void *spdm_context,
                                                        libspdm_vendor_response_callback_func resp_callback);
 
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+/**
+ * This function registers the callback function for doing a
+ * encapsulate GET_ENDPOINT_INFO to the device.
+ *
+ * @param  spdm_context                 A pointer to the SPDM context.
+ * @param  get_endpoint_info_callback   get endpoint info callback function
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS Success
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER Some parameters invalid or NULL
+ **/
+libspdm_return_t libspdm_register_get_endpoint_info_callback_func(
+    void *spdm_context, libspdm_get_endpoint_info_callback_func get_endpoint_info_callback);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP && LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
 
 #ifdef __cplusplus
 }

--- a/library/spdm_requester_lib/CMakeLists.txt
+++ b/library/spdm_requester_lib/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(spdm_requester_lib
         libspdm_req_encap_error.c
         libspdm_req_encap_key_update.c
         libspdm_req_encap_event_ack.c
+        libspdm_req_encap_endpoint_info.c
         libspdm_req_encap_request.c
         libspdm_req_end_session.c
         libspdm_req_finish.c

--- a/library/spdm_requester_lib/libspdm_req_encap_endpoint_info.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_endpoint_info.c
@@ -1,0 +1,238 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_requester_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP)
+
+libspdm_return_t libspdm_get_encap_response_endpoint_info(void *spdm_context,
+                                                          size_t request_size,
+                                                          void *request,
+                                                          size_t *response_size,
+                                                          void *response)
+{
+    uint32_t session_id;
+    spdm_get_endpoint_info_request_t *spdm_request;
+    size_t spdm_request_size;
+    spdm_endpoint_info_response_t *spdm_response;
+    size_t spdm_response_size;
+    libspdm_return_t status;
+    libspdm_context_t *context;
+    size_t signature_size;
+    uint32_t endpoint_info_size;
+    uint8_t slot_id;
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+    uint8_t *ptr;
+    bool result;
+
+    context = spdm_context;
+    spdm_request = request;
+
+    /* -=[Verify State Phase]=- */
+    if (libspdm_get_connection_version(context) < SPDM_MESSAGE_VERSION_13) {
+        return libspdm_generate_encap_error_response(
+            context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+            SPDM_GET_ENDPOINT_INFO, response_size, response);
+    }
+
+    if (context->last_spdm_request_session_id_valid) {
+        session_id = context->last_spdm_request_session_id;
+        session_info = libspdm_get_session_info_via_session_id(context, session_id);
+        if (session_info == NULL) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                response_size, response);
+        }
+        session_state = libspdm_secured_message_get_session_state(
+            session_info->secured_message_context);
+        if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                response_size, response);
+        }
+    } else {
+        session_info = NULL;
+    }
+
+    if (!libspdm_is_capabilities_flag_supported(
+            context, true,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP, 0)) {
+        return libspdm_generate_encap_error_response(
+            context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+            SPDM_GET_ENDPOINT_INFO, response_size, response);
+    }
+
+    /* -=[Validate Request Phase]=- */
+    if (spdm_request->header.spdm_version != libspdm_get_connection_version(context)) {
+        return libspdm_generate_encap_error_response(
+            context, SPDM_ERROR_CODE_VERSION_MISMATCH,
+            0, response_size, response);
+    }
+
+    if (spdm_request->header.param1 !=
+        SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER) {
+        return libspdm_generate_encap_error_response(
+            context, SPDM_ERROR_CODE_INVALID_REQUEST,
+            0, response_size, response);
+    }
+
+    if ((spdm_request->request_attributes &
+         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED) != 0) {
+        signature_size = libspdm_get_req_asym_signature_size(
+            context->connection_info.algorithm.req_base_asym_alg);
+        if (request_size <
+            sizeof(spdm_get_endpoint_info_request_t) +
+            SPDM_NONCE_SIZE) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                0, response_size, response);
+        }
+        spdm_request_size = sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+    } else {
+        if (request_size < sizeof(spdm_get_endpoint_info_request_t)) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                0, response_size, response);
+        }
+        spdm_request_size = sizeof(spdm_get_endpoint_info_request_t);
+    }
+
+    slot_id = 0;
+    if ((spdm_request->request_attributes &
+         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED) != 0) {
+        if (!libspdm_is_capabilities_flag_supported(
+                context, false, 0,
+                SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG)) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+                SPDM_GET_ENDPOINT_INFO, response_size, response);
+        }
+
+        slot_id = spdm_request->header.param2 & SPDM_GET_ENDPOINT_INFO_REQUEST_SLOT_ID_MASK;
+
+        if ((slot_id != 0xF) && (slot_id >= SPDM_MAX_SLOT_COUNT)) {
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                0, response_size, response);
+        }
+
+        if (slot_id != 0xF) {
+            if (context->local_context.local_cert_chain_provision[slot_id] == NULL) {
+                return libspdm_generate_encap_error_response(
+                    context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                    0, response_size, response);
+            }
+        } else {
+            if (context->local_context.local_public_key_provision == NULL) {
+                return libspdm_generate_encap_error_response(
+                    context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                    0, response_size, response);
+            }
+        }
+
+        if (context->connection_info.multi_key_conn_req && slot_id != 0xF) {
+            if ((context->local_context.local_key_usage_bit_mask[slot_id] &
+                 SPDM_KEY_USAGE_BIT_MASK_ENDPOINT_INFO_USE) == 0) {
+                return libspdm_generate_encap_error_response(
+                    context, SPDM_ERROR_CODE_INVALID_REQUEST,
+                    0, response_size, response);
+            }
+        }
+    }
+
+    /* -=[Construct Response Phase]=- */
+    /* response_size should be large enough to hold a ENDPOINT_INFO response without
+     * EPInfo. */
+    if ((spdm_request->request_attributes &
+         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED) != 0) {
+        LIBSPDM_ASSERT(*response_size >= (sizeof(spdm_endpoint_info_response_t) +
+                                          SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                                          signature_size));
+        spdm_response_size = sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+                             sizeof(uint32_t) + signature_size;
+    } else {
+        LIBSPDM_ASSERT(*response_size >= (sizeof(spdm_endpoint_info_response_t) +
+                                          sizeof(uint32_t)));
+        spdm_response_size = sizeof(spdm_endpoint_info_response_t) + sizeof(uint32_t);
+    }
+
+    libspdm_zero_mem(response, *response_size);
+    spdm_response = response;
+
+    libspdm_reset_message_buffer_via_request_code(context, NULL,
+                                                  spdm_request->header.request_response_code);
+
+    spdm_response->header.spdm_version = spdm_request->header.spdm_version;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = slot_id;
+    ptr = (uint8_t *)spdm_response + sizeof(spdm_endpoint_info_response_t);
+
+    if ((spdm_request->request_attributes &
+         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED) != 0) {
+        if(!libspdm_get_random_number(SPDM_NONCE_SIZE, ptr)) {
+            libspdm_reset_message_encap_e(context, session_info);
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
+        ptr += SPDM_NONCE_SIZE;
+    }
+    ptr += sizeof(uint32_t);
+
+    endpoint_info_size = (uint32_t) (*response_size - spdm_response_size);
+    status = libspdm_generate_device_endpoint_info(
+        context, spdm_request->header.param1,
+        spdm_request->request_attributes,
+        &endpoint_info_size, ptr);
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        return libspdm_generate_encap_error_response(
+            context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+            SPDM_GET_ENDPOINT_INFO, response_size, response);
+    }
+    libspdm_write_uint32(ptr - sizeof(uint32_t), endpoint_info_size);
+    spdm_response_size += endpoint_info_size;
+    *response_size = spdm_response_size;
+    ptr += endpoint_info_size;
+
+    if ((spdm_request->request_attributes &
+         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED) != 0) {
+
+        status = libspdm_append_message_encap_e(context, session_info, spdm_request,
+                                                spdm_request_size);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            libspdm_reset_message_e(context, session_info);
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
+
+        status = libspdm_append_message_encap_e(context, session_info, spdm_response,
+                                                spdm_response_size - signature_size);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            libspdm_reset_message_e(context, session_info);
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
+
+        result = libspdm_generate_endpoint_info_signature(context, session_info, true, ptr);
+
+        if (!result) {
+            libspdm_reset_message_encap_e(context, session_info);
+            return libspdm_generate_encap_error_response(
+                context, SPDM_ERROR_CODE_UNSPECIFIED,
+                0, response_size, response);
+        }
+    }
+
+    libspdm_reset_message_encap_e(context, session_info);
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (..) */

--- a/library/spdm_requester_lib/libspdm_req_encap_request.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_request.c
@@ -52,6 +52,10 @@ libspdm_get_encap_response_func_via_request_code(uint8_t request_response_code)
         #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
         { SPDM_SEND_EVENT, libspdm_get_encap_response_event_ack },
         #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+
+        #if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
+        { SPDM_GET_ENDPOINT_INFO, libspdm_get_encap_response_endpoint_info },
+        #endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
     };
 
     for (index = 0; index < LIBSPDM_ARRAY_SIZE(get_encap_response_struct); index++) {

--- a/library/spdm_responder_lib/CMakeLists.txt
+++ b/library/spdm_responder_lib/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(spdm_responder_lib
         libspdm_rsp_encap_challenge.c
         libspdm_rsp_encap_get_certificate.c
         libspdm_rsp_encap_get_digests.c
+        libspdm_rsp_encap_get_endpoint_info.c
         libspdm_rsp_encap_key_update.c
         libspdm_rsp_encap_response.c
         libspdm_rsp_end_session.c

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_endpoint_info.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_endpoint_info.c
@@ -1,0 +1,267 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_responder_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+
+libspdm_return_t libspdm_register_get_endpoint_info_callback_func(
+    void *spdm_context, libspdm_get_endpoint_info_callback_func get_endpoint_info_callback)
+{
+    libspdm_context_t *context = (libspdm_context_t *)spdm_context;
+    context->get_endpoint_info_callback = get_endpoint_info_callback;
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+libspdm_return_t libspdm_get_encap_request_get_endpoint_info(
+    libspdm_context_t *spdm_context,
+    size_t *encap_request_size,
+    void *encap_request)
+{
+    libspdm_return_t status;
+    spdm_get_endpoint_info_request_t *spdm_request;
+    uint32_t session_id;
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+    uint8_t *spdm_nonce;
+
+    LIBSPDM_ASSERT(spdm_context->get_endpoint_info_callback != NULL);
+
+    spdm_context->encap_context.last_encap_request_size = 0;
+
+    if (libspdm_get_connection_version(spdm_context) < SPDM_MESSAGE_VERSION_13) {
+        return LIBSPDM_STATUS_UNSUPPORTED_CAP;
+    }
+
+    if (!libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP, 0)) {
+        return LIBSPDM_STATUS_UNSUPPORTED_CAP;
+    }
+
+    if (spdm_context->last_spdm_request_session_id_valid) {
+        session_id = spdm_context->last_spdm_request_session_id;
+        session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+        if (session_info == NULL) {
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        session_state = libspdm_secured_message_get_session_state(
+            session_info->secured_message_context);
+        if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+    } else {
+        session_info = NULL;
+    }
+
+    LIBSPDM_ASSERT(*encap_request_size >= sizeof(spdm_get_endpoint_info_request_t));
+
+    spdm_request = encap_request;
+
+    libspdm_reset_message_buffer_via_request_code(spdm_context, session_info,
+                                                  spdm_request->header.request_response_code);
+
+    spdm_request->header.spdm_version = libspdm_get_connection_version (spdm_context);
+    spdm_request->header.request_response_code = SPDM_GET_ENDPOINT_INFO;
+    spdm_request->header.param1 = SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER;
+    spdm_request->header.param2 =
+        spdm_context->encap_context.req_slot_id & SPDM_GET_ENDPOINT_INFO_REQUEST_SLOT_ID_MASK;
+
+    /* request signature if requester support */
+    if (libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG, 0)) {
+        LIBSPDM_ASSERT(
+            *encap_request_size >= sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE);
+        *encap_request_size = sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+        spdm_request->request_attributes =
+            SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED;
+        libspdm_write_uint24(spdm_request->reserved, 0);
+
+        spdm_nonce = (uint8_t *)(spdm_request + 1);
+        if(!libspdm_get_random_number(SPDM_NONCE_SIZE, spdm_nonce)) {
+            libspdm_release_sender_buffer (spdm_context);
+            return LIBSPDM_STATUS_LOW_ENTROPY;
+        }
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "Encap RequesterNonce - "));
+        LIBSPDM_INTERNAL_DUMP_DATA(spdm_nonce, SPDM_NONCE_SIZE);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
+
+        status = libspdm_append_message_encap_e(spdm_context, session_info,
+                                                spdm_request, *encap_request_size);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return status;
+        }
+
+    } else {
+        *encap_request_size = sizeof(spdm_get_endpoint_info_request_t);
+        spdm_request->request_attributes = 0;
+        libspdm_write_uint24(spdm_request->reserved, 0);
+    }
+
+    libspdm_copy_mem(&spdm_context->encap_context.last_encap_request_header,
+                     sizeof(spdm_context->encap_context.last_encap_request_header),
+                     &spdm_request->header, sizeof(spdm_message_header_t));
+    spdm_context->encap_context.last_encap_request_size =
+        *encap_request_size;
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+libspdm_return_t libspdm_process_encap_response_endpoint_info(
+    libspdm_context_t *spdm_context, size_t encap_response_size,
+    const void *encap_response, bool *need_continue)
+{
+    libspdm_return_t status;
+    spdm_get_endpoint_info_request_t *spdm_request;
+    const spdm_endpoint_info_response_t *spdm_response;
+    size_t spdm_response_size;
+    uint32_t session_id;
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+    const uint8_t *ptr;
+    const uint8_t *ep_info_data;
+    uint32_t ep_info_data_len;
+    size_t signature_size;
+    const void *signature;
+    uint8_t slot_id;
+    bool result;
+    uint8_t request_attributes;
+
+    LIBSPDM_ASSERT(spdm_context->get_endpoint_info_callback != NULL);
+
+    if (spdm_context->last_spdm_request_session_id_valid) {
+        session_id = spdm_context->last_spdm_request_session_id;
+        session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+        if (session_info == NULL) {
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        session_state = libspdm_secured_message_get_session_state(
+            session_info->secured_message_context);
+        if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+    } else {
+        session_info = NULL;
+    }
+
+    spdm_request =
+        (void *)&spdm_context->encap_context.last_encap_request_header;
+
+    spdm_response = encap_response;
+    spdm_response_size = encap_response_size;
+
+    if (spdm_response->header.spdm_version != libspdm_get_connection_version (spdm_context)) {
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
+
+    if (spdm_response->header.request_response_code == SPDM_ERROR) {
+        status = libspdm_handle_encap_error_response_main(
+            spdm_context, spdm_response->header.param1);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return status;
+        }
+    } else if (spdm_response->header.request_response_code != SPDM_ENDPOINT_INFO) {
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
+
+    if (spdm_response_size < sizeof(spdm_endpoint_info_response_t) + sizeof(uint32_t)) {
+        return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+    }
+
+    slot_id = spdm_context->encap_context.req_slot_id & SPDM_GET_ENDPOINT_INFO_REQUEST_SLOT_ID_MASK;
+    spdm_context->connection_info.peer_used_cert_chain_slot_id = slot_id;
+
+    /* request signature if requester support */
+    if (libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG, 0)) {
+        signature_size = libspdm_get_req_asym_signature_size(
+            spdm_context->connection_info.algorithm.req_base_asym_alg);
+        request_attributes = SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED;
+
+        if ((spdm_response->header.param2 & SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK) != slot_id) {
+            return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        }
+
+        if (spdm_response_size <
+            sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE + signature_size) {
+            return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        }
+
+        ptr = (const uint8_t *)(spdm_response + 1);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "Encap ResponderNonce (0x%x) - ", SPDM_NONCE_SIZE));
+        LIBSPDM_INTERNAL_DUMP_DATA(ptr, SPDM_NONCE_SIZE);
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "\n"));
+
+        ptr += SPDM_NONCE_SIZE;
+        ep_info_data_len = *(const uint32_t *) ptr;
+
+        if (spdm_response_size !=
+            sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+            signature_size + ep_info_data_len + sizeof(uint32_t)) {
+            return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        }
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ep_info_data_len - 0x%06x\n",
+                       ep_info_data_len));
+        ptr += sizeof(uint32_t);
+        ep_info_data = ptr;
+
+        status = libspdm_append_message_encap_e(spdm_context, session_info, spdm_response,
+                                                spdm_response_size - signature_size);
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return status;
+        }
+
+        ptr += ep_info_data_len;
+        signature = ptr;
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "signature (0x%zx):\n", signature_size));
+        LIBSPDM_INTERNAL_DUMP_HEX(signature, signature_size);
+
+        result = libspdm_verify_endpoint_info_signature(
+            spdm_context, session_info, false, signature, signature_size);
+        if (!result) {
+            return LIBSPDM_STATUS_VERIF_FAIL;
+        }
+
+        libspdm_reset_message_encap_e(spdm_context, session_info);
+    } else {
+        request_attributes = 0;
+
+        /* responder's slot_id should be 0 */
+        if ((spdm_response->header.param2 & SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK) != 0) {
+            return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        }
+
+        /* nonce and signature not present */
+        ptr = (const uint8_t *)(spdm_response + 1);
+        ep_info_data_len = *(const uint32_t *) ptr;
+        if (spdm_response_size <
+            sizeof(spdm_endpoint_info_response_t) + ep_info_data_len + sizeof(uint32_t)) {
+            return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        }
+
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "ep_info_data_len - 0x%06x\n",
+                       ep_info_data_len));
+        ptr += sizeof(uint32_t);
+        ep_info_data = ptr;
+    }
+
+    *need_continue = false;
+
+    status = spdm_context->get_endpoint_info_callback(
+        spdm_context, spdm_request->header.param1, spdm_request->header.param2,
+        request_attributes, ep_info_data_len, ep_info_data);
+
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        return status;
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (...) */

--- a/library/spdm_responder_lib/libspdm_rsp_encap_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_response.c
@@ -63,6 +63,11 @@ static libspdm_return_t libspdm_get_encap_struct_via_op_code
 
         { SPDM_KEY_UPDATE, libspdm_get_encap_request_key_update,
           libspdm_process_encap_response_key_update },
+
+        #if LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
+        { SPDM_GET_ENDPOINT_INFO, libspdm_get_encap_request_get_endpoint_info,
+          libspdm_process_encap_response_endpoint_info }
+        #endif /* LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
     };
 
     for (index = 0; index < LIBSPDM_ARRAY_SIZE(encap_response_struct); index++) {
@@ -197,6 +202,28 @@ void libspdm_init_key_update_encap_state(void *spdm_context)
     context->encap_context.request_op_code_count = 1;
     context->encap_context.request_op_code_sequence[0] = SPDM_KEY_UPDATE;
 }
+
+
+#if LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
+void libspdm_init_get_endpoint_info_encap_state(void *spdm_context)
+{
+    libspdm_context_t *context;
+
+    context = spdm_context;
+
+    context->encap_context.current_request_op_code = 0x00;
+    context->encap_context.request_id = 0;
+    context->encap_context.last_encap_request_size = 0;
+    libspdm_zero_mem(&context->encap_context.last_encap_request_header,
+                     sizeof(context->encap_context.last_encap_request_header));
+    context->response_state = LIBSPDM_RESPONSE_STATE_PROCESSING_ENCAP;
+
+    libspdm_zero_mem(context->encap_context.request_op_code_sequence,
+                     sizeof(context->encap_context.request_op_code_sequence));
+    context->encap_context.request_op_code_count = 1;
+    context->encap_context.request_op_code_sequence[0] = SPDM_GET_ENDPOINT_INFO;
+}
+#endif /* LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
 
 libspdm_return_t libspdm_get_response_encapsulated_request(
     libspdm_context_t *spdm_context, size_t request_size, const void *request,

--- a/unit_test/test_spdm_requester/CMakeLists.txt
+++ b/unit_test/test_spdm_requester/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(test_spdm_requester
         encap_challenge_auth.c
         encap_digests.c
         encap_event_ack.c
+        encap_endpoint_info.c
         encap_key_update.c
         encap_request.c
         set_certificate.c
@@ -61,6 +62,7 @@ target_sources(test_spdm_requester
         error_test/set_key_pair_info_err.c
         error_test/encap_event_ack_err.c
         error_test/get_endpoint_info_err.c
+        error_test/encap_endpoint_info_err.c
         ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
         ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
         ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_requester/encap_endpoint_info.c
+++ b/unit_test/test_spdm_requester/encap_endpoint_info.c
@@ -1,0 +1,581 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP)
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    /* param1 - subcode of the request
+     * param2 - Bit[7:4]: reserved
+     *          Bit[3:0]: slot_id */
+    uint8_t request_attributes;
+    uint8_t reserved[3];
+    uint8_t nonce[32];
+} spdm_get_endpoint_info_request_max_t;
+#pragma pack()
+
+/* request signature, correct */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request1 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request1_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, correct, with slot_id == 0x1 */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request2 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0x1},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request2_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, correct, with slot_id == 0xF */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request3 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0xF},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request3_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* not request signature, correct */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request4 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0},
+    0,
+    {0, 0, 0},
+};
+size_t m_libspdm_get_endpoint_info_request4_size =
+    sizeof(spdm_get_endpoint_info_request_t);
+
+/**
+ * Test 1: Successful response to get endpoint_info with signature
+ * Expected Behavior: get a RETURN_SUCCESS return code,
+ *                    correct transcript.message_encap_e size,
+ *                    correct response message size and fields
+ *                    correct signature verification
+ **/
+void libspdm_test_requester_encap_endpoint_info_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_endpoint_info_response_t *spdm_response;
+    uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
+    void* signature;
+    size_t signature_size;
+    bool result;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.req_base_asym_alg,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request1.nonce);
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request1_size,
+        &m_libspdm_get_endpoint_info_request1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    endpoint_info_size = 0;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, endpoint_info_buffer);
+    signature_size = libspdm_get_asym_signature_size(
+        spdm_context->connection_info.algorithm.req_base_asym_alg);
+    assert_int_equal(response_size,
+                     sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+                     sizeof(uint32_t) + endpoint_info_size + signature_size);
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* signature verification */
+    status = libspdm_append_message_encap_e(spdm_context, session_info,
+                                            &m_libspdm_get_endpoint_info_request1,
+                                            m_libspdm_get_endpoint_info_request1_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    status = libspdm_append_message_encap_e(spdm_context, session_info, spdm_response,
+                                            response_size - signature_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    signature = (void *)((uint8_t *)spdm_response + response_size - signature_size);
+    result = libspdm_verify_endpoint_info_signature(
+        spdm_context, session_info, false, signature, signature_size);
+    assert_true(result);
+}
+
+/**
+ * Test 2: Successful response to get endpoint_info with signature, slot_id == 0x1
+ * Expected Behavior: get a RETURN_SUCCESS return code,
+ *                    correct transcript.message_encap_e size,
+ *                    correct response message size and fields
+ *                    correct signature verification
+ **/
+void libspdm_test_requester_encap_endpoint_info_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_endpoint_info_response_t *spdm_response;
+    uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
+    void* signature;
+    size_t signature_size;
+    bool result;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    spdm_context->local_context.local_cert_chain_provision_size[1] = data_size;
+    spdm_context->local_context.local_cert_chain_provision[1] = data;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[1].buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[1].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[1].buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain[1].buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain[1].buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.req_base_asym_alg,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[1].leaf_cert_public_key);
+#endif
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request1.nonce);
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request2_size,
+        &m_libspdm_get_endpoint_info_request2, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    endpoint_info_size = 0;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, endpoint_info_buffer);
+    signature_size = libspdm_get_asym_signature_size(
+        spdm_context->connection_info.algorithm.req_base_asym_alg);
+    assert_int_equal(response_size,
+                     sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+                     sizeof(uint32_t) + endpoint_info_size + signature_size);
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* signature verification */
+    status = libspdm_append_message_encap_e(spdm_context, session_info,
+                                            &m_libspdm_get_endpoint_info_request2,
+                                            m_libspdm_get_endpoint_info_request2_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    status = libspdm_append_message_encap_e(spdm_context, session_info, spdm_response,
+                                            response_size - signature_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    signature = (void *)((uint8_t *)spdm_response + response_size - signature_size);
+    result = libspdm_verify_endpoint_info_signature(
+        spdm_context, session_info, false, signature, signature_size);
+    assert_true(result);
+}
+
+/**
+ * Test 3: Successful response to get endpoint_info with signature, slot_id == 0xF
+ * Expected Behavior: get a RETURN_SUCCESS return code,
+ *                    correct transcript.message_encap_e size,
+ *                    correct response message size and fields
+ *                    correct signature verification
+ **/
+void libspdm_test_requester_encap_endpoint_info_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_endpoint_info_response_t *spdm_response;
+    uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
+    void* signature;
+    size_t signature_size;
+    bool result;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    libspdm_read_requester_public_key(m_libspdm_use_req_asym_algo, &data, &data_size);
+    spdm_context->local_context.local_public_key_provision = data;
+    spdm_context->local_context.local_public_key_provision_size = data_size;
+    spdm_context->connection_info.peer_used_cert_chain_slot_id = 0xF;
+    spdm_context->local_context.peer_public_key_provision = data;
+    spdm_context->local_context.peer_public_key_provision_size = data_size;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request1.nonce);
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request3_size,
+        &m_libspdm_get_endpoint_info_request3, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    endpoint_info_size = 0;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, endpoint_info_buffer);
+    signature_size = libspdm_get_asym_signature_size(
+        spdm_context->connection_info.algorithm.req_base_asym_alg);
+    assert_int_equal(response_size,
+                     sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+                     sizeof(uint32_t) + endpoint_info_size + signature_size);
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* signature verification */
+    status = libspdm_append_message_encap_e(spdm_context, session_info,
+                                            &m_libspdm_get_endpoint_info_request3,
+                                            m_libspdm_get_endpoint_info_request3_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    status = libspdm_append_message_encap_e(spdm_context, session_info, spdm_response,
+                                            response_size - signature_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    signature = (void *)((uint8_t *)spdm_response + response_size - signature_size);
+    result = libspdm_verify_endpoint_info_signature(
+        spdm_context, session_info, false, signature, signature_size);
+    assert_true(result);
+}
+
+/**
+ * Test 4: Successful response to get endpoint_info without signature
+ * Expected Behavior: get a RETURN_SUCCESS return code,
+ *                    correct response message size and fields
+ **/
+void libspdm_test_requester_encap_endpoint_info_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_endpoint_info_response_t *spdm_response;
+    uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_NO_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    response_size = sizeof(response);
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request4_size,
+        &m_libspdm_get_endpoint_info_request4, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    endpoint_info_size = 0;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        0, &endpoint_info_size, endpoint_info_buffer);
+    assert_int_equal(response_size,
+                     sizeof(spdm_endpoint_info_response_t) +
+                     sizeof(uint32_t) + endpoint_info_size);
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ENDPOINT_INFO);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 5: Successful response to get session-based endpoint_info with signature
+ * Expected Behavior: get a RETURN_SUCCESS return code,
+ *                    correct transcript.message_encap_e size,
+ *                    correct response message size and fields
+ *                    correct signature verification
+ **/
+void libspdm_test_requester_encap_endpoint_info_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_endpoint_info_response_t *spdm_response;
+    uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
+    void* signature;
+    size_t signature_size;
+    bool result;
+    void *data;
+    size_t data_size;
+    uint32_t session_id;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+
+    spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+    spdm_context->local_context.local_cert_chain_provision[0] = data;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_size = data_size;
+    libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                     sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                     data, data_size);
+#else
+    libspdm_hash_all(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        data, data_size,
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash);
+    spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash_size =
+        libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+    libspdm_get_leaf_cert_public_key_from_cert_chain(
+        spdm_context->connection_info.algorithm.base_hash_algo,
+        spdm_context->connection_info.algorithm.req_base_asym_alg,
+        data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+
+    session_id = 0xFFFFFFFF;
+    spdm_context->latest_session_id = session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request1.nonce);
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request1_size,
+        &m_libspdm_get_endpoint_info_request1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    endpoint_info_size = 0;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, endpoint_info_buffer);
+    signature_size = libspdm_get_asym_signature_size(
+        spdm_context->connection_info.algorithm.req_base_asym_alg);
+    assert_int_equal(response_size,
+                     sizeof(spdm_endpoint_info_response_t) + SPDM_NONCE_SIZE +
+                     sizeof(uint32_t) + endpoint_info_size + signature_size);
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(session_info->session_transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* signature verification */
+    status = libspdm_append_message_encap_e(spdm_context, session_info,
+                                            &m_libspdm_get_endpoint_info_request1,
+                                            m_libspdm_get_endpoint_info_request1_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    status = libspdm_append_message_encap_e(spdm_context, session_info, spdm_response,
+                                            response_size - signature_size);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    signature = (void *)((uint8_t *)spdm_response + response_size - signature_size);
+    result = libspdm_verify_endpoint_info_signature(
+        spdm_context, session_info, false, signature, signature_size);
+    assert_true(result);
+}
+
+int libspdm_requester_encap_endpoint_info_test_main(void)
+{
+    const struct CMUnitTest spdm_requester_endpoint_info_tests[] = {
+        /* Successful response to get endpoint_info with signature */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case1),
+        /* Successful response to get endpoint_info with signature, slot_id == 0x1 */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case2),
+        /* Successful response to get endpoint_info with signature, slot_id == 0xF */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case3),
+        /* Successful response to get endpoint_info without signature */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case4),
+        /* Successful response to get session-based endpoint_info with signature */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case5),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(spdm_requester_endpoint_info_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (...) */

--- a/unit_test/test_spdm_requester/error_test/encap_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_endpoint_info_err.c
@@ -1,0 +1,727 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_requester_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP)
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    /* param1 - subcode of the request
+     * param2 - Bit[7:4]: reserved
+     *          Bit[3:0]: slot_id */
+    uint8_t request_attributes;
+    uint8_t reserved[3];
+    uint8_t nonce[32];
+} spdm_get_endpoint_info_request_max_t;
+#pragma pack()
+
+/* request signature, correct */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err1 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err1_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, but version 12 */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err2 = {
+    { SPDM_MESSAGE_VERSION_12, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err2_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, but no nonce */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err3 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* no nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err3_size =
+    sizeof(spdm_get_endpoint_info_request_t);
+
+/* request signature, but invalid slot_id */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err4 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0xA},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err4_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, correct, with slot_id == 0xF */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err5 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 0xF},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err5_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, correct, with slot_id == 0x1 */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err6 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER, 1},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err6_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/* request signature, but sub_code invalid */
+spdm_get_endpoint_info_request_max_t m_libspdm_get_endpoint_info_request_err7 = {
+    { SPDM_MESSAGE_VERSION_13, SPDM_GET_ENDPOINT_INFO,
+      2, 0},
+    SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+    {0, 0, 0},
+    /* nonce */
+};
+size_t m_libspdm_get_endpoint_info_request_err7_size =
+    sizeof(spdm_get_endpoint_info_request_t) + SPDM_NONCE_SIZE;
+
+/**
+ * Test 1: Error case, connection version is lower than 1.3
+ * Expected Behavior: generate an ERROR_RESPONSE with code
+ *                    SPDM_ERROR_CODE_UNSUPPORTED_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+    /* connection version is lower than 1.3 */
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err1.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err1_size,
+        &m_libspdm_get_endpoint_info_request_err1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_GET_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 2: Error Case: Requester does not support EP_INFO_CAP
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNSUPPORTED_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0; /* no EP_INFO_CAP */
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err1.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err1_size,
+        &m_libspdm_get_endpoint_info_request_err1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_GET_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 3: Error Case: Request contains mismatch version
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err2.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err2_size,
+        &m_libspdm_get_endpoint_info_request_err2, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_VERSION_MISMATCH);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 4: Error Case: Signature was required, but responder only support EP_INFO_CAP_NO_SIG
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNSUPPORTED_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_NO_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err1.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err1_size,
+        &m_libspdm_get_endpoint_info_request_err1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_GET_ENDPOINT_INFO);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 5: Error Case: Signature was required, but there is no nonce in request
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err3_size,
+        &m_libspdm_get_endpoint_info_request_err3, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 6: Error Case: Request contains invalid slot_id
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x6;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err4.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err4_size,
+        &m_libspdm_get_endpoint_info_request_err4, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 7: Error case, signature was required
+ *         but local_cert_chain_provision[slot_id] == NULL
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case7(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x7;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    /* no initialization for spdm_context->local_context.local_cert_chain_provision */
+    for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_cert_chain_provision_size[i] = 0;
+        spdm_context->local_context.local_cert_chain_provision[i] = NULL;
+    }
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err1.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err1_size,
+        &m_libspdm_get_endpoint_info_request_err1, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 8: Error case, signature was required, slot_id == 0xF
+ *         but local_public_key_provision == NULL
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x8;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    /* no initialization for spdm_context->local_context.local_public_key_provision */
+    spdm_context->local_context.local_public_key_provision = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err5.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err5_size,
+        &m_libspdm_get_endpoint_info_request_err5, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 9: Error case, signature was required, multi_key_conn_rsp is set
+ *         but local_key_usage_bit_mask[slot_id] not meet requirement
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case9(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x9;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+
+    for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
+        spdm_context->local_context.local_cert_chain_provision[0] = data;
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[0].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[0].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[0].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+#endif
+    }
+
+    session_info = NULL;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+    /* no initialization for spdm_context->local_context.local_key_usage_bit_mask */
+    for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_key_usage_bit_mask[i] = 0;
+    }
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err6.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err6_size,
+        &m_libspdm_get_endpoint_info_request_err6, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 10: Error case, invalid sub_code
+ * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
+ **/
+void libspdm_test_requester_encap_endpoint_info_err_case10(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_session_info_t* session_info;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x10;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.capability.flags = 0;
+
+    session_info = NULL;
+
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+    response_size = sizeof(response);
+    libspdm_get_random_number(SPDM_NONCE_SIZE,
+                              m_libspdm_get_endpoint_info_request_err7.nonce);
+
+    status = libspdm_get_encap_response_endpoint_info(
+        spdm_context, m_libspdm_get_endpoint_info_request_err7_size,
+        &m_libspdm_get_endpoint_info_request_err7, &response_size, response);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    /* response size check */
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+
+    /* response message check */
+    assert_int_equal(spdm_response->header.request_response_code,
+                     SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1,
+                     SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    /* transcript.message_encap_e size check */
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+int libspdm_requester_encap_endpoint_info_error_test_main(void)
+{
+    const struct CMUnitTest spdm_requester_endpoint_info_tests[] = {
+        /* Connection version is lower than 1.3 */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case1),
+        /* Requester does not support EP_INFO_CAP */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case2),
+        /* Request contains mismatch version */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case3),
+        /* Signature was required, but responder only support EP_INFO_CAP_NO_SIG */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case4),
+        /* Signature was required, but there is no nonce in request */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case5),
+        /* Request contains invalid slot_id */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case6),
+        /* Signature was required but local_cert_chain_provision[slot_id] == NULL */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case7),
+        /* Signature was required, slot_id == 0xF but local_public_key_provision == NULL */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case8),
+        /* Signature was required, multi_key_conn_rsp is set but
+         * local_key_usage_bit_mask[slot_id] not meet requirement
+         */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case9),
+        /* Invalid sub_code */
+        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case10),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(spdm_requester_endpoint_info_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (...) */

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -66,6 +66,10 @@ int libspdm_requester_encap_event_ack_test_main(void);
 int libspdm_requester_encap_event_ack_error_test_main(void);
 #endif /* #if LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 int libspdm_requester_encap_key_update_test_main(void);
+#if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
+int libspdm_requester_encap_endpoint_info_test_main(void);
+int libspdm_requester_encap_endpoint_info_error_test_main(void);
+#endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
 int libspdm_requester_set_certificate_test_main(void);
@@ -106,6 +110,7 @@ int libspdm_requester_get_endpoint_info_error_test_main(void);
 int main(void)
 {
     int return_value = 0;
+
     if (libspdm_requester_get_version_test_main() != 0) {
         return_value = 1;
     }
@@ -238,6 +243,14 @@ int main(void)
         return_value = 1;
     }
     #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+    #if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
+    if (libspdm_requester_encap_endpoint_info_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_requester_encap_endpoint_info_error_test_main() != 0) {
+        return_value = 1;
+    }
+    #endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
     #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
     #if LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP

--- a/unit_test/test_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_spdm_responder/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(test_spdm_responder
         vendor_response.c
         encap_get_certificate.c
         encap_get_digests.c
+        encap_get_endpoint_info.c
         encap_key_update.c
         encap_challenge.c
         encap_response.c
@@ -45,6 +46,7 @@ target_sources(test_spdm_responder
         error_test/subscribe_event_types_ack_err.c
         error_test/vendor_response_err.c
         error_test/endpoint_info_err.c
+        error_test/encap_get_endpoint_info_err.c
         set_certificate_rsp.c
         csr.c
         receive_send.c

--- a/unit_test/test_spdm_responder/encap_get_endpoint_info.c
+++ b/unit_test/test_spdm_responder/encap_get_endpoint_info.c
@@ -1,0 +1,538 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+#include "spdm_unit_test.h"
+#include "internal/libspdm_responder_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+
+#define LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE 0x20
+
+static uint8_t m_endpoint_info_buffer_receive[LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE];
+static uint8_t m_endpoint_info_buffer_send[LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE];
+
+libspdm_return_t get_endpoint_info_callback (
+    void *spdm_context,
+    uint8_t subcode,
+    uint8_t param2,
+    uint8_t request_attributes,
+    uint32_t endpoint_info_size,
+    const void *endpoint_info)
+{
+    LIBSPDM_ASSERT (endpoint_info_size <= LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE);
+    libspdm_copy_mem (m_endpoint_info_buffer_send, endpoint_info_size,
+                      endpoint_info, endpoint_info_size);
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+/**
+ * Test 1: Normal case, request a endpoint info with signature
+ * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ *                    and an empty transcript.message_encap_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t sig_size;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x1;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+
+    /* Subcase 1: slot_id = 0 */
+    spdm_context->encap_context.req_slot_id = 0;
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    for (uint32_t index = 0; index < endpoint_info_size; index++) {
+        assert_int_equal (m_endpoint_info_buffer_receive[index],
+                          m_endpoint_info_buffer_send[index]);
+    }
+    /* Completion of GET_ENDPOINT_INFO sets mut IL1/IL2 to null. */
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#else
+    assert_null(spdm_context->transcript.digest_context_encap_il1il2);
+#endif
+
+
+    /* Subcase 2: slot_id = 1 */
+    spdm_context->encap_context.req_slot_id = 1;
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    for (uint32_t index = 0; index < endpoint_info_size; index++) {
+        assert_int_equal (m_endpoint_info_buffer_receive[index],
+                          m_endpoint_info_buffer_send[index]);
+    }
+    /* Completion of GET_ENDPOINT_INFO sets mut IL1/IL2 to null. */
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#else
+    assert_null(spdm_context->transcript.digest_context_encap_il1il2);
+#endif
+}
+
+/**
+ * Test 2: Normal case, request a endpoint info with signature, req_slot_id = 0xFF
+ * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ *                    and an empty transcript.message_encap_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t sig_size;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x2;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback;
+
+    libspdm_read_requester_public_key(m_libspdm_use_req_asym_algo, &data, &data_size);
+    spdm_context->local_context.peer_public_key_provision = data;
+    spdm_context->local_context.peer_public_key_provision_size = data_size;
+
+    spdm_context->encap_context.req_slot_id = 0xFF;
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    for (uint32_t index = 0; index < endpoint_info_size; index++) {
+        assert_int_equal (m_endpoint_info_buffer_receive[index],
+                          m_endpoint_info_buffer_send[index]);
+    }
+    /* Completion of GET_ENDPOINT_INFO sets mut IL1/IL2 to null. */
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#else
+    assert_null(spdm_context->transcript.digest_context_encap_il1il2);
+#endif
+}
+
+/**
+ * Test 3: Normal case, request a endpoint info without signature
+ * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x3;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_NO_SIG;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback;
+
+    spdm_context->encap_context.req_slot_id = 0;
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    sizeof(uint32_t) + endpoint_info_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    for (uint32_t index = 0; index < endpoint_info_size; index++) {
+        assert_int_equal (m_endpoint_info_buffer_receive[index],
+                          m_endpoint_info_buffer_send[index]);
+    }
+}
+
+/**
+ * Test 4: Normal case, request a endpoint info with signature within session
+ * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ *                    and an empty session_transcript.message_encap_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t sig_size;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+    uint32_t session_id;
+    libspdm_session_info_t *session_info;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x4;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags = 0;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MAC_CAP;
+    spdm_context->connection_info.algorithm.dhe_named_group =
+        m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite =
+        m_libspdm_use_aead_algo;
+
+    session_id = 0xFFFFFFFF;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, session_info);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+
+    spdm_context->encap_context.req_slot_id = 0;
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    for (uint32_t index = 0; index < endpoint_info_size; index++) {
+        assert_int_equal (m_endpoint_info_buffer_receive[index],
+                          m_endpoint_info_buffer_send[index]);
+    }
+    /* Completion of GET_ENDPOINT_INFO sets mut IL1/IL2 to null. */
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(session_info->session_transcript.message_encap_e.buffer_size, 0);
+#else
+    assert_null(session_info->session_transcript.digest_context_encap_il1il2);
+#endif
+}
+
+int libspdm_responder_encap_get_endpoint_info_test_main(void)
+{
+    const struct CMUnitTest spdm_responder_encap_get_endpoint_info_tests[] = {
+        /* Success requeset endpoint info with signature */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case1),
+        /* Success requeset endpoint info with signature, req_slot_id = 0xFF */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case2),
+        /* Success requeset endpoint info without signature */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case3),
+        /* Success requeset endpoint info with signature in a session */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case4),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(spdm_responder_encap_get_endpoint_info_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (...) */

--- a/unit_test/test_spdm_responder/error_test/encap_get_endpoint_info_err.c
+++ b/unit_test/test_spdm_responder/error_test/encap_get_endpoint_info_err.c
@@ -1,0 +1,604 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+#include "spdm_unit_test.h"
+#include "internal/libspdm_responder_lib.h"
+
+#if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT)
+
+#define LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE 0x20
+
+static uint8_t m_endpoint_info_buffer_receive[LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE];
+
+libspdm_return_t get_endpoint_info_callback_in_err (
+    void *spdm_context,
+    uint8_t subcode,
+    uint8_t param2,
+    uint8_t request_attributes,
+    uint32_t endpoint_info_size,
+    const void *endpoint_info)
+{
+    /* should never reach here */
+    LIBSPDM_ASSERT (0);
+    return LIBSPDM_STATUS_UNSUPPORTED_CAP;
+}
+
+/**
+ * Test 1: Error case, get an error response
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
+ *                    with an empty transcript.message_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_err_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_error_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    size_t response_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x1;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback_in_err;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+    spdm_context->encap_context.req_slot_id = 0;
+
+    response_size = sizeof(spdm_error_response_t);
+
+    spdm_response = (void *)temp_buf;
+
+    /* Subcase 1: SPDM_ERROR_CODE_INVALID_REQUEST */
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ERROR;
+    spdm_response->header.param1 = SPDM_ERROR_CODE_INVALID_REQUEST;
+    spdm_response->header.param2 = 0;
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* Subcase 2: SPDM_ERROR_CODE_UNSUPPORTED_REQUEST */
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ERROR;
+    spdm_response->header.param1 = SPDM_ERROR_CODE_UNSUPPORTED_REQUEST;
+    spdm_response->header.param2 = SPDM_GET_ENDPOINT_INFO;
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 2: Error case, get incorrect response
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code
+ *                    with an empty transcript.message_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf_valid[LIBSPDM_SENDER_BUFFER_SIZE];
+    uint8_t temp_buf_error[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t sig_size;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x2;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback_in_err;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+    spdm_context->encap_context.req_slot_id = 0;
+
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    /* create a valid response */
+    spdm_response = (void *)temp_buf_valid;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    /* Subcase 1: wrong version */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* Subcase 2: wrong response code */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO + 1;
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* Subcase 3: wrong slot_id */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    spdm_response->header.param2 = 0x1; /* slot_id = 1 */
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* Subcase 4: wrong ep_info_len */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    ptr = (void *)(spdm_response + 1);
+    ptr += SPDM_NONCE_SIZE;
+    *(uint32_t *)ptr = endpoint_info_size + 1; /* ep_info_len */
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+
+    /* Subcase 5: wrong signature */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    ptr = (void *)(spdm_response + 1);
+    ptr += SPDM_NONCE_SIZE + sizeof(uint32_t) + endpoint_info_size;
+    libspdm_get_random_number(sig_size, ptr);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_VERIF_FAIL);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 3: Error case, request signature but get response without signature
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code
+ *                    with an empty transcript.message_e
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x3;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback_in_err;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+    spdm_context->encap_context.req_slot_id = 0;
+
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    sizeof(uint32_t) + endpoint_info_size;
+
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = 0;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    assert_int_equal(spdm_context->transcript.message_encap_e.buffer_size, 0);
+#endif
+}
+
+/**
+ * Test 4: Error case, request no signature but get response with signature
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t sig_size;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+    void *data;
+    size_t data_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x4;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_NO_SIG; /* no signature */
+    spdm_context->connection_info.algorithm.base_hash_algo =
+        m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg =
+        m_libspdm_use_req_asym_algo;
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback_in_err;
+
+    libspdm_read_requester_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                    m_libspdm_use_req_asym_algo, &data,
+                                                    &data_size, NULL, NULL);
+    libspdm_reset_message_a(spdm_context);
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+
+    for (uint32_t index = 0; index < 2; index++) {
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_size = data_size;
+        libspdm_copy_mem(spdm_context->connection_info.peer_used_cert_chain[index].buffer,
+                         sizeof(spdm_context->connection_info.peer_used_cert_chain[index].buffer),
+                         data, data_size);
+#else
+        libspdm_hash_all(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            data, data_size,
+            spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash);
+        spdm_context->connection_info.peer_used_cert_chain[index].buffer_hash_size =
+            libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
+        libspdm_get_leaf_cert_public_key_from_cert_chain(
+            spdm_context->connection_info.algorithm.base_hash_algo,
+            spdm_context->connection_info.algorithm.req_base_asym_alg,
+            data, data_size,
+            &spdm_context->connection_info.peer_used_cert_chain[index].leaf_cert_public_key);
+#endif
+    }
+    spdm_context->encap_context.req_slot_id = 0;
+
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+    sig_size = libspdm_get_asym_signature_size(m_libspdm_use_req_asym_algo);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    SPDM_NONCE_SIZE + sizeof(uint32_t) +
+                    endpoint_info_size + sig_size;
+
+    /* create a valid response */
+    spdm_response = (void *)temp_buf;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = spdm_context->encap_context.req_slot_id &
+                                   SPDM_ENDPOINT_INFO_RESPONSE_SLOT_ID_MASK;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    libspdm_get_random_number(SPDM_NONCE_SIZE, ptr);
+    ptr += SPDM_NONCE_SIZE;
+
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    libspdm_requester_data_sign(
+#if LIBSPDM_HAL_PASS_SPDM_CONTEXT
+        spdm_context,
+#endif
+        spdm_response->header.spdm_version << SPDM_VERSION_NUMBER_SHIFT_BIT,
+            SPDM_ENDPOINT_INFO,
+            m_libspdm_use_req_asym_algo, m_libspdm_use_hash_algo,
+            false, (uint8_t*)spdm_response, response_size - sig_size,
+            ptr, &sig_size);
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+/**
+ * Test 5: Error case, get incorrect response when request no signature
+ * Expected Behavior: get a RETURN_DEVICE_ERROR return code
+ **/
+void libspdm_test_responder_encap_get_endpoint_info_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_endpoint_info_response_t *spdm_response;
+    uint8_t temp_buf_valid[LIBSPDM_SENDER_BUFFER_SIZE];
+    uint8_t temp_buf_error[LIBSPDM_SENDER_BUFFER_SIZE];
+    bool need_continue;
+    uint8_t *ptr;
+    size_t response_size;
+    uint32_t endpoint_info_size;
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x5;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state =
+        LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_NO_SIG; /* no signature */
+    spdm_context->get_endpoint_info_callback = get_endpoint_info_callback_in_err;
+
+    spdm_context->encap_context.req_slot_id = 0;
+
+    endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
+    libspdm_generate_device_endpoint_info(
+        spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+        SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+        &endpoint_info_size, m_endpoint_info_buffer_receive);
+
+    response_size = sizeof(spdm_endpoint_info_response_t) +
+                    sizeof(uint32_t) + endpoint_info_size;
+
+    /* create a valid response */
+    spdm_response = (void *)temp_buf_valid;
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_ENDPOINT_INFO;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = 0;
+    spdm_response->reserved = 0;
+
+    ptr = (void *)(spdm_response + 1);
+    *(uint32_t *)ptr = endpoint_info_size; /* ep_info_len */
+    ptr += sizeof(uint32_t);
+
+    libspdm_copy_mem(ptr, endpoint_info_size,
+                     m_endpoint_info_buffer_receive, endpoint_info_size);
+    ptr += endpoint_info_size;
+
+    /* Subcase 1: wrong slot id */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    spdm_response->header.param2 = 0x1; /* slot_id = 1 */
+
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+
+    /* Subcase 2: wrong ep_info_len */
+    libspdm_copy_mem(temp_buf_error, response_size,
+                     temp_buf_valid, response_size);
+    spdm_response = (void *)temp_buf_error;
+    ptr = (void *)(spdm_response + 1);
+    *(uint32_t *)ptr = endpoint_info_size + 1; /* ep_info_len */
+    status = libspdm_process_encap_response_endpoint_info(spdm_context, response_size,
+                                                          spdm_response, &need_continue);
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+
+int libspdm_responder_encap_get_endpoint_info_error_test_main(void)
+{
+    const struct CMUnitTest spdm_responder_encap_get_endpoint_info_tests[] = {
+        /* Get an error response */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case1),
+        /* Get an incorrect response */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case2),
+        /* Request signature but get response without signature */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case3),
+        /* Request no signature but get response with signature */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case4),
+        /* Request no signature and get incorrect response */
+        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case5),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(spdm_responder_encap_get_endpoint_info_tests,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (...) */

--- a/unit_test/test_spdm_responder/test_spdm_responder.c
+++ b/unit_test/test_spdm_responder/test_spdm_responder.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -78,6 +78,10 @@ int libspdm_responder_encap_challenge_auth_test_main(void);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP */
 int libspdm_responder_encapsulated_response_test_main(void);
 int libspdm_responder_encap_key_update_test_main(void);
+#if LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
+int libspdm_responder_encap_get_endpoint_info_test_main(void);
+int libspdm_responder_encap_get_endpoint_info_error_test_main(void);
+#endif /* LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP*/
 
 int libspdm_responder_set_certificate_rsp_test_main(void);
@@ -233,6 +237,14 @@ int main(void)
     if (libspdm_responder_encap_key_update_test_main() != 0) {
         return_value = 1;
     }
+    #if LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT
+    if (libspdm_responder_encap_get_endpoint_info_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_responder_encap_get_endpoint_info_error_test_main() != 0) {
+        return_value = 1;
+    }
+    #endif /* LIBSPDM_SEND_GET_ENDPOINT_INFO_SUPPORT */
     #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP


### PR DESCRIPTION
Fix the issue: #2294

ENDPOINT_INFO is SPDM spec 1.3 new feature.
Add encapsulate ENDPOINT_INFO for Libspdm.

This PR is dependent on https://github.com/DMTF/libspdm/pull/3000