### PR TITLE
scripts: format_nix: allow newer versions of uncrustify

### DIFF
--- a/script/format_nix.sh
+++ b/script/format_nix.sh
@@ -17,8 +17,8 @@ fi
 VERSION=$(uncrustify --version 2>/dev/null | sed -E 's/Uncrustify-([0-9]+\.[0-9]+).*/\1/')
 REQUIRED_VERSION="0.78"
 
-if [ "$VERSION" != "$REQUIRED_VERSION" ]; then
-    echo "ERROR: uncrustify version $REQUIRED_VERSION is required, but found $VERSION."
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+    echo "ERROR: uncrustify version $REQUIRED_VERSION or higher is required, but found $VERSION."
     exit 1
 fi
 


### PR DESCRIPTION
Use `sort -v` to sort versions and allow versions greater than 0.78. For example, Fedora 42 ships 0.80, which fails to work since this script currently checks exactly for 0.78.