### PR TITLE
Move event handlers to common library

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1969,10 +1969,50 @@ uint32_t libspdm_mask_base_asym_algo(libspdm_context_t *spdm_context, uint32_t b
  *
  * @param  id             Registry or standards body identifier (SPDM_REGISTRY_ID_*).
  *                        Its size is two bytes due to the vendor-defined messages.
- * @param  vendor_id_len  Length, in bytes, of the VendorID field. *
+ * @param  vendor_id_len  Length, in bytes, of the VendorID field.
  * @retval true  The ID and VendorIDLen are legal.
  * @retval false The ID and VendorIDLen are illegal.
  */
 bool libspdm_validate_svh_vendor_id_len(uint16_t id, uint8_t vendor_id_len);
+
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+/**
+ * Check if the combination of DMTF EventTypeId and EventDetailLen is legal in a SEND_EVENT message.
+ *
+ * @param  event_type_id     Value of the DMTF EventTypeId.
+ * @param  event_detail_len  Size, in bytes, of EventDetail.
+ *
+ * @retval true  The EventTypeId and EventDetailLen are legal.
+ * @retval false The EventTypeId and EventDetailLen are illegal.
+ */
+bool libspdm_validate_dmtf_event_type(uint16_t event_type_id, uint16_t event_detail_len);
+
+/**
+ * Given a list of events, finds the event identified by the target EventInstanceID.
+ *
+ * @param  events_list_start         Pointer to list of events.
+ * @param  event_count               Number of events in the list.
+ * @param  target_event_instance_id  EventInstanceID to be found.
+ *
+ * @retval  NULL     Could not find the EventInstanceID.
+ * @retval  non-NULL Pointer to the event corresponding to the target EventInstanceID
+ */
+void *libspdm_find_event_instance_id(void *events_list_start, uint32_t event_count,
+                                     uint32_t target_event_instance_id);
+/**
+ * Parses and sends an event to the Integrator. This function shall not be called if the Integrator
+ * has not registered an event handler via libspdm_register_event_callback.
+ *
+ * @param  context          A pointer to the SPDM context.
+ * @param  session_id       Secure session identifier.
+ * @param  event_data       A pointer to the event do be parsed and sent to Integrator.
+ * @param  next_event_data  On output, returns a pointer to the next event in event_data.
+ *
+ * @retval  true   The event was successfully parsed and sent to the Integrator.
+ * @retval  false  Unable to parse the event or the Integrator returned an error for the event.
+ */
+bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_id,
+                                  void *event_data, void **next_event_data);
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 
 #endif /* SPDM_COMMON_LIB_INTERNAL_H */

--- a/library/spdm_common_lib/CMakeLists.txt
+++ b/library/spdm_common_lib/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(spdm_common_lib
         libspdm_com_context_data_session.c
         libspdm_com_crypto_service.c
         libspdm_com_crypto_service_session.c
+        libspdm_com_event.c
         libspdm_com_opaque_data.c
         libspdm_com_support.c
         libspdm_com_msg_log.c

--- a/library/spdm_common_lib/libspdm_com_event.c
+++ b/library/spdm_common_lib/libspdm_com_event.c
@@ -1,0 +1,108 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_common_lib.h"
+
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+
+bool libspdm_validate_dmtf_event_type(uint16_t event_type_id, uint16_t event_detail_len)
+{
+    switch (event_type_id) {
+    case SPDM_DMTF_EVENT_TYPE_EVENT_LOST:
+        return (event_detail_len == SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE);
+    case SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED:
+        return (event_detail_len == SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED_SIZE);
+    case SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE:
+        return (event_detail_len == SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE_SIZE);
+    case SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED:
+        return (event_detail_len == SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE);
+    default:
+        return false;
+    }
+}
+
+bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_id,
+                                  void *event_data, void **next_event_data)
+{
+    libspdm_return_t status;
+    uint8_t *ptr;
+    uint32_t event_instance_id;
+    uint8_t svh_id;
+    uint8_t svh_vendor_id_len;
+    void *svh_vendor_id;
+    uint16_t event_type_id;
+    uint16_t event_detail_len;
+
+    LIBSPDM_ASSERT(context->process_event != NULL);
+
+    ptr = event_data;
+    event_instance_id = libspdm_read_uint32(ptr);
+
+    ptr += sizeof(uint32_t);
+    ptr += sizeof(uint32_t);
+    svh_id = *ptr;
+    ptr++;
+    svh_vendor_id_len = *ptr;
+    ptr++;
+
+    if (svh_vendor_id_len == 0) {
+        svh_vendor_id = NULL;
+    } else {
+        svh_vendor_id = ptr;
+    }
+    ptr += svh_vendor_id_len;
+
+    event_type_id = libspdm_read_uint16(ptr);
+    ptr += sizeof(uint16_t);
+    event_detail_len = libspdm_read_uint16(ptr);
+    ptr += sizeof(uint16_t);
+
+    status = context->process_event(context, session_id, event_instance_id, svh_id,
+                                    svh_vendor_id_len, svh_vendor_id, event_type_id,
+                                    event_detail_len, ptr);
+
+    if (next_event_data != NULL) {
+        ptr += event_detail_len;
+        *next_event_data = ptr;
+    }
+
+    return (status == LIBSPDM_STATUS_SUCCESS);
+}
+
+void *libspdm_find_event_instance_id(void *events_list_start, uint32_t event_count,
+                                     uint32_t target_event_instance_id)
+{
+    uint32_t index;
+    uint8_t *ptr;
+
+    ptr = events_list_start;
+
+    for (index = 0; index < event_count; index++) {
+        uint32_t event_instance_id;
+
+        event_instance_id = libspdm_read_uint32(ptr);
+
+        if (event_instance_id == target_event_instance_id) {
+            return ptr;
+        } else {
+            uint8_t vendor_id_len;
+            uint16_t event_detail_len;
+
+            ptr += sizeof(uint32_t) +  sizeof(uint32_t) + sizeof(uint8_t);
+            vendor_id_len = *ptr;
+            ptr += sizeof(uint8_t);
+            ptr += vendor_id_len;
+            ptr += sizeof(uint16_t);
+            event_detail_len = libspdm_read_uint16(ptr);
+            ptr += sizeof(uint16_t);
+            ptr += event_detail_len;
+        }
+    }
+
+    return NULL;
+}
+
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */


### PR DESCRIPTION
This commit moves the event handlers from the Requester library to the common library so that the Responder can use them as well.