### PR TITLE
libspdm_generate_device_endpoint_info should not be called twice

### DIFF
--- a/include/hal/library/endpointinfolib.h
+++ b/include/hal/library/endpointinfolib.h
@@ -22,13 +22,14 @@
  * @param  sub_code             The subcode of endpoint info, should be one of the
  *                              SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_* values.
  * @param  request_attributes   The request attributes of the endpoint info.
- * @param  endpoint_info_size   On output, the size, in bytes, of the buffer to
- *                              hold the device class identifier.
- * @param  endpoint_info        On output, the buffer to hold the device class identifier
- *                              content.
+ * @param  endpoint_info_size   On input, the size, in bytes, of the buffer to hold
+ *                              the device class identifier.
+ *                              On output, the size, in bytes, of the device class identifier.
+ * @param  endpoint_info        The buffer to hold the device class identifier content.
  *
  * @retval LIBSPDM_STATUS_SUCCESS          Success.
  * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP  The operation is not supported.
+ * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL The buffer is too small to hold the device class identifier.
  **/
 extern libspdm_return_t libspdm_generate_device_endpoint_info(
     void *spdm_context,

--- a/os_stub/spdm_device_secret_lib_sample/endpointinfo.c
+++ b/os_stub/spdm_device_secret_lib_sample/endpointinfo.c
@@ -33,45 +33,54 @@ libspdm_return_t libspdm_generate_device_endpoint_info(
     uint8_t *num_sub_ids;
     spdm_endpoint_info_device_class_identifier_subordinate_id_t *subordinate_id;
     uint8_t *sub_identifier;
+    uint32_t ep_info_size;
+
+    LIBSPDM_ASSERT(endpoint_info_size != NULL);
+    LIBSPDM_ASSERT(endpoint_info != NULL);
 
     switch (sub_code) {
     case SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER:
-        *endpoint_info_size = sizeof(spdm_endpoint_info_device_class_identifier_t) +
-                              sizeof(spdm_endpoint_info_device_class_identifier_element_t) +
-                              sizeof(uint8_t) +
-                              sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t) +
-                              3;
+        ep_info_size = sizeof(spdm_endpoint_info_device_class_identifier_t) +
+                       sizeof(spdm_endpoint_info_device_class_identifier_element_t) +
+                       sizeof(uint8_t) +
+                       sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t) +
+                       3;
 
-        if (endpoint_info != NULL) {
-            ptr = (uint8_t *)endpoint_info;
-            device_class_identifier = (spdm_endpoint_info_device_class_identifier_t *) ptr;
-            device_class_identifier->num_identifiers = 1;
-
-            ptr += sizeof(spdm_endpoint_info_device_class_identifier_t);
-            identifier = (spdm_endpoint_info_device_class_identifier_element_t *) ptr;
-            identifier->id_elem_length =
-                sizeof(spdm_svh_header_t) + sizeof(uint8_t) +
-                sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t) + 3;
-
-            identifier->svh.id = 0x0;
-            identifier->svh.vendor_id_len = 0x0;
-            /* DMTF does not have a Vendor ID registry*/
-            ptr += sizeof(spdm_endpoint_info_device_class_identifier_element_t);
-
-            /* a fake sub id for structure sample*/
-            num_sub_ids = (uint8_t *) ptr;
-            *num_sub_ids = 1;
-
-            ptr += sizeof(uint8_t);
-            subordinate_id = (spdm_endpoint_info_device_class_identifier_subordinate_id_t *) ptr;
-            subordinate_id->sub_id_len = 0x3;
-
-            ptr += sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t);
-            sub_identifier = (uint8_t *) ptr;
-            sub_identifier[0] = 0x12;
-            sub_identifier[1] = 0x34;
-            sub_identifier[2] = 0x56;
+        if (*endpoint_info_size < ep_info_size) {
+            *endpoint_info_size = ep_info_size;
+            return LIBSPDM_STATUS_BUFFER_TOO_SMALL;
         }
+        *endpoint_info_size = ep_info_size;
+
+        ptr = (uint8_t *)endpoint_info;
+        device_class_identifier = (spdm_endpoint_info_device_class_identifier_t *) ptr;
+        device_class_identifier->num_identifiers = 1;
+
+        ptr += sizeof(spdm_endpoint_info_device_class_identifier_t);
+        identifier = (spdm_endpoint_info_device_class_identifier_element_t *) ptr;
+        identifier->id_elem_length =
+            sizeof(spdm_svh_header_t) + sizeof(uint8_t) +
+            sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t) + 3;
+
+        identifier->svh.id = 0x0;
+        identifier->svh.vendor_id_len = 0x0;
+        /* DMTF does not have a Vendor ID registry*/
+        ptr += sizeof(spdm_endpoint_info_device_class_identifier_element_t);
+
+        /* a fake sub id for structure sample*/
+        num_sub_ids = (uint8_t *) ptr;
+        *num_sub_ids = 1;
+
+        ptr += sizeof(uint8_t);
+        subordinate_id = (spdm_endpoint_info_device_class_identifier_subordinate_id_t *) ptr;
+        subordinate_id->sub_id_len = 0x3;
+
+        ptr += sizeof(spdm_endpoint_info_device_class_identifier_subordinate_id_t);
+        sub_identifier = (uint8_t *) ptr;
+        sub_identifier[0] = 0x12;
+        sub_identifier[1] = 0x34;
+        sub_identifier[2] = 0x56;
+
         break;
     default:
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;

