### PR TITLE
Rename Requester unit test send and receive functions

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -17,10 +17,8 @@ static uint8_t m_libspdm_opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
 
 static uint8_t m_requester_context[SPDM_REQ_CONTEXT_SIZE];
 
-libspdm_return_t libspdm_requester_challenge_test_send_message(void *spdm_context,
-                                                               size_t request_size,
-                                                               const void *request,
-                                                               uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     const uint8_t *ptr;
@@ -144,9 +142,8 @@ libspdm_return_t libspdm_requester_challenge_test_send_message(void *spdm_contex
     }
 }
 
-libspdm_return_t libspdm_requester_challenge_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -4005,8 +4002,8 @@ int libspdm_req_challenge_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_challenge_test_send_message,
-        libspdm_requester_challenge_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -325,9 +325,8 @@ void libspdm_requester_chunk_get_test_case8_build_digest_response(
     spdm_response->header.param2 |= (0xFF << 0);
 }
 
-libspdm_return_t libspdm_requester_chunk_get_test_send_message(
-    void* spdm_context, size_t request_size, const void* request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t* spdm_test_context;
     size_t header_size = sizeof(libspdm_test_message_header_t);
@@ -369,9 +368,8 @@ libspdm_return_t libspdm_requester_chunk_get_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_chunk_get_test_receive_message(
-    void* spdm_context, size_t* response_size,
-    void** response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t* spdm_test_context;
     uint8_t chunk_handle = CHUNK_GET_UNIT_TEST_CHUNK_HANDLE;
@@ -1255,8 +1253,8 @@ int libspdm_req_chunk_get_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_chunk_get_test_send_message,
-        libspdm_requester_chunk_get_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -68,9 +68,8 @@ void libspdm_requester_chunk_send_test_case15_build_algorithms_response(
     spdm_response->ext_hash_sel_count = 0;
 }
 
-libspdm_return_t libspdm_requester_chunk_send_test_send_message(
-    void* spdm_context, size_t request_size, const void* request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t* spdm_test_context;
     const spdm_chunk_send_request_t* chunk_send;
@@ -149,12 +148,10 @@ libspdm_return_t libspdm_requester_chunk_send_test_send_message(
     return LIBSPDM_STATUS_SEND_FAIL;
 }
 
-libspdm_return_t libspdm_requester_chunk_send_test_receive_message(
-    void *context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
-    libspdm_context_t *spdm_context;
     spdm_chunk_send_ack_response_t *chunk_send_ack_rsp;
     spdm_chunk_send_ack_response_14_t *chunk_send_ack_rsp_14;
     spdm_error_response_t *error_response;
@@ -163,7 +160,6 @@ libspdm_return_t libspdm_requester_chunk_send_test_receive_message(
     size_t chunk_size;
 
     spdm_test_context = libspdm_get_test_context();
-    spdm_context = context;
 
     if ((spdm_test_context->case_id == 1) || (spdm_test_context->case_id == 10) ||
         (spdm_test_context->case_id == 11)) {
@@ -706,8 +702,8 @@ int libspdm_req_chunk_send_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_chunk_send_test_send_message,
-        libspdm_requester_chunk_send_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -38,9 +38,8 @@ static void libspdm_secured_message_set_response_data_salt(
                      salt, secured_message_context->aead_iv_size);
 }
 
-libspdm_return_t libspdm_requester_end_session_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -75,9 +74,8 @@ libspdm_return_t libspdm_requester_end_session_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_end_session_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -1785,8 +1783,8 @@ int libspdm_req_end_session_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_end_session_test_send_message,
-        libspdm_requester_end_session_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -48,9 +48,8 @@
      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP | \
      SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP)
 
-static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -139,9 +138,8 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -2096,8 +2094,8 @@ int libspdm_req_get_capabilities_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_capabilities_test_send_message,
-        libspdm_requester_get_capabilities_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -17,9 +17,8 @@ static size_t m_libspdm_local_certificate_chain_size;
 
 static bool m_get_digest;
 
-static libspdm_return_t libspdm_requester_get_digests_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -80,9 +79,8 @@ static libspdm_return_t libspdm_requester_get_digests_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_digests_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -1627,8 +1625,8 @@ int libspdm_req_get_digests_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_digests_test_send_message,
-        libspdm_requester_get_digests_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
@@ -16,9 +16,8 @@ static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_IL1IL2_BUFFER_SIZE];
 #define LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE 0x20
 static uint8_t m_endpoint_info_buffer[LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_get_endpoint_info_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -72,9 +71,8 @@ static libspdm_return_t libspdm_requester_get_endpoint_info_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_endpoint_info_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     uint32_t endpoint_info_buffer_size;
@@ -2530,8 +2528,8 @@ int libspdm_req_get_endpoint_info_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_endpoint_info_test_send_message,
-        libspdm_requester_get_endpoint_info_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/get_key_pair_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_key_pair_info_err.c
@@ -10,9 +10,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
 
-libspdm_return_t libspdm_requester_get_key_pair_info_error_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -25,9 +24,8 @@ libspdm_return_t libspdm_requester_get_key_pair_info_error_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_get_key_pair_info_error_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -83,13 +81,6 @@ void libspdm_test_requester_get_key_pair_info_error_case1(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 }
 
-libspdm_test_context_t m_libspdm_requester_get_key_pair_info_error_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_get_key_pair_info_error_test_send_message,
-    libspdm_requester_get_key_pair_info_error_test_receive_message,
-};
-
 int libspdm_req_get_key_pair_info_error_test(void)
 {
     const struct CMUnitTest spdm_requester_get_key_pair_info_error_tests[] = {
@@ -97,8 +88,14 @@ int libspdm_req_get_key_pair_info_error_test(void)
         cmocka_unit_test(libspdm_test_requester_get_key_pair_info_error_case1),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_get_key_pair_info_error_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        send_message,
+        receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_get_key_pair_info_error_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -61,9 +61,8 @@ static size_t libspdm_test_get_measurement_request_size(const void *spdm_context
     return message_size;
 }
 
-static libspdm_return_t libspdm_requester_get_measurements_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -418,9 +417,8 @@ static libspdm_return_t libspdm_requester_get_measurements_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_return_t status;
@@ -4774,8 +4772,8 @@ int libspdm_req_get_measurements_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_measurements_test_send_message,
-        libspdm_requester_get_measurements_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -20,8 +20,7 @@ static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
 static libspdm_return_t send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -76,8 +75,7 @@ static libspdm_return_t send_message(
 }
 
 static libspdm_return_t receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -58,9 +58,8 @@ static size_t libspdm_test_get_key_exchange_request_size(const void *spdm_contex
     return message_size;
 }
 
-static libspdm_return_t libspdm_requester_key_exchange_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -351,9 +350,8 @@ static libspdm_return_t libspdm_requester_key_exchange_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -6375,8 +6373,8 @@ int libspdm_req_key_exchange_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_key_exchange_test_send_message,
-        libspdm_requester_key_exchange_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
+++ b/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
@@ -27,7 +27,7 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message(
+static libspdm_return_t send_message(
     void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
@@ -134,9 +134,8 @@ static libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message
     }
 }
 
-static libspdm_return_t libspdm_requester_negotiate_algorithm_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -3166,8 +3165,8 @@ int libspdm_req_negotiate_algorithms_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_negotiate_algorithms_test_send_message,
-        libspdm_requester_negotiate_algorithm_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/error_test/set_key_pair_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/set_key_pair_info_err.c
@@ -10,9 +10,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_SET_KEY_PAIR_INFO_CAP
 
-libspdm_return_t libspdm_requester_set_key_pair_info_err_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -25,9 +24,8 @@ libspdm_return_t libspdm_requester_set_key_pair_info_err_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_set_key_pair_info_err_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -80,13 +78,6 @@ void libspdm_test_requester_set_key_pair_info_err_case1(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 }
 
-libspdm_test_context_t m_libspdm_requester_set_key_pair_info_err_test_context = {
-    LIBSPDM_TEST_CONTEXT_VERSION,
-    true,
-    libspdm_requester_set_key_pair_info_err_test_send_message,
-    libspdm_requester_set_key_pair_info_err_test_receive_message,
-};
-
 int libspdm_req_set_key_pair_info_error_test(void)
 {
     const struct CMUnitTest spdm_requester_set_key_pair_info_err_tests[] = {
@@ -94,8 +85,14 @@ int libspdm_req_set_key_pair_info_error_test(void)
         cmocka_unit_test(libspdm_test_requester_set_key_pair_info_err_case1),
     };
 
-    libspdm_setup_test_context(
-        &m_libspdm_requester_set_key_pair_info_err_test_context);
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        true,
+        send_message,
+        receive_message,
+    };
+
+    libspdm_setup_test_context(&test_context);
 
     return cmocka_run_group_tests(spdm_requester_set_key_pair_info_err_tests,
                                   libspdm_unit_test_group_setup,

--- a/unit_test/test_spdm_requester/error_test/vendor_request_err.c
+++ b/unit_test/test_spdm_requester/error_test/vendor_request_err.c
@@ -32,9 +32,8 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_vendor_cmds_err_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -82,9 +81,8 @@ static libspdm_return_t libspdm_requester_vendor_cmds_err_test_send_message(
 }
 
 /* Acts as the Responder Integration */
-static libspdm_return_t libspdm_requester_vendor_cmds_err_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_return_t status = LIBSPDM_STATUS_SUCCESS;
@@ -522,8 +520,8 @@ int libspdm_req_vendor_defined_request_error_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_vendor_cmds_err_test_send_message,
-        libspdm_requester_vendor_cmds_err_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -30,10 +30,8 @@ void libspdm_secured_message_set_response_finished_key(
                      key, secured_message_context->hash_size);
 }
 
-libspdm_return_t libspdm_requester_finish_test_send_message(void *spdm_context,
-                                                            size_t request_size,
-                                                            const void *request,
-                                                            uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     const uint8_t *ptr;
@@ -187,9 +185,8 @@ libspdm_return_t libspdm_requester_finish_test_send_message(void *spdm_context,
     }
 }
 
-libspdm_return_t libspdm_requester_finish_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -4074,8 +4071,8 @@ int libspdm_req_finish_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_finish_test_send_message,
-        libspdm_requester_finish_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -60,9 +60,8 @@
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -152,9 +151,8 @@ static libspdm_return_t libspdm_requester_get_capabilities_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_capabilities_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -1583,8 +1581,8 @@ int libspdm_req_get_capabilities_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_capabilities_test_send_message,
-        libspdm_requester_get_capabilities_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -95,9 +95,8 @@ bool libspdm_libspdm_read_responder_public_certificate_chain_expiration(
     return true;
 }
 
-libspdm_return_t libspdm_requester_get_certificate_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -189,9 +188,8 @@ libspdm_return_t libspdm_requester_get_certificate_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_get_certificate_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -4674,8 +4672,8 @@ int libspdm_req_get_certificate_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_certificate_test_send_message,
-        libspdm_requester_get_certificate_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -111,9 +111,8 @@ void libspdm_clear_cached_csr()
     rename(file_name, new_name);
 }
 
-libspdm_return_t libspdm_requester_get_csr_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -158,9 +157,8 @@ libspdm_return_t libspdm_requester_get_csr_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_get_csr_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *context;
@@ -605,8 +603,8 @@ int libspdm_req_get_csr_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_csr_test_send_message,
-        libspdm_requester_get_csr_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -24,9 +24,8 @@ static spdm_key_usage_bit_mask_t m_local_key_usage_bit_mask[SPDM_MAX_SLOT_COUNT]
 static spdm_certificate_info_t m_local_cert_info[SPDM_MAX_SLOT_COUNT];
 static spdm_key_pair_id_t m_local_key_pair_id[SPDM_MAX_SLOT_COUNT];
 
-static libspdm_return_t libspdm_requester_get_digests_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -98,9 +97,8 @@ static libspdm_return_t libspdm_requester_get_digests_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_digests_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -2013,8 +2011,8 @@ int libspdm_req_get_digests_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_digests_test_send_message,
-        libspdm_requester_get_digests_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_endpoint_info.c
+++ b/unit_test/test_spdm_requester/get_endpoint_info.c
@@ -16,9 +16,8 @@ static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_IL1IL2_BUFFER_SIZE];
 #define LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE 0x20
 static uint8_t m_endpoint_info_buffer[LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_get_endpoint_info_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -86,9 +85,8 @@ static libspdm_return_t libspdm_requester_get_endpoint_info_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_endpoint_info_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     uint32_t endpoint_info_buffer_size;
@@ -1287,8 +1285,8 @@ int libspdm_req_get_endpoint_info_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_endpoint_info_test_send_message,
-        libspdm_requester_get_endpoint_info_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_key_pair_info.c
+++ b/unit_test/test_spdm_requester/get_key_pair_info.c
@@ -19,9 +19,8 @@ uint32_t m_response_asym_algo_capabilities;
 uint32_t m_response_current_asym_algo;
 uint8_t m_response_assoc_cert_slot_mask;
 
-libspdm_return_t libspdm_requester_get_key_pair_info_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -35,9 +34,8 @@ libspdm_return_t libspdm_requester_get_key_pair_info_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_get_key_pair_info_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -588,8 +586,8 @@ int libspdm_req_get_key_pair_info_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_key_pair_info_test_send_message,
-        libspdm_requester_get_key_pair_info_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_measurement_extension_log.c
+++ b/unit_test/test_spdm_requester/get_measurement_extension_log.c
@@ -155,8 +155,7 @@ static void generate_long_mel(uint32_t measurement_hash_algo)
 }
 
 static libspdm_return_t send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -179,8 +178,7 @@ static libspdm_return_t send_message(
 }
 
 static libspdm_return_t receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -67,9 +67,8 @@ static size_t libspdm_test_get_measurement_request_size(const void *spdm_context
     return message_size;
 }
 
-static libspdm_return_t libspdm_requester_get_measurements_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -467,9 +466,8 @@ static libspdm_return_t libspdm_requester_get_measurements_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_measurements_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_return_t status;
@@ -6482,8 +6480,8 @@ int libspdm_req_get_measurements_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_measurements_test_send_message,
-        libspdm_requester_get_measurements_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -19,9 +19,8 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_get_version_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -75,9 +74,8 @@ static libspdm_return_t libspdm_requester_get_version_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_get_version_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -813,8 +811,8 @@ int libspdm_req_get_version_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_get_version_test_send_message,
-        libspdm_requester_get_version_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -38,10 +38,8 @@ void libspdm_secured_message_set_response_data_salt(
                      salt, secured_message_context->aead_iv_size);
 }
 
-libspdm_return_t libspdm_requester_heartbeat_test_send_message(void *spdm_context,
-                                                               size_t request_size,
-                                                               const void *request,
-                                                               uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -76,9 +74,8 @@ libspdm_return_t libspdm_requester_heartbeat_test_send_message(void *spdm_contex
     }
 }
 
-libspdm_return_t libspdm_requester_heartbeat_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -1863,8 +1860,8 @@ int libspdm_req_heartbeat_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_heartbeat_test_send_message,
-        libspdm_requester_heartbeat_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -58,9 +58,8 @@ static size_t libspdm_test_get_key_exchange_request_size(const void *spdm_contex
     return message_size;
 }
 
-static libspdm_return_t libspdm_requester_key_exchange_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -378,9 +377,8 @@ static libspdm_return_t libspdm_requester_key_exchange_test_send_message(
     }
 }
 
-static libspdm_return_t libspdm_requester_key_exchange_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -8258,8 +8256,8 @@ int libspdm_req_key_exchange_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_key_exchange_test_send_message,
-        libspdm_requester_key_exchange_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -126,9 +126,8 @@ static void libspdm_compute_secret_update(spdm_version_number_t spdm_version,
                         bin_str9_size, out_secret, out_secret_size);
 }
 
