### PR TITLE
format_nix: Add version check for uncrustify

### DIFF
--- a/script/format_nix.sh
+++ b/script/format_nix.sh
@@ -13,6 +13,15 @@ then
     exit 1
 fi
 
+# Extract the version number.
+VERSION=$(uncrustify --version 2>/dev/null | sed -E 's/Uncrustify-([0-9]+\.[0-9]+).*/\1/')
+REQUIRED_VERSION="0.72"
+
+if [ "$VERSION" != "$REQUIRED_VERSION" ]; then
+    echo "ERROR: uncrustify version $REQUIRED_VERSION is required, but found $VERSION."
+    exit 1
+fi
+
 # Change directory to top of repository.
 cd `dirname $0`
 cd ../


### PR DESCRIPTION
It seems that the uncrustify config file that we have does not work with Ubuntu 24.04 which comes with 0.78.

And the current config file with 0.78 seems to complain about deprecated keys and actually did much more changes than what the CI did. Hence added a version check in the format script. We need to ensure that we change the version here as and when we start supporting new versions of uncrustify in CI.