### PR TITLE
`SEND_EVENT` support for Responder 

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -2015,4 +2015,12 @@ bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_i
                                   void *event_data, void **next_event_data);
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 
+/**
+ * Given a buffer that spans from ptr to end_ptr, check if ptr + increment is within the buffer.
+ *
+ * @retval true  There is enough space in the buffer.
+ * @retval false There is not enough space in the buffer.
+ */
+bool libspdm_check_for_space(const uint8_t *ptr, const uint8_t *end_ptr, size_t increment);
+
 #endif /* SPDM_COMMON_LIB_INTERNAL_H */

--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1997,8 +1997,8 @@ bool libspdm_validate_dmtf_event_type(uint16_t event_type_id, uint16_t event_det
  * @retval  NULL     Could not find the EventInstanceID.
  * @retval  non-NULL Pointer to the event corresponding to the target EventInstanceID
  */
-void *libspdm_find_event_instance_id(void *events_list_start, uint32_t event_count,
-                                     uint32_t target_event_instance_id);
+const void *libspdm_find_event_instance_id(const void *events_list_start, uint32_t event_count,
+                                           uint32_t target_event_instance_id);
 /**
  * Parses and sends an event to the Integrator. This function shall not be called if the Integrator
  * has not registered an event handler via libspdm_register_event_callback.
@@ -2012,7 +2012,7 @@ void *libspdm_find_event_instance_id(void *events_list_start, uint32_t event_cou
  * @retval  false  Unable to parse the event or the Integrator returned an error for the event.
  */
 bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_id,
-                                  void *event_data, void **next_event_data);
+                                  const void *event_data, const void **next_event_data);
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -657,6 +657,12 @@ libspdm_return_t libspdm_process_encap_response_event_ack(
 #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+libspdm_return_t libspdm_get_response_send_event(
+    libspdm_context_t *spdm_context, size_t request_size, const void *request,
+    size_t *response_size, void *response);
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+
 /**
  * Return the GET_SPDM_RESPONSE function via request code.
  *

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -1005,10 +1005,10 @@ typedef libspdm_return_t (*libspdm_process_event_func)(void *spdm_context,
                                                        uint32_t event_instance_id,
                                                        uint8_t svh_id,
                                                        uint8_t svh_vendor_id_len,
-                                                       void *svh_vendor_id,
+                                                       const void *svh_vendor_id,
                                                        uint16_t event_type_id,
                                                        uint16_t event_detail_len,
-                                                       void *event_detail);
+                                                       const void *event_detail);
 
 /**
  * Register callback to process SPDM events.

--- a/library/spdm_common_lib/libspdm_com_event.c
+++ b/library/spdm_common_lib/libspdm_com_event.c
@@ -25,14 +25,14 @@ bool libspdm_validate_dmtf_event_type(uint16_t event_type_id, uint16_t event_det
 }
 
 bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_id,
-                                  void *event_data, void **next_event_data)
+                                  const void *event_data, const void **next_event_data)
 {
     libspdm_return_t status;
-    uint8_t *ptr;
+    const uint8_t *ptr;
     uint32_t event_instance_id;
     uint8_t svh_id;
     uint8_t svh_vendor_id_len;
-    void *svh_vendor_id;
+    const void *svh_vendor_id;
     uint16_t event_type_id;
     uint16_t event_detail_len;
 
@@ -72,11 +72,11 @@ bool libspdm_parse_and_send_event(libspdm_context_t *context, uint32_t session_i
     return (status == LIBSPDM_STATUS_SUCCESS);
 }
 
-void *libspdm_find_event_instance_id(void *events_list_start, uint32_t event_count,
-                                     uint32_t target_event_instance_id)
+const void *libspdm_find_event_instance_id(const void *events_list_start, uint32_t event_count,
+                                           uint32_t target_event_instance_id)
 {
     uint32_t index;
-    uint8_t *ptr;
+    const uint8_t *ptr;
 
     ptr = events_list_start;
 

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -515,3 +515,10 @@ bool libspdm_validate_svh_vendor_id_len(uint16_t id, uint8_t vendor_id_len)
         return false;
     }
 }
+
+bool libspdm_check_for_space(const uint8_t *ptr, const uint8_t *end_ptr, size_t increment)
+{
+    LIBSPDM_ASSERT(ptr <= end_ptr);
+
+    return ((uintptr_t)(end_ptr - ptr) >= increment);
+}

--- a/library/spdm_requester_lib/libspdm_req_encap_event_ack.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_event_ack.c
@@ -183,7 +183,7 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
     }
 
     if (context->process_event != NULL) {
-        void *next_event_data = spdm_request + 1;
+        const void *next_event_data = spdm_request + 1;
 
         for (index = 0; index < spdm_request->event_count; index++) {
             if (events_list_is_sequential) {
@@ -193,7 +193,7 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
                         context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
                 }
             } else {
-                void *event_data;
+                const void *event_data;
 
                 event_data = libspdm_find_event_instance_id(
                     next_event_data, spdm_request->event_count,

--- a/library/spdm_requester_lib/libspdm_req_encap_event_ack.c
+++ b/library/spdm_requester_lib/libspdm_req_encap_event_ack.c
@@ -8,13 +8,6 @@
 
  #if (LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP) && (LIBSPDM_EVENT_RECIPIENT_SUPPORT)
 
-static bool check_for_space(const uint8_t *ptr, const uint8_t *end_ptr, size_t increment)
-{
-    LIBSPDM_ASSERT(ptr <= end_ptr);
-
-    return ((uintptr_t)(end_ptr - ptr) >= increment);
-}
-
 libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
                                                       size_t request_size,
                                                       void *request,
@@ -74,7 +67,7 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
     libspdm_reset_message_buffer_via_request_code(context, NULL,
                                                   spdm_request->header.request_response_code);
 
-    if (!check_for_space((uint8_t *)request, end_ptr, sizeof(spdm_send_event_request_t))) {
+    if (!libspdm_check_for_space((uint8_t *)request, end_ptr, sizeof(spdm_send_event_request_t))) {
         return libspdm_generate_encap_error_response(
             context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
     }
@@ -100,9 +93,9 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
         uint16_t event_type_id;
         uint16_t event_detail_len;
 
-        if (!check_for_space(ptr, end_ptr,
-                             sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint8_t) +
-                             sizeof(uint8_t))) {
+        if (!libspdm_check_for_space(ptr, end_ptr,
+                                     sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint8_t) +
+                                     sizeof(uint8_t))) {
             return libspdm_generate_encap_error_response(
                 context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
         }
@@ -133,8 +126,8 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
                 context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
         }
 
-        if (!check_for_space(ptr, end_ptr,
-                             (size_t)svh_vendor_id_len + sizeof(uint16_t) + sizeof(uint16_t))) {
+        if (!libspdm_check_for_space(
+                ptr, end_ptr, (size_t)svh_vendor_id_len + sizeof(uint16_t) + sizeof(uint16_t))) {
             return libspdm_generate_encap_error_response(
                 context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
         }
@@ -153,7 +146,7 @@ libspdm_return_t libspdm_get_encap_response_event_ack(void *spdm_context,
             }
         }
 
-        if (!check_for_space(ptr, end_ptr, (size_t)event_detail_len)) {
+        if (!libspdm_check_for_space(ptr, end_ptr, (size_t)event_detail_len)) {
             return libspdm_generate_encap_error_response(
                 context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
         }

--- a/library/spdm_responder_lib/CMakeLists.txt
+++ b/library/spdm_responder_lib/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(spdm_responder_lib
         libspdm_rsp_end_session.c
         libspdm_rsp_endpoint_info.c
         libspdm_rsp_error.c
+        libspdm_rsp_event_ack.c
         libspdm_rsp_finish.c
         libspdm_rsp_handle_response_state.c
         libspdm_rsp_heartbeat.c

--- a/library/spdm_responder_lib/libspdm_rsp_event_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_event_ack.c
@@ -1,0 +1,259 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+
+libspdm_return_t libspdm_get_response_send_event(libspdm_context_t *spdm_context,
+                                                 size_t request_size,
+                                                 const void *request,
+                                                 size_t *response_size,
+                                                 void *response)
+{
+    const spdm_send_event_request_t *spdm_request;
+    spdm_event_ack_response_t *spdm_response;
+    libspdm_session_info_t *session_info;
+    libspdm_session_state_t session_state;
+    uint32_t session_id;
+    uint64_t index;
+    uint32_t prev_event_instance_id;
+    uint32_t event_instance_id_min;
+    uint32_t event_instance_id_max;
+    bool events_list_is_sequential;
+    const uint8_t *ptr;
+    const uint8_t *end_ptr = (const uint8_t *)request + request_size;
+    size_t calculated_request_size;
+
+    spdm_request = (const spdm_send_event_request_t *)request;
+
+    /* -=[Check Parameters Phase]=- */
+    LIBSPDM_ASSERT(spdm_request->header.request_response_code == SPDM_SEND_EVENT);
+
+    if (libspdm_get_connection_version(spdm_context) < SPDM_MESSAGE_VERSION_13) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+                                               SPDM_KEY_UPDATE,
+                                               response_size, response);
+    }
+
+    if (spdm_request->header.spdm_version != libspdm_get_connection_version(spdm_context)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_VERSION_MISMATCH, 0,
+                                               response_size, response);
+    }
+    if (spdm_context->response_state != LIBSPDM_RESPONSE_STATE_NORMAL) {
+        return libspdm_responder_handle_response_state(
+            spdm_context,
+            spdm_request->header.request_response_code,
+            response_size, response);
+    }
+
+    if (!libspdm_is_capabilities_flag_supported(
+            spdm_context, false,
+            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EVENT_CAP, 0)) {
+        return libspdm_generate_error_response(
+            spdm_context, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
+            SPDM_SEND_EVENT, response_size, response);
+    }
+    if (spdm_context->connection_info.connection_state < LIBSPDM_CONNECTION_STATE_NEGOTIATED) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNEXPECTED_REQUEST,
+                                               0, response_size, response);
+    }
+
+    if (!spdm_context->last_spdm_request_session_id_valid) {
+        if (libspdm_get_connection_version(spdm_context) >= SPDM_MESSAGE_VERSION_12) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_SESSION_REQUIRED, 0,
+                                                   response_size, response);
+        } else {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                                                   response_size, response);
+        }
+    }
+    session_id = spdm_context->last_spdm_request_session_id;
+    session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+    if (session_info == NULL) {
+        if (libspdm_get_connection_version(spdm_context) >= SPDM_MESSAGE_VERSION_12) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_SESSION_REQUIRED, 0,
+                                                   response_size, response);
+        } else {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                                                   response_size, response);
+        }
+    }
+    session_state = libspdm_secured_message_get_session_state(
+        session_info->secured_message_context);
+    if (session_state != LIBSPDM_SESSION_STATE_ESTABLISHED) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+                                               response_size, response);
+    }
+
+
+    if (!libspdm_check_for_space((const uint8_t *)request, end_ptr,
+                                 sizeof(spdm_send_event_request_t))) {
+        return libspdm_generate_error_response(
+            spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+    }
+
+    if (spdm_request->event_count == 0) {
+        return libspdm_generate_error_response(
+            spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+    }
+
+    ptr = (const uint8_t *)(spdm_request + 1);
+
+    event_instance_id_min = UINT32_MAX;
+    event_instance_id_max = 0;
+    events_list_is_sequential = true;
+
+    calculated_request_size = sizeof(spdm_send_event_request_t);
+
+    /* Parse and validate all events for size and fields. */
+    for (index = 0; index < spdm_request->event_count; index++) {
+        uint32_t event_instance_id;
+        uint8_t svh_id;
+        uint8_t svh_vendor_id_len;
+        uint16_t event_type_id;
+        uint16_t event_detail_len;
+
+        if (!libspdm_check_for_space(ptr, end_ptr,
+                                     sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint8_t) +
+                                     sizeof(uint8_t))) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+        }
+
+        event_instance_id = libspdm_read_uint32(ptr);
+
+        if ((index != 0) && events_list_is_sequential) {
+            if (event_instance_id != (prev_event_instance_id + 1)) {
+                events_list_is_sequential = false;
+            }
+        }
+        if (event_instance_id < event_instance_id_min) {
+            event_instance_id_min = event_instance_id;
+        }
+        if (event_instance_id > event_instance_id_max) {
+            event_instance_id_max = event_instance_id;
+        }
+        prev_event_instance_id = event_instance_id;
+
+        ptr += sizeof(uint32_t) + sizeof(uint32_t);
+        svh_id = *ptr;
+        ptr += sizeof(uint8_t);
+        svh_vendor_id_len = *ptr;
+        ptr += sizeof(uint8_t);
+
+        if (!libspdm_validate_svh_vendor_id_len(svh_id, svh_vendor_id_len)) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+        }
+
+        if (!libspdm_check_for_space(
+                ptr, end_ptr, (size_t)svh_vendor_id_len + sizeof(uint16_t) + sizeof(uint16_t))) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+        }
+
+        ptr += svh_vendor_id_len;
+
+        event_type_id = libspdm_read_uint16(ptr);
+        ptr += sizeof(uint16_t);
+        event_detail_len = libspdm_read_uint16(ptr);
+        ptr += sizeof(uint16_t);
+
+        if (svh_id == SPDM_REGISTRY_ID_DMTF) {
+            if (!libspdm_validate_dmtf_event_type(event_type_id, event_detail_len)) {
+                return libspdm_generate_error_response(
+                    spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+            }
+        }
+
+        if (!libspdm_check_for_space(ptr, end_ptr, (size_t)event_detail_len)) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+        }
+
+        ptr += event_detail_len;
+        calculated_request_size += sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint8_t) +
+                                   sizeof(uint8_t) + (size_t)svh_vendor_id_len + sizeof(uint16_t) +
+                                   sizeof(uint16_t) + (size_t)event_detail_len;
+    }
+
+    /* Event must be sent in a secure session so message size can be calculated exactly. */
+    if (request_size != calculated_request_size) {
+        return libspdm_generate_error_response(
+            spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+    }
+
+    /* If event instance IDs are not sequential then ensure there are no gaps or duplicates before
+     * sending individual events to Integrator. */
+    if (!events_list_is_sequential) {
+        const void *event_data = spdm_request + 1;
+
+        if ((event_instance_id_max - event_instance_id_min + 1) != spdm_request->event_count) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+        }
+
+        for (index = 0; index < spdm_request->event_count; index++) {
+            if (libspdm_find_event_instance_id(event_data, spdm_request->event_count,
+                                               event_instance_id_min + (uint32_t)index) == NULL) {
+                return libspdm_generate_error_response(
+                    spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+            }
+        }
+    }
+
+    if (spdm_context->process_event != NULL) {
+        const void *next_event_data = spdm_request + 1;
+
+        for (index = 0; index < spdm_request->event_count; index++) {
+            if (events_list_is_sequential) {
+                if (!libspdm_parse_and_send_event(
+                        spdm_context, session_id, next_event_data, &next_event_data)) {
+                    return libspdm_generate_error_response(
+                        spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+                }
+            } else {
+                const void *event_data;
+
+                event_data = libspdm_find_event_instance_id(
+                    (const void *)next_event_data, spdm_request->event_count,
+                    event_instance_id_min + (uint32_t)index);
+                if (event_data == NULL) {
+                    return libspdm_generate_error_response(
+                        spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+                }
+
+                if (!libspdm_parse_and_send_event(spdm_context, session_id, event_data, NULL)) {
+                    return libspdm_generate_error_response(
+                        spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST, 0, response_size, response);
+                }
+            }
+        }
+    }
+
+    spdm_response = (spdm_event_ack_response_t *)response;
+
+    spdm_response->header.spdm_version = libspdm_get_connection_version(spdm_context);
+    spdm_response->header.request_response_code = SPDM_EVENT_ACK;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = 0;
+
+    *response_size = sizeof(spdm_event_ack_response_t);
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */

--- a/unit_test/test_spdm_requester/encap_event_ack.c
+++ b/unit_test/test_spdm_requester/encap_event_ack.c
@@ -32,10 +32,10 @@ static libspdm_return_t process_event(void *spdm_context,
                                       uint32_t event_instance_id,
                                       uint8_t svh_id,
                                       uint8_t svh_vendor_id_len,
-                                      void *svh_vendor_id,
+                                      const void *svh_vendor_id,
                                       uint16_t event_type_id,
                                       uint16_t event_detail_len,
-                                      void *event_detail)
+                                      const void *event_detail)
 {
     printf("Event Received\n");
     printf("Event Instance ID = [0x%x]\n", event_instance_id);

--- a/unit_test/test_spdm_requester/error_test/encap_event_ack_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_event_ack_err.c
@@ -32,10 +32,10 @@ static libspdm_return_t process_event(void *spdm_context,
                                       uint32_t event_instance_id,
                                       uint8_t svh_id,
                                       uint8_t svh_vendor_id_len,
-                                      void *svh_vendor_id,
+                                      const void *svh_vendor_id,
                                       uint16_t event_type_id,
                                       uint16_t event_detail_len,
-                                      void *event_detail)
+                                      const void *event_detail)
 {
     printf("Event Received\n");
     printf("Event Instance ID = [0x%x]\n", event_instance_id);

--- a/unit_test/test_spdm_responder/CMakeLists.txt
+++ b/unit_test/test_spdm_responder/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(test_spdm_responder
         encap_challenge.c
         encap_response.c
         encap_send_event.c
+        event_ack.c
         supported_event_types.c
         subscribe_event_types_ack.c
         error_test/supported_event_types_err.c
@@ -49,6 +50,7 @@ target_sources(test_spdm_responder
         error_test/endpoint_info_err.c
         error_test/encap_get_endpoint_info_err.c
         error_test/encap_send_event_err.c
+        error_test/event_ack_err.c
         set_certificate_rsp.c
         csr.c
         receive_send.c

--- a/unit_test/test_spdm_responder/error_test/event_ack_err.c
+++ b/unit_test/test_spdm_responder/error_test/event_ack_err.c
@@ -1,0 +1,387 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+
+static uint8_t m_spdm_request_buffer[0x1000];
+static uint8_t m_spdm_response_buffer[0x1000];
+
+static const uint32_t m_session_id = 0xffffffff;
+
+typedef struct {
+    uint32_t event_instance_id;
+    uint8_t svh_id;
+    uint8_t svh_vendor_id_len;
+    uint8_t svh_vendor_id[4];
+    uint16_t event_type_id;
+    uint16_t event_detail_len;
+    uint8_t event_detail[100];
+} expected_event_t;
+
+static expected_event_t m_expected_event[4];
+static uint32_t m_event_counter;
+
+static libspdm_return_t process_event(void *spdm_context,
+                                      uint32_t session_id,
+                                      uint32_t event_instance_id,
+                                      uint8_t svh_id,
+                                      uint8_t svh_vendor_id_len,
+                                      const void *svh_vendor_id,
+                                      uint16_t event_type_id,
+                                      uint16_t event_detail_len,
+                                      const void *event_detail)
+{
+    printf("Event Received\n");
+    printf("Event Instance ID = [0x%x]\n", event_instance_id);
+    printf("SVH ID = [0x%x], SVH VendorIDLen = [0x%x]\n", svh_id, svh_vendor_id_len);
+    if (svh_vendor_id_len != 0) {
+        printf("SVH VendorID\n");
+        libspdm_dump_hex(svh_vendor_id, svh_vendor_id_len);
+        printf("\n");
+    }
+    printf("EventTypeID = [0x%x], EventDetailLen = [0x%x]\n", event_type_id, event_detail_len);
+    printf("Event Detail\n");
+    libspdm_dump_hex(event_detail, event_detail_len);
+
+    assert_int_equal(session_id, m_session_id);
+    assert_int_equal(event_instance_id, m_expected_event[m_event_counter].event_instance_id);
+    assert_int_equal(event_type_id, m_expected_event[m_event_counter].event_type_id);
+    assert_int_equal(svh_id, m_expected_event[m_event_counter].svh_id);
+    assert_int_equal(svh_vendor_id_len, m_expected_event[m_event_counter].svh_vendor_id_len);
+    if (svh_vendor_id_len == 0) {
+        assert_ptr_equal(svh_vendor_id, NULL);
+    }
+    assert_int_equal(event_detail_len, m_expected_event[m_event_counter].event_detail_len);
+    assert_memory_equal(m_expected_event[m_event_counter].event_detail, event_detail,
+                        event_detail_len);
+    m_event_counter++;
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+static void set_standard_state(libspdm_context_t *spdm_context)
+{
+    libspdm_session_info_t *session_info;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_EVENT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP;
+
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+
+    spdm_context->latest_session_id = m_session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = m_session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, m_session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    libspdm_register_event_callback(spdm_context, process_event);
+}
+
+/**
+ * Test 1: Illegal EventCount is set to 0.
+ * Expected behavior: InvalidRequest error response.
+ **/
+static void rsp_event_ack_err_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size;
+    spdm_dmtf_event_type_event_lost_t event_lost;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x01;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    /* Illegal value for EventCount. */
+    send_event->event_count = 0;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    generate_dmtf_event_data(send_event + 1, &event_data_size, 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size;
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 2: Send two events with gap in event instance IDs.
+ * Expected behavior: InvalidRequest error response.
+ **/
+static void rsp_event_ack_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size[2];
+    spdm_dmtf_event_type_event_lost_t event_lost;
+    spdm_dmtf_event_type_certificate_changed_t certificate_changed;
+    uint8_t *ptr;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x02;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 2;
+
+    certificate_changed.certificate_changed = 5;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    ptr = (uint8_t *)(send_event + 1);
+
+    generate_dmtf_event_data(ptr, &event_data_size[0], 0x11223343,
+                             SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED, &certificate_changed);
+    ptr += event_data_size[0];
+
+    generate_dmtf_event_data(ptr, &event_data_size[1], 0x11223345,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+    ptr += event_data_size[1];
+
+    m_event_counter = 0;
+
+    m_expected_event[0].event_instance_id = 0x11223343;
+    m_expected_event[0].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[0].svh_vendor_id_len = 0;
+    m_expected_event[0].event_type_id = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED;
+
+    m_expected_event[1].event_instance_id = 0x11223344;
+    m_expected_event[1].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[1].svh_vendor_id_len = 0;
+    m_expected_event[1].event_type_id = SPDM_DMTF_EVENT_TYPE_EVENT_LOST;
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 3: Send one event but the value of EventCount is two.
+ * Expected behavior: InvalidRequest error response.
+ **/
+static void rsp_event_ack_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size;
+    spdm_dmtf_event_type_event_lost_t event_lost;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x03;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    /* Only one event but event_count is two. */
+    send_event->event_count = 2;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    generate_dmtf_event_data(send_event + 1, &event_data_size, 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size;
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 4: Send one event but request_size is not exact.
+ * Expected behavior: InvalidRequest error response.
+ **/
+static void rsp_event_ack_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size;
+    spdm_dmtf_event_type_event_lost_t event_lost;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x04;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 1;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    generate_dmtf_event_data(send_event + 1, &event_data_size, 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+
+    m_event_counter = 0;
+
+    /* request_size is not exact (+ 1). */
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size + 1;
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+int libspdm_rsp_event_ack_error_test(void)
+{
+    const struct CMUnitTest test_cases[] = {
+        cmocka_unit_test(rsp_event_ack_err_case1),
+        cmocka_unit_test(rsp_event_ack_err_case2),
+        cmocka_unit_test(rsp_event_ack_err_case3),
+        cmocka_unit_test(rsp_event_ack_err_case4),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(test_cases,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */

--- a/unit_test/test_spdm_responder/event_ack.c
+++ b/unit_test/test_spdm_responder/event_ack.c
@@ -1,0 +1,479 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2025 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_responder_lib.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+
+static uint8_t m_spdm_request_buffer[0x1000];
+static uint8_t m_spdm_response_buffer[0x1000];
+
+static const uint32_t m_session_id = 0xffffffff;
+
+typedef struct {
+    uint32_t event_instance_id;
+    uint8_t svh_id;
+    uint8_t svh_vendor_id_len;
+    uint8_t svh_vendor_id[4];
+    uint16_t event_type_id;
+    uint16_t event_detail_len;
+    uint8_t event_detail[100];
+} expected_event_t;
+
+static expected_event_t m_expected_event[4];
+static uint32_t m_event_counter;
+
+static libspdm_return_t process_event(void *spdm_context,
+                                      uint32_t session_id,
+                                      uint32_t event_instance_id,
+                                      uint8_t svh_id,
+                                      uint8_t svh_vendor_id_len,
+                                      const void *svh_vendor_id,
+                                      uint16_t event_type_id,
+                                      uint16_t event_detail_len,
+                                      const void *event_detail)
+{
+    printf("Event Received\n");
+    printf("Event Instance ID = [0x%x]\n", event_instance_id);
+    printf("SVH ID = [0x%x], SVH VendorIDLen = [0x%x]\n", svh_id, svh_vendor_id_len);
+    if (svh_vendor_id_len != 0) {
+        printf("SVH VendorID\n");
+        libspdm_dump_hex(svh_vendor_id, svh_vendor_id_len);
+        printf("\n");
+    }
+    printf("EventTypeID = [0x%x], EventDetailLen = [0x%x]\n", event_type_id, event_detail_len);
+    printf("Event Detail\n");
+    libspdm_dump_hex(event_detail, event_detail_len);
+
+    assert_int_equal(session_id, m_session_id);
+    assert_int_equal(event_instance_id, m_expected_event[m_event_counter].event_instance_id);
+    assert_int_equal(event_type_id, m_expected_event[m_event_counter].event_type_id);
+    assert_int_equal(svh_id, m_expected_event[m_event_counter].svh_id);
+    assert_int_equal(svh_vendor_id_len, m_expected_event[m_event_counter].svh_vendor_id_len);
+    if (svh_vendor_id_len == 0) {
+        assert_ptr_equal(svh_vendor_id, NULL);
+    }
+    assert_int_equal(event_detail_len, m_expected_event[m_event_counter].event_detail_len);
+    assert_memory_equal(m_expected_event[m_event_counter].event_detail, event_detail,
+                        event_detail_len);
+    m_event_counter++;
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+static void set_standard_state(libspdm_context_t *spdm_context)
+{
+    libspdm_session_info_t *session_info;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_EVENT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP;
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP;
+
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->connection_info.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->connection_info.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+
+    spdm_context->latest_session_id = m_session_id;
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = m_session_id;
+    session_info = &spdm_context->session_info[0];
+    libspdm_session_info_init(spdm_context, session_info, m_session_id, true);
+    libspdm_secured_message_set_session_state(
+        session_info->secured_message_context,
+        LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    libspdm_register_event_callback(spdm_context, process_event);
+}
+
+/**
+ * Test 1: Send exactly one event.
+ * Expected behavior: Event is handled by process_event and one event is registered.
+ **/
+static void rsp_event_ack_case1(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size;
+    spdm_dmtf_event_type_event_lost_t event_lost;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 1;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    generate_dmtf_event_data(send_event + 1, &event_data_size, 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+
+    m_event_counter = 0;
+    m_expected_event[0].event_instance_id = 0x11223344;
+    m_expected_event[0].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[0].svh_vendor_id_len = 0;
+    m_expected_event[0].event_type_id = SPDM_DMTF_EVENT_TYPE_EVENT_LOST;
+    m_expected_event[0].event_detail_len = SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE;
+    memcpy(m_expected_event[0].event_detail, &event_lost, SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE);
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size;
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_event_ack_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_EVENT_ACK);
+    assert_int_equal(event_ack->header.param1, 0);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 1);
+}
+
+/**
+ * Test 2: Send two events with in-order event instance IDs.
+ * Expected behavior: Events are handled by process_event and two events are registered.
+ **/
+static void rsp_event_ack_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size[2];
+    spdm_dmtf_event_type_event_lost_t event_lost;
+    spdm_dmtf_event_type_certificate_changed_t certificate_changed;
+    uint8_t *ptr;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x02;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 2;
+
+    certificate_changed.certificate_changed = 5;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    ptr = (uint8_t *)(send_event + 1);
+
+    generate_dmtf_event_data(ptr, &event_data_size[0], 0x11223343,
+                             SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED, &certificate_changed);
+    ptr += event_data_size[0];
+
+    generate_dmtf_event_data(ptr, &event_data_size[1], 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+    ptr += event_data_size[1];
+
+    m_event_counter = 0;
+
+    m_expected_event[0].event_instance_id = 0x11223343;
+    m_expected_event[0].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[0].svh_vendor_id_len = 0;
+    m_expected_event[0].event_type_id = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED;
+    m_expected_event[0].event_detail_len = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE;
+    memcpy(m_expected_event[0].event_detail, &certificate_changed,
+           SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE);
+
+    m_expected_event[1].event_instance_id = 0x11223344;
+    m_expected_event[1].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[1].svh_vendor_id_len = 0;
+    m_expected_event[1].event_type_id = SPDM_DMTF_EVENT_TYPE_EVENT_LOST;
+    m_expected_event[1].event_detail_len = SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE;
+    memcpy(m_expected_event[1].event_detail, &event_lost, SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE);
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_event_ack_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_EVENT_ACK);
+    assert_int_equal(event_ack->header.param1, 0);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 2);
+}
+
+/**
+ * Test 3: Send two events with out-of-order event instance IDs.
+ * Expected behavior: Events are handled by process_event and two events are registered.
+ **/
+static void rsp_event_ack_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size[2];
+    spdm_dmtf_event_type_event_lost_t event_lost;
+    spdm_dmtf_event_type_certificate_changed_t certificate_changed;
+    uint8_t *ptr;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x03;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 2;
+
+    certificate_changed.certificate_changed = 5;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    ptr = (uint8_t *)(send_event + 1);
+
+    generate_dmtf_event_data(ptr, &event_data_size[0], 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED, &certificate_changed);
+    ptr += event_data_size[0];
+
+    generate_dmtf_event_data(ptr, &event_data_size[1], 0x11223343,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+    ptr += event_data_size[1];
+
+    m_event_counter = 0;
+
+    m_expected_event[0].event_instance_id = 0x11223343;
+    m_expected_event[0].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[0].svh_vendor_id_len = 0;
+    m_expected_event[0].event_type_id = SPDM_DMTF_EVENT_TYPE_EVENT_LOST;
+    m_expected_event[0].event_detail_len = SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE;
+    memcpy(m_expected_event[0].event_detail, &event_lost, SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE);
+
+    m_expected_event[1].event_instance_id = 0x11223344;
+    m_expected_event[1].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[1].svh_vendor_id_len = 0;
+    m_expected_event[1].event_type_id = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED;
+    m_expected_event[1].event_detail_len = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE;
+    memcpy(m_expected_event[1].event_detail, &certificate_changed,
+           SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE);
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_event_ack_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_EVENT_ACK);
+    assert_int_equal(event_ack->header.param1, 0);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 2);
+}
+
+/**
+ * Test 4: Send four events with in-order event instance IDs.
+ * Expected behavior: Events are handled by process_event and four events are registered.
+ **/
+static void rsp_event_ack_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_event_ack_response_t *event_ack;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size[4];
+    spdm_dmtf_event_type_event_lost_t event_lost;
+    spdm_dmtf_event_type_certificate_changed_t certificate_changed;
+    spdm_dmtf_event_type_measurement_changed_t measurement_changed;
+    spdm_dmtf_event_type_measurement_pre_update_t measurement_pre_update;
+    uint8_t *ptr;
+    uint32_t index;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x04;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 4;
+
+    ptr = (uint8_t *)(send_event + 1);
+
+    certificate_changed.certificate_changed = 5;
+    generate_dmtf_event_data(ptr, &event_data_size[0], 0x11223343,
+                             SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED, &certificate_changed);
+    ptr += event_data_size[0];
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+    generate_dmtf_event_data(ptr, &event_data_size[1], 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+    ptr += event_data_size[1];
+
+    for (index = 0; index < SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED_SIZE; index++) {
+        measurement_changed.changed_measurements[index] = (uint8_t)index;
+    }
+    generate_dmtf_event_data(ptr, &event_data_size[2], 0x11223345,
+                             SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED, &measurement_changed);
+    ptr += event_data_size[2];
+
+    for (index = 0; index < SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE_SIZE; index++) {
+        measurement_pre_update.pre_update_measurement_changes[index] = (uint8_t)(2 * index);
+    }
+    generate_dmtf_event_data(ptr, &event_data_size[3], 0x11223346,
+                             SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE, &measurement_pre_update);
+    ptr += event_data_size[3];
+
+    m_event_counter = 0;
+
+    m_expected_event[0].event_instance_id = 0x11223343;
+    m_expected_event[0].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[0].svh_vendor_id_len = 0;
+    m_expected_event[0].event_type_id = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED;
+    m_expected_event[0].event_detail_len = SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE;
+    memcpy(m_expected_event[0].event_detail, &certificate_changed,
+           SPDM_DMTF_EVENT_TYPE_CERTIFICATE_CHANGED_SIZE);
+
+    m_expected_event[1].event_instance_id = 0x11223344;
+    m_expected_event[1].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[1].svh_vendor_id_len = 0;
+    m_expected_event[1].event_type_id = SPDM_DMTF_EVENT_TYPE_EVENT_LOST;
+    m_expected_event[1].event_detail_len = SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE;
+    memcpy(m_expected_event[1].event_detail, &event_lost, SPDM_DMTF_EVENT_TYPE_EVENT_LOST_SIZE);
+
+    m_expected_event[2].event_instance_id = 0x11223345;
+    m_expected_event[2].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[2].svh_vendor_id_len = 0;
+    m_expected_event[2].event_type_id = SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED;
+    m_expected_event[2].event_detail_len = SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED_SIZE;
+    memcpy(m_expected_event[2].event_detail, &measurement_changed,
+           SPDM_DMTF_EVENT_TYPE_MEASUREMENT_CHANGED_SIZE);
+
+    m_expected_event[3].event_instance_id = 0x11223346;
+    m_expected_event[3].svh_id = SPDM_REGISTRY_ID_DMTF;
+    m_expected_event[3].svh_vendor_id_len = 0;
+    m_expected_event[3].event_type_id = SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE;
+    m_expected_event[3].event_detail_len = SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE_SIZE;
+    memcpy(m_expected_event[3].event_detail, &measurement_pre_update,
+           SPDM_DMTF_EVENT_TYPE_MEASUREMENT_PRE_UPDATE_SIZE);
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1] +
+                   event_data_size[2] + event_data_size[3];
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_event_ack_response_t));
+    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(event_ack->header.request_response_code, SPDM_EVENT_ACK);
+    assert_int_equal(event_ack->header.param1, 0);
+    assert_int_equal(event_ack->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 4);
+}
+
+int libspdm_rsp_event_ack_test(void)
+{
+    const struct CMUnitTest test_cases[] = {
+        cmocka_unit_test(rsp_event_ack_case1),
+        cmocka_unit_test(rsp_event_ack_case2),
+        cmocka_unit_test(rsp_event_ack_case3),
+        cmocka_unit_test(rsp_event_ack_case4),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(test_cases,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */

--- a/unit_test/test_spdm_responder/test_spdm_responder.c
+++ b/unit_test/test_spdm_responder/test_spdm_responder.c
@@ -104,6 +104,11 @@ int libspdm_responder_subscribe_event_types_ack_test_main(void);
 int libspdm_responder_subscribe_event_types_ack_error_test_main(void);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 
+#if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+int libspdm_rsp_event_ack_test(void);
+int libspdm_rsp_event_ack_error_test(void);
+#endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
 int libspdm_responder_vendor_cmds_test_main(void);
 int libspdm_responder_vendor_cmds_error_test_main(void);
@@ -299,6 +304,15 @@ int main(void)
         return_value = 1;
     }
     #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
+
+    #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+    if (libspdm_rsp_event_ack_test() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_rsp_event_ack_error_test() != 0) {
+        return_value = 1;
+    }
+    #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
 
     #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
     if (libspdm_responder_vendor_cmds_test_main() != 0) {


### PR DESCRIPTION
These commits add `SEND_EVENT` support for the Responder. In contrast to encapsulated requests on the Requester side, the request buffer on the Responder is `const`. Therefore the event handlers needed to be changed to `const` as well.