### PR TITLE
Add dependabot file for auto scan and update.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions

[Using Dependabot version updates to keep actions up to date](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-dependabot-version-updates-to-keep-actions-up-to-date)


It is also related to https://github.com/DMTF/libspdm/issues/3034