### PR TITLE
Fix typo SPDM_SUPPORTED_EVENT_TYPES to SPDM_GET_SUPPORTED_EVENT_TYPES…

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -102,7 +102,7 @@ libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_
         #endif /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
 
         #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
-        { SPDM_SUPPORTED_EVENT_TYPES, libspdm_get_response_supported_event_types },
+        { SPDM_GET_SUPPORTED_EVENT_TYPES, libspdm_get_response_supported_event_types },
         { SPDM_SUBSCRIBE_EVENT_TYPES, libspdm_get_response_subscribe_event_types_ack },
         #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 


### PR DESCRIPTION
libspdm_get_response_func_via_request_code(uint8_t request_code)        
{
    ...
    #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
    { **SPDM_GET_SUPPORTED_EVENT_TYPES** , /* Corrected the typo here * / libspdm_get_response_supported_event_types }, 
    { SPDM_SUBSCRIBE_EVENT_TYPES, libspdm_get_response_subscribe_event_types_ack },
    #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
}


In this corrected version, SPDM_GET_SUPPORTED_EVENT_TYPES (0x62) is used instead of  (0xE2)SPDM_SUPPORTED_EVENT_TYPES, ensuring the request code matches the `uint8_t request_code` correctly.