### PR TITLE
fix typo SPDM_SUPPORTED_EVENT_TYPES to SPDM_GET_SUPPORTED_EVENT_TYPES…

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -102,7 +102,7 @@ libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_
         #endif /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
 
         #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
-        { SPDM_SUPPORTED_EVENT_TYPES, libspdm_get_response_supported_event_types },
+        { SPDM_GET_SUPPORTED_EVENT_TYPES, libspdm_get_response_supported_event_types },
         { SPDM_SUBSCRIBE_EVENT_TYPES, libspdm_get_response_subscribe_event_types_ack },
         #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 


### PR DESCRIPTION
fix: correct request code from **SPDM_SUPPORTED_EVENT_TYPES** (0x62) to **SPDM_GET_SUPPORTED_EVENT_TYPES** (0xE2) in libspdm_get_response_supported_event_types to avoid handler mismatch and ASSERT failure