### PR TITLE
lib: spdm_transport_storage: cleanup dead code

### DIFF
--- a/library/spdm_transport_storage_lib/libspdm_storage.c
+++ b/library/spdm_transport_storage_lib/libspdm_storage.c
@@ -841,10 +841,6 @@ libspdm_return_t libspdm_transport_storage_encode_discovery_response(
         return LIBSPDM_STATUS_BUFFER_TOO_SMALL;
     }
 
-    if (!transport_message) {
-        return LIBSPDM_STATUS_INVALID_MSG_SIZE;
-    }
-
     *transport_message_size = sizeof(spdm_storage_discovery_response_t);
     libspdm_zero_mem(transport_message, *transport_message_size);
     discovery_response = transport_message;


### PR DESCRIPTION
Clean up dead code as per Coverity 482735. @steven-bellock

Fixes: https://github.com/DMTF/libspdm/issues/3116