### PR TITLE
Rename unit test array variable

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -3946,7 +3946,7 @@ void libspdm_test_requester_challenge_case28(void **state)
 
 int libspdm_req_challenge_test(void)
 {
-    const struct CMUnitTest spdm_requester_challenge_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_challenge_case1),
         /* Successful response*/
@@ -4008,7 +4008,7 @@ int libspdm_req_challenge_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_challenge_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -1216,7 +1216,7 @@ void libspdm_test_requester_chunk_get_case8(void** state)
 int libspdm_req_chunk_get_test(void)
 {
     /* Test the CHUNK_GET handlers in various requester handlers */
-    const struct CMUnitTest spdm_requester_chunk_get_tests[] = {
+    const struct CMUnitTest test_cases[] = {
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
         /* Request a certificate in portions */
         cmocka_unit_test(libspdm_test_requester_chunk_get_case1),
@@ -1259,7 +1259,7 @@ int libspdm_req_chunk_get_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_chunk_get_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -664,7 +664,7 @@ void libspdm_test_requester_chunk_send_case15(void** state)
 int libspdm_req_chunk_send_test(void)
 {
     /* Test the CHUNK_SEND handlers in various requester handlers */
-    const struct CMUnitTest spdm_requester_chunk_send_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Request Algorithms successfully sent in chunks. */
         cmocka_unit_test(libspdm_test_requester_chunk_send_case1),
         /* Chunk Request fail send */
@@ -708,7 +708,7 @@ int libspdm_req_chunk_send_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_chunk_send_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_certificate.c
+++ b/unit_test/test_spdm_requester/encap_certificate.c
@@ -528,7 +528,7 @@ void libspdm_test_requester_encap_certificate_case7(void **state)
 
 int libspdm_req_encap_certificate_test(void)
 {
-    const struct CMUnitTest spdm_requester_encap_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_requester_encap_certificate_case1),
         /* Can be populated with new test.*/
@@ -550,7 +550,7 @@ int libspdm_req_encap_certificate_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_encap_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_challenge_auth.c
+++ b/unit_test/test_spdm_requester/encap_challenge_auth.c
@@ -565,7 +565,7 @@ void test_libspdm_requester_encap_challenge_auth_case8(void **state)
 
 int libspdm_req_encap_challenge_auth_test(void)
 {
-    const struct CMUnitTest spdm_requester_challenge_auth_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case1),
         /* Can be populated with new test.*/
@@ -589,7 +589,7 @@ int libspdm_req_encap_challenge_auth_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_challenge_auth_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_digests.c
+++ b/unit_test/test_spdm_requester/encap_digests.c
@@ -408,7 +408,7 @@ void test_spdm_requester_encap_get_digests_case6(void **state)
 
 int libspdm_req_encap_digests_test(void)
 {
-    const struct CMUnitTest spdm_requester_digests_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(test_spdm_requester_encap_get_digests_case1),
         /* Can be populated with new test.*/
@@ -430,7 +430,7 @@ int libspdm_req_encap_digests_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_digests_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_endpoint_info.c
+++ b/unit_test/test_spdm_requester/encap_endpoint_info.c
@@ -553,7 +553,7 @@ void libspdm_test_requester_encap_endpoint_info_case5(void **state)
 
 int libspdm_req_encap_endpoint_info_test(void)
 {
-    const struct CMUnitTest spdm_requester_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Successful response to get endpoint_info with signature */
         cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case1),
         /* Successful response to get endpoint_info with signature, slot_id == 0x1 */
@@ -573,7 +573,7 @@ int libspdm_req_encap_endpoint_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_event_ack.c
+++ b/unit_test/test_spdm_requester/encap_event_ack.c
@@ -452,7 +452,7 @@ static void test_libspdm_requester_encap_event_ack_case4(void **state)
 
 int libspdm_req_encap_event_ack_test(void)
 {
-    const struct CMUnitTest spdm_requester_event_ack_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_libspdm_requester_encap_event_ack_case1),
         cmocka_unit_test(test_libspdm_requester_encap_event_ack_case2),
         cmocka_unit_test(test_libspdm_requester_encap_event_ack_case3),
@@ -466,7 +466,7 @@ int libspdm_req_encap_event_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_event_ack_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_key_update_ack.c
+++ b/unit_test/test_spdm_requester/encap_key_update_ack.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 #include "spdm_unit_test.h"
@@ -1080,7 +1080,7 @@ void test_libspdm_requester_encap_key_update_case14(void **state)
 
 int libspdm_req_encap_key_update_ack_test(void)
 {
-    const struct CMUnitTest spdm_requester_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case -- UpdateKey*/
         cmocka_unit_test(test_libspdm_requester_encap_key_update_case1),
         /* Bad request size*/
@@ -1118,7 +1118,7 @@ int libspdm_req_encap_key_update_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_request.c
+++ b/unit_test/test_spdm_requester/encap_request.c
@@ -1395,7 +1395,7 @@ void libspdm_test_requester_encap_request_case15(void **State)
 
 int libspdm_req_encap_request_test(void)
 {
-    const struct CMUnitTest spdm_requester_encap_request_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP)
         cmocka_unit_test(libspdm_test_requester_encap_request_case1),
@@ -1437,7 +1437,7 @@ int libspdm_req_encap_request_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_encap_request_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_subscribe_event_types_ack.c
+++ b/unit_test/test_spdm_requester/encap_subscribe_event_types_ack.c
@@ -159,7 +159,7 @@ static void test_subscribe_event_types_ack_case2(void **state)
 
 int libspdm_req_encap_subscribe_event_types_ack_test(void)
 {
-    const struct CMUnitTest spdm_requester_subscribe_event_types_ack_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_subscribe_event_types_ack_case1),
         cmocka_unit_test(test_subscribe_event_types_ack_case2),
     };
@@ -171,7 +171,7 @@ int libspdm_req_encap_subscribe_event_types_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_subscribe_event_types_ack_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/encap_supported_event_types.c
+++ b/unit_test/test_spdm_requester/encap_supported_event_types.c
@@ -112,7 +112,7 @@ static void test_supported_event_types_case1(void **state)
 
 int libspdm_req_encap_supported_event_types_test(void)
 {
-    const struct CMUnitTest spdm_requester_supported_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_supported_event_types_case1),
     };
 
@@ -123,7 +123,7 @@ int libspdm_req_encap_supported_event_types_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_supported_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -1753,7 +1753,7 @@ void libspdm_test_requester_end_session_case12(void **state)
 
 int libspdm_req_end_session_test(void)
 {
-    const struct CMUnitTest spdm_requester_end_session_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_end_session_case1),
         /* Successful response*/
@@ -1789,7 +1789,7 @@ int libspdm_req_end_session_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_end_session_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/encap_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_endpoint_info_err.c
@@ -687,7 +687,7 @@ void libspdm_test_requester_encap_endpoint_info_err_case10(void **state)
 
 int libspdm_req_encap_endpoint_info_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Connection version is lower than 1.3 */
         cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_err_case1),
         /* Requester does not support EP_INFO_CAP */
@@ -719,7 +719,7 @@ int libspdm_req_encap_endpoint_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/encap_subscribe_event_types_ack_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_subscribe_event_types_ack_err.c
@@ -151,7 +151,7 @@ static void test_encap_subscribe_event_types_ack_err_case2(void **state)
 
 int libspdm_req_encap_subscribe_event_types_ack_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_encap_subscribe_event_types_ack_err_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_encap_subscribe_event_types_ack_err_case1),
         cmocka_unit_test(test_encap_subscribe_event_types_ack_err_case2),
     };
@@ -163,7 +163,7 @@ int libspdm_req_encap_subscribe_event_types_ack_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_encap_subscribe_event_types_ack_err_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/encap_supported_event_types_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_supported_event_types_err.c
@@ -154,7 +154,7 @@ static void test_encap_supported_event_types_err_case2(void **state)
 
 int libspdm_req_encap_supported_event_types_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_encap_supported_event_types_err_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_encap_supported_event_types_err_case1),
         cmocka_unit_test(test_encap_supported_event_types_err_case2),
     };
