### PR TITLE
Honor the MBEDTLS_CONFIG_FILE override

### DIFF
--- a/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
+++ b/os_stub/cryptlib_mbedtls/sys_call/crt_wrapper_host.c
@@ -11,7 +11,7 @@
 #include <base.h>
 #include "library/debuglib.h"
 #include "library/memlib.h"
-#include "mbedtls/libspdm_mbedtls_config.h"
+#include <mbedtls/build_info.h>
 #include <stddef.h>
 
 int my_printf(const char *fmt, ...)


### PR DESCRIPTION
The crt_wrapper_host.c file hard-coded the include path. The user should be able to override this path via the MBEDTLS_CONFIG_FILE option. The change updates the include path to correct this.

Fixes #3207