-libspdm_return_t libspdm_requester_key_update_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -827,9 +826,8 @@ libspdm_return_t libspdm_requester_key_update_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_key_update_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -5735,8 +5733,8 @@ int libspdm_req_key_update_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_key_update_test_send_message,
-        libspdm_requester_key_update_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -34,7 +34,7 @@ static uint8_t m_mel_specification_sel;
 
 static uint8_t m_measurement_specification_sel;
 
-static libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message(
+static libspdm_return_t send_message(
     void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
@@ -132,9 +132,8 @@ static libspdm_return_t libspdm_requester_negotiate_algorithms_test_send_message
     }
 }
 
-static libspdm_return_t libspdm_requester_negotiate_algorithm_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -2221,8 +2220,8 @@ int libspdm_req_negotiate_algorithms_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_negotiate_algorithms_test_send_message,
-        libspdm_requester_negotiate_algorithm_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -52,9 +52,8 @@ size_t libspdm_test_get_psk_exchange_request_size(const void *spdm_context,
     return message_size;
 }
 
-libspdm_return_t libspdm_requester_psk_exchange_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     size_t header_size;
@@ -308,9 +307,8 @@ libspdm_return_t libspdm_requester_psk_exchange_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_psk_exchange_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -5134,8 +5132,8 @@ int libspdm_req_psk_exchange_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_psk_exchange_test_send_message,
-        libspdm_requester_psk_exchange_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -47,10 +47,8 @@ void libspdm_secured_message_set_response_handshake_salt(
                      salt, secured_message_context->aead_iv_size);
 }
 