@@ -166,7 +166,7 @@ int libspdm_req_encap_supported_event_types_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_encap_supported_event_types_err_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_capabilities_err.c
@@ -2047,7 +2047,7 @@ static void libspdm_test_requester_get_capabilities_err_case41(void **state)
 
 int libspdm_req_get_capabilities_error_test(void)
 {
-    const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case1),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_capabilities_err_case3),
@@ -2100,7 +2100,7 @@ int libspdm_req_get_capabilities_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(m_spdm_requester_get_capabilities_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_digests_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_digests_err.c
@@ -1594,7 +1594,7 @@ static void libspdm_test_requester_get_digests_err_case25(void **state)
 
 int libspdm_req_get_digests_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_digests_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case1),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_digests_err_case3),
@@ -1631,7 +1631,7 @@ int libspdm_req_get_digests_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_digests_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
@@ -2502,7 +2502,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case20(void **state)
 
 int libspdm_req_get_endpoint_info_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_err_case1),
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_err_case3),
@@ -2534,7 +2534,7 @@ int libspdm_req_get_endpoint_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_event_types_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_event_types_err.c
@@ -183,7 +183,7 @@ static void libspdm_test_requester_get_event_types_err_case1(void **state)
 
 int libspdm_req_get_supported_event_types_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_event_types_err_case1)
     };
 
@@ -196,7 +196,7 @@ int libspdm_req_get_supported_event_types_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_key_pair_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_key_pair_info_err.c
@@ -83,7 +83,7 @@ void libspdm_test_requester_get_key_pair_info_error_case1(void **state)
 
 int libspdm_req_get_key_pair_info_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_key_pair_info_error_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_get_key_pair_info_error_case1),
     };
@@ -97,7 +97,7 @@ int libspdm_req_get_key_pair_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_key_pair_info_error_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -4729,7 +4729,7 @@ static void libspdm_test_requester_get_measurements_err_case37(void **state)
 
 int libspdm_req_get_measurements_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_measurements_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_measurements_err_case1),
         cmocka_unit_test(libspdm_test_requester_get_measurements_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_measurements_err_case3),
@@ -4778,7 +4778,7 @@ int libspdm_req_get_measurements_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_measurements_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/get_version_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_version_err.c
@@ -844,7 +844,7 @@ static void libspdm_test_requester_get_version_err_case18(void **state)
 
 int libspdm_req_get_version_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_version_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_version_err_case1),
         cmocka_unit_test(libspdm_test_requester_get_version_err_case2),
         cmocka_unit_test(libspdm_test_requester_get_version_err_case3),