--- a/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
@@ -79,6 +79,7 @@ static libspdm_return_t libspdm_requester_get_endpoint_info_test_receive_message
     libspdm_test_context_t *spdm_test_context;
     uint32_t endpoint_info_buffer_size;
 
+    endpoint_info_buffer_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
     spdm_test_context = libspdm_get_test_context();
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,

--- a/unit_test/test_spdm_requester/get_endpoint_info.c
+++ b/unit_test/test_spdm_requester/get_endpoint_info.c
@@ -93,6 +93,7 @@ static libspdm_return_t libspdm_requester_get_endpoint_info_test_receive_message
     libspdm_test_context_t *spdm_test_context;
     uint32_t endpoint_info_buffer_size;
 
+    endpoint_info_buffer_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
     spdm_test_context = libspdm_get_test_context();
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,

--- a/unit_test/test_spdm_responder/endpoint_info.c
+++ b/unit_test/test_spdm_responder/endpoint_info.c
@@ -82,6 +82,7 @@ void libspdm_test_responder_endpoint_info_case1(void **state)
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     spdm_endpoint_info_response_t *spdm_response;
     uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
     void* signature;
     size_t signature_size;
     bool result;
@@ -145,10 +146,11 @@ void libspdm_test_responder_endpoint_info_case1(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     /* response size check */
+    endpoint_info_size = 0;
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
-        &endpoint_info_size, NULL);
+        &endpoint_info_size, endpoint_info_buffer);
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);
     assert_int_equal(response_size,
@@ -198,6 +200,7 @@ void libspdm_test_responder_endpoint_info_case2(void **state)
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     spdm_endpoint_info_response_t *spdm_response;
     uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
     void* signature;
     size_t signature_size;
     bool result;
@@ -240,10 +243,11 @@ void libspdm_test_responder_endpoint_info_case2(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     /* response size check */
+    endpoint_info_size = 0;
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
-        &endpoint_info_size, NULL);
+        &endpoint_info_size, endpoint_info_buffer);
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);
     assert_int_equal(response_size,
@@ -294,6 +298,7 @@ void libspdm_test_responder_endpoint_info_case3(void **state)
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     spdm_endpoint_info_response_t *spdm_response;
     uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
     void* signature;
     size_t signature_size;
     bool result;
@@ -361,10 +366,11 @@ void libspdm_test_responder_endpoint_info_case3(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     /* response size check */
+    endpoint_info_size = 0;
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
-        &endpoint_info_size, NULL);
+        &endpoint_info_size, endpoint_info_buffer);
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);
     assert_int_equal(response_size,
@@ -412,6 +418,7 @@ void libspdm_test_responder_endpoint_info_case4(void **state)
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     spdm_endpoint_info_response_t *spdm_response;
     uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -440,10 +447,11 @@ void libspdm_test_responder_endpoint_info_case4(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     /* response size check */
+    endpoint_info_size = 0;
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
-        &endpoint_info_size, NULL);
+        &endpoint_info_size, endpoint_info_buffer);
     assert_int_equal(response_size,
                      sizeof(spdm_endpoint_info_response_t) +
                      sizeof(uint32_t) + endpoint_info_size);
@@ -472,6 +480,7 @@ void libspdm_test_responder_endpoint_info_case5(void **state)
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     spdm_endpoint_info_response_t *spdm_response;
     uint32_t endpoint_info_size;
+    uint8_t endpoint_info_buffer[LIBSPDM_MAX_ENDPOINT_INFO_LENGTH];
     void* signature;
     size_t signature_size;
     bool result;
@@ -546,10 +555,11 @@ void libspdm_test_responder_endpoint_info_case5(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     /* response size check */
+    endpoint_info_size = 0;
     libspdm_generate_device_endpoint_info(
         spdm_context, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
-        &endpoint_info_size, NULL);
+        &endpoint_info_size, endpoint_info_buffer);
     signature_size = libspdm_get_asym_signature_size(
         spdm_context->connection_info.algorithm.base_asym_algo);
     assert_int_equal(response_size,


### PR DESCRIPTION
Fix the issue: #2294