### PR TITLE
Backport API introduced in openssl 3.5.0

### DIFF
--- a/os_stub/openssllib/openssl_gen/openssl/asn1.h
+++ b/os_stub/openssllib/openssl_gen/openssl/asn1.h
@@ -368,6 +368,7 @@ typedef struct ASN1_VALUE_st ASN1_VALUE;
 
 typedef void *d2i_of_void(void **, const unsigned char **, long);
 typedef int i2d_of_void(const void *, unsigned char **);
+typedef int OSSL_i2d_of_void_ctx(const void *, unsigned char **, void *vctx);
 
 /*-
  * The following macros and typedefs allow an ASN1_ITEM


### PR DESCRIPTION
This commit [1] introduced this new API which is used by pem.h from openssl and it should be provided by asn1.h which is vendored here so it goes out of sync and causes build errors e.g

In file included from ./os_stub/cryptlib_openssl/pk/x509.c:18: /usr/include/openssl/pem.h:399:28: error: unknown type name 'OSSL_i2d_of_void_ctx'
  399 | int PEM_ASN1_write_bio_ctx(OSSL_i2d_of_void_ctx *i2d, void *vctx,

[1] https://github.com/openssl/openssl/commit/35f6e7ea02b599d5aaf220b4720cbadd946d8023