### PR TITLE
Remove mbedtls_platform_zeroize definition

### DIFF
--- a/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
@@ -24,8 +24,3 @@ int my_snprintf(char *str, size_t size, const char *format, ...)
     LIBSPDM_ASSERT(false);
     return 0;
 }
-
-void mbedtls_platform_zeroize(void *buf, size_t len)
-{
-    libspdm_zero_mem(buf, len);
-}


### PR DESCRIPTION
The mbedtls has a function by the same name which creates a linker error.

Fixes #3070 