@@ -874,7 +874,7 @@ int libspdm_req_get_version_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_version_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/key_exchange_err.c
+++ b/unit_test/test_spdm_requester/error_test/key_exchange_err.c
@@ -6312,7 +6312,7 @@ static void libspdm_test_requester_key_exchange_err_case31(void **state)
 
 int libspdm_req_key_exchange_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_key_exchange_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_key_exchange_err_case1),
         /* Successful response*/
@@ -6379,7 +6379,7 @@ int libspdm_req_key_exchange_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_key_exchange_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
+++ b/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
@@ -3113,7 +3113,7 @@ static void libspdm_test_requester_negotiate_algorithms_error_case43(void** stat
 
 int libspdm_req_negotiate_algorithms_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_negotiate_algorithms_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case1),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case2),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case3),
@@ -3171,7 +3171,7 @@ int libspdm_req_negotiate_algorithms_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_negotiate_algorithms_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/set_key_pair_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/set_key_pair_info_err.c
@@ -80,7 +80,7 @@ void libspdm_test_requester_set_key_pair_info_err_case1(void **state)
 
 int libspdm_req_set_key_pair_info_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_set_key_pair_info_err_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_set_key_pair_info_err_case1),
     };
@@ -94,7 +94,7 @@ int libspdm_req_set_key_pair_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_set_key_pair_info_err_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/subscribe_event_types_err.c
+++ b/unit_test/test_spdm_requester/error_test/subscribe_event_types_err.c
@@ -241,7 +241,7 @@ int libspdm_req_subscribe_event_types_error_test(void)
         receive_message,
     };
 
-    const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_err_case1),
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_err_case2),
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_err_case3)
@@ -249,7 +249,7 @@ int libspdm_req_subscribe_event_types_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/error_test/vendor_request_err.c
+++ b/unit_test/test_spdm_requester/error_test/vendor_request_err.c
@@ -510,7 +510,7 @@ static void libspdm_test_requester_vendor_cmds_err_case4(void **state)
 
 int libspdm_req_vendor_defined_request_error_test(void)
 {
-    const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case1),
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case2),
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_err_case3),
@@ -526,7 +526,7 @@ int libspdm_req_vendor_defined_request_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -4020,7 +4020,7 @@ void libspdm_test_requester_finish_case25(void **state)
 
 int libspdm_req_finish_test(void)
 {
-    const struct CMUnitTest spdm_requester_finish_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_finish_case1),
         /* Successful response*/
@@ -4077,7 +4077,7 @@ int libspdm_req_finish_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_finish_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -1539,7 +1539,7 @@ static void libspdm_test_requester_get_capabilities_case36(void **state)
 
 int libspdm_req_get_capabilities_test(void)
 {
-    const struct CMUnitTest m_spdm_requester_get_capabilities_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case1), */
         cmocka_unit_test(libspdm_test_requester_get_capabilities_case2),
         /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case3),
@@ -1587,7 +1587,7 @@ int libspdm_req_get_capabilities_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(m_spdm_requester_get_capabilities_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -4601,7 +4601,7 @@ void libspdm_test_requester_get_certificate_case31(void **state)
 
 int libspdm_req_get_certificate_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_get_certificate_case1),
         /* Successful response: check root certificate hash*/
@@ -4678,7 +4678,7 @@ int libspdm_req_get_certificate_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -584,7 +584,7 @@ void libspdm_test_requester_get_csr_case7(void **state)
 
 int libspdm_req_get_csr_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_csr_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_get_csr_case1),
         /* Successful response to get csr*/
@@ -612,7 +612,7 @@ int libspdm_req_get_csr_test(void)
     /*ensure that cached.csr exists in test_csr at the beginning*/
     libspdm_clear_cached_csr();
 
-    return cmocka_run_group_tests(spdm_requester_get_csr_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1976,7 +1976,7 @@ static void libspdm_test_requester_get_digests_case29(void **state)
 
 int libspdm_req_get_digests_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_digests_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_digests_case1),
         cmocka_unit_test(libspdm_test_requester_get_digests_case2),
         cmocka_unit_test(libspdm_test_requester_get_digests_case3),
@@ -2017,7 +2017,7 @@ int libspdm_req_get_digests_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_digests_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_endpoint_info.c
+++ b/unit_test/test_spdm_requester/get_endpoint_info.c
@@ -1272,7 +1272,7 @@ static void libspdm_test_requester_get_endpoint_info_case7(void **state)
 
 int libspdm_req_get_endpoint_info_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case1),
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case2),
         cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case3),
@@ -1291,7 +1291,7 @@ int libspdm_req_get_endpoint_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_key_pair_info.c
+++ b/unit_test/test_spdm_requester/get_key_pair_info.c
@@ -578,7 +578,7 @@ void libspdm_test_requester_get_key_pair_info_case3(void **state)
 
 int libspdm_req_get_key_pair_info_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_key_pair_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Successful response to get key pair info, key_pair_id is 1*/
         cmocka_unit_test(libspdm_test_requester_get_key_pair_info_case1),
     };
@@ -592,7 +592,7 @@ int libspdm_req_get_key_pair_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_key_pair_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_measurement_extension_log.c
+++ b/unit_test/test_spdm_requester/get_measurement_extension_log.c
@@ -1067,7 +1067,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case9(void **st
 
 int libspdm_req_get_measurement_extension_log_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_measurement_extension_log_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case1),
         /* Successful response, the MEL size remains unchanged*/