-libspdm_return_t libspdm_requester_psk_finish_test_send_message(void *spdm_context,
-                                                                size_t request_size,
-                                                                const void *request,
-                                                                uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -132,9 +130,8 @@ libspdm_return_t libspdm_requester_psk_finish_test_send_message(void *spdm_conte
     }
 }
 
-libspdm_return_t libspdm_requester_psk_finish_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -2679,8 +2676,8 @@ int libspdm_req_psk_finish_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_psk_finish_test_send_message,
-        libspdm_requester_psk_finish_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -10,9 +10,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP
 
-libspdm_return_t libspdm_requester_set_certificate_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     uint32_t *session_id;
@@ -120,9 +119,8 @@ libspdm_return_t libspdm_requester_set_certificate_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_set_certificate_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -620,8 +618,8 @@ int libspdm_req_set_certificate_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_set_certificate_test_send_message,
-        libspdm_requester_set_certificate_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/set_key_pair_info.c
+++ b/unit_test/test_spdm_requester/set_key_pair_info.c
@@ -10,9 +10,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_SET_KEY_PAIR_INFO_CAP
 
-libspdm_return_t libspdm_requester_set_key_pair_info_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -28,9 +27,8 @@ libspdm_return_t libspdm_requester_set_key_pair_info_test_send_message(
     }
 }
 
-libspdm_return_t libspdm_requester_set_key_pair_info_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -305,8 +303,8 @@ int libspdm_req_set_key_pair_info_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_set_key_pair_info_test_send_message,
-        libspdm_requester_set_key_pair_info_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/vendor_defined_request.c
+++ b/unit_test/test_spdm_requester/vendor_defined_request.c
@@ -32,9 +32,8 @@ typedef struct {
 static size_t m_libspdm_local_buffer_size;
 static uint8_t m_libspdm_local_buffer[LIBSPDM_MAX_MESSAGE_VCA_BUFFER_SIZE];
 
-static libspdm_return_t libspdm_requester_vendor_cmds_test_send_message(
-    void *spdm_context, size_t request_size, const void *request,
-    uint64_t timeout)
+static libspdm_return_t send_message(
+    void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
 
@@ -64,9 +63,8 @@ static libspdm_return_t libspdm_requester_vendor_cmds_test_send_message(
 }
 
 /* Acts as the Responder Integration */
-static libspdm_return_t libspdm_requester_vendor_cmds_test_receive_message(
-    void *spdm_context, size_t *response_size,
-    void **response, uint64_t timeout)
+static libspdm_return_t receive_message(
+    void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_return_t status = LIBSPDM_STATUS_SUCCESS;
@@ -297,8 +295,8 @@ int libspdm_req_vendor_defined_request_test(void)
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         true,
-        libspdm_requester_vendor_cmds_test_send_message,
-        libspdm_requester_vendor_cmds_test_receive_message,
+        send_message,
+        receive_message,
     };
 
     libspdm_setup_test_context(&test_context);


### PR DESCRIPTION
Rename Requester send and receive functions so that they conform to https://github.com/DMTF/libspdm/blob/main/doc/internal/unit_test_template.md.