@@ -1098,7 +1098,7 @@ int libspdm_req_get_measurement_extension_log_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_measurement_extension_log_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -6433,7 +6433,7 @@ static void libspdm_test_requester_get_measurements_case41(void **state)
 
 int libspdm_req_get_measurements_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_measurements_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_measurements_case1),
         cmocka_unit_test(libspdm_test_requester_get_measurements_case2),
         cmocka_unit_test(libspdm_test_requester_get_measurements_case3),
@@ -6486,7 +6486,7 @@ int libspdm_req_get_measurements_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_measurements_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_supported_event_types.c
+++ b/unit_test/test_spdm_requester/get_supported_event_types.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2024 DMTF. All rights reserved.
+ *  Copyright 2024-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -183,7 +183,7 @@ static void libspdm_test_requester_get_event_types_case1(void **state)
 
 int libspdm_req_get_supported_event_types_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_get_event_types_case1)
     };
 
@@ -196,7 +196,7 @@ int libspdm_req_get_supported_event_types_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -787,7 +787,7 @@ static void libspdm_test_requester_get_version_case16(void **state)
 
 int libspdm_req_get_version_test(void)
 {
-    const struct CMUnitTest spdm_requester_get_version_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* cmocka_unit_test(libspdm_test_requester_get_version_case1), */
         cmocka_unit_test(libspdm_test_requester_get_version_case2),
         /* cmocka_unit_test(libspdm_test_requester_get_version_case3),
@@ -817,7 +817,7 @@ int libspdm_req_get_version_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_version_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -1829,7 +1829,7 @@ void libspdm_test_requester_heartbeat_case13(void **state)
 
 int libspdm_req_heartbeat_test(void)
 {
-    const struct CMUnitTest spdm_requester_heartbeat_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_heartbeat_case1),
         /* Successful response*/
@@ -1866,7 +1866,7 @@ int libspdm_req_heartbeat_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_heartbeat_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -8184,7 +8184,7 @@ static void libspdm_test_requester_key_exchange_case34(void **state)
 
 int libspdm_req_key_exchange_test(void)
 {
-    const struct CMUnitTest spdm_requester_key_exchange_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_key_exchange_case1),
         /* Successful response*/
@@ -8262,7 +8262,7 @@ int libspdm_req_key_exchange_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_key_exchange_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -5658,7 +5658,7 @@ void libspdm_test_requester_key_update_case35(void **state)
 
 int libspdm_req_key_update_test(void)
 {
-    const struct CMUnitTest spdm_requester_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_key_update_case1),
         /* update single key
@@ -5739,7 +5739,7 @@ int libspdm_req_key_update_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -2178,7 +2178,7 @@ static void libspdm_test_requester_negotiate_algorithms_case36(void **state)
 
 int libspdm_req_negotiate_algorithms_test(void)
 {
-    const struct CMUnitTest spdm_requester_negotiate_algorithms_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case1),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case2),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case3),
@@ -2226,7 +2226,7 @@ int libspdm_req_negotiate_algorithms_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_negotiate_algorithms_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -5074,7 +5074,7 @@ void libspdm_test_requester_psk_exchange_case27(void **state)
 
 int libspdm_req_psk_exchange_test(void)
 {
-    const struct CMUnitTest spdm_requester_psk_exchange_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_psk_exchange_case1),
         /* Successful response*/
@@ -5138,7 +5138,7 @@ int libspdm_req_psk_exchange_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_psk_exchange_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -2636,7 +2636,7 @@ void libspdm_test_requester_psk_finish_case17(void **state)
 
 int libspdm_req_psk_finish_test(void)
 {
-    const struct CMUnitTest spdm_requester_psk_finish_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_psk_finish_case1),
         /* Successful response*/
@@ -2682,7 +2682,7 @@ int libspdm_req_psk_finish_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_psk_finish_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -598,7 +598,7 @@ void libspdm_test_requester_set_certificate_case9(void **state)
 
 int libspdm_req_set_certificate_test(void)
 {
-    const struct CMUnitTest spdm_requester_set_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
         cmocka_unit_test(libspdm_test_requester_set_certificate_case1),
         /* Successful response to set certificate*/
@@ -624,7 +624,7 @@ int libspdm_req_set_certificate_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_set_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/set_key_pair_info.c
+++ b/unit_test/test_spdm_requester/set_key_pair_info.c
@@ -289,7 +289,7 @@ void libspdm_test_requester_set_key_pair_info_case4(void **state)
 
 int libspdm_req_set_key_pair_info_test(void)
 {
-    const struct CMUnitTest spdm_requester_set_key_pair_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Successful response to set key pair info, key_pair_id is 1*/
         cmocka_unit_test(libspdm_test_requester_set_key_pair_info_case1),
         /* The response version is incorrect */
@@ -309,7 +309,7 @@ int libspdm_req_set_key_pair_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_set_key_pair_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/subscribe_event_types.c
+++ b/unit_test/test_spdm_requester/subscribe_event_types.c
@@ -254,7 +254,7 @@ int libspdm_req_subscribe_event_types_test(void)
         receive_message,
     };
 
-    const struct CMUnitTest spdm_requester_get_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case1),
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case2),
         cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case3)
@@ -262,7 +262,7 @@ int libspdm_req_subscribe_event_types_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_get_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_requester/vendor_defined_request.c
+++ b/unit_test/test_spdm_requester/vendor_defined_request.c
@@ -287,7 +287,7 @@ static void libspdm_test_requester_vendor_cmds_case2(void **state)
 
 int libspdm_req_vendor_defined_request_test(void)
 {
-    const struct CMUnitTest spdm_requester_vendor_cmds_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_case1),
         cmocka_unit_test(libspdm_test_requester_vendor_cmds_case2),
     };
@@ -301,7 +301,7 @@ int libspdm_req_vendor_defined_request_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_requester_vendor_cmds_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -2933,7 +2933,7 @@ void libspdm_test_responder_algorithms_case32(void **state)
 
 int libspdm_rsp_algorithms_test(void)
 {
-    const struct CMUnitTest spdm_responder_algorithms_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_algorithms_case1),
         /* Bad request size*/
@@ -3082,7 +3082,7 @@ int libspdm_rsp_algorithms_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_algorithms_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -1276,7 +1276,7 @@ void libspdm_test_responder_capabilities_case28(void **state)
 
 int libspdm_rsp_capabilities_test(void)
 {
-    const struct CMUnitTest spdm_responder_capabilities_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_capabilities_case1),
         /* Success case where request size is larger than actual message. */
@@ -1340,7 +1340,7 @@ int libspdm_rsp_capabilities_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_capabilities_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -1376,7 +1376,7 @@ void libspdm_test_responder_certificate_case19(void **state)
 
 int libspdm_rsp_certificate_test(void)
 {
-    const struct CMUnitTest spdm_responder_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_certificate_case1),
         /* Can be populated with new test.*/
@@ -1424,7 +1424,7 @@ int libspdm_rsp_certificate_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -1219,7 +1219,7 @@ void libspdm_test_responder_challenge_auth_case19(void **state)
 
 int libspdm_rsp_challenge_auth_test(void)
 {
-    const struct CMUnitTest spdm_responder_challenge_auth_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_challenge_auth_case1),
         /* Can be populated with new test.*/
@@ -1261,7 +1261,7 @@ int libspdm_rsp_challenge_auth_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_challenge_auth_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/chunk_response.c
+++ b/unit_test/test_spdm_responder/chunk_response.c
@@ -1520,7 +1520,7 @@ void libspdm_test_responder_chunk_get_rsp_case18(void** state)
 
 int libspdm_rsp_chunk_response_test(void)
 {
-    const struct CMUnitTest spdm_responder_chunk_get_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Responder has no response flag chunk cap */
         cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case1),
         /* Responder has response state != NORMAL */
@@ -1566,7 +1566,7 @@ int libspdm_rsp_chunk_response_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_chunk_get_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -2025,7 +2025,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case22(void** state)
 
 int libspdm_rsp_chunk_send_ack_test(void)
 {
-    const struct CMUnitTest spdm_responder_chunk_send_ack_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Responder sent multiple chunks and processed correctly */
         cmocka_unit_test(libspdm_test_responder_chunk_send_ack_rsp_case0),
         /* Responder has no response flag chunk cap */
@@ -2084,7 +2084,7 @@ int libspdm_rsp_chunk_send_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_chunk_send_ack_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -1981,7 +1981,7 @@ void libspdm_test_responder_csr_case16(void **state)
 
 int libspdm_rsp_csr_test(void)
 {
-    const struct CMUnitTest spdm_responder_csr_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case for csr response with device_cert mode */
         cmocka_unit_test(libspdm_test_responder_csr_case1),
         /* Bad request size*/
@@ -2025,7 +2025,7 @@ int libspdm_rsp_csr_test(void)
     /*ensure that cached.csr exists in test_csr at the beginning*/
     libspdm_clear_cached_csr();
 
-    return cmocka_run_group_tests(spdm_responder_csr_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -641,7 +641,7 @@ void libspdm_test_responder_digests_case11(void **state)
 
 int libspdm_rsp_digests_test(void)
 {
-    const struct CMUnitTest spdm_responder_digests_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_digests_case1),
         /* Can be populated with new test.*/
@@ -674,7 +674,7 @@ int libspdm_rsp_digests_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_digests_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -473,7 +473,7 @@ void libspdm_test_responder_encap_challenge_case6(void **state)
 
 int libspdm_rsp_encap_challenge_test(void)
 {
-    const struct CMUnitTest spdm_responder_challenge_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_encap_challenge_case1),
         /* Error response: SPDM_ERROR*/
         cmocka_unit_test(libspdm_test_responder_encap_challenge_case2),
@@ -494,7 +494,7 @@ int libspdm_rsp_encap_challenge_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_challenge_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_get_certificate.c
+++ b/unit_test/test_spdm_responder/encap_get_certificate.c
@@ -593,7 +593,7 @@ void test_spdm_responder_encap_get_certificate_case5(void **state)
 
 int spdm_rsp_encap_get_certificate_test(void)
 {
-    const struct CMUnitTest spdm_responder_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(test_spdm_responder_encap_get_certificate_case1),
         /* Bad request size ,remaining length is 0*/
@@ -616,7 +616,7 @@ int spdm_rsp_encap_get_certificate_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_get_digests.c
+++ b/unit_test/test_spdm_responder/encap_get_digests.c
@@ -475,7 +475,7 @@ void test_spdm_responder_encap_get_digests_case7(void **state)
 
 int spdm_rsp_encap_get_digests_test(void)
 {
-    const struct CMUnitTest spdm_responder_digests_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(test_spdm_responder_encap_get_digests_case1),
         /* Error response: SPDM_ERROR*/
@@ -499,7 +499,7 @@ int spdm_rsp_encap_get_digests_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_digests_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_get_endpoint_info.c
+++ b/unit_test/test_spdm_responder/encap_get_endpoint_info.c
@@ -505,7 +505,7 @@ void libspdm_test_responder_encap_get_endpoint_info_case4(void **state)
 
 int libspdm_rsp_encap_get_endpoint_info_test(void)
 {
-    const struct CMUnitTest spdm_responder_encap_get_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success requeset endpoint info with signature */
         cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case1),
         /* Success requeset endpoint info with signature, req_slot_id = 0xFF */
@@ -523,7 +523,7 @@ int libspdm_rsp_encap_get_endpoint_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_encap_get_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_key_update.c
+++ b/unit_test/test_spdm_responder/encap_key_update.c
@@ -246,7 +246,7 @@ void libspdm_test_responder_encap_key_update_case5(void **state)
 
 int libspdm_rsp_encap_key_update_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Successful response*/
         cmocka_unit_test(libspdm_test_responder_encap_key_update_case1),
         /* Successful response,No further communication is required.*/
@@ -266,7 +266,7 @@ int libspdm_rsp_encap_key_update_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_response.c
+++ b/unit_test/test_spdm_responder/encap_response.c
@@ -1206,7 +1206,7 @@ void libspdm_test_get_response_encapsulated_response_ack_case9(void **State)
 
 int libspdm_rsp_encapsulated_response_test(void)
 {
-    const struct CMUnitTest spdm_responder_encapsulated_response_tests[] = {
+    const struct CMUnitTest test_cases[] = {
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT)
         /*Success Case request_op_code_sequence: SPDM_GET_DIGESTS*/
         cmocka_unit_test(libspdm_test_get_response_encapsulated_request_case1),
@@ -1261,7 +1261,7 @@ int libspdm_rsp_encapsulated_response_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_encapsulated_response_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/encap_send_event.c
+++ b/unit_test/test_spdm_responder/encap_send_event.c
@@ -132,7 +132,7 @@ static void test_responder_encap_send_event_case2(void **state)
 
 int libspdm_rsp_encap_send_event_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_responder_encap_send_event_case1),
         cmocka_unit_test(test_responder_encap_send_event_case2),
     };
@@ -144,7 +144,7 @@ int libspdm_rsp_encap_send_event_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/end_session_ack.c
+++ b/unit_test/test_spdm_responder/end_session_ack.c
@@ -636,7 +636,7 @@ void libspdm_test_responder_end_session_case8(void **state)
 
 int libspdm_rsp_end_session_ack_test(void)
 {
-    const struct CMUnitTest spdm_responder_end_session_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_end_session_case1),
         /* Bad request size*/
@@ -664,7 +664,7 @@ int libspdm_rsp_end_session_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_end_session_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/endpoint_info.c
+++ b/unit_test/test_spdm_responder/endpoint_info.c
@@ -594,7 +594,7 @@ void libspdm_test_responder_endpoint_info_case5(void **state)
 
 int libspdm_rsp_endpoint_info_test(void)
 {
-    const struct CMUnitTest spdm_responder_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_endpoint_info_case1),
         cmocka_unit_test(libspdm_test_responder_endpoint_info_case2),
         cmocka_unit_test(libspdm_test_responder_endpoint_info_case3),
@@ -609,7 +609,7 @@ int libspdm_rsp_endpoint_info_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/encap_get_endpoint_info_err.c
+++ b/unit_test/test_spdm_responder/error_test/encap_get_endpoint_info_err.c
@@ -573,7 +573,7 @@ void libspdm_test_responder_encap_get_endpoint_info_err_case5(void **state)
 
 int libspdm_rsp_encap_get_endpoint_info_error_test(void)
 {
-    const struct CMUnitTest spdm_responder_encap_get_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Get an error response */
         cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_err_case1),
         /* Get an incorrect response */
@@ -593,7 +593,7 @@ int libspdm_rsp_encap_get_endpoint_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_encap_get_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/encap_send_event_err.c
+++ b/unit_test/test_spdm_responder/error_test/encap_send_event_err.c
@@ -117,7 +117,7 @@ static void test_responder_encap_send_event_err_case2(void **state)
 
 int libspdm_rsp_encap_send_event_error_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_responder_encap_send_event_err_case1),
         cmocka_unit_test(test_responder_encap_send_event_err_case2),
     };
@@ -129,7 +129,7 @@ int libspdm_rsp_encap_send_event_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/endpoint_info_err.c
+++ b/unit_test/test_spdm_responder/error_test/endpoint_info_err.c
@@ -995,7 +995,7 @@ void libspdm_test_responder_endpoint_info_err_case14(void **state)
 
 int libspdm_rsp_endpoint_info_error_test(void)
 {
-    const struct CMUnitTest spdm_responder_endpoint_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_endpoint_info_err_case1),
         cmocka_unit_test(libspdm_test_responder_endpoint_info_err_case2),
         cmocka_unit_test(libspdm_test_responder_endpoint_info_err_case3),
@@ -1021,7 +1021,7 @@ int libspdm_rsp_endpoint_info_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_endpoint_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/subscribe_event_types_ack_err.c
+++ b/unit_test/test_spdm_responder/error_test/subscribe_event_types_ack_err.c
@@ -141,19 +141,19 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case2(void **st
 
 int libspdm_rsp_subscribe_event_types_ack_error_test(void)
 {
+    const struct CMUnitTest test_cases[] = {
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case1),
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case2)
+    };
+
     libspdm_test_context_t m_test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         false,
     };
 
-    const struct CMUnitTest spdm_responder_supported_event_types_err_tests[] = {
-        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case1),
-        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case2)
-    };
-
     libspdm_setup_test_context(&m_test_context);
 
-    return cmocka_run_group_tests(spdm_responder_supported_event_types_err_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
+++ b/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
@@ -96,18 +96,18 @@ static void libspdm_test_responder_supported_event_types_err_case1(void **state)
 
 int libspdm_rsp_supported_event_types_error_test(void)
 {
+    const struct CMUnitTest test_cases[] = {
+        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case1),
+    };
+
     libspdm_test_context_t test_context = {
         LIBSPDM_TEST_CONTEXT_VERSION,
         false,
     };
 
-    const struct CMUnitTest spdm_responder_supported_event_types_err_tests[] = {
-        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case1),
-    };
-
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_supported_event_types_err_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/error_test/vendor_response_err.c
+++ b/unit_test/test_spdm_responder/error_test/vendor_response_err.c
@@ -567,7 +567,7 @@ static void libspdm_test_responder_vendor_cmds_err_case7(void **state)
 
 int libspdm_rsp_vendor_defined_response_error_test(void)
 {
-    const struct CMUnitTest spdm_responder_vendor_cmds_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_err_case1),
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_err_case2),
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_err_case3),
@@ -584,7 +584,7 @@ int libspdm_rsp_vendor_defined_response_error_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_vendor_cmds_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/finish_rsp.c
+++ b/unit_test/test_spdm_responder/finish_rsp.c
@@ -3967,7 +3967,7 @@ void libspdm_test_responder_finish_case30(void **state)
 
 int libspdm_rsp_finish_test(void)
 {
-    const struct CMUnitTest spdm_responder_finish_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_finish_case1),
         /* Can be populated with new test.*/
@@ -4035,7 +4035,7 @@ int libspdm_rsp_finish_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_finish_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/heartbeat_ack.c
+++ b/unit_test/test_spdm_responder/heartbeat_ack.c
@@ -627,7 +627,7 @@ void libspdm_test_responder_heartbeat_case8(void **state)
 
 int libspdm_rsp_heartbeat_ack_test(void)
 {
-    const struct CMUnitTest spdm_responder_heartbeat_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_heartbeat_case1),
         /* Bad request size*/
@@ -654,7 +654,7 @@ int libspdm_rsp_heartbeat_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_heartbeat_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/key_exchange_rsp.c
+++ b/unit_test/test_spdm_responder/key_exchange_rsp.c
@@ -2195,7 +2195,7 @@ void libspdm_test_responder_key_exchange_case24(void **state)
 
 int libspdm_rsp_key_exchange_rsp_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_exchange_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_key_exchange_case1),
         /* Bad request size*/
@@ -2249,7 +2249,7 @@ int libspdm_rsp_key_exchange_rsp_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_exchange_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/key_pair_info.c
+++ b/unit_test/test_spdm_responder/key_pair_info.c
@@ -198,7 +198,7 @@ void libspdm_test_responder_key_pair_info_case4(void **state)
 
 int libspdm_rsp_key_pair_info_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_pair_info_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case to get key pair info*/
         cmocka_unit_test(libspdm_test_responder_key_pair_info_case1),
         /* The KeyPairID is at least 1 , KeyPairID is set to 0.*/
@@ -215,7 +215,7 @@ int libspdm_rsp_key_pair_info_test(void)
     };
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_pair_info_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/key_update_ack.c
+++ b/unit_test/test_spdm_responder/key_update_ack.c
@@ -2158,7 +2158,7 @@ void libspdm_test_responder_key_update_case27(void **state)
 
 int libspdm_rsp_key_update_ack_test(void)
 {
-    const struct CMUnitTest spdm_responder_key_update_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case -- UpdateKey*/
         cmocka_unit_test(libspdm_test_responder_key_update_case1),
         /* Bad request size*/
@@ -2224,7 +2224,7 @@ int libspdm_rsp_key_update_ack_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_key_update_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/measurement_extension_log.c
+++ b/unit_test/test_spdm_responder/measurement_extension_log.c
@@ -357,7 +357,7 @@ void libspdm_test_responder_measurement_extension_log_case5(void **state)
 
 int libspdm_rsp_measurement_extension_log_test(void)
 {
-    const struct CMUnitTest spdm_responder_measurement_extension_log_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case1),
         /* Success Case, request.length < total MEL len*/
@@ -377,7 +377,7 @@ int libspdm_rsp_measurement_extension_log_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_measurement_extension_log_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -2735,7 +2735,7 @@ int libspdm_rsp_measurements_test(void)
     m_libspdm_get_measurements_request11.slot_id_param = SPDM_MAX_SLOT_COUNT - 1;
     m_libspdm_get_measurements_request12.slot_id_param = SPDM_MAX_SLOT_COUNT + 1;
 
-    const struct CMUnitTest spdm_responder_measurements_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case to get measurement number without signature*/
         cmocka_unit_test(libspdm_test_responder_measurements_case1),
         /* Can be populated with new test.*/
@@ -2817,7 +2817,7 @@ int libspdm_rsp_measurements_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_measurements_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/psk_exchange_rsp.c
+++ b/unit_test/test_spdm_responder/psk_exchange_rsp.c
@@ -1722,7 +1722,7 @@ void libspdm_test_responder_psk_exchange_case17(void **state)
 
 int libspdm_rsp_psk_exchange_rsp_test(void)
 {
-    const struct CMUnitTest spdm_responder_psk_exchange_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_psk_exchange_case1),
         /* Bad request size*/
@@ -1768,7 +1768,7 @@ int libspdm_rsp_psk_exchange_rsp_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_psk_exchange_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/psk_finish_rsp.c
+++ b/unit_test/test_spdm_responder/psk_finish_rsp.c
@@ -1689,7 +1689,7 @@ void libspdm_test_responder_psk_finish_case15(void **state)
 
 int libspdm_rsp_psk_finish_rsp_test(void)
 {
-    const struct CMUnitTest spdm_responder_psk_finish_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
         cmocka_unit_test(libspdm_test_responder_psk_finish_case1),
         /* Bad request size*/
@@ -1729,7 +1729,7 @@ int libspdm_rsp_psk_finish_rsp_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_psk_finish_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -498,7 +498,7 @@ void libspdm_test_responder_receive_send_rsp_case4(void** state)
 
 int libspdm_rsp_receive_send_test(void)
 {
-    const struct CMUnitTest spdm_responder_receive_send_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* response message size is larger than requester data_transfer_size */
         cmocka_unit_test(libspdm_test_responder_receive_send_rsp_case1),
         /* response message size is larger than responder sending transmit buffer size */
@@ -522,7 +522,7 @@ int libspdm_rsp_receive_send_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_receive_send_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -1372,7 +1372,7 @@ void libspdm_test_responder_respond_if_ready_case14(void **state) {
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
 int libspdm_rsp_respond_if_ready_test(void) {
-    const struct CMUnitTest spdm_responder_respond_if_ready_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case*/
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
         cmocka_unit_test(libspdm_test_responder_respond_if_ready_case1),
@@ -1415,7 +1415,7 @@ int libspdm_rsp_respond_if_ready_test(void) {
 
     libspdm_setup_test_context (&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_respond_if_ready_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1115,7 +1115,7 @@ void libspdm_test_responder_set_certificate_rsp_case13(void **state)
 
 int libspdm_rsp_set_certificate_rsp_test(void)
 {
-    const struct CMUnitTest spdm_responder_set_certificate_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case for set_certificate to slot_id:0 with device_cert mode*/
         cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case1),
         /* Bad request size*/
@@ -1149,7 +1149,7 @@ int libspdm_rsp_set_certificate_rsp_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_set_certificate_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/set_key_pair_info_ack.c
+++ b/unit_test/test_spdm_responder/set_key_pair_info_ack.c
@@ -678,7 +678,7 @@ void libspdm_test_responder_set_key_pair_info_ack_case4(void **state)
 
 int libspdm_rsp_set_key_pair_info_ack_test(void)
 {
-    const struct CMUnitTest spdm_responder_set_key_pair_info_ack_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         /* Success Case to set key pair info*/
         cmocka_unit_test(libspdm_test_responder_set_key_pair_info_ack_case1),
         /* Success Case to set key pair info with reset*/
@@ -695,7 +695,7 @@ int libspdm_rsp_set_key_pair_info_ack_test(void)
     };
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_set_key_pair_info_ack_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/subscribe_event_types_ack.c
+++ b/unit_test/test_spdm_responder/subscribe_event_types_ack.c
@@ -157,14 +157,14 @@ int libspdm_rsp_subscribe_event_types_ack_test(void)
         false,
     };
 
-    const struct CMUnitTest spdm_responder_subscribe_event_types_ack_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_case1),
         cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_case2)
     };
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_subscribe_event_types_ack_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/supported_event_types.c
+++ b/unit_test/test_spdm_responder/supported_event_types.c
@@ -105,7 +105,7 @@ static void libspdm_test_responder_supported_event_types_case1(void **state)
 
 int libspdm_rsp_supported_event_types_test(void)
 {
-    const struct CMUnitTest spdm_responder_supported_event_types_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_supported_event_types_case1),
     };
 
@@ -116,7 +116,7 @@ int libspdm_rsp_supported_event_types_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_supported_event_types_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/vendor_defined_response.c
+++ b/unit_test/test_spdm_responder/vendor_defined_response.c
@@ -245,7 +245,7 @@ static void libspdm_test_responder_vendor_cmds_case2(void **state)
 
 int libspdm_rsp_vendor_defined_response_test(void)
 {
-    const struct CMUnitTest spdm_responder_vendor_cmds_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_case1),
         cmocka_unit_test(libspdm_test_responder_vendor_cmds_case2),
     };
@@ -257,7 +257,7 @@ int libspdm_rsp_vendor_defined_response_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_vendor_cmds_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }

--- a/unit_test/test_spdm_responder/version.c
+++ b/unit_test/test_spdm_responder/version.c
@@ -258,7 +258,7 @@ void libspdm_test_responder_version_case8(void **state)
 
 int libspdm_rsp_version_test(void)
 {
-    const struct CMUnitTest spdm_responder_version_tests[] = {
+    const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_version_case1),
         /* Invalid request*/
         cmocka_unit_test(libspdm_test_responder_version_case2),
@@ -281,7 +281,7 @@ int libspdm_rsp_version_test(void)
 
     libspdm_setup_test_context(&test_context);
 
-    return cmocka_run_group_tests(spdm_responder_version_tests,
+    return cmocka_run_group_tests(test_cases,
                                   libspdm_unit_test_group_setup,
                                   libspdm_unit_test_group_teardown);
 }


### PR DESCRIPTION
Rename the CMUnitTest variable name so that it conforms to https://github.com/DMTF/libspdm/blob/main/doc/internal/unit_test_template.md.