### PR TITLE
Rename Requester unit test case names

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -1987,7 +1987,7 @@ static libspdm_return_t receive_message(
  * device error.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_challenge_case1(void **state)
+static void req_challenge_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2067,7 +2067,7 @@ void libspdm_test_requester_challenge_case1(void **state)
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case2(void **state)
+static void req_challenge_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2152,7 +2152,7 @@ void libspdm_test_requester_challenge_case2(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is not set.
  **/
-void libspdm_test_requester_challenge_case3(void **state)
+static void req_challenge_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2225,7 +2225,7 @@ void libspdm_test_requester_challenge_case3(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is reset.
  **/
-void libspdm_test_requester_challenge_case4(void **state)
+static void req_challenge_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2298,7 +2298,7 @@ void libspdm_test_requester_challenge_case4(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is reset.
  **/
-void libspdm_test_requester_challenge_case5(void **state)
+static void req_challenge_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2371,7 +2371,7 @@ void libspdm_test_requester_challenge_case5(void **state)
  * message to the challenge, with no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case6(void **state)
+static void req_challenge_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2443,7 +2443,7 @@ void libspdm_test_requester_challenge_case6(void **state)
  * transcript buffer is reset, and the communication is reset to expect a new
  * GET_VERSION message.
  **/
-void libspdm_test_requester_challenge_case7(void **state)
+static void req_challenge_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2518,7 +2518,7 @@ void libspdm_test_requester_challenge_case7(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * buffer stores nothing.
  **/
-void libspdm_test_requester_challenge_case8(void **state)
+static void req_challenge_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2592,7 +2592,7 @@ void libspdm_test_requester_challenge_case8(void **state)
  * on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case9(void **state)
+static void req_challenge_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2663,7 +2663,7 @@ void libspdm_test_requester_challenge_case9(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and the "C"
  * transcript buffer is not set.
  **/
-void libspdm_test_requester_challenge_case10(void **state) {
+static void req_challenge_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2728,7 +2728,7 @@ void libspdm_test_requester_challenge_case10(void **state) {
  * response message, smaller then a standard SPDM message header.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR,.
  **/
-void libspdm_test_requester_challenge_case11(void **state) {
+static void req_challenge_case11(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2791,7 +2791,7 @@ void libspdm_test_requester_challenge_case11(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_challenge_case12(void **state) {
+static void req_challenge_case12(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2855,7 +2855,7 @@ void libspdm_test_requester_challenge_case12(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_challenge_case13(void **state) {
+static void req_challenge_case13(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2918,7 +2918,7 @@ void libspdm_test_requester_challenge_case13(void **state) {
  * The remaining message data is as a correct CHALLENGE_AUTH message.
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_challenge_case14(void **state) {
+static void req_challenge_case14(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2978,7 +2978,7 @@ void libspdm_test_requester_challenge_case14(void **state) {
 /**
  * Test 15: free to be populated by test.
  **/
-void libspdm_test_requester_challenge_case15(void **state) {
+static void req_challenge_case15(void **state) {
 }
 
 /**
@@ -2994,7 +2994,7 @@ void libspdm_test_requester_challenge_case15(void **state) {
  * data with bytes from the string "libspdm", and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case16(void **state) {
+static void req_challenge_case16(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3071,7 +3071,7 @@ void libspdm_test_requester_challenge_case16(void **state) {
  * but with an invalid signature.
  * Expected behavior: client returns a status of RETURN_SECURITY_VIOLATION.
  **/
-void libspdm_test_requester_challenge_case17(void **state) {
+static void req_challenge_case17(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3141,7 +3141,7 @@ void libspdm_test_requester_challenge_case17(void **state) {
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case18(void **state) {
+static void req_challenge_case18(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3211,7 +3211,7 @@ void libspdm_test_requester_challenge_case18(void **state) {
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case19(void **state) {
+static void req_challenge_case19(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3276,7 +3276,7 @@ void libspdm_test_requester_challenge_case19(void **state) {
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_challenge_case20(void **state) {
+static void req_challenge_case20(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3359,7 +3359,7 @@ void libspdm_test_requester_challenge_case20(void **state) {
  * Test 21: test correct CHALLENGE_AUTH message with multiple slot numbers
  * Expected behavior: success and slot_id is included in slot_mask.
  **/
-void libspdm_test_requester_challenge_case21(void **state) {
+static void req_challenge_case21(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3425,7 +3425,7 @@ void libspdm_test_requester_challenge_case21(void **state) {
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a CHALLENGE_AUTH message is
  * received, buffer C appends the exchanged CHALLENGE and CHALLENGE_AUTH messages.
  **/
-void libspdm_test_requester_challenge_case22(void **state)
+static void req_challenge_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3517,7 +3517,7 @@ void libspdm_test_requester_challenge_case22(void **state)
  * no opaque data and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case23(void **state)
+static void req_challenge_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3619,7 +3619,7 @@ void libspdm_test_requester_challenge_case23(void **state)
  * Test 24: Challenge using provisioned public key (slot_id 0xFF)
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case24(void **state)
+static void req_challenge_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3666,7 +3666,7 @@ void libspdm_test_requester_challenge_case24(void **state)
  * Test 25: Error case, CHALLENGE_AUTH message contains opaque_length greater than the maximum allowed.
  * Expected Behavior: get a LIBSPDM_STATUS_INVALID_MSG_FIELD return code.
  **/
-void libspdm_test_requester_challenge_case25(void **state) {
+static void req_challenge_case25(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3730,7 +3730,7 @@ void libspdm_test_requester_challenge_case25(void **state) {
  * data with bytes from the string "libspdm", and a signature on the sent nonce.
  * Expected behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case26(void **state) {
+static void req_challenge_case26(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3799,7 +3799,7 @@ void libspdm_test_requester_challenge_case26(void **state) {
  * Test 27: Successful case , With the correct challenge context field
  * Expected Behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_challenge_case27(void **state)
+static void req_challenge_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3876,7 +3876,7 @@ void libspdm_test_requester_challenge_case27(void **state)
  * Test 28: Error case , challenge context fields are inconsistent
  * Expected Behavior: get a LIBSPDM_STATUS_INVALID_MSG_FIELD return code
  **/
-void libspdm_test_requester_challenge_case28(void **state)
+static void req_challenge_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3948,55 +3948,56 @@ int libspdm_req_challenge_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case1),
+        cmocka_unit_test(req_challenge_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case2),
+        cmocka_unit_test(req_challenge_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case3),
+        cmocka_unit_test(req_challenge_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case4),
+        cmocka_unit_test(req_challenge_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case5),
+        cmocka_unit_test(req_challenge_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case6),
+        cmocka_unit_test(req_challenge_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case7),
+        cmocka_unit_test(req_challenge_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case8),
+        cmocka_unit_test(req_challenge_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case9),
+        cmocka_unit_test(req_challenge_case9),
         /* SpdmCmdReceiveState check failed*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case10),
+        cmocka_unit_test(req_challenge_case10),
         /* Successful response + device error*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case11),
-        cmocka_unit_test(libspdm_test_requester_challenge_case12),
-        cmocka_unit_test(libspdm_test_requester_challenge_case13),
-        cmocka_unit_test(libspdm_test_requester_challenge_case14),
+        cmocka_unit_test(req_challenge_case11),
+        cmocka_unit_test(req_challenge_case12),
+        cmocka_unit_test(req_challenge_case13),
+        cmocka_unit_test(req_challenge_case14),
         /* Invalid parameter*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case15),
+        cmocka_unit_test(req_challenge_case15),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case16),
+        cmocka_unit_test(req_challenge_case16),
         /* Signature check failed*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case17),
+        cmocka_unit_test(req_challenge_case17),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case18),
-        cmocka_unit_test(libspdm_test_requester_challenge_case19),
+        cmocka_unit_test(req_challenge_case18),
+        cmocka_unit_test(req_challenge_case19),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case20),
+        cmocka_unit_test(req_challenge_case20),
+        cmocka_unit_test(req_challenge_case21),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case22),
+        cmocka_unit_test(req_challenge_case22),
         /* Challeng differenr slot with GetCert*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case23),
+        cmocka_unit_test(req_challenge_case23),
         /* Challeng using provisioned public key (slot_id 0xFF) */
-        cmocka_unit_test(libspdm_test_requester_challenge_case24),
+        cmocka_unit_test(req_challenge_case24),
         /* opaque_length greater than the maximum allowed */
-        cmocka_unit_test(libspdm_test_requester_challenge_case25),
+        cmocka_unit_test(req_challenge_case25),
         /* the OpaqueDataFmt1 bit is selected in OtherParamsSelection of ALGORITHMS*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case26),
+        cmocka_unit_test(req_challenge_case26),
         /* Successful response, With the correct challenge context field*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case27),
+        cmocka_unit_test(req_challenge_case27),
         /* Error response: challenge context fields are inconsistent*/
-        cmocka_unit_test(libspdm_test_requester_challenge_case28),
+        cmocka_unit_test(req_challenge_case28),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -642,7 +642,7 @@ static libspdm_return_t receive_message(
 
 }
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
-void libspdm_test_requester_chunk_get_case1(void** state)
+static void req_chunk_get_case1(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -716,7 +716,7 @@ void libspdm_test_requester_chunk_get_case1(void** state)
 }
 #endif
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
-void libspdm_test_requester_chunk_get_case2(void** state)
+static void req_chunk_get_case2(void** state)
 {
     /* Copied from Get Measurements Test Case 0x20 */
     libspdm_return_t status;
@@ -805,7 +805,7 @@ void libspdm_test_requester_chunk_get_case2(void** state)
 }
 #endif
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-void libspdm_test_requester_chunk_get_case3(void** state)
+static void req_chunk_get_case3(void** state)
 {
     /* Copied from Challenge Test Case 2*/
     libspdm_return_t status;
@@ -881,7 +881,7 @@ void libspdm_test_requester_chunk_get_case3(void** state)
 }
 #endif
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
-void libspdm_test_requester_chunk_get_case4(void** state)
+static void req_chunk_get_case4(void** state)
 {
     /* Copied from Get Digests Test Case 2*/
     libspdm_return_t status;
@@ -968,7 +968,7 @@ void libspdm_test_requester_chunk_get_case4(void** state)
 #endif
 
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
-static void libspdm_test_requester_chunk_get_case5(void **state)
+static void req_chunk_get_case5(void **state)
 {
     /* Copied from Vendor Request case 1*/
     libspdm_return_t status;
@@ -1019,7 +1019,7 @@ static void libspdm_test_requester_chunk_get_case5(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
 }
 
-static void libspdm_test_requester_chunk_get_case6(void **state)
+static void req_chunk_get_case6(void **state)
 {
     /* Copied from Chunk Get Request case 5*/
     libspdm_return_t status;
@@ -1071,7 +1071,7 @@ static void libspdm_test_requester_chunk_get_case6(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
 }
 
-static void libspdm_test_requester_chunk_get_case7(void **state)
+static void req_chunk_get_case7(void **state)
 {
     /* Copied from Chunk Get Request case 5*/
     libspdm_return_t status;
@@ -1126,7 +1126,7 @@ static void libspdm_test_requester_chunk_get_case7(void **state)
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
-void libspdm_test_requester_chunk_get_case8(void** state)
+static void req_chunk_get_case8(void** state)
 {
     /* Copied from Chunk Send Test Case 4, use spdm 1.4*/
     libspdm_return_t status;
@@ -1219,34 +1219,34 @@ int libspdm_req_chunk_get_test(void)
     const struct CMUnitTest test_cases[] = {
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
         /* Request a certificate in portions */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case1),
+        cmocka_unit_test(req_chunk_get_case1),
 #endif
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
         /* Request all measurements */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case2),
+        cmocka_unit_test(req_chunk_get_case2),
 #endif
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
         /* Request Challenge */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case3),
+        cmocka_unit_test(req_chunk_get_case3),
 #endif
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
         /* Request Digests */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case4),
+        cmocka_unit_test(req_chunk_get_case4),
 #endif
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
         /* Request Vendor Specific Response and chunk data size
          * exceed max_chunk_data_transfer_size
          */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case5),
+        cmocka_unit_test(req_chunk_get_case5),
         /* Request Vendor Specific Response and chunk seq no wrapped */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case6),
+        cmocka_unit_test(req_chunk_get_case6),
         /* Request Vendor Specific Response
          * and recieve error code RequestResync */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case7),
+        cmocka_unit_test(req_chunk_get_case7),
 #endif
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT
         /* Request Digests with spdm 1.4 */
-        cmocka_unit_test(libspdm_test_requester_chunk_get_case8),
+        cmocka_unit_test(req_chunk_get_case8),
 #endif
     };
 

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -526,7 +526,7 @@ libspdm_return_t libspdm_test_requester_chunk_send_vendor_specific_test_case(
 }
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
 
-void libspdm_test_requester_chunk_send_case1(void** state)
+static void req_chunk_send_case1(void** state)
 {
     libspdm_return_t status;
 
@@ -534,70 +534,70 @@ void libspdm_test_requester_chunk_send_case1(void** state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-void libspdm_test_requester_chunk_send_case2(void** state)
+static void req_chunk_send_case2(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 2);
     assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
 }
 
-void libspdm_test_requester_chunk_send_case3(void** state)
+static void req_chunk_send_case3(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 3);
     assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
 }
 
-void libspdm_test_requester_chunk_send_case4(void** state)
+static void req_chunk_send_case4(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 4);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-void libspdm_test_requester_chunk_send_case5(void** state)
+static void req_chunk_send_case5(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 5);
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
-void libspdm_test_requester_chunk_send_case6(void** state)
+static void req_chunk_send_case6(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 6);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 }
 
-void libspdm_test_requester_chunk_send_case7(void** state)
+static void req_chunk_send_case7(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 7);
     assert_int_equal(status, LIBSPDM_STATUS_ERROR_PEER);
 }
 
-void libspdm_test_requester_chunk_send_case8(void** state)
+static void req_chunk_send_case8(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 8);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-void libspdm_test_requester_chunk_send_case9(void** state)
+static void req_chunk_send_case9(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 9);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
-void libspdm_test_requester_chunk_send_case10(void** state)
+static void req_chunk_send_case10(void** state)
 {
     libspdm_return_t status;
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 10);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-void libspdm_test_requester_chunk_send_case11(void** state)
+static void req_chunk_send_case11(void** state)
 {
     libspdm_return_t status;
 
@@ -610,7 +610,7 @@ void libspdm_test_requester_chunk_send_case11(void** state)
  * Expected behavior: returns a status of LIBSPDM_STATUS_ERROR_PEER,
  * Received an unexpected error message.
  **/
-void libspdm_test_requester_chunk_send_case12(void** state)
+static void req_chunk_send_case12(void** state)
 {
     libspdm_return_t status;
 
@@ -623,7 +623,7 @@ void libspdm_test_requester_chunk_send_case12(void** state)
  * Test 13: Request size shall not exceed max supported transfer size.
  * Expected behavior: returns a status of LIBSPDM_STATUS_SEND_FAIL,
  **/
-void libspdm_test_requester_chunk_send_case13(void** state)
+static void req_chunk_send_case13(void** state)
 {
     libspdm_return_t status;
 
@@ -638,7 +638,7 @@ void libspdm_test_requester_chunk_send_case13(void** state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_chunk_send_case14(void** state)
+static void req_chunk_send_case14(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -653,7 +653,7 @@ void libspdm_test_requester_chunk_send_case14(void** state)
                      LIBSPDM_CONNECTION_STATE_NOT_STARTED);
 }
 
-void libspdm_test_requester_chunk_send_case15(void** state)
+static void req_chunk_send_case15(void** state)
 {
     libspdm_return_t status;
 
@@ -666,37 +666,37 @@ int libspdm_req_chunk_send_test(void)
     /* Test the CHUNK_SEND handlers in various requester handlers */
     const struct CMUnitTest test_cases[] = {
         /* Request Algorithms successfully sent in chunks. */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case1),
+        cmocka_unit_test(req_chunk_send_case1),
         /* Chunk Request fail send */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case2),
+        cmocka_unit_test(req_chunk_send_case2),
         /* Chunk Response fail receive */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case3),
+        cmocka_unit_test(req_chunk_send_case3),
         /* Chunk Response has bad SPDM version */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case4),
+        cmocka_unit_test(req_chunk_send_case4),
         /* Chunk Response has bad request response code */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case5),
+        cmocka_unit_test(req_chunk_send_case5),
         /* Chunk Response has bad response size */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case6),
+        cmocka_unit_test(req_chunk_send_case6),
         /* Chunk Response has early error detected */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case7),
+        cmocka_unit_test(req_chunk_send_case7),
         /* Chunk Response has bad chunk handle */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case8),
+        cmocka_unit_test(req_chunk_send_case8),
         /* Chunk Response has bad chunk seq no */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case9),
+        cmocka_unit_test(req_chunk_send_case9),
         /* sent in chunks due to greater than the sending transmit buffer size. */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case10),
+        cmocka_unit_test(req_chunk_send_case10),
         /* requester message size greater than the responder max_spdm_msg_size, return LIBSPDM_STATUS_PEER_BUFFER_TOO_SMALL */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case11),
+        cmocka_unit_test(req_chunk_send_case11),
         /* ErrorCode == LargeResponse shall not be allowed in ResponseToLargeRequest */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case12),
+        cmocka_unit_test(req_chunk_send_case12),
 #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
         /* Request size exceed max chunks */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case13),
+        cmocka_unit_test(req_chunk_send_case13),
 #endif
         /* Recieved and error message indicating RequestResynch */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case14),
+        cmocka_unit_test(req_chunk_send_case14),
         /* Request Algorithms successfully sent in chunks, with SPDM 1.4 */
-        cmocka_unit_test(libspdm_test_requester_chunk_send_case15),
+        cmocka_unit_test(req_chunk_send_case15),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_certificate.c
+++ b/unit_test/test_spdm_requester/encap_certificate.c
@@ -43,7 +43,7 @@ size_t m_spdm_get_certificate_request4_size =
  * certificate chain Expected Behavior: generate a correctly formed Certificate
  * message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_requester_encap_certificate_case1(void **state)
+static void req_encap_certificate_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -101,7 +101,7 @@ void libspdm_test_requester_encap_certificate_case1(void **state)
  * Test 2:
  * Expected Behavior:
  **/
-void libspdm_test_requester_encap_certificate_case2(void **state)
+static void req_encap_certificate_case2(void **state)
 {
 }
 
@@ -110,7 +110,7 @@ void libspdm_test_requester_encap_certificate_case2(void **state)
  * keeping offset 0 Expected Behavior: generate correctly formed Certificate
  * messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_requester_encap_certificate_case3(void **state)
+static void req_encap_certificate_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -188,7 +188,7 @@ void libspdm_test_requester_encap_certificate_case3(void **state)
  * keeping length 0 Expected Behavior: generate correctly formed Certificate
  * messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_requester_encap_certificate_case4(void **state)
+static void req_encap_certificate_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -279,7 +279,7 @@ void libspdm_test_requester_encap_certificate_case4(void **state)
  * formed Certificate messages, including its portion_length and remainder_length
  * fields
  **/
-void libspdm_test_requester_encap_certificate_case5(void **state)
+static void req_encap_certificate_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -383,7 +383,7 @@ void libspdm_test_requester_encap_certificate_case5(void **state)
  * Expected Behavior: generate correctly formed Certificate messages, including
  * its portion_length and remainder_length fields
  **/
-void libspdm_test_requester_encap_certificate_case6(void **state)
+static void req_encap_certificate_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -471,7 +471,7 @@ void libspdm_test_requester_encap_certificate_case6(void **state)
  * GET_CERTIFICATE request shall be ignored by the Responder
  * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_requester_encap_certificate_case7(void **state)
+static void req_encap_certificate_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -530,17 +530,18 @@ int libspdm_req_encap_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case1),
+        cmocka_unit_test(req_encap_certificate_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case2),
+        cmocka_unit_test(req_encap_certificate_case2),
+        cmocka_unit_test(req_encap_certificate_case3),
         /* Tests varying offset*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case4),
+        cmocka_unit_test(req_encap_certificate_case4),
         /* Tests large certificate chains*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case5),
+        cmocka_unit_test(req_encap_certificate_case5),
         /* Requests byte by byte*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case6),
+        cmocka_unit_test(req_encap_certificate_case6),
         /* check request attributes and response attributes*/
-        cmocka_unit_test(libspdm_test_requester_encap_certificate_case7),
+        cmocka_unit_test(req_encap_certificate_case7),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_challenge_auth.c
+++ b/unit_test/test_spdm_requester/encap_challenge_auth.c
@@ -42,7 +42,7 @@ extern size_t libspdm_secret_lib_challenge_opaque_data_size;
  * Expected behavior: the requester accepts the request and produces a valid
  * CHALLENGE_AUTH response message and Completion of CHALLENGE sets M1/M2 to null.
  **/
-void test_libspdm_requester_encap_challenge_auth_case1(void **state)
+static void req_encap_challenge_auth_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -131,7 +131,7 @@ void test_libspdm_requester_encap_challenge_auth_case1(void **state)
  * Test 2:
  * Expected behavior:
  **/
-void test_libspdm_requester_encap_challenge_auth_case2(void **state)
+static void req_encap_challenge_auth_case2(void **state)
 {
 }
 
@@ -141,7 +141,7 @@ void test_libspdm_requester_encap_challenge_auth_case2(void **state)
  * Expected behavior: the requester accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void test_libspdm_requester_encap_challenge_auth_case3(void **state)
+static void req_encap_challenge_auth_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -195,7 +195,7 @@ void test_libspdm_requester_encap_challenge_auth_case3(void **state)
  * Expected behavior: the requester rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void test_libspdm_requester_encap_challenge_auth_case4(void **state)
+static void req_encap_challenge_auth_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -249,7 +249,7 @@ void test_libspdm_requester_encap_challenge_auth_case4(void **state)
  * Expected behavior: the requester rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void test_libspdm_requester_encap_challenge_auth_case5(void **state)
+static void req_encap_challenge_auth_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -303,7 +303,7 @@ void test_libspdm_requester_encap_challenge_auth_case5(void **state)
  * Expected behavior: the requester accepts the request and produces a valid
  * CHALLENGE_AUTH response message using provisioned public key (slot number 0xFF).
  **/
-void test_libspdm_requester_encap_challenge_auth_case6(void **state)
+static void req_encap_challenge_auth_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -369,7 +369,7 @@ void test_libspdm_requester_encap_challenge_auth_case6(void **state)
  * no opaque data, no measurements, and slot number 0.
  * Expected behavior:  get a RETURN_SUCCESS return code, correct context field
  **/
-void test_libspdm_requester_encap_challenge_auth_case7(void **state)
+static void req_encap_challenge_auth_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -473,7 +473,7 @@ void test_libspdm_requester_encap_challenge_auth_case7(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the invalid state.
  **/
-void test_libspdm_requester_encap_challenge_auth_case8(void **state)
+static void req_encap_challenge_auth_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -567,19 +567,19 @@ int libspdm_req_encap_challenge_auth_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case1),
+        cmocka_unit_test(req_encap_challenge_auth_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case2),
+        cmocka_unit_test(req_encap_challenge_auth_case2),
         /* connection_state Check*/
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case3),
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case4),
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case5),
+        cmocka_unit_test(req_encap_challenge_auth_case3),
+        cmocka_unit_test(req_encap_challenge_auth_case4),
+        cmocka_unit_test(req_encap_challenge_auth_case5),
         /* Success Case, use provisioned public key (slot 0xFF) */
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case6),
+        cmocka_unit_test(req_encap_challenge_auth_case6),
         /* Success Case: V1.3 get a correct context field */
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case7),
+        cmocka_unit_test(req_encap_challenge_auth_case7),
         /* The key usage bit mask is not set, failed Case*/
-        cmocka_unit_test(test_libspdm_requester_encap_challenge_auth_case8),
+        cmocka_unit_test(req_encap_challenge_auth_case8),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_digests.c
+++ b/unit_test/test_spdm_requester/encap_digests.c
@@ -32,7 +32,7 @@ static uint8_t m_local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
  * Test 1: receives a valid GET_DIGESTS request message from Requester
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void test_spdm_requester_encap_get_digests_case1(void **state)
+static void req_encap_digests_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -88,7 +88,7 @@ void test_spdm_requester_encap_get_digests_case1(void **state)
  * Test 2:
  * Expected Behavior:
  **/
-void test_spdm_requester_encap_get_digests_case2(void **state)
+static void req_encap_digests_case2(void **state)
 {
 }
 
@@ -96,7 +96,7 @@ void test_spdm_requester_encap_get_digests_case2(void **state)
  * Test 3: receives a valid GET_DIGESTS request message from Requester, but the request message cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void test_spdm_requester_encap_get_digests_case3(void **state)
+static void req_encap_digests_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -154,7 +154,7 @@ void test_spdm_requester_encap_get_digests_case3(void **state)
  * Test 4: receives a valid GET_DIGESTS request message from Requester, but the response message cannot be appended to the internal cache since the internal cache is full
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void test_spdm_requester_encap_get_digests_case4(void **state)
+static void req_encap_digests_case4(void **state)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -212,7 +212,7 @@ void test_spdm_requester_encap_get_digests_case4(void **state)
  * Set multi_key_conn_req to check if it responds correctly
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void test_spdm_requester_encap_get_digests_case5(void **state)
+static void req_encap_digests_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -307,7 +307,7 @@ void test_spdm_requester_encap_get_digests_case5(void **state)
  * Check KeyPairID CertificateInfo and KeyUsageMask
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void test_spdm_requester_encap_get_digests_case6(void **state)
+static void req_encap_digests_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -410,17 +410,17 @@ int libspdm_req_encap_digests_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case1),
+        cmocka_unit_test(req_encap_digests_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case2),
+        cmocka_unit_test(req_encap_digests_case2),
         /* Internal cache full (request message)*/
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case3),
+        cmocka_unit_test(req_encap_digests_case3),
         /* Internal cache full (response message)*/
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case4),
+        cmocka_unit_test(req_encap_digests_case4),
         /* Set multi_key_conn_req to check if it responds correctly */
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case5),
+        cmocka_unit_test(req_encap_digests_case5),
         /* Check KeyPairID CertificateInfo and KeyUsageMask*/
-        cmocka_unit_test(test_spdm_requester_encap_get_digests_case6),
+        cmocka_unit_test(req_encap_digests_case6),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_endpoint_info.c
+++ b/unit_test/test_spdm_requester/encap_endpoint_info.c
@@ -71,7 +71,7 @@ size_t m_libspdm_get_endpoint_info_request4_size =
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_requester_encap_endpoint_info_case1(void **state)
+static void req_encap_endpoint_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -183,7 +183,7 @@ void libspdm_test_requester_encap_endpoint_info_case1(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_requester_encap_endpoint_info_case2(void **state)
+static void req_encap_endpoint_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -294,7 +294,7 @@ void libspdm_test_requester_encap_endpoint_info_case2(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_requester_encap_endpoint_info_case3(void **state)
+static void req_encap_endpoint_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -386,7 +386,7 @@ void libspdm_test_requester_encap_endpoint_info_case3(void **state)
  * Expected Behavior: get a RETURN_SUCCESS return code,
  *                    correct response message size and fields
  **/
-void libspdm_test_requester_encap_endpoint_info_case4(void **state)
+static void req_encap_endpoint_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -437,7 +437,7 @@ void libspdm_test_requester_encap_endpoint_info_case4(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_requester_encap_endpoint_info_case5(void **state)
+static void req_encap_endpoint_info_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -555,15 +555,15 @@ int libspdm_req_encap_endpoint_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Successful response to get endpoint_info with signature */
-        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case1),
+        cmocka_unit_test(req_encap_endpoint_info_case1),
         /* Successful response to get endpoint_info with signature, slot_id == 0x1 */
-        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case2),
+        cmocka_unit_test(req_encap_endpoint_info_case2),
         /* Successful response to get endpoint_info with signature, slot_id == 0xF */
-        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case3),
+        cmocka_unit_test(req_encap_endpoint_info_case3),
         /* Successful response to get endpoint_info without signature */
-        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case4),
+        cmocka_unit_test(req_encap_endpoint_info_case4),
         /* Successful response to get session-based endpoint_info with signature */
-        cmocka_unit_test(libspdm_test_requester_encap_endpoint_info_case5),
+        cmocka_unit_test(req_encap_endpoint_info_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_event_ack.c
+++ b/unit_test/test_spdm_requester/encap_event_ack.c
@@ -111,7 +111,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
 }
 
 /* Send exactly one event. */
-static void test_libspdm_requester_encap_event_ack_case1(void **state)
+static void req_encap_event_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -173,7 +173,7 @@ static void test_libspdm_requester_encap_event_ack_case1(void **state)
 }
 
 /* Send two events with in-order event instance IDs. */
-static void test_libspdm_requester_encap_event_ack_case2(void **state)
+static void req_encap_event_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -255,7 +255,7 @@ static void test_libspdm_requester_encap_event_ack_case2(void **state)
 }
 
 /* Send two events with out-of-order event instance IDs. */
-static void test_libspdm_requester_encap_event_ack_case3(void **state)
+static void req_encap_event_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -337,7 +337,7 @@ static void test_libspdm_requester_encap_event_ack_case3(void **state)
 }
 
 /* Send four events with in-order event instance IDs. */
-static void test_libspdm_requester_encap_event_ack_case4(void **state)
+static void req_encap_event_ack_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -453,10 +453,10 @@ static void test_libspdm_requester_encap_event_ack_case4(void **state)
 int libspdm_req_encap_event_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(test_libspdm_requester_encap_event_ack_case1),
-        cmocka_unit_test(test_libspdm_requester_encap_event_ack_case2),
-        cmocka_unit_test(test_libspdm_requester_encap_event_ack_case3),
-        cmocka_unit_test(test_libspdm_requester_encap_event_ack_case4)
+        cmocka_unit_test(req_encap_event_ack_case1),
+        cmocka_unit_test(req_encap_event_ack_case2),
+        cmocka_unit_test(req_encap_event_ack_case3),
+        cmocka_unit_test(req_encap_event_ack_case4)
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_key_update_ack.c
+++ b/unit_test/test_spdm_requester/encap_key_update_ack.c
@@ -167,7 +167,7 @@ static void libspdm_compute_secret_update(spdm_version_number_t spdm_version,
  * Expected behavior: the encap requester accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void test_libspdm_requester_encap_key_update_case1(void **state)
+static void req_encap_key_update_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -238,7 +238,7 @@ void test_libspdm_requester_encap_key_update_case1(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_libspdm_requester_encap_key_update_case2(void **state)
+static void req_encap_key_update_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -295,7 +295,7 @@ void test_libspdm_requester_encap_key_update_case2(void **state)
                         m_rsp_secret_buffer, secured_message_context->hash_size);
 }
 
-void test_libspdm_requester_encap_key_update_case3(void **state)
+static void req_encap_key_update_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -387,7 +387,7 @@ void test_libspdm_requester_encap_key_update_case3(void **state)
  * produces an ERROR message indicating the UnsupportedRequest. No keys are
  * updated.
  **/
-void test_libspdm_requester_encap_key_update_case4(void **state)
+static void req_encap_key_update_ack_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -457,7 +457,7 @@ void test_libspdm_requester_encap_key_update_case4(void **state)
  * Expected behavior: the encap requester refuses the KEY_UPDATE message and produces
  * an ERROR message indicating the UnsupportedRequest. No keys are updated.
  **/
-void test_libspdm_requester_encap_key_update_case5(void **state)
+static void req_encap_key_update_ack_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -524,7 +524,7 @@ void test_libspdm_requester_encap_key_update_case5(void **state)
  * Expected behavior: the encap requester refuses the KEY_UPDATE message and produces
  * an ERROR message indicating the UnsupportedRequest. No keys are updated.
  **/
-void test_libspdm_requester_encap_key_update_case6(void **state)
+static void req_encap_key_update_ack_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -569,7 +569,7 @@ void test_libspdm_requester_encap_key_update_case6(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_libspdm_requester_encap_key_update_case7(void **state)
+static void req_encap_key_update_ack_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -635,7 +635,7 @@ void test_libspdm_requester_encap_key_update_case7(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void test_libspdm_requester_encap_key_update_case8(void **state)
+static void req_encap_key_update_ack_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -693,7 +693,7 @@ void test_libspdm_requester_encap_key_update_case8(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void test_libspdm_requester_encap_key_update_case9(void **state)
+static void req_encap_key_update_ack_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -751,7 +751,7 @@ void test_libspdm_requester_encap_key_update_case9(void **state)
 }
 
 /* UpdateKey + UpdateKey: failed*/
-void test_libspdm_requester_encap_key_update_case10(void **state)
+static void req_encap_key_update_ack_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -813,7 +813,7 @@ void test_libspdm_requester_encap_key_update_case10(void **state)
 }
 
 /* VerifyNewKey + UpdateKey: success*/
-void test_libspdm_requester_encap_key_update_case11(void **state)
+static void req_encap_key_update_ack_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -883,7 +883,7 @@ void test_libspdm_requester_encap_key_update_case11(void **state)
 }
 
 /* VerifyNewKey + VerifyNewKey: failed*/
-void test_libspdm_requester_encap_key_update_case12(void **state)
+static void req_encap_key_update_ack_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -948,7 +948,7 @@ void test_libspdm_requester_encap_key_update_case12(void **state)
 
 
 /* other command + UpdateKey: success*/
-void test_libspdm_requester_encap_key_update_case13(void **state)
+static void req_encap_key_update_ack_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1017,7 +1017,7 @@ void test_libspdm_requester_encap_key_update_case13(void **state)
 
 
 /* other command + VerifyNewKey: failed*/
-void test_libspdm_requester_encap_key_update_case14(void **state)
+static void req_encap_key_update_ack_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1082,33 +1082,33 @@ int libspdm_req_encap_key_update_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case -- UpdateKey*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case1),
+        cmocka_unit_test(req_encap_key_update_ack_case1),
         /* Bad request size*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case2),
+        cmocka_unit_test(req_encap_key_update_ack_case2),
         /* Buffer reset*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case3),
+        cmocka_unit_test(req_encap_key_update_ack_case3),
         /* Unsupported KEY_UPD capabilities*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case4),
+        cmocka_unit_test(req_encap_key_update_ack_case4),
         /* Uninitialized session*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case5),
+        cmocka_unit_test(req_encap_key_update_ack_case5),
         /* ruquster RETURN_UNSUPPORTED*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case6),
+        cmocka_unit_test(req_encap_key_update_ack_case6),
         /* Bad request size*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case7),
+        cmocka_unit_test(req_encap_key_update_ack_case7),
         /* Uninitialized key update*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case8),
+        cmocka_unit_test(req_encap_key_update_ack_case8),
         /* Invalid operation*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case9),
+        cmocka_unit_test(req_encap_key_update_ack_case9),
         /* UpdateKey + UpdateKey: failed*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case10),
+        cmocka_unit_test(req_encap_key_update_ack_case10),
         /* VerifyNewKey + UpdateKey: success*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case11),
+        cmocka_unit_test(req_encap_key_update_ack_case11),
         /* VerifyNewKey + VerifyNewKey: failed*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case12),
+        cmocka_unit_test(req_encap_key_update_ack_case12),
         /* other command + UpdateKey: success*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case13),
+        cmocka_unit_test(req_encap_key_update_ack_case13),
         /* other command + VerifyNewKey: failed*/
-        cmocka_unit_test(test_libspdm_requester_encap_key_update_case14),
+        cmocka_unit_test(req_encap_key_update_ack_case14),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_request.c
+++ b/unit_test/test_spdm_requester/encap_request.c
@@ -752,7 +752,7 @@ libspdm_return_t libspdm_requester_encap_request_test_receive_message(
 }
 
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP)
-void libspdm_test_requester_encap_request_case1(void **State)
+static void req_encap_request_case1(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -806,7 +806,7 @@ void libspdm_test_requester_encap_request_case1(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case2(void **State)
+static void req_encap_request_case2(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -859,11 +859,11 @@ void libspdm_test_requester_encap_request_case2(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case3(void **State)
+static void req_encap_request_case3(void **State)
 {
 }
 
-void libspdm_test_requester_encap_request_case4(void **State)
+static void req_encap_request_case4(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -916,7 +916,7 @@ void libspdm_test_requester_encap_request_case4(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case5(void **State)
+static void req_encap_request_case5(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -969,11 +969,11 @@ void libspdm_test_requester_encap_request_case5(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case6(void **State)
+static void req_encap_request_case6(void **State)
 {
 }
 
-void libspdm_test_requester_encap_request_case7(void **State)
+static void req_encap_request_case7(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1026,7 +1026,7 @@ void libspdm_test_requester_encap_request_case7(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case8(void **State)
+static void req_encap_request_case8(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1084,7 +1084,7 @@ void libspdm_test_requester_encap_request_case8(void **State)
 }
 #endif /* (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP) */
 
-void libspdm_test_requester_encap_request_case9(void **State)
+static void req_encap_request_case9(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1147,7 +1147,7 @@ void libspdm_test_requester_encap_request_case9(void **State)
  * Test 10: GET_ENCAPSULATED_REQUEST request message is encapsulated in ENCAPSULATED_REQUEST response message.
  * Expected Behavior: the Requester should respond with ErrorCode=UnexpectedRequest.
  **/
-void libspdm_test_requester_encap_request_case10(void **State)
+static void req_encap_request_case10(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1175,7 +1175,7 @@ void libspdm_test_requester_encap_request_case10(void **State)
  * Expected Behavior: return LIBSPDM_STATUS_SUCCESS as Responder did not have a pending request for
  *                    the Requester.
  **/
-void libspdm_test_requester_encap_request_case11(void **State)
+static void req_encap_request_case11(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1203,7 +1203,7 @@ void libspdm_test_requester_encap_request_case11(void **State)
  * Expected Behavior: return LIBSPDM_STATUS_SUCCESS as Responder did not have a pending request for
  *                    the Requester.
  **/
-void libspdm_test_requester_encap_request_case12(void **State)
+static void req_encap_request_case12(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1226,7 +1226,7 @@ void libspdm_test_requester_encap_request_case12(void **State)
 }
 
 #if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
-void libspdm_test_requester_encap_request_case13(void **State)
+static void req_encap_request_case13(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1279,7 +1279,7 @@ void libspdm_test_requester_encap_request_case13(void **State)
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
 
-void libspdm_test_requester_encap_request_case14(void **State)
+static void req_encap_request_case14(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1336,7 +1336,7 @@ void libspdm_test_requester_encap_request_case14(void **State)
     free(data);
 }
 
-void libspdm_test_requester_encap_request_case15(void **State)
+static void req_encap_request_case15(void **State)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1398,33 +1398,35 @@ int libspdm_req_encap_request_test(void)
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
 #if (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (LIBSPDM_ENABLE_CAPABILITY_CERT_CAP)
-        cmocka_unit_test(libspdm_test_requester_encap_request_case1),
+        cmocka_unit_test(req_encap_request_case1),
         /* Success Case ,func :libspdm_get_encap_response_digest*/
-        cmocka_unit_test(libspdm_test_requester_encap_request_case2),
+        cmocka_unit_test(req_encap_request_case2),
+        cmocka_unit_test(req_encap_request_case3),
         /* Error response:Receive message only SPDM ENCAPSULATED_REQUEST response*/
-        cmocka_unit_test(libspdm_test_requester_encap_request_case4),
+        cmocka_unit_test(req_encap_request_case4),
         /* Error response: spdm_encapsulated_response_ack_response == NULL*/
-        cmocka_unit_test(libspdm_test_requester_encap_request_case5),
+        cmocka_unit_test(req_encap_request_case5),
+        cmocka_unit_test(req_encap_request_case6),
         /* response: param2 == SPDM_ENCAPSULATED_RESPONSE_ACK_RESPONSE_PAYLOAD_TYPE_REQ_SLOT_NUMBER*/
-        cmocka_unit_test(libspdm_test_requester_encap_request_case7),
+        cmocka_unit_test(req_encap_request_case7),
         /*Success Case ,func :libspdm_get_encap_response_certificate */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case8),
+        cmocka_unit_test(req_encap_request_case8),
 #endif /* (LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP) && (..) */
 
         /*Success Case ,func :libspdm_get_encap_response_key_update */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case9),
+        cmocka_unit_test(req_encap_request_case9),
         /*Error response: GET_ENCAPSULATED_REQUEST message is encapsulated */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case10),
-        cmocka_unit_test(libspdm_test_requester_encap_request_case11),
-        cmocka_unit_test(libspdm_test_requester_encap_request_case12),
+        cmocka_unit_test(req_encap_request_case10),
+        cmocka_unit_test(req_encap_request_case11),
+        cmocka_unit_test(req_encap_request_case12),
 #if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
         /*Success Case ,func :libspdm_get_encap_response_endpoint_info */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case13),
+        cmocka_unit_test(req_encap_request_case13),
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
         /* Error response: send SPDM_GET_ENCAPSULATED_REQUEST and receive request resync */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case14),
+        cmocka_unit_test(req_encap_request_case14),
         /* Error response: send SPDM_DELIVER_ENCAPSULATED_RESPONSE and receive request resync */
-        cmocka_unit_test(libspdm_test_requester_encap_request_case15),
+        cmocka_unit_test(req_encap_request_case15),
 
     };
 

--- a/unit_test/test_spdm_requester/encap_subscribe_event_types_ack.c
+++ b/unit_test/test_spdm_requester/encap_subscribe_event_types_ack.c
@@ -64,7 +64,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
  * Test 1: Successful response to subscribe event types that clears all events.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS with the expected values.
  **/
-static void test_subscribe_event_types_ack_case1(void **state)
+static void req_encap_subscribe_event_types_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -108,7 +108,7 @@ static void test_subscribe_event_types_ack_case1(void **state)
     assert_true(!g_event_all_subscribe && g_event_all_unsubscribe);
 }
 
-static void test_subscribe_event_types_ack_case2(void **state)
+static void req_encap_subscribe_event_types_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -160,8 +160,8 @@ static void test_subscribe_event_types_ack_case2(void **state)
 int libspdm_req_encap_subscribe_event_types_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(test_subscribe_event_types_ack_case1),
-        cmocka_unit_test(test_subscribe_event_types_ack_case2),
+        cmocka_unit_test(req_encap_subscribe_event_types_ack_case1),
+        cmocka_unit_test(req_encap_subscribe_event_types_ack_case2),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/encap_supported_event_types.c
+++ b/unit_test/test_spdm_requester/encap_supported_event_types.c
@@ -60,7 +60,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
         LIBSPDM_SESSION_STATE_ESTABLISHED);
 }
 
-static void test_supported_event_types_case1(void **state)
+static void req_encap_supported_event_types_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -113,7 +113,7 @@ static void test_supported_event_types_case1(void **state)
 int libspdm_req_encap_supported_event_types_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(test_supported_event_types_case1),
+        cmocka_unit_test(req_encap_supported_event_types_case1),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/end_session.c
+++ b/unit_test/test_spdm_requester/end_session.c
@@ -671,7 +671,7 @@ static libspdm_return_t receive_message(
     }
 }
 
-void libspdm_test_requester_end_session_case1(void **state)
+static void req_end_session_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -736,7 +736,7 @@ void libspdm_test_requester_end_session_case1(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case2(void **state)
+static void req_end_session_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -828,7 +828,7 @@ void libspdm_test_requester_end_session_case2(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case3(void **state)
+static void req_end_session_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -916,7 +916,7 @@ void libspdm_test_requester_end_session_case3(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case4(void **state)
+static void req_end_session_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1004,7 +1004,7 @@ void libspdm_test_requester_end_session_case4(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case5(void **state)
+static void req_end_session_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1092,7 +1092,7 @@ void libspdm_test_requester_end_session_case5(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case6(void **state)
+static void req_end_session_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1185,7 +1185,7 @@ void libspdm_test_requester_end_session_case6(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case7(void **state)
+static void req_end_session_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1275,7 +1275,7 @@ void libspdm_test_requester_end_session_case7(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case8(void **state)
+static void req_end_session_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1363,7 +1363,7 @@ void libspdm_test_requester_end_session_case8(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case9(void **state)
+static void req_end_session_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1456,7 +1456,7 @@ void libspdm_test_requester_end_session_case9(void **state)
     free(data);
 }
 
-void libspdm_test_requester_end_session_case10(void **state) {
+static void req_end_session_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1546,7 +1546,7 @@ void libspdm_test_requester_end_session_case10(void **state) {
     free(data);
 }
 
-void libspdm_test_requester_end_session_case11(void **state)
+static void req_end_session_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1661,7 +1661,7 @@ void libspdm_test_requester_end_session_case11(void **state)
  * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void libspdm_test_requester_end_session_case12(void **state)
+static void req_end_session_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1755,29 +1755,29 @@ int libspdm_req_end_session_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case1),
+        cmocka_unit_test(req_end_session_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case2),
+        cmocka_unit_test(req_end_session_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case3),
+        cmocka_unit_test(req_end_session_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case4),
+        cmocka_unit_test(req_end_session_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case5),
+        cmocka_unit_test(req_end_session_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case6),
+        cmocka_unit_test(req_end_session_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case7),
+        cmocka_unit_test(req_end_session_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case8),
+        cmocka_unit_test(req_end_session_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case9),
+        cmocka_unit_test(req_end_session_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case10),
+        cmocka_unit_test(req_end_session_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case11),
+        cmocka_unit_test(req_end_session_case11),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(libspdm_test_requester_end_session_case12),
+        cmocka_unit_test(req_end_session_case12),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -1559,7 +1559,7 @@ static libspdm_return_t receive_message(
  * device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case1(void **state)
+static void req_finish_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1656,7 +1656,7 @@ void libspdm_test_requester_finish_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_finish_case2(void **state)
+static void req_finish_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1761,7 +1761,7 @@ void libspdm_test_requester_finish_case2(void **state)
  * NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_finish_case3(void **state)
+static void req_finish_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1857,7 +1857,7 @@ void libspdm_test_requester_finish_case3(void **state)
  * message indicating InvalidParameters.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case4(void **state)
+static void req_finish_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1954,7 +1954,7 @@ void libspdm_test_requester_finish_case4(void **state)
  * message indicating the Busy status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case5(void **state)
+static void req_finish_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2051,7 +2051,7 @@ void libspdm_test_requester_finish_case5(void **state)
  * message with only MAC (no mutual authentication).
  * Expected behavior: client returns a Status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_finish_case6(void **state)
+static void req_finish_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2153,7 +2153,7 @@ void libspdm_test_requester_finish_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_finish_case7(void **state)
+static void req_finish_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2251,7 +2251,7 @@ void libspdm_test_requester_finish_case7(void **state)
  * message indicating the ResponseNotReady status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR,.
  **/
-void libspdm_test_requester_finish_case8(void **state)
+static void req_finish_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2348,7 +2348,7 @@ void libspdm_test_requester_finish_case8(void **state)
  * FINISH_RSP message with only MAC (no mutual authentication).
  * Expected behavior: client returns a Status of RETURN_SUCCESS.
  **/
-void libspdm_test_requester_finish_case9(void **state)
+static void req_finish_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2448,7 +2448,7 @@ void libspdm_test_requester_finish_case9(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case10(void **state) {
+static void req_finish_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -2547,7 +2547,7 @@ void libspdm_test_requester_finish_case10(void **state) {
     free(data);
 }
 
-void libspdm_test_requester_finish_case11(void **state)
+static void req_finish_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2669,7 +2669,7 @@ void libspdm_test_requester_finish_case11(void **state)
  * FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_finish_case12(void **state)
+static void req_finish_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2768,7 +2768,7 @@ void libspdm_test_requester_finish_case12(void **state)
  * responder would attempt to return a correct FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_finish_case13(void **state)
+static void req_finish_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2864,7 +2864,7 @@ void libspdm_test_requester_finish_case13(void **state)
  * code, but all other field correct.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case14(void **state)
+static void req_finish_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2961,7 +2961,7 @@ void libspdm_test_requester_finish_case14(void **state)
  * return a correct FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_finish_case15(void **state)
+static void req_finish_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3058,7 +3058,7 @@ void libspdm_test_requester_finish_case15(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_finish_case16(void **state)
+static void req_finish_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3170,7 +3170,7 @@ void libspdm_test_requester_finish_case16(void **state)
  * (all-zero), mutual authentication, and 'handshake in the clear'.
  * Expected behavior: client returns a Status of RETURN_SECURITY_VIOLATION.
  **/
-void libspdm_test_requester_finish_case17(void **state)
+static void req_finish_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3278,7 +3278,7 @@ void libspdm_test_requester_finish_case17(void **state)
  * (arbitrary), mutual authentication, and 'handshake in the clear'.
  * Expected behavior: client returns a Status of RETURN_SECURITY_VIOLATION.
  **/
-void libspdm_test_requester_finish_case18(void **state)
+static void req_finish_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3385,7 +3385,7 @@ void libspdm_test_requester_finish_case18(void **state)
  * Test 19:
  * Expected behavior:
  **/
-void libspdm_test_requester_finish_case19(void **state)
+static void req_finish_case19(void **state)
 {
 }
 
@@ -3395,7 +3395,7 @@ void libspdm_test_requester_finish_case19(void **state)
  * in the clear'.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_finish_case20(void **state)
+static void req_finish_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3502,7 +3502,7 @@ void libspdm_test_requester_finish_case20(void **state)
  * Test 21: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void libspdm_test_requester_finish_case21(void **state)
+static void req_finish_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3600,7 +3600,7 @@ void libspdm_test_requester_finish_case21(void **state)
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a FINISH_RSP message is
  * received, buffer F appends the exchanged FINISH and FINISH_RSP
  **/
-void libspdm_test_requester_finish_case22(void **state)
+static void req_finish_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3717,7 +3717,7 @@ void libspdm_test_requester_finish_case22(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_finish_case23(void **state)
+static void req_finish_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3805,7 +3805,7 @@ void libspdm_test_requester_finish_case23(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_finish_case24(void **state)
+static void req_finish_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3914,7 +3914,7 @@ void libspdm_test_requester_finish_case24(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_finish_case25(void **state)
+static void req_finish_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4022,50 +4022,50 @@ int libspdm_req_finish_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_finish_case1),
+        cmocka_unit_test(req_finish_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_finish_case2),
+        cmocka_unit_test(req_finish_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_finish_case3),
+        cmocka_unit_test(req_finish_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_finish_case4),
+        cmocka_unit_test(req_finish_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_finish_case5),
+        cmocka_unit_test(req_finish_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_finish_case6),
+        cmocka_unit_test(req_finish_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_finish_case7),
+        cmocka_unit_test(req_finish_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_finish_case8),
+        cmocka_unit_test(req_finish_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_finish_case9),
+        cmocka_unit_test(req_finish_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_finish_case10),
+        cmocka_unit_test(req_finish_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_finish_case11),
+        cmocka_unit_test(req_finish_case11),
         /* No correct setup*/
-        cmocka_unit_test(libspdm_test_requester_finish_case12),
-        cmocka_unit_test(libspdm_test_requester_finish_case13),
-        cmocka_unit_test(libspdm_test_requester_finish_case14),
-        cmocka_unit_test(libspdm_test_requester_finish_case15),
+        cmocka_unit_test(req_finish_case12),
+        cmocka_unit_test(req_finish_case13),
+        cmocka_unit_test(req_finish_case14),
+        cmocka_unit_test(req_finish_case15),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_finish_case16),
+        cmocka_unit_test(req_finish_case16),
         /* Response with invalid MAC*/
-        cmocka_unit_test(libspdm_test_requester_finish_case17),
-        cmocka_unit_test(libspdm_test_requester_finish_case18),
+        cmocka_unit_test(req_finish_case17),
+        cmocka_unit_test(req_finish_case18),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_requester_finish_case19),
-        cmocka_unit_test(libspdm_test_requester_finish_case20),
+        cmocka_unit_test(req_finish_case19),
+        cmocka_unit_test(req_finish_case20),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(libspdm_test_requester_finish_case21),
+        cmocka_unit_test(req_finish_case21),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_finish_case22),
+        cmocka_unit_test(req_finish_case22),
         /* Successful response using provisioned public key (slot_id 0xFF) */
-        cmocka_unit_test(libspdm_test_requester_finish_case23),
+        cmocka_unit_test(req_finish_case23),
         /* Set HANDSHAKE_IN_THE_CLEAR_CAP to 0 , The ResponderVerifyData field is absent.*/
-        cmocka_unit_test(libspdm_test_requester_finish_case24),
+        cmocka_unit_test(req_finish_case24),
         /* SPDM 1.4 with OpaqueData */
-        cmocka_unit_test(libspdm_test_requester_finish_case25),
+        cmocka_unit_test(req_finish_case25),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_capabilities.c
+++ b/unit_test/test_spdm_requester/get_capabilities.c
@@ -1094,12 +1094,12 @@ static libspdm_return_t receive_message(
 }
 
 /*
- * static void libspdm_test_requester_get_capabilities_case1(void **state)
+ * static void req_get_capabilities_case1(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case2(void **state)
+static void req_get_capabilities_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1129,24 +1129,24 @@ static void libspdm_test_requester_get_capabilities_case2(void **state)
 }
 
 /*
- * static void libspdm_test_requester_get_capabilities_case3(void **state)
+ * static void req_get_capabilities_case3(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case4(void **state)
+ * static void req_get_capabilities_case4(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case5(void **state)
+ * static void req_get_capabilities_case5(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case6(void **state)
+static void req_get_capabilities_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1171,24 +1171,24 @@ static void libspdm_test_requester_get_capabilities_case6(void **state)
 }
 
 /*
- * static void libspdm_test_requester_get_capabilities_case7(void **state)
+ * static void req_get_capabilities_case7(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case8(void **state)
+ * static void req_get_capabilities_case8(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case9(void **state)
+ * static void req_get_capabilities_case9(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case10(void **state)
+static void req_get_capabilities_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1215,7 +1215,7 @@ static void libspdm_test_requester_get_capabilities_case10(void **state)
                       SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
 }
 
-static void libspdm_test_requester_get_capabilities_case11(void **state)
+static void req_get_capabilities_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1242,7 +1242,7 @@ static void libspdm_test_requester_get_capabilities_case11(void **state)
           SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP));
 }
 
-static void libspdm_test_requester_get_capabilities_case12(void **state)
+static void req_get_capabilities_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1266,24 +1266,24 @@ static void libspdm_test_requester_get_capabilities_case12(void **state)
 }
 
 /*
- * static void libspdm_test_requester_get_capabilities_case13(void **state)
+ * static void req_get_capabilities_case13(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case14(void **state)
+ * static void req_get_capabilities_case14(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case15(void **state)
+ * static void req_get_capabilities_case15(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case16(void **state)
+static void req_get_capabilities_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1306,96 +1306,96 @@ static void libspdm_test_requester_get_capabilities_case16(void **state)
 }
 
 /*
- * static void libspdm_test_requester_get_capabilities_case17(void **state)
+ * static void req_get_capabilities_case17(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case18(void **state)
+ * static void req_get_capabilities_case18(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case19(void **state)
+ * static void req_get_capabilities_case19(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case20(void **state)
+ * static void req_get_capabilities_case20(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case21(void **state)
+ * static void req_get_capabilities_case21(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case22(void **state)
+ * static void req_get_capabilities_case22(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case23(void **state)
+ * static void req_get_capabilities_case23(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case24(void **state)
+ * static void req_get_capabilities_case24(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case25(void **state)
+ * static void req_get_capabilities_case25(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case26(void **state)
+ * static void req_get_capabilities_case26(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case27(void **state)
+ * static void req_get_capabilities_case27(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case28(void **state)
+ * static void req_get_capabilities_case28(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case29(void **state)
+ * static void req_get_capabilities_case29(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case30(void **state)
+ * static void req_get_capabilities_case30(void **state)
  * {
  * }
  */
 
 /*
- * static void libspdm_test_requester_get_capabilities_case31(void **state)
+ * static void req_get_capabilities_case31(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case32(void **state)
+static void req_get_capabilities_case32(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1433,7 +1433,7 @@ static void libspdm_test_requester_get_capabilities_case32(void **state)
                         m_libspdm_local_buffer, m_libspdm_local_buffer_size);
 }
 
-static void libspdm_test_requester_get_capabilities_case33(void **state)
+static void req_get_capabilities_case33(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1461,12 +1461,12 @@ static void libspdm_test_requester_get_capabilities_case33(void **state)
 
 
 /*
- * static void libspdm_test_requester_get_capabilities_case34(void **state)
+ * static void req_get_capabilities_case34(void **state)
  * {
  * }
  */
 
-static void libspdm_test_requester_get_capabilities_case35(void **state)
+static void req_get_capabilities_case35(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1491,7 +1491,7 @@ static void libspdm_test_requester_get_capabilities_case35(void **state)
                      LIBSPDM_DEFAULT_CAPABILITY_RESPONSE_FLAG_VERSION_13);
 }
 
-static void libspdm_test_requester_get_capabilities_case36(void **state)
+static void req_get_capabilities_case36(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1540,42 +1540,42 @@ static void libspdm_test_requester_get_capabilities_case36(void **state)
 int libspdm_req_get_capabilities_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case1), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case2),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case3),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case4),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case5), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case6),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case7),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case8),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case9), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case10),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case11),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case12),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case13),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case14),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case15), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case16),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case17),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case18),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case19),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case20),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case21),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case22),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case23),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case24),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case25),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case26),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case27),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case28),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case29),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case30),
-         * cmocka_unit_test(libspdm_test_requester_get_capabilities_case31), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case32),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case33),
-        /* cmocka_unit_test(libspdm_test_requester_get_capabilities_case34), */
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case35),
-        cmocka_unit_test(libspdm_test_requester_get_capabilities_case36),
+        /* cmocka_unit_test(req_get_capabilities_case1), */
+        cmocka_unit_test(req_get_capabilities_case2),
+        /* cmocka_unit_test(req_get_capabilities_case3),
+         * cmocka_unit_test(req_get_capabilities_case4),
+         * cmocka_unit_test(req_get_capabilities_case5), */
+        cmocka_unit_test(req_get_capabilities_case6),
+        /* cmocka_unit_test(req_get_capabilities_case7),
+         * cmocka_unit_test(req_get_capabilities_case8),
+         * cmocka_unit_test(req_get_capabilities_case9), */
+        cmocka_unit_test(req_get_capabilities_case10),
+        cmocka_unit_test(req_get_capabilities_case11),
+        cmocka_unit_test(req_get_capabilities_case12),
+        /* cmocka_unit_test(req_get_capabilities_case13),
+         * cmocka_unit_test(req_get_capabilities_case14),
+         * cmocka_unit_test(req_get_capabilities_case15), */
+        cmocka_unit_test(req_get_capabilities_case16),
+        /* cmocka_unit_test(req_get_capabilities_case17),
+         * cmocka_unit_test(req_get_capabilities_case18),
+         * cmocka_unit_test(req_get_capabilities_case19),
+         * cmocka_unit_test(req_get_capabilities_case20),
+         * cmocka_unit_test(req_get_capabilities_case21),
+         * cmocka_unit_test(req_get_capabilities_case22),
+         * cmocka_unit_test(req_get_capabilities_case23),
+         * cmocka_unit_test(req_get_capabilities_case24),
+         * cmocka_unit_test(req_get_capabilities_case25),
+         * cmocka_unit_test(req_get_capabilities_case26),
+         * cmocka_unit_test(req_get_capabilities_case27),
+         * cmocka_unit_test(req_get_capabilities_case28),
+         * cmocka_unit_test(req_get_capabilities_case29),
+         * cmocka_unit_test(req_get_capabilities_case30),
+         * cmocka_unit_test(req_get_capabilities_case31), */
+        cmocka_unit_test(req_get_capabilities_case32),
+        cmocka_unit_test(req_get_capabilities_case33),
+        /* cmocka_unit_test(req_get_capabilities_case34), */
+        cmocka_unit_test(req_get_capabilities_case35),
+        cmocka_unit_test(req_get_capabilities_case36),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -2311,7 +2311,7 @@ static libspdm_return_t receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a LIBSPDM_STATUS_SEND_FAIL, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void libspdm_test_requester_get_certificate_case1(void **state)
+static void req_get_certificate_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2370,7 +2370,7 @@ void libspdm_test_requester_get_certificate_case1(void **state)
  * Test 2: Normal case, request a certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case2(void **state)
+static void req_get_certificate_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2474,7 +2474,7 @@ void libspdm_test_requester_get_certificate_case2(void **state)
  * Test 3: simulate wrong connection_state when sending GET_CERTIFICATE (missing SPDM_GET_DIGESTS_RECEIVE_FLAG and SPDM_GET_CAPABILITIES_RECEIVE_FLAG)
  * Expected Behavior: get a LIBSPDM_STATUS_INVALID_STATE_LOCAL, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void libspdm_test_requester_get_certificate_case3(void **state)
+static void req_get_certificate_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2533,7 +2533,7 @@ void libspdm_test_requester_get_certificate_case3(void **state)
  * Test 4: force responder to send an ERROR message with code SPDM_ERROR_CODE_INVALID_REQUEST
  * Expected Behavior: get a LIBSPDM_STATUS_ERROR_PEER, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void libspdm_test_requester_get_certificate_case4(void **state)
+static void req_get_certificate_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2592,7 +2592,7 @@ void libspdm_test_requester_get_certificate_case4(void **state)
  * Test 5: force responder to send an ERROR message with code SPDM_ERROR_CODE_BUSY
  * Expected Behavior: get a LIBSPDM_STATUS_BUSY_PEER, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void libspdm_test_requester_get_certificate_case5(void **state)
+static void req_get_certificate_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2651,7 +2651,7 @@ void libspdm_test_requester_get_certificate_case5(void **state)
  * Test 6: force responder to first send an ERROR message with code SPDM_ERROR_CODE_BUSY, but functions normally afterwards
  * Expected Behavior: receives the correct number of CERTIFICATE messages
  **/
-void libspdm_test_requester_get_certificate_case6(void **state)
+static void req_get_certificate_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2719,7 +2719,7 @@ void libspdm_test_requester_get_certificate_case6(void **state)
  * Test 7: force responder to send an ERROR message with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  * Expected Behavior: get a LIBSPDM_STATUS_RESYNCH_PEER, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void libspdm_test_requester_get_certificate_case7(void **state)
+static void req_get_certificate_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2780,7 +2780,7 @@ void libspdm_test_requester_get_certificate_case7(void **state)
  * Test 8: force responder to send an ERROR message with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  * Expected Behavior: get a LIBSPDM_STATUS_ERROR_PEER
  **/
-void libspdm_test_requester_get_certificate_case8(void **state)
+static void req_get_certificate_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2836,7 +2836,7 @@ void libspdm_test_requester_get_certificate_case8(void **state)
  * Test 9: force responder to first send an ERROR message with code SPDM_ERROR_CODE_RESPONSE_NOT_READY, but functions normally afterwards
  * Expected Behavior: receives the correct number of CERTIFICATE messages
  **/
-void libspdm_test_requester_get_certificate_case9(void **state)
+static void req_get_certificate_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2901,7 +2901,7 @@ void libspdm_test_requester_get_certificate_case9(void **state)
  * Test 10: Normal case, request a certificate chain. Validates certificate by using a preloaded chain instead of root hash
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case10(void **state)
+static void req_get_certificate_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2969,7 +2969,7 @@ void libspdm_test_requester_get_certificate_case10(void **state)
  * Test 11: Normal procedure, but the retrieved certificate chain has an invalid signature
  * Expected Behavior: get a LIBSPDM_STATUS_VERIF_FAIL, and receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case11(void **state)
+static void req_get_certificate_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3040,7 +3040,7 @@ void libspdm_test_requester_get_certificate_case11(void **state)
  * Test 12: Normal procedure, but the retrieved root certificate does not match
  * Expected Behavior: get a LIBSPDM_STATUS_VERIF_NO_AUTHORITY, and receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case12(void **state)
+static void req_get_certificate_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3117,7 +3117,7 @@ void libspdm_test_requester_get_certificate_case12(void **state)
  * Test 13: Gets a short certificate chain (fits in 1 message)
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case13(void **state)
+static void req_get_certificate_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3194,7 +3194,7 @@ void libspdm_test_requester_get_certificate_case13(void **state)
  * Test 14: request a whole certificate chain byte by byte
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case14(void **state)
+static void req_get_certificate_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3271,7 +3271,7 @@ void libspdm_test_requester_get_certificate_case14(void **state)
  * Test 15: request a long certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case15(void **state)
+static void req_get_certificate_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3350,7 +3350,7 @@ void libspdm_test_requester_get_certificate_case15(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of LIBSPDM_STATUS_ERROR_PEER.
  **/
-void libspdm_test_requester_get_certificate_case16(void **state) {
+static void req_get_certificate_case16(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3419,7 +3419,7 @@ void libspdm_test_requester_get_certificate_case16(void **state) {
  * Test 17: Normal case, get a certificate chain start not with root cert. Validates certificate by using a preloaded chain.
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case17(void **state)
+static void req_get_certificate_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3476,7 +3476,7 @@ void libspdm_test_requester_get_certificate_case17(void **state)
  * Test 18: Fail case, get a certificate chain start not with root cert and with wrong signature. Validates certificate by using a preloaded chain.
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case18(void **state)
+static void req_get_certificate_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3532,7 +3532,7 @@ void libspdm_test_requester_get_certificate_case18(void **state)
  * Test 19: Normal procedure, but one certificate in the retrieved certificate chain past its expiration date.
  * Expected Behavior: get a LIBSPDM_STATUS_VERIF_FAIL, and receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case19(void **state)
+static void req_get_certificate_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3601,7 +3601,7 @@ void libspdm_test_requester_get_certificate_case19(void **state)
  * Test 20: Fail case, request a certificate chain, responder return portion_length is 0.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_get_certificate_case20(void **state)
+static void req_get_certificate_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3661,7 +3661,7 @@ void libspdm_test_requester_get_certificate_case20(void **state)
  * Test 21: Fail case, request a certificate chain, responder return portion_length > spdm_request.length.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_get_certificate_case21(void **state)
+static void req_get_certificate_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3723,7 +3723,7 @@ void libspdm_test_requester_get_certificate_case21(void **state)
  * total_responder_cert_chain_buffer_length.
  * Expected Behavior:returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-void libspdm_test_requester_get_certificate_case22(void **state)
+static void req_get_certificate_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3785,7 +3785,7 @@ void libspdm_test_requester_get_certificate_case22(void **state)
  * Expected Behavior: requester returns the status RETURN_SUCCESS and CERTIFICATE messages are
  * received, buffer B appends the exchanged GET_CERTIFICATE and CERTIFICATE messages.
  **/
-void libspdm_test_requester_get_certificate_case23(void **state)
+static void req_get_certificate_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3858,7 +3858,7 @@ void libspdm_test_requester_get_certificate_case23(void **state)
  * Test 24: test the Alias Cert model, hardware identify OID is found in AliasCert model cert
  * Expected Behavior: return RETURN_SECURITY_VIOLATION
  **/
-void libspdm_test_requester_get_certificate_case24(void **state)
+static void req_get_certificate_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3921,7 +3921,7 @@ void libspdm_test_requester_get_certificate_case24(void **state)
  * Test 25: Normal case, request a certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case25(void **state)
+static void req_get_certificate_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4029,7 +4029,7 @@ void libspdm_test_requester_get_certificate_case25(void **state)
  * Test 26: Normal case, request a certificate chain in a session
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case26(void **state)
+static void req_get_certificate_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4127,7 +4127,7 @@ void libspdm_test_requester_get_certificate_case26(void **state)
  * Test 27: Fail case, responder return wrong SlotID 3, but it should be equal with SlotID 0 in request message.
  * Expected Behavior:returns a status of INVALID_MSG_FIELD.
  **/
-void libspdm_test_requester_get_certificate_case27(void **state)
+static void req_get_certificate_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4192,7 +4192,7 @@ void libspdm_test_requester_get_certificate_case27(void **state)
  * Test 28: Normal case, request a certificate chain. Validates certificate by using a preloaded chain instead of root hash
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case28(void **state)
+static void req_get_certificate_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4261,7 +4261,7 @@ void libspdm_test_requester_get_certificate_case28(void **state)
  * Test 29: Normal case, request a certificate chain. Validates certificate by using a preloaded chain instead of root hash
  * Expected Behavior: receives the correct number of Certificate messages
  **/
-void libspdm_test_requester_get_certificate_case29(void **state)
+static void req_get_certificate_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4322,7 +4322,7 @@ void libspdm_test_requester_get_certificate_case29(void **state)
  * Expected Behavior: CertModel is GenericCert model and slot 0 , returns a status of RETURN_DEVICE_ERROR.
  * Expected Behavior: CertModel Value of 0 and certificate chain is valid, returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_get_certificate_case30(void **state)
+static void req_get_certificate_case30(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4515,7 +4515,7 @@ void libspdm_test_requester_get_certificate_case30(void **state)
  * Test 31: Fail case, input buffer size too small for holding cert chain.
  * Expected Behavior: returns a status of BUFFER_TOO_SMALL.
  **/
-void libspdm_test_requester_get_certificate_case31(void **state)
+static void req_get_certificate_case31(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4603,70 +4603,70 @@ int libspdm_req_get_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case1),
+        cmocka_unit_test(req_get_certificate_case1),
         /* Successful response: check root certificate hash*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case2),
+        cmocka_unit_test(req_get_certificate_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case3),
+        cmocka_unit_test(req_get_certificate_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case4),
+        cmocka_unit_test(req_get_certificate_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case5),
+        cmocka_unit_test(req_get_certificate_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case6),
+        cmocka_unit_test(req_get_certificate_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case7),
+        cmocka_unit_test(req_get_certificate_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case8),
+        cmocka_unit_test(req_get_certificate_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case9),
+        cmocka_unit_test(req_get_certificate_case9),
         /* Successful response: check certificate chain*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case10),
+        cmocka_unit_test(req_get_certificate_case10),
         /* Invalid certificate signature*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case11),
+        cmocka_unit_test(req_get_certificate_case11),
         /* Fail certificate chain check*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case12),
+        cmocka_unit_test(req_get_certificate_case12),
         /* Successful response: get a certificate chain that fits in one single message*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case13),
+        cmocka_unit_test(req_get_certificate_case13),
         /* Successful response: get certificate chain byte by byte*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case14),
+        cmocka_unit_test(req_get_certificate_case14),
         /* Successful response: get a long certificate chain*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case15),
+        cmocka_unit_test(req_get_certificate_case15),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case16),
+        cmocka_unit_test(req_get_certificate_case16),
         /* Successful response: get a certificate chain not start with root cert.*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case17),
+        cmocka_unit_test(req_get_certificate_case17),
         /* Fail response: get a certificate chain not start with root cert but with wrong signature.*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case18),
+        cmocka_unit_test(req_get_certificate_case18),
         /* Fail response: one certificate in the retrieved certificate chain past its expiration date.*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case19),
+        cmocka_unit_test(req_get_certificate_case19),
         /* Fail response: responder return portion_length is 0.*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case20),
+        cmocka_unit_test(req_get_certificate_case20),
         /* Fail response: responder return portion_length > spdm_request.length*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case21),
+        cmocka_unit_test(req_get_certificate_case21),
         /* Fail response: spdm_request.offset + spdm_response->portion_length + spdm_response->remainder_length !=
          * total_responder_cert_chain_buffer_length.*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case22),
+        cmocka_unit_test(req_get_certificate_case22),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case23),
+        cmocka_unit_test(req_get_certificate_case23),
         /* hardware identify OID is found in AliasCert model cert*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case24),
+        cmocka_unit_test(req_get_certificate_case24),
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
         /* GetCert (0), GetCert(1) and Challenge(0) */
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case25),
+        cmocka_unit_test(req_get_certificate_case25),
 #endif
         /* get cert in secure session */
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case26),
+        cmocka_unit_test(req_get_certificate_case26),
         /* Fail response: responder return wrong SlotID 3, not equal with SlotID 0 in request message. */
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case27),
+        cmocka_unit_test(req_get_certificate_case27),
         /*Successful response: get the entire alias_cert model cert_chain*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case28),
+        cmocka_unit_test(req_get_certificate_case28),
         /*Fail response: get the partial alias_cert model cert_chain*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case29),
+        cmocka_unit_test(req_get_certificate_case29),
         /* check request attributes and response attributes*/
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case30),
+        cmocka_unit_test(req_get_certificate_case30),
         /* Fail response: input buffer size too small for holding cert chain */
-        cmocka_unit_test(libspdm_test_requester_get_certificate_case31),
+        cmocka_unit_test(req_get_certificate_case31),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -310,7 +310,7 @@ static libspdm_return_t receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-void libspdm_test_requester_get_csr_case1(void **state)
+static void req_get_csr_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -345,7 +345,7 @@ void libspdm_test_requester_get_csr_case1(void **state)
  * Test 2: Successful response to get csr
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_get_csr_case2(void **state)
+static void req_get_csr_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -380,7 +380,7 @@ void libspdm_test_requester_get_csr_case2(void **state)
  * with a reset required
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_get_csr_case3(void **state)
+static void req_get_csr_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -424,7 +424,7 @@ void libspdm_test_requester_get_csr_case3(void **state)
  * Test 4: Send correct req_info and opaque_data
  * Expected Behavior: get a RETURN_SUCCESS return code and determine if req_info and opaque_data are correct
  **/
-void libspdm_test_requester_get_csr_case4(void **state)
+static void req_get_csr_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -466,7 +466,7 @@ void libspdm_test_requester_get_csr_case4(void **state)
  * with a reset required
  * Expected Behavior: get a LIBSPDM_STATUS_RESET_REQUIRED_PEER return code and available csr_tracking_tag
  **/
-void libspdm_test_requester_get_csr_case5(void **state)
+static void req_get_csr_case5(void **state)
 {
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -505,7 +505,7 @@ void libspdm_test_requester_get_csr_case5(void **state)
  * Expected Behavior: libspdm returns LIBSPDM_STATUS_ERROR_PEER since Responder should
  *                    not produce that error message unless CERT_INSTALL_RESET_CAP is 1.
  **/
-void libspdm_test_requester_get_csr_case6(void **state)
+static void req_get_csr_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -545,7 +545,7 @@ void libspdm_test_requester_get_csr_case6(void **state)
  * Test 7: Illegal combination of MULTI_KEY_CONN_RSP = true and CSRCertModel = 0.
  * Expected Behavior: returns LIBSPDM_STATUS_INVALID_PARAMETER.
  **/
-void libspdm_test_requester_get_csr_case7(void **state)
+static void req_get_csr_case7(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX
     libspdm_return_t status;
@@ -586,18 +586,18 @@ int libspdm_req_get_csr_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_get_csr_case1),
+        cmocka_unit_test(req_get_csr_case1),
         /* Successful response to get csr*/
-        cmocka_unit_test(libspdm_test_requester_get_csr_case2),
+        cmocka_unit_test(req_get_csr_case2),
         /* Successful response to get csr with a reset required */
-        cmocka_unit_test(libspdm_test_requester_get_csr_case3),
+        cmocka_unit_test(req_get_csr_case3),
         /* Send req_info and opaque_data Successful response to get csr */
-        cmocka_unit_test(libspdm_test_requester_get_csr_case4),
+        cmocka_unit_test(req_get_csr_case4),
         /* Successful response to libspdm_get_csr_ex with a reset required */
-        cmocka_unit_test(libspdm_test_requester_get_csr_case5),
+        cmocka_unit_test(req_get_csr_case5),
         /* Illegal ResetRequired error response. */
-        cmocka_unit_test(libspdm_test_requester_get_csr_case6),
-        cmocka_unit_test(libspdm_test_requester_get_csr_case7),
+        cmocka_unit_test(req_get_csr_case6),
+        cmocka_unit_test(req_get_csr_case7),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1189,7 +1189,7 @@ static libspdm_return_t receive_message(
  * Test 1:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case1(void **state)
+static void req_get_digests_case1(void **state)
 {
 }
 
@@ -1197,7 +1197,7 @@ static void libspdm_test_requester_get_digests_case1(void **state)
  * Test 2: a request message is successfully sent and a response message is successfully received
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is received
  **/
-static void libspdm_test_requester_get_digests_case2(void **state)
+static void req_get_digests_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1268,7 +1268,7 @@ static void libspdm_test_requester_get_digests_case2(void **state)
  * Test 3:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case3(void **state)
+static void req_get_digests_case3(void **state)
 {
 }
 
@@ -1276,7 +1276,7 @@ static void libspdm_test_requester_get_digests_case3(void **state)
  * Test 4:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case4(void **state)
+static void req_get_digests_case4(void **state)
 {
 }
 
@@ -1284,7 +1284,7 @@ static void libspdm_test_requester_get_digests_case4(void **state)
  * Test 5:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case5(void **state)
+static void req_get_digests_case5(void **state)
 {
 }
 
@@ -1292,7 +1292,7 @@ static void libspdm_test_requester_get_digests_case5(void **state)
  * Test 6:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case6(void **state)
+static void req_get_digests_case6(void **state)
 {
 }
 
@@ -1300,7 +1300,7 @@ static void libspdm_test_requester_get_digests_case6(void **state)
  * Test 7:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case7(void **state)
+static void req_get_digests_case7(void **state)
 {
 }
 
@@ -1308,7 +1308,7 @@ static void libspdm_test_requester_get_digests_case7(void **state)
  * Test 8:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case8(void **state)
+static void req_get_digests_case8(void **state)
 {
 }
 
@@ -1316,7 +1316,7 @@ static void libspdm_test_requester_get_digests_case8(void **state)
  * Test 9:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case9(void **state)
+static void req_get_digests_case9(void **state)
 {
 }
 
@@ -1324,7 +1324,7 @@ static void libspdm_test_requester_get_digests_case9(void **state)
  * Test 10:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case10(void **state)
+static void req_get_digests_case10(void **state)
 {
 }
 
@@ -1332,7 +1332,7 @@ static void libspdm_test_requester_get_digests_case10(void **state)
  * Test 11:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case11(void **state)
+static void req_get_digests_case11(void **state)
 {
 }
 
@@ -1340,7 +1340,7 @@ static void libspdm_test_requester_get_digests_case11(void **state)
  * Test 12:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case12(void **state)
+static void req_get_digests_case12(void **state)
 {
 }
 
@@ -1348,7 +1348,7 @@ static void libspdm_test_requester_get_digests_case12(void **state)
  * Test 13:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case13(void **state)
+static void req_get_digests_case13(void **state)
 {
 }
 
@@ -1356,7 +1356,7 @@ static void libspdm_test_requester_get_digests_case13(void **state)
  * Test 14:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case14(void **state)
+static void req_get_digests_case14(void **state)
 {
 }
 
@@ -1364,7 +1364,7 @@ static void libspdm_test_requester_get_digests_case14(void **state)
  * Test 15:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case15(void **state)
+static void req_get_digests_case15(void **state)
 {
 }
 
@@ -1372,7 +1372,7 @@ static void libspdm_test_requester_get_digests_case15(void **state)
  * Test 16:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case16(void **state)
+static void req_get_digests_case16(void **state)
 {
 }
 
@@ -1380,7 +1380,7 @@ static void libspdm_test_requester_get_digests_case16(void **state)
  * Test 17:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case17(void **state)
+static void req_get_digests_case17(void **state)
 {
 }
 
@@ -1388,7 +1388,7 @@ static void libspdm_test_requester_get_digests_case17(void **state)
  * Test 18:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case18(void **state)
+static void req_get_digests_case18(void **state)
 {
 }
 
@@ -1396,7 +1396,7 @@ static void libspdm_test_requester_get_digests_case18(void **state)
  * Test 19:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case19(void **state)
+static void req_get_digests_case19(void **state)
 {
 }
 
@@ -1404,7 +1404,7 @@ static void libspdm_test_requester_get_digests_case19(void **state)
  * Test 20:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case20(void **state)
+static void req_get_digests_case20(void **state)
 {
 }
 
@@ -1412,7 +1412,7 @@ static void libspdm_test_requester_get_digests_case20(void **state)
  * Test 21:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_digests_case21(void **state)
+static void req_get_digests_case21(void **state)
 {
 }
 
@@ -1420,7 +1420,7 @@ static void libspdm_test_requester_get_digests_case21(void **state)
  * Test 22:
  * Expected behavior:.
  **/
-static void libspdm_test_requester_get_digests_case22(void **state)
+static void req_get_digests_case22(void **state)
 {
 }
 
@@ -1430,7 +1430,7 @@ static void libspdm_test_requester_get_digests_case22(void **state)
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is
  * received, buffer B appends the exchanged GET_DIGESTS and DIGESTS messages.
  **/
-static void libspdm_test_requester_get_digests_case23(void **state)
+static void req_get_digests_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1473,7 +1473,7 @@ static void libspdm_test_requester_get_digests_case23(void **state)
  * Test 24: Test case for GetDigest, GetCert and GetDigest
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a second GetDigest can be sent.
  **/
-static void libspdm_test_requester_get_digests_case24(void **state)
+static void req_get_digests_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1633,7 +1633,7 @@ static void libspdm_test_requester_get_digests_case24(void **state)
  * in a session.
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is received
  **/
-static void libspdm_test_requester_get_digests_case25(void **state)
+static void req_get_digests_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1727,7 +1727,7 @@ static void libspdm_test_requester_get_digests_case25(void **state)
  * Set multi_key_conn_rsp to check if it responds correctly
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS
  **/
-static void libspdm_test_requester_get_digests_case26(void **state)
+static void req_get_digests_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1781,7 +1781,7 @@ static void libspdm_test_requester_get_digests_case26(void **state)
  * Set multi_key_conn_rsp to check if it responds correctly
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS
  **/
-static void libspdm_test_requester_get_digests_case27(void **state)
+static void req_get_digests_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1877,7 +1877,7 @@ static void libspdm_test_requester_get_digests_case27(void **state)
  * Set KeyUsageMask to 0 and Set CertificateInfo to SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT(GenericCert model)
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_INVALID_MSG_FIELD
  **/
-static void libspdm_test_requester_get_digests_case28(void **state)
+static void req_get_digests_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1932,7 +1932,7 @@ static void libspdm_test_requester_get_digests_case28(void **state)
  * MULTI_KEY_CONN_REQ or MULTI_KEY_CONN_RSP is false.
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_INVALID_MSG_FIELD
  **/
-static void libspdm_test_requester_get_digests_case29(void **state)
+static void req_get_digests_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1977,35 +1977,35 @@ static void libspdm_test_requester_get_digests_case29(void **state)
 int libspdm_req_get_digests_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_get_digests_case1),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case2),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case3),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case4),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case5),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case6),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case7),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case8),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case9),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case10),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case11),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case12),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case13),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case14),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case15),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case16),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case17),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case18),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case19),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case20),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case21),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case22),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case23),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case24),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case25),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case26),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case27),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case28),
-        cmocka_unit_test(libspdm_test_requester_get_digests_case29),
+        cmocka_unit_test(req_get_digests_case1),
+        cmocka_unit_test(req_get_digests_case2),
+        cmocka_unit_test(req_get_digests_case3),
+        cmocka_unit_test(req_get_digests_case4),
+        cmocka_unit_test(req_get_digests_case5),
+        cmocka_unit_test(req_get_digests_case6),
+        cmocka_unit_test(req_get_digests_case7),
+        cmocka_unit_test(req_get_digests_case8),
+        cmocka_unit_test(req_get_digests_case9),
+        cmocka_unit_test(req_get_digests_case10),
+        cmocka_unit_test(req_get_digests_case11),
+        cmocka_unit_test(req_get_digests_case12),
+        cmocka_unit_test(req_get_digests_case13),
+        cmocka_unit_test(req_get_digests_case14),
+        cmocka_unit_test(req_get_digests_case15),
+        cmocka_unit_test(req_get_digests_case16),
+        cmocka_unit_test(req_get_digests_case17),
+        cmocka_unit_test(req_get_digests_case18),
+        cmocka_unit_test(req_get_digests_case19),
+        cmocka_unit_test(req_get_digests_case20),
+        cmocka_unit_test(req_get_digests_case21),
+        cmocka_unit_test(req_get_digests_case22),
+        cmocka_unit_test(req_get_digests_case23),
+        cmocka_unit_test(req_get_digests_case24),
+        cmocka_unit_test(req_get_digests_case25),
+        cmocka_unit_test(req_get_digests_case26),
+        cmocka_unit_test(req_get_digests_case27),
+        cmocka_unit_test(req_get_digests_case28),
+        cmocka_unit_test(req_get_digests_case29),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_endpoint_info.c
+++ b/unit_test/test_spdm_requester/get_endpoint_info.c
@@ -643,7 +643,7 @@ static libspdm_return_t receive_message(
  * Test 1: Successful response to get a endpoint info with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case1(void **state)
+static void req_get_endpoint_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -740,7 +740,7 @@ static void libspdm_test_requester_get_endpoint_info_case1(void **state)
  *         after getting SPDM_ERROR_CODE_BUSY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case2(void **state)
+static void req_get_endpoint_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -838,7 +838,7 @@ static void libspdm_test_requester_get_endpoint_info_case2(void **state)
  *         after getting SPDM_ERROR_CODE_RESPONSE_NOT_READY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case3(void **state)
+static void req_get_endpoint_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -939,7 +939,7 @@ static void libspdm_test_requester_get_endpoint_info_case3(void **state)
  * Test 4: Successful response to get a endpoint info with signature with slot_id = 1
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case4(void **state)
+static void req_get_endpoint_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1036,7 +1036,7 @@ static void libspdm_test_requester_get_endpoint_info_case4(void **state)
  *         Using provisioned public key (slot_id = 0xF)
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case5(void **state)
+static void req_get_endpoint_info_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1111,7 +1111,7 @@ static void libspdm_test_requester_get_endpoint_info_case5(void **state)
  * Test 6: Successful response to get a endpoint info without signature
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-static void libspdm_test_requester_get_endpoint_info_case6(void **state)
+static void req_get_endpoint_info_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1150,7 +1150,7 @@ static void libspdm_test_requester_get_endpoint_info_case6(void **state)
  * Test 7: Successful response to get a session based endpoint info with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_e
  **/
-static void libspdm_test_requester_get_endpoint_info_case7(void **state)
+static void req_get_endpoint_info_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1273,13 +1273,13 @@ static void libspdm_test_requester_get_endpoint_info_case7(void **state)
 int libspdm_req_get_endpoint_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case1),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case2),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case3),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case4),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case5),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case6),
-        cmocka_unit_test(libspdm_test_requester_get_endpoint_info_case7),
+        cmocka_unit_test(req_get_endpoint_info_case1),
+        cmocka_unit_test(req_get_endpoint_info_case2),
+        cmocka_unit_test(req_get_endpoint_info_case3),
+        cmocka_unit_test(req_get_endpoint_info_case4),
+        cmocka_unit_test(req_get_endpoint_info_case5),
+        cmocka_unit_test(req_get_endpoint_info_case6),
+        cmocka_unit_test(req_get_endpoint_info_case7),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_key_pair_info.c
+++ b/unit_test/test_spdm_requester/get_key_pair_info.c
@@ -148,7 +148,7 @@ static libspdm_return_t receive_message(
  * Test 1: Successful response to get key pair info
  * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
-void libspdm_test_requester_get_key_pair_info_case1(void **state)
+static void req_get_key_pair_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -200,7 +200,7 @@ void libspdm_test_requester_get_key_pair_info_case1(void **state)
 /**
  * Test 2: The collection of multiple sub-cases.
  **/
-void libspdm_test_requester_get_key_pair_info_case3(void **state)
+void req_get_key_pair_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -580,7 +580,8 @@ int libspdm_req_get_key_pair_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Successful response to get key pair info, key_pair_id is 1*/
-        cmocka_unit_test(libspdm_test_requester_get_key_pair_info_case1),
+        cmocka_unit_test(req_get_key_pair_info_case1),
+        /* cmocka_unit_test(req_get_key_pair_info_case2) */
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_measurement_extension_log.c
+++ b/unit_test/test_spdm_requester/get_measurement_extension_log.c
@@ -670,7 +670,7 @@ static libspdm_return_t receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a LIBSPDM_STATUS_SEND_FAIL, with no MEL messages received
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case1(void **state)
+static void req_get_measurement_extension_log_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -713,7 +713,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case1(void **st
  * Test 2: Normal case, request a MEL, the MEL size remains unchanged
  * Expected Behavior: receives a valid MEL
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case2(void **state)
+static void req_get_measurement_extension_log_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -757,7 +757,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case2(void **st
  * The original MEL number is 3, the new MEL number is 4.
  * Expected Behavior: receives a valid MEL, and the MEL size is same with the before MEL size.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case3(void **state)
+static void req_get_measurement_extension_log_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -802,7 +802,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case3(void **st
  * The original MEL number is 100, the new MEL number is 105.
  * Expected Behavior: receives a valid MEL, and the MEL size is same with the before MEL size.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case4(void **state)
+static void req_get_measurement_extension_log_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -846,7 +846,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case4(void **st
  * The original MEL number is 100, the new MEL number is 200.
  * Expected Behavior: receives a valid MEL, and the MEL size is same with the before MEL size.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case5(void **state)
+static void req_get_measurement_extension_log_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -889,7 +889,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case5(void **st
  * Test 6: Normal case, request a LIBSPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE MEL
  * Expected Behavior: receives a valid MEL
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case6(void **state)
+static void req_get_measurement_extension_log_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -937,7 +937,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case6(void **st
  * Test 7: The total amount of messages actually sent by the responder is less than the negotiated total mel len.
  * Expected Behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case7(void **state)
+static void req_get_measurement_extension_log_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -981,7 +981,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case7(void **st
  * Test 8: Portion_length is greater than the LIBSPDM_MAX_MEL_BLOCK_LEN
  * Expected Behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case8(void **state)
+static void req_get_measurement_extension_log_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1025,7 +1025,7 @@ static void libspdm_test_requester_get_measurement_extension_log_case8(void **st
  * Test 9: The total MEL length is larger than SPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE
  * Expected Behavior: returns with status LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-static void libspdm_test_requester_get_measurement_extension_log_case9(void **state)
+static void req_get_measurement_extension_log_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1069,23 +1069,23 @@ int libspdm_req_get_measurement_extension_log_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case1),
+        cmocka_unit_test(req_get_measurement_extension_log_case1),
         /* Successful response, the MEL size remains unchanged*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case2),
+        cmocka_unit_test(req_get_measurement_extension_log_case2),
         /* Successful response, the MEL size become more bigger when get MEL. MEL number change from 3 to 4*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case3),
+        cmocka_unit_test(req_get_measurement_extension_log_case3),
         /* Successful response, the MEL size become more bigger when get MEL. MEL number change from 100 to 105*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case4),
+        cmocka_unit_test(req_get_measurement_extension_log_case4),
         /* Successful response, the MEL size become more bigger when get MEL. MEL number change from 100 to 200*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case5),
+        cmocka_unit_test(req_get_measurement_extension_log_case5),
         /* Successful response , LIBSPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case6),
+        cmocka_unit_test(req_get_measurement_extension_log_case6),
         /* Failed response , The total amount of messages actually sent by the responder is less than the negotiated total mel len*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case7),
+        cmocka_unit_test(req_get_measurement_extension_log_case7),
         /* Failed response , Portion_length is greater than the LIBSPDM_MAX_MEL_BLOCK_LEN*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case8),
+        cmocka_unit_test(req_get_measurement_extension_log_case8),
         /* Failed response , The total MEL length is larger than SPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE*/
-        cmocka_unit_test(libspdm_test_requester_get_measurement_extension_log_case9),
+        cmocka_unit_test(req_get_measurement_extension_log_case9),
 
     };
 

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -3291,7 +3291,7 @@ static libspdm_return_t receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case1(void **state)
+static void req_get_measurements_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3369,7 +3369,7 @@ static void libspdm_test_requester_get_measurements_case1(void **state)
  * Test 2: Successful response to get a measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case2(void **state)
+static void req_get_measurements_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3451,7 +3451,7 @@ static void libspdm_test_requester_get_measurements_case2(void **state)
  * Test 3: Exercise the libspdm_get_measurement_ex function.
  * Expected Behavior: Requester uses requester_nonce_in and returns responder_nonce.
  **/
-static void libspdm_test_requester_get_measurements_case3(void **state)
+static void req_get_measurements_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3547,7 +3547,7 @@ static void libspdm_test_requester_get_measurements_case3(void **state)
  * Test 4: Error case, always get an error response with code SPDM_ERROR_CODE_INVALID_REQUEST
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case4(void **state)
+static void req_get_measurements_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3625,7 +3625,7 @@ static void libspdm_test_requester_get_measurements_case4(void **state)
  * Test 5: Error case, always get an error response with code SPDM_ERROR_CODE_BUSY
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case5(void **state)
+static void req_get_measurements_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3703,7 +3703,7 @@ static void libspdm_test_requester_get_measurements_case5(void **state)
  * Test 6: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_BUSY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case6(void **state)
+static void req_get_measurements_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3782,7 +3782,7 @@ static void libspdm_test_requester_get_measurements_case6(void **state)
  * Test 7: Error case, get an error response with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case7(void **state)
+static void req_get_measurements_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3862,7 +3862,7 @@ static void libspdm_test_requester_get_measurements_case7(void **state)
  * Test 8: Error case, always get an error response with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case8(void **state)
+static void req_get_measurements_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3937,7 +3937,7 @@ static void libspdm_test_requester_get_measurements_case8(void **state)
  * Test 9: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_RESPONSE_NOT_READY on first attempt
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case9(void **state)
+static void req_get_measurements_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4013,7 +4013,7 @@ static void libspdm_test_requester_get_measurements_case9(void **state)
  * Test 10: Successful response to get total number of measurements, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct number_of_blocks, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case10(void **state)
+static void req_get_measurements_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4091,7 +4091,7 @@ static void libspdm_test_requester_get_measurements_case10(void **state)
  * Test 11: Successful response to get a measurement block, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case11(void **state)
+static void req_get_measurements_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4174,7 +4174,7 @@ static void libspdm_test_requester_get_measurements_case11(void **state)
  * Test 12: Error case, signature is invalid (all bytes are 0)
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION return code
  **/
-static void libspdm_test_requester_get_measurements_case12(void **state)
+static void req_get_measurements_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4253,7 +4253,7 @@ static void libspdm_test_requester_get_measurements_case12(void **state)
  * Test 13: Error case, signature is invalid (random)
  * Expected Behavior: get a RETURN_SECURITY_VIOLATION return code
  **/
-static void libspdm_test_requester_get_measurements_case13(void **state)
+static void req_get_measurements_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4332,7 +4332,7 @@ static void libspdm_test_requester_get_measurements_case13(void **state)
  * Test 14: Error case, request a signed response, but response is malformed (signature absent)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-static void libspdm_test_requester_get_measurements_case14(void **state)
+static void req_get_measurements_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4411,7 +4411,7 @@ static void libspdm_test_requester_get_measurements_case14(void **state)
  * Test 15: Error case, response with wrong response code
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-static void libspdm_test_requester_get_measurements_case15(void **state)
+static void req_get_measurements_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4490,7 +4490,7 @@ static void libspdm_test_requester_get_measurements_case15(void **state)
  * Test 16: SlotID verificaton, the response's SlotID should match the request
  * Expected Behavior: get a RETURN_SUCCESS return code if the fields match, RETURN_DEVICE_ERROR otherwise. Either way, transcript.message_m should be empty
  **/
-static void libspdm_test_requester_get_measurements_case16(void **state)
+static void req_get_measurements_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4585,7 +4585,7 @@ static void libspdm_test_requester_get_measurements_case16(void **state)
  * Test 17: Error case, response to get total number of measurements, but response number_of_blocks and/or measurement_record_length are non 0
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-static void libspdm_test_requester_get_measurements_case17(void **state)
+static void req_get_measurements_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4666,7 +4666,7 @@ static void libspdm_test_requester_get_measurements_case17(void **state)
  * Test 18:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_measurements_case18(void **state)
+static void req_get_measurements_case18(void **state)
 {
 }
 
@@ -4674,7 +4674,7 @@ static void libspdm_test_requester_get_measurements_case18(void **state)
  * Test 19: Error case, measurement_specification field in response has 2 bits set (bit 0 is one of them)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-static void libspdm_test_requester_get_measurements_case19(void **state)
+static void req_get_measurements_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4752,7 +4752,7 @@ static void libspdm_test_requester_get_measurements_case19(void **state)
  * Test 20: Error case, measurement_specification field in response has 2 bits set (bit 0 is not one of them)
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-static void libspdm_test_requester_get_measurements_case20(void **state)
+static void req_get_measurements_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4830,7 +4830,7 @@ static void libspdm_test_requester_get_measurements_case20(void **state)
  * Test 21: Error case, measurement_specification field in response does not "match the selected measurement specification in the ALGORITHMS message"
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code,
  **/
-static void libspdm_test_requester_get_measurements_case21(void **state)
+static void req_get_measurements_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4908,7 +4908,7 @@ static void libspdm_test_requester_get_measurements_case21(void **state)
  * Test 22: request a large number of unsigned measurements before requesting a signature
  * Expected Behavior: RETURN_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
  **/
-static void libspdm_test_requester_get_measurements_case22(void **state)
+static void req_get_measurements_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5010,7 +5010,7 @@ static void libspdm_test_requester_get_measurements_case22(void **state)
  * Test 23: Successful response to get a measurement block, without signature. response contains opaque data
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case23(void **state)
+static void req_get_measurements_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5095,7 +5095,7 @@ static void libspdm_test_requester_get_measurements_case23(void **state)
  * Test 24: Error case, response contains opaque data larger than the maximum allowed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case24(void **state)
+static void req_get_measurements_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5174,7 +5174,7 @@ static void libspdm_test_requester_get_measurements_case24(void **state)
  * Test 25: Successful response to get a measurement block, with signature. response contains opaque data
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case25(void **state)
+static void req_get_measurements_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5253,7 +5253,7 @@ static void libspdm_test_requester_get_measurements_case25(void **state)
  * Test 26: Error case, request with signature, but response opaque data is S bytes shorter than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case26(void **state)
+static void req_get_measurements_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5333,7 +5333,7 @@ static void libspdm_test_requester_get_measurements_case26(void **state)
  * Test 27: Error case, request with signature, but response opaque data is (S+1) bytes shorter than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case27(void **state)
+static void req_get_measurements_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5413,7 +5413,7 @@ static void libspdm_test_requester_get_measurements_case27(void **state)
  * Test 28: Error case, request with signature, but response opaque data is 1 byte longer than informed
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case28(void **state)
+static void req_get_measurements_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5496,7 +5496,7 @@ static void libspdm_test_requester_get_measurements_case28(void **state)
  * Test 29: request measurement without signature, but response opaque data is 1 byte longer than informed
  * Expected Behavior: extra byte should just be ignored. Get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case29(void **state)
+static void req_get_measurements_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5582,7 +5582,7 @@ static void libspdm_test_requester_get_measurements_case29(void **state)
  * Test 30:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_measurements_case30(void **state)
+static void req_get_measurements_case30(void **state)
 {
 }
 
@@ -5590,7 +5590,7 @@ static void libspdm_test_requester_get_measurements_case30(void **state)
  * Test 31:
  * Expected Behavior:
  **/
-static void libspdm_test_requester_get_measurements_case31(void **state)
+static void req_get_measurements_case31(void **state)
 {
 }
 
@@ -5598,7 +5598,7 @@ static void libspdm_test_requester_get_measurements_case31(void **state)
  * Test 32: Successful response to get all measurement blocks, without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
-static void libspdm_test_requester_get_measurements_case32(void **state)
+static void req_get_measurements_case32(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5686,7 +5686,7 @@ static void libspdm_test_requester_get_measurements_case32(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-static void libspdm_test_requester_get_measurements_case33(void **state) {
+static void req_get_measurements_case33(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -5773,7 +5773,7 @@ static void libspdm_test_requester_get_measurements_case33(void **state) {
  * Test 34: Successful response to get a session based measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
  **/
-static void libspdm_test_requester_get_measurements_case34(void **state)
+static void req_get_measurements_case34(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5877,7 +5877,7 @@ static void libspdm_test_requester_get_measurements_case34(void **state)
  *
  * Note that this test is only exercised when LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT is enabled.
  **/
-static void libspdm_test_requester_get_measurements_case35(void **state)
+static void req_get_measurements_case35(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5964,7 +5964,7 @@ static void libspdm_test_requester_get_measurements_case35(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_get_measurements_case36(void **state)
+static void req_get_measurements_case36(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6038,7 +6038,7 @@ static void libspdm_test_requester_get_measurements_case36(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_get_measurements_case37(void **state)
+static void req_get_measurements_case37(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6112,7 +6112,7 @@ static void libspdm_test_requester_get_measurements_case37(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_get_measurements_case38(void **state)
+static void req_get_measurements_case38(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6168,7 +6168,7 @@ static void libspdm_test_requester_get_measurements_case38(void **state)
  * Test 39: Exercise the libspdm_get_measurement_ex function.
  * Expected Behavior: client returns a status of RETURN_SUCCESS.
  **/
-static void libspdm_test_requester_get_measurements_case39(void **state)
+static void req_get_measurements_case39(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6266,7 +6266,7 @@ static void libspdm_test_requester_get_measurements_case39(void **state)
  * Test 40: Successful case , correct measuerments context field , without signature
  * Expected Behavior: client returns a status of RETURN_SUCCESS.
  **/
-static void libspdm_test_requester_get_measurements_case40(void **state)
+static void req_get_measurements_case40(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6353,7 +6353,7 @@ static void libspdm_test_requester_get_measurements_case40(void **state)
  * Test 41: Error case , Measurement context fields are inconsistent , without signature
  * Expected Behavior: get a LIBSPDM_STATUS_INVALID_MSG_FIELD return code
  **/
-static void libspdm_test_requester_get_measurements_case41(void **state)
+static void req_get_measurements_case41(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6434,47 +6434,47 @@ static void libspdm_test_requester_get_measurements_case41(void **state)
 int libspdm_req_get_measurements_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case1),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case2),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case3),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case4),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case5),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case6),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case7),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case8),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case9),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case10),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case11),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case12),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case13),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case14),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case15),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case16),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case17),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case18),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case19),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case20),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case21),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case22),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case23),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case24),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case25),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case26),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case27),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case28),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case29),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case30),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case31),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case32),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case33),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case34),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case35),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case36),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case37),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case38),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case39),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case40),
-        cmocka_unit_test(libspdm_test_requester_get_measurements_case41),
+        cmocka_unit_test(req_get_measurements_case1),
+        cmocka_unit_test(req_get_measurements_case2),
+        cmocka_unit_test(req_get_measurements_case3),
+        cmocka_unit_test(req_get_measurements_case4),
+        cmocka_unit_test(req_get_measurements_case5),
+        cmocka_unit_test(req_get_measurements_case6),
+        cmocka_unit_test(req_get_measurements_case7),
+        cmocka_unit_test(req_get_measurements_case8),
+        cmocka_unit_test(req_get_measurements_case9),
+        cmocka_unit_test(req_get_measurements_case10),
+        cmocka_unit_test(req_get_measurements_case11),
+        cmocka_unit_test(req_get_measurements_case12),
+        cmocka_unit_test(req_get_measurements_case13),
+        cmocka_unit_test(req_get_measurements_case14),
+        cmocka_unit_test(req_get_measurements_case15),
+        cmocka_unit_test(req_get_measurements_case16),
+        cmocka_unit_test(req_get_measurements_case17),
+        cmocka_unit_test(req_get_measurements_case18),
+        cmocka_unit_test(req_get_measurements_case19),
+        cmocka_unit_test(req_get_measurements_case20),
+        cmocka_unit_test(req_get_measurements_case21),
+        cmocka_unit_test(req_get_measurements_case22),
+        cmocka_unit_test(req_get_measurements_case23),
+        cmocka_unit_test(req_get_measurements_case24),
+        cmocka_unit_test(req_get_measurements_case25),
+        cmocka_unit_test(req_get_measurements_case26),
+        cmocka_unit_test(req_get_measurements_case27),
+        cmocka_unit_test(req_get_measurements_case28),
+        cmocka_unit_test(req_get_measurements_case29),
+        cmocka_unit_test(req_get_measurements_case30),
+        cmocka_unit_test(req_get_measurements_case31),
+        cmocka_unit_test(req_get_measurements_case32),
+        cmocka_unit_test(req_get_measurements_case33),
+        cmocka_unit_test(req_get_measurements_case34),
+        cmocka_unit_test(req_get_measurements_case35),
+        cmocka_unit_test(req_get_measurements_case36),
+        cmocka_unit_test(req_get_measurements_case37),
+        cmocka_unit_test(req_get_measurements_case38),
+        cmocka_unit_test(req_get_measurements_case39),
+        cmocka_unit_test(req_get_measurements_case40),
+        cmocka_unit_test(req_get_measurements_case41),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_supported_event_types.c
+++ b/unit_test/test_spdm_requester/get_supported_event_types.c
@@ -158,7 +158,7 @@ static libspdm_return_t receive_message(
  * Test 1: Successful response to get supported event types.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS with the expected values.
  **/
-static void libspdm_test_requester_get_event_types_case1(void **state)
+static void req_get_supported_event_types_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -184,7 +184,7 @@ static void libspdm_test_requester_get_event_types_case1(void **state)
 int libspdm_req_get_supported_event_types_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_get_event_types_case1)
+        cmocka_unit_test(req_get_supported_event_types_case1)
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -533,7 +533,7 @@ static libspdm_return_t receive_message(
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case1(void **state)
+ * static void req_get_version_case1(void **state)
  * {
  * }
  */
@@ -542,7 +542,7 @@ static libspdm_return_t receive_message(
  * Test 2: receiving a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
-static void libspdm_test_requester_get_version_case2(void **state)
+static void req_get_version_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -561,7 +561,7 @@ static void libspdm_test_requester_get_version_case2(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case3(void **state)
+ * static void req_get_version_case3(void **state)
  * {
  * }
  */
@@ -571,7 +571,7 @@ static void libspdm_test_requester_get_version_case2(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case4(void **state)
+ * static void req_get_version_case4(void **state)
  * {
  * }
  */
@@ -581,7 +581,7 @@ static void libspdm_test_requester_get_version_case2(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case5(void **state)
+ * static void req_get_version_case5(void **state)
  * {
  * }
  */
@@ -591,7 +591,7 @@ static void libspdm_test_requester_get_version_case2(void **state)
  * a correct VERSION message with available version 1.0 and 1.1.
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
-static void libspdm_test_requester_get_version_case6(void **state)
+static void req_get_version_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -611,7 +611,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case7(void **state)
+ * static void req_get_version_case7(void **state)
  * {
  * }
  */
@@ -621,7 +621,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case8(void **state)
+ * static void req_get_version_case8(void **state)
  * {
  * }
  */
@@ -631,7 +631,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case9(void **state)
+ * static void req_get_version_case9(void **state)
  * {
  * }
  */
@@ -643,7 +643,7 @@ static void libspdm_test_requester_get_version_case6(void **state)
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS, but truncate the message
  * to consider only the two first versions, as indicated in the message.
  **/
-static void libspdm_test_requester_get_version_case10(void **state)
+static void req_get_version_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -662,7 +662,7 @@ static void libspdm_test_requester_get_version_case10(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case11(void **state)
+ * static void req_get_version_case11(void **state)
  * {
  * }
  */
@@ -672,7 +672,7 @@ static void libspdm_test_requester_get_version_case10(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case12(void **state)
+ * static void req_get_version_case12(void **state)
  * {
  * }
  */
@@ -682,7 +682,7 @@ static void libspdm_test_requester_get_version_case10(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case13(void **state)
+ * static void req_get_version_case13(void **state)
  * {
  * }
  */
@@ -692,7 +692,7 @@ static void libspdm_test_requester_get_version_case10(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case14(void **state)
+ * static void req_get_version_case14(void **state)
  * {
  * }
  */
@@ -703,7 +703,7 @@ static void libspdm_test_requester_get_version_case10(void **state)
  * Responder list:4.2, 5.2, 1.2, 1.1, 1.0
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and right negotiated version 1.1.
  **/
-static void libspdm_test_requester_get_version_case15(void **state)
+static void req_get_version_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -730,7 +730,7 @@ static void libspdm_test_requester_get_version_case15(void **state)
  * should be first reset, and then buffer A receives only the exchanged GET_VERSION
  * and VERSION messages.
  **/
-static void libspdm_test_requester_get_version_case16(void **state)
+static void req_get_version_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -770,7 +770,7 @@ static void libspdm_test_requester_get_version_case16(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case17(void **state)
+ * static void req_get_version_case17(void **state)
  * {
  * }
  */
@@ -780,7 +780,7 @@ static void libspdm_test_requester_get_version_case16(void **state)
  **/
 
 /*
- * static void libspdm_test_requester_get_version_case18(void **state)
+ * static void req_get_version_case18(void **state)
  * {
  * }
  */
@@ -788,24 +788,24 @@ static void libspdm_test_requester_get_version_case16(void **state)
 int libspdm_req_get_version_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case1), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case2),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case3),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case4),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case5), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case6),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case7),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case8),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case9), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case10),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case11),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case12),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case13),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case14), */
-        cmocka_unit_test(libspdm_test_requester_get_version_case15),
-        cmocka_unit_test(libspdm_test_requester_get_version_case16),
-        /* cmocka_unit_test(libspdm_test_requester_get_version_case17),
-         * cmocka_unit_test(libspdm_test_requester_get_version_case18), */
+        /* cmocka_unit_test(req_get_version_case1), */
+        cmocka_unit_test(req_get_version_case2),
+        /* cmocka_unit_test(req_get_version_case3),
+         * cmocka_unit_test(req_get_version_case4),
+         * cmocka_unit_test(req_get_version_case5), */
+        cmocka_unit_test(req_get_version_case6),
+        /* cmocka_unit_test(req_get_version_case7),
+         * cmocka_unit_test(req_get_version_case8),
+         * cmocka_unit_test(req_get_version_case9), */
+        cmocka_unit_test(req_get_version_case10),
+        /* cmocka_unit_test(req_get_version_case11),
+         * cmocka_unit_test(req_get_version_case12),
+         * cmocka_unit_test(req_get_version_case13),
+         * cmocka_unit_test(req_get_version_case14), */
+        cmocka_unit_test(req_get_version_case15),
+        cmocka_unit_test(req_get_version_case16),
+        /* cmocka_unit_test(req_get_version_case17),
+         * cmocka_unit_test(req_get_version_case18), */
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/heartbeat.c
+++ b/unit_test/test_spdm_requester/heartbeat.c
@@ -672,7 +672,7 @@ static libspdm_return_t receive_message(
     }
 }
 
-void libspdm_test_requester_heartbeat_case1(void **state)
+static void req_heartbeat_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -738,7 +738,7 @@ void libspdm_test_requester_heartbeat_case1(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case2(void **state)
+static void req_heartbeat_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -827,7 +827,7 @@ void libspdm_test_requester_heartbeat_case2(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case3(void **state)
+static void req_heartbeat_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -915,7 +915,7 @@ void libspdm_test_requester_heartbeat_case3(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case4(void **state)
+static void req_heartbeat_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1004,7 +1004,7 @@ void libspdm_test_requester_heartbeat_case4(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case5(void **state)
+static void req_heartbeat_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1093,7 +1093,7 @@ void libspdm_test_requester_heartbeat_case5(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case6(void **state)
+static void req_heartbeat_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1183,7 +1183,7 @@ void libspdm_test_requester_heartbeat_case6(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case7(void **state)
+static void req_heartbeat_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1274,7 +1274,7 @@ void libspdm_test_requester_heartbeat_case7(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case8(void **state)
+static void req_heartbeat_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1363,7 +1363,7 @@ void libspdm_test_requester_heartbeat_case8(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case9(void **state)
+static void req_heartbeat_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1456,7 +1456,7 @@ void libspdm_test_requester_heartbeat_case9(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case10(void **state) {
+static void req_heartbeat_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1548,7 +1548,7 @@ void libspdm_test_requester_heartbeat_case10(void **state) {
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case11(void **state)
+static void req_heartbeat_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1660,7 +1660,7 @@ void libspdm_test_requester_heartbeat_case11(void **state)
  * Test 12: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void libspdm_test_requester_heartbeat_case12(void **state)
+static void req_heartbeat_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1751,7 +1751,7 @@ void libspdm_test_requester_heartbeat_case12(void **state)
     free(data);
 }
 
-void libspdm_test_requester_heartbeat_case13(void **state)
+static void req_heartbeat_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1831,30 +1831,30 @@ int libspdm_req_heartbeat_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case1),
+        cmocka_unit_test(req_heartbeat_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case2),
+        cmocka_unit_test(req_heartbeat_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case3),
+        cmocka_unit_test(req_heartbeat_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case4),
+        cmocka_unit_test(req_heartbeat_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case5),
+        cmocka_unit_test(req_heartbeat_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case6),
+        cmocka_unit_test(req_heartbeat_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case7),
+        cmocka_unit_test(req_heartbeat_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case8),
+        cmocka_unit_test(req_heartbeat_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case9),
+        cmocka_unit_test(req_heartbeat_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case10),
+        cmocka_unit_test(req_heartbeat_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case11),
+        cmocka_unit_test(req_heartbeat_case11),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case12),
-        cmocka_unit_test(libspdm_test_requester_heartbeat_case13),
+        cmocka_unit_test(req_heartbeat_case12),
+        cmocka_unit_test(req_heartbeat_case13),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/key_exchange.c
+++ b/unit_test/test_spdm_requester/key_exchange.c
@@ -5247,7 +5247,7 @@ static libspdm_return_t receive_message(
     }
 }
 
-static void libspdm_test_requester_key_exchange_case1(void **state)
+static void req_key_exchange_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5320,7 +5320,7 @@ static void libspdm_test_requester_key_exchange_case1(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case2(void **state)
+static void req_key_exchange_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5401,7 +5401,7 @@ static void libspdm_test_requester_key_exchange_case2(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case3(void **state)
+static void req_key_exchange_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5474,7 +5474,7 @@ static void libspdm_test_requester_key_exchange_case3(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case4(void **state)
+static void req_key_exchange_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5547,7 +5547,7 @@ static void libspdm_test_requester_key_exchange_case4(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case5(void **state)
+static void req_key_exchange_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5620,7 +5620,7 @@ static void libspdm_test_requester_key_exchange_case5(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case6(void **state)
+static void req_key_exchange_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5699,7 +5699,7 @@ static void libspdm_test_requester_key_exchange_case6(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case7(void **state)
+static void req_key_exchange_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5774,7 +5774,7 @@ static void libspdm_test_requester_key_exchange_case7(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case8(void **state)
+static void req_key_exchange_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5847,7 +5847,7 @@ static void libspdm_test_requester_key_exchange_case8(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case9(void **state)
+static void req_key_exchange_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5930,7 +5930,7 @@ static void libspdm_test_requester_key_exchange_case9(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case10(void **state) {
+static void req_key_exchange_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -6009,7 +6009,7 @@ static void libspdm_test_requester_key_exchange_case10(void **state) {
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case11(void **state)
+static void req_key_exchange_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6106,7 +6106,7 @@ static void libspdm_test_requester_key_exchange_case11(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case12(void **state)
+static void req_key_exchange_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6196,7 +6196,7 @@ static void libspdm_test_requester_key_exchange_case12(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case13(void **state)
+static void req_key_exchange_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6286,7 +6286,7 @@ static void libspdm_test_requester_key_exchange_case13(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case14(void **state)
+static void req_key_exchange_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6376,7 +6376,7 @@ static void libspdm_test_requester_key_exchange_case14(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case15(void **state)
+static void req_key_exchange_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6457,7 +6457,7 @@ static void libspdm_test_requester_key_exchange_case15(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case16(void **state)
+static void req_key_exchange_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6538,7 +6538,7 @@ static void libspdm_test_requester_key_exchange_case16(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case17(void **state)
+static void req_key_exchange_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6619,7 +6619,7 @@ static void libspdm_test_requester_key_exchange_case17(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case18(void **state)
+static void req_key_exchange_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6700,7 +6700,7 @@ static void libspdm_test_requester_key_exchange_case18(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case19(void **state)
+static void req_key_exchange_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6791,7 +6791,7 @@ static void libspdm_test_requester_key_exchange_case19(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case20(void **state)
+static void req_key_exchange_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6873,7 +6873,7 @@ static void libspdm_test_requester_key_exchange_case20(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case21(void **state)
+static void req_key_exchange_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -6971,7 +6971,7 @@ static void libspdm_test_requester_key_exchange_case21(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case22(void **state)
+static void req_key_exchange_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7071,7 +7071,7 @@ static void libspdm_test_requester_key_exchange_case22(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case23(void **state)
+static void req_key_exchange_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7171,7 +7171,7 @@ static void libspdm_test_requester_key_exchange_case23(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case24(void **state)
+static void req_key_exchange_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7270,7 +7270,7 @@ static void libspdm_test_requester_key_exchange_case24(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case25(void **state)
+static void req_key_exchange_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7374,7 +7374,7 @@ static void libspdm_test_requester_key_exchange_case25(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case26(void **state)
+static void req_key_exchange_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7466,7 +7466,7 @@ static void libspdm_test_requester_key_exchange_case26(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case27(void **state)
+static void req_key_exchange_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7558,7 +7558,7 @@ static void libspdm_test_requester_key_exchange_case27(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case28(void **state)
+static void req_key_exchange_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7650,7 +7650,7 @@ static void libspdm_test_requester_key_exchange_case28(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case29(void **state)
+static void req_key_exchange_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7740,7 +7740,7 @@ static void libspdm_test_requester_key_exchange_case29(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case30(void **state)
+static void req_key_exchange_case30(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7828,7 +7828,7 @@ static void libspdm_test_requester_key_exchange_case30(void **state)
  * Expected Behavior: requester_random_in is sent to Responder and correct responder_random is
  *                    returned to Requester.
  **/
-static void libspdm_test_requester_key_exchange_case31(void **state)
+static void req_key_exchange_case31(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -7935,7 +7935,7 @@ static void libspdm_test_requester_key_exchange_case31(void **state)
     free(data);
 }
 
-void libspdm_test_requester_key_exchange_case32(void **state)
+void req_key_exchange_case32(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -8001,7 +8001,7 @@ void libspdm_test_requester_key_exchange_case32(void **state)
     free(data);
 }
 
-static void libspdm_test_requester_key_exchange_case33(void **state)
+static void req_key_exchange_case33(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -8095,7 +8095,7 @@ static void libspdm_test_requester_key_exchange_case33(void **state)
  *          little-endian as 277 1.2 only supports little-endian.
  * Expected Behavior: A successful key exchange with the session's endianness set to little-endian.
  **/
-static void libspdm_test_requester_key_exchange_case34(void **state)
+static void req_key_exchange_case34(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -8186,71 +8186,71 @@ int libspdm_req_key_exchange_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case1),
+        cmocka_unit_test(req_key_exchange_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case2),
+        cmocka_unit_test(req_key_exchange_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case3),
+        cmocka_unit_test(req_key_exchange_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case4),
+        cmocka_unit_test(req_key_exchange_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case5),
+        cmocka_unit_test(req_key_exchange_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case6),
+        cmocka_unit_test(req_key_exchange_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case7),
+        cmocka_unit_test(req_key_exchange_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case8),
+        cmocka_unit_test(req_key_exchange_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case9),
+        cmocka_unit_test(req_key_exchange_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case10),
+        cmocka_unit_test(req_key_exchange_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case11),
+        cmocka_unit_test(req_key_exchange_case11),
         /* Measurement hash 1, returns a measurement hash*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case12),
+        cmocka_unit_test(req_key_exchange_case12),
         /* Measurement hash 1, returns a 0x00 array (no TCB components)*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case13),
+        cmocka_unit_test(req_key_exchange_case13),
         /* Measurement hash FF, returns a measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case14),
+        cmocka_unit_test(req_key_exchange_case14),
         /* Measurement hash 1, returns no measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case15),
+        cmocka_unit_test(req_key_exchange_case15),
         /* Measurement hash FF, returns no measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case16),
+        cmocka_unit_test(req_key_exchange_case16),
         /* Measurement hash not requested, returns a measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case17),
+        cmocka_unit_test(req_key_exchange_case17),
         /* Wrong signature*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case18),
+        cmocka_unit_test(req_key_exchange_case18),
         /* Requester and Responder Handshake in the clear set, no ResponderVerifyData*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case19),
+        cmocka_unit_test(req_key_exchange_case19),
         /* Heartbeat not supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case20),
+        cmocka_unit_test(req_key_exchange_case20),
         /* Heartbeat supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case21),
+        cmocka_unit_test(req_key_exchange_case21),
         /* Heartbeat supported, heartbeat period 0 sent NOTE: This should disable heartbeat*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case22),
+        cmocka_unit_test(req_key_exchange_case22),
         /* Muth Auth requested*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case23),
+        cmocka_unit_test(req_key_exchange_case23),
         /* Muth Auth requested with Encapsulated request*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case24),
+        cmocka_unit_test(req_key_exchange_case24),
         /* Muth Auth requested with implicit get digest*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case25),
+        cmocka_unit_test(req_key_exchange_case25),
         /* Muth Auth requested with Encapsulated request and bit 0 set*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case26),
+        cmocka_unit_test(req_key_exchange_case26),
         /* Muth Auth requested with implicit get digest and bit 0 set*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case27),
+        cmocka_unit_test(req_key_exchange_case27),
         /* Muth Auth requested with Encapsulated request and Muth Auth requested with implicit get digest simultaneously*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case28),
+        cmocka_unit_test(req_key_exchange_case28),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case29),
+        cmocka_unit_test(req_key_exchange_case29),
         /* Successful response V1.2*/
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case30),
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case31),
+        cmocka_unit_test(req_key_exchange_case30),
+        cmocka_unit_test(req_key_exchange_case31),
         /* Successful response using provisioned public key (slot_id 0xFF) */
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case32),
+        cmocka_unit_test(req_key_exchange_case32),
         /* OpaqueData only supports OpaqueDataFmt1, Success Case */
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case33),
-        cmocka_unit_test(libspdm_test_requester_key_exchange_case34),
+        cmocka_unit_test(req_key_exchange_case33),
+        cmocka_unit_test(req_key_exchange_case34),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -3590,7 +3590,7 @@ static libspdm_return_t receive_message(
  * returns a device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_key_update_case1(void **state)
+static void req_key_update_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3629,7 +3629,7 @@ void libspdm_test_requester_key_update_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void libspdm_test_requester_key_update_case2(void **state)
+static void req_key_update_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3685,7 +3685,7 @@ void libspdm_test_requester_key_update_case2(void **state)
  * GET_CAPABILITIES and NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_key_update_case3(void **state)
+static void req_key_update_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3728,7 +3728,7 @@ void libspdm_test_requester_key_update_case3(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case4(void **state)
+static void req_key_update_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3779,7 +3779,7 @@ void libspdm_test_requester_key_update_case4(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case5(void **state)
+static void req_key_update_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3832,7 +3832,7 @@ void libspdm_test_requester_key_update_case5(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void libspdm_test_requester_key_update_case6(void **state)
+static void req_key_update_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3891,7 +3891,7 @@ void libspdm_test_requester_key_update_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_key_update_case7(void **state)
+static void req_key_update_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3933,7 +3933,7 @@ void libspdm_test_requester_key_update_case7(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case8(void **state)
+static void req_key_update_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -3986,7 +3986,7 @@ void libspdm_test_requester_key_update_case8(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
-void libspdm_test_requester_key_update_case9(void **state)
+static void req_key_update_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4049,7 +4049,7 @@ void libspdm_test_requester_key_update_case9(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case10(void **state)
+static void req_key_update_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4116,7 +4116,7 @@ void libspdm_test_requester_key_update_case10(void **state)
     }
 }
 
-void libspdm_test_requester_key_update_case11(void **state)
+static void req_key_update_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4193,7 +4193,7 @@ void libspdm_test_requester_key_update_case11(void **state)
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED,
  * and no keys are updated.
  **/
-void libspdm_test_requester_key_update_case12(void **state)
+static void req_key_update_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4250,7 +4250,7 @@ void libspdm_test_requester_key_update_case12(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR,
  * no keys are updated.
  **/
-void libspdm_test_requester_key_update_case13(void **state)
+static void req_key_update_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4302,7 +4302,7 @@ void libspdm_test_requester_key_update_case13(void **state)
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED,
  * and no keys are updated.
  **/
-void libspdm_test_requester_key_update_case14(void **state)
+static void req_key_update_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4359,7 +4359,7 @@ void libspdm_test_requester_key_update_case14(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case15(void **state)
+static void req_key_update_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4411,7 +4411,7 @@ void libspdm_test_requester_key_update_case15(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case16(void **state)
+static void req_key_update_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4462,7 +4462,7 @@ void libspdm_test_requester_key_update_case16(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case17(void **state)
+static void req_key_update_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4518,7 +4518,7 @@ void libspdm_test_requester_key_update_case17(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case18(void **state)
+static void req_key_update_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4577,7 +4577,7 @@ void libspdm_test_requester_key_update_case18(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case19(void **state)
+static void req_key_update_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4636,7 +4636,7 @@ void libspdm_test_requester_key_update_case19(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_key_update_case20(void **state)
+static void req_key_update_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4678,7 +4678,7 @@ void libspdm_test_requester_key_update_case20(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case21(void **state)
+static void req_key_update_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4736,7 +4736,7 @@ void libspdm_test_requester_key_update_case21(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case22(void **state)
+static void req_key_update_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4800,7 +4800,7 @@ void libspdm_test_requester_key_update_case22(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case23(void **state)
+static void req_key_update_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4879,7 +4879,7 @@ void libspdm_test_requester_key_update_case23(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case24(void **state)
+static void req_key_update_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4937,7 +4937,7 @@ void libspdm_test_requester_key_update_case24(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case25(void **state)
+static void req_key_update_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -4995,7 +4995,7 @@ void libspdm_test_requester_key_update_case25(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, the
  * request data key is not rollbacked.
  **/
-void libspdm_test_requester_key_update_case26(void **state)
+static void req_key_update_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5052,7 +5052,7 @@ void libspdm_test_requester_key_update_case26(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void libspdm_test_requester_key_update_case27(void **state)
+static void req_key_update_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5114,7 +5114,7 @@ void libspdm_test_requester_key_update_case27(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case28(void **state)
+static void req_key_update_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5181,7 +5181,7 @@ void libspdm_test_requester_key_update_case28(void **state)
  * Expected behavior: client returns a Status of RETURN_NO_RESPONSE, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case29(void **state)
+static void req_key_update_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5249,7 +5249,7 @@ void libspdm_test_requester_key_update_case29(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void libspdm_test_requester_key_update_case30(void **state)
+static void req_key_update_case30(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5328,7 +5328,7 @@ void libspdm_test_requester_key_update_case30(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_key_update_case31(void **state)
+static void req_key_update_case31(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5385,7 +5385,7 @@ void libspdm_test_requester_key_update_case31(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case32(void **state)
+static void req_key_update_case32(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5453,7 +5453,7 @@ void libspdm_test_requester_key_update_case32(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS, and
  * the request data key and response data key are updated.
  **/
-void libspdm_test_requester_key_update_case33(void **state)
+static void req_key_update_case33(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5536,7 +5536,7 @@ void libspdm_test_requester_key_update_case33(void **state)
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR, and
  * no keys should be updated.
  **/
-void libspdm_test_requester_key_update_case34(void **state)
+static void req_key_update_case34(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5622,7 +5622,7 @@ void libspdm_test_requester_key_update_case34(void **state)
  * Test 35: the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void libspdm_test_requester_key_update_case35(void **state)
+static void req_key_update_case35(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -5660,74 +5660,74 @@ int libspdm_req_key_update_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case1),
+        cmocka_unit_test(req_key_update_case1),
         /* update single key
          * Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case2),
+        cmocka_unit_test(req_key_update_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case3),
+        cmocka_unit_test(req_key_update_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case4),
+        cmocka_unit_test(req_key_update_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case5),
+        cmocka_unit_test(req_key_update_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case6),
+        cmocka_unit_test(req_key_update_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case7),
+        cmocka_unit_test(req_key_update_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case8),
+        cmocka_unit_test(req_key_update_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case9),
+        cmocka_unit_test(req_key_update_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case10),
+        cmocka_unit_test(req_key_update_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case11),
+        cmocka_unit_test(req_key_update_case11),
         /* No correct setup*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case12),
-        cmocka_unit_test(libspdm_test_requester_key_update_case13),
-        cmocka_unit_test(libspdm_test_requester_key_update_case14),
+        cmocka_unit_test(req_key_update_case12),
+        cmocka_unit_test(req_key_update_case13),
+        cmocka_unit_test(req_key_update_case14),
         /* Wrong parameters*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case15),
-        cmocka_unit_test(libspdm_test_requester_key_update_case16),
+        cmocka_unit_test(req_key_update_case15),
+        cmocka_unit_test(req_key_update_case16),
         /* verify key
          * Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case17),
+        cmocka_unit_test(req_key_update_case17),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case18),
+        cmocka_unit_test(req_key_update_case18),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case19),
+        cmocka_unit_test(req_key_update_case19),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case20),
+        cmocka_unit_test(req_key_update_case20),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case21),
+        cmocka_unit_test(req_key_update_case21),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case22),
+        cmocka_unit_test(req_key_update_case22),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case23),
+        cmocka_unit_test(req_key_update_case23),
         /* No correct setup*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case24),
+        cmocka_unit_test(req_key_update_case24),
         /* Wrong parameters*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case25),
-        cmocka_unit_test(libspdm_test_requester_key_update_case26),
+        cmocka_unit_test(req_key_update_case25),
+        cmocka_unit_test(req_key_update_case26),
         /* update all keys
          * Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case27),
+        cmocka_unit_test(req_key_update_case27),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case28),
+        cmocka_unit_test(req_key_update_case28),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case29),
+        cmocka_unit_test(req_key_update_case29),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case30),
+        cmocka_unit_test(req_key_update_case30),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case31),
+        cmocka_unit_test(req_key_update_case31),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case32),
+        cmocka_unit_test(req_key_update_case32),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case33),
+        cmocka_unit_test(req_key_update_case33),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case34),
+        cmocka_unit_test(req_key_update_case34),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(libspdm_test_requester_key_update_case35),
+        cmocka_unit_test(req_key_update_case35),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -1419,11 +1419,11 @@ static libspdm_return_t receive_message(
     }
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case1(void **state)
+static void req_negotiate_algorithms_case1(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case2(void **state)
+static void req_negotiate_algorithms_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1477,7 +1477,7 @@ static void libspdm_test_requester_negotiate_algorithms_case2(void **state)
  * | Not set  | 0                          | 0                           | LIBSPDM_STATUS_SUCCESS            |
  *  ----------------------------------------------------------------------------------------------------------
  **/
-static void libspdm_test_requester_negotiate_algorithms_case3(void **state)
+static void req_negotiate_algorithms_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1562,15 +1562,15 @@ static void libspdm_test_requester_negotiate_algorithms_case3(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case4(void **state)
+static void req_negotiate_algorithms_case4(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case5(void **state)
+static void req_negotiate_algorithms_case5(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case6(void **state)
+static void req_negotiate_algorithms_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1601,72 +1601,72 @@ static void libspdm_test_requester_negotiate_algorithms_case6(void **state)
 #endif
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case7(void **state)
+static void req_negotiate_algorithms_case7(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case8(void **state)
+static void req_negotiate_algorithms_case8(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case9(void **state)
+static void req_negotiate_algorithms_case9(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case10(void **state)
+static void req_negotiate_algorithms_case10(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case11(void **state)
+static void req_negotiate_algorithms_case11(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case12(void **state)
+static void req_negotiate_algorithms_case12(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case13(void **state)
+static void req_negotiate_algorithms_case13(void **state)
 {
 
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case14(void **state)
+static void req_negotiate_algorithms_case14(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case15(void **state)
+static void req_negotiate_algorithms_case15(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case16(void **state)
+static void req_negotiate_algorithms_case16(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case17(void **state)
+static void req_negotiate_algorithms_case17(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case18(void **state)
+static void req_negotiate_algorithms_case18(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case19(void **state)
+static void req_negotiate_algorithms_case19(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case20(void **state)
+static void req_negotiate_algorithms_case20(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case21(void **state)
+static void req_negotiate_algorithms_case21(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case22(void **state)
+static void req_negotiate_algorithms_case22(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case23(void **state)
+static void req_negotiate_algorithms_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1720,39 +1720,39 @@ static void libspdm_test_requester_negotiate_algorithms_case23(void **state)
 #endif
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case24(void **state)
+static void req_negotiate_algorithms_case24(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case25(void **state)
+static void req_negotiate_algorithms_case25(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case26(void **state)
+static void req_negotiate_algorithms_case26(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case27(void **state)
+static void req_negotiate_algorithms_case27(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case28(void **state)
+static void req_negotiate_algorithms_case28(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case29(void **state)
+static void req_negotiate_algorithms_case29(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case30(void **state)
+static void req_negotiate_algorithms_case30(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case31(void **state)
+static void req_negotiate_algorithms_case31(void **state)
 {
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case32(void **state) {
+static void req_negotiate_algorithms_case32(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -1825,7 +1825,7 @@ static void libspdm_test_requester_negotiate_algorithms_case32(void **state) {
 #endif
 }
 
-static void libspdm_test_requester_negotiate_algorithms_case33(void **state) {
+static void req_negotiate_algorithms_case33(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1897,7 +1897,7 @@ static void libspdm_test_requester_negotiate_algorithms_case33(void **state) {
 }
 
 
-static void libspdm_test_requester_negotiate_algorithms_case34(void **state)
+static void req_negotiate_algorithms_case34(void **state)
 {
 }
 
@@ -1933,7 +1933,7 @@ static void libspdm_test_requester_negotiate_algorithms_case34(void **state)
  * | 10b           | 1                        | true               |
  *  ----------------------------------------------------------------
  **/
-static void libspdm_test_requester_negotiate_algorithms_case35(void **state)
+static void req_negotiate_algorithms_case35(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2064,7 +2064,7 @@ static void libspdm_test_requester_negotiate_algorithms_case35(void **state)
  * | Not set  | 0                          | 0                           | LIBSPDM_STATUS_SUCCESS            |
  *  ----------------------------------------------------------------------------------------------------------
  **/
-static void libspdm_test_requester_negotiate_algorithms_case36(void **state)
+static void req_negotiate_algorithms_case36(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2179,42 +2179,42 @@ static void libspdm_test_requester_negotiate_algorithms_case36(void **state)
 int libspdm_req_negotiate_algorithms_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case1),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case2),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case3),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case4),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case5),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case6),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case7),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case8),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case9),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case10),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case11),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case12),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case13),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case14),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case15),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case16),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case17),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case18),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case19),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case20),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case21),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case22),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case23),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case24),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case25),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case26),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case27),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case28),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case29),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case30),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case31),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case32),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case33),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case34),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case35),
-        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_case36),
+        cmocka_unit_test(req_negotiate_algorithms_case1),
+        cmocka_unit_test(req_negotiate_algorithms_case2),
+        cmocka_unit_test(req_negotiate_algorithms_case3),
+        cmocka_unit_test(req_negotiate_algorithms_case4),
+        cmocka_unit_test(req_negotiate_algorithms_case5),
+        cmocka_unit_test(req_negotiate_algorithms_case6),
+        cmocka_unit_test(req_negotiate_algorithms_case7),
+        cmocka_unit_test(req_negotiate_algorithms_case8),
+        cmocka_unit_test(req_negotiate_algorithms_case9),
+        cmocka_unit_test(req_negotiate_algorithms_case10),
+        cmocka_unit_test(req_negotiate_algorithms_case11),
+        cmocka_unit_test(req_negotiate_algorithms_case12),
+        cmocka_unit_test(req_negotiate_algorithms_case13),
+        cmocka_unit_test(req_negotiate_algorithms_case14),
+        cmocka_unit_test(req_negotiate_algorithms_case15),
+        cmocka_unit_test(req_negotiate_algorithms_case16),
+        cmocka_unit_test(req_negotiate_algorithms_case17),
+        cmocka_unit_test(req_negotiate_algorithms_case18),
+        cmocka_unit_test(req_negotiate_algorithms_case19),
+        cmocka_unit_test(req_negotiate_algorithms_case20),
+        cmocka_unit_test(req_negotiate_algorithms_case21),
+        cmocka_unit_test(req_negotiate_algorithms_case22),
+        cmocka_unit_test(req_negotiate_algorithms_case23),
+        cmocka_unit_test(req_negotiate_algorithms_case24),
+        cmocka_unit_test(req_negotiate_algorithms_case25),
+        cmocka_unit_test(req_negotiate_algorithms_case26),
+        cmocka_unit_test(req_negotiate_algorithms_case27),
+        cmocka_unit_test(req_negotiate_algorithms_case28),
+        cmocka_unit_test(req_negotiate_algorithms_case29),
+        cmocka_unit_test(req_negotiate_algorithms_case30),
+        cmocka_unit_test(req_negotiate_algorithms_case31),
+        cmocka_unit_test(req_negotiate_algorithms_case32),
+        cmocka_unit_test(req_negotiate_algorithms_case33),
+        cmocka_unit_test(req_negotiate_algorithms_case34),
+        cmocka_unit_test(req_negotiate_algorithms_case35),
+        cmocka_unit_test(req_negotiate_algorithms_case36),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/psk_exchange.c
+++ b/unit_test/test_spdm_requester/psk_exchange.c
@@ -3107,7 +3107,7 @@ static libspdm_return_t receive_message(
     }
 }
 
-void libspdm_test_requester_psk_exchange_case1(void **state)
+static void req_psk_exchange_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3167,7 +3167,7 @@ void libspdm_test_requester_psk_exchange_case1(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case2(void **state)
+static void req_psk_exchange_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3234,7 +3234,7 @@ void libspdm_test_requester_psk_exchange_case2(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case3(void **state)
+static void req_psk_exchange_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3293,7 +3293,7 @@ void libspdm_test_requester_psk_exchange_case3(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case4(void **state)
+static void req_psk_exchange_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3352,7 +3352,7 @@ void libspdm_test_requester_psk_exchange_case4(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case5(void **state)
+static void req_psk_exchange_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3411,7 +3411,7 @@ void libspdm_test_requester_psk_exchange_case5(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case6(void **state)
+static void req_psk_exchange_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3476,7 +3476,7 @@ void libspdm_test_requester_psk_exchange_case6(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case7(void **state)
+static void req_psk_exchange_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3537,7 +3537,7 @@ void libspdm_test_requester_psk_exchange_case7(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case8(void **state)
+static void req_psk_exchange_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3596,7 +3596,7 @@ void libspdm_test_requester_psk_exchange_case8(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case9(void **state)
+static void req_psk_exchange_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3666,7 +3666,7 @@ void libspdm_test_requester_psk_exchange_case9(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case10(void **state) {
+static void req_psk_exchange_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -3735,7 +3735,7 @@ void libspdm_test_requester_psk_exchange_case10(void **state) {
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case11(void **state)
+static void req_psk_exchange_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3803,7 +3803,7 @@ void libspdm_test_requester_psk_exchange_case11(void **state)
         SPDM_PSK_EXCHANGE_REQUEST_NO_MEASUREMENT_SUMMARY_HASH, 0, &session_id,
         &heartbeat_period, measurement_hash);
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
-    assert_int_equal(session_id, 0xFFFFFFFF);
+    assert_int_equal(session_id, 0xfffcfffc);
     assert_int_equal(
         libspdm_secured_message_get_session_state(
             spdm_context->session_info[0].secured_message_context),
@@ -3819,7 +3819,7 @@ void libspdm_test_requester_psk_exchange_case11(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case12(void **state)
+static void req_psk_exchange_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3894,7 +3894,7 @@ void libspdm_test_requester_psk_exchange_case12(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case13(void **state)
+static void req_psk_exchange_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3965,7 +3965,7 @@ void libspdm_test_requester_psk_exchange_case13(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case14(void **state)
+static void req_psk_exchange_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4049,7 +4049,7 @@ void libspdm_test_requester_psk_exchange_case14(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case15(void **state)
+static void req_psk_exchange_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4133,7 +4133,7 @@ void libspdm_test_requester_psk_exchange_case15(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case16(void **state)
+static void req_psk_exchange_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4218,7 +4218,7 @@ void libspdm_test_requester_psk_exchange_case16(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case17(void **state)
+static void req_psk_exchange_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4294,7 +4294,7 @@ void libspdm_test_requester_psk_exchange_case17(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case18(void **state)
+static void req_psk_exchange_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4370,7 +4370,7 @@ void libspdm_test_requester_psk_exchange_case18(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case19(void **state)
+static void req_psk_exchange_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4446,7 +4446,7 @@ void libspdm_test_requester_psk_exchange_case19(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case20(void **state)
+static void req_psk_exchange_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4523,7 +4523,7 @@ void libspdm_test_requester_psk_exchange_case20(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case21(void **state)
+static void req_psk_exchange_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4617,7 +4617,7 @@ void libspdm_test_requester_psk_exchange_case21(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case22(void **state)
+static void req_psk_exchange_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4713,7 +4713,7 @@ void libspdm_test_requester_psk_exchange_case22(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case23(void **state)
+static void req_psk_exchange_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4780,7 +4780,7 @@ void libspdm_test_requester_psk_exchange_case23(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case24(void **state)
+static void req_psk_exchange_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4852,7 +4852,7 @@ void libspdm_test_requester_psk_exchange_case24(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case25(void **state)
+static void req_psk_exchange_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4924,7 +4924,7 @@ void libspdm_test_requester_psk_exchange_case25(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case26(void **state)
+static void req_psk_exchange_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -4996,7 +4996,7 @@ void libspdm_test_requester_psk_exchange_case26(void **state)
     free(data);
 }
 
-void libspdm_test_requester_psk_exchange_case27(void **state)
+static void req_psk_exchange_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -5076,57 +5076,58 @@ int libspdm_req_psk_exchange_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case1),
+        cmocka_unit_test(req_psk_exchange_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case2),
+        cmocka_unit_test(req_psk_exchange_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case3),
+        cmocka_unit_test(req_psk_exchange_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case4),
+        cmocka_unit_test(req_psk_exchange_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case5),
+        cmocka_unit_test(req_psk_exchange_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case6),
+        cmocka_unit_test(req_psk_exchange_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case7),
+        cmocka_unit_test(req_psk_exchange_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case8),
+        cmocka_unit_test(req_psk_exchange_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case9),
+        cmocka_unit_test(req_psk_exchange_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case10),
+        cmocka_unit_test(req_psk_exchange_case10),
+        cmocka_unit_test(req_psk_exchange_case11),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case12),
+        cmocka_unit_test(req_psk_exchange_case12),
         /* Successful response V1.2*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case13),
+        cmocka_unit_test(req_psk_exchange_case13),
         /* Measurement hash 1, returns a measurement hash*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case14),
+        cmocka_unit_test(req_psk_exchange_case14),
         /* Measurement hash 1, returns a 0x00 array (no TCB components)*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case15),
+        cmocka_unit_test(req_psk_exchange_case15),
         /* Measurement hash FF, returns a measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case16),
+        cmocka_unit_test(req_psk_exchange_case16),
         /* Measurement hash 1, returns no measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case17),
+        cmocka_unit_test(req_psk_exchange_case17),
         /* Measurement hash FF, returns no measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case18),
+        cmocka_unit_test(req_psk_exchange_case18),
         /* Measurement hash not requested, returns a measurement_hash*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case19),
+        cmocka_unit_test(req_psk_exchange_case19),
         /* Heartbeat not supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case20),
+        cmocka_unit_test(req_psk_exchange_case20),
         /* Heartbeat supported, heartbeat period different from 0 sent*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case21),
+        cmocka_unit_test(req_psk_exchange_case21),
         /* Heartbeat supported, heartbeat period 0 sent NOTE: This should disable heartbeat*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case22),
+        cmocka_unit_test(req_psk_exchange_case22),
         /* Wrong ResponderVerifyData*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case23),
+        cmocka_unit_test(req_psk_exchange_case23),
         /* No ResponderContext*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case24),
+        cmocka_unit_test(req_psk_exchange_case24),
         /* No OpaqueData*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case25),
+        cmocka_unit_test(req_psk_exchange_case25),
         /* No ResponderContext and OpaqueData*/
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case26),
+        cmocka_unit_test(req_psk_exchange_case26),
         /* OpaqueData only supports OpaqueDataFmt1, Success Case */
-        cmocka_unit_test(libspdm_test_requester_psk_exchange_case27),
+        cmocka_unit_test(req_psk_exchange_case27),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -962,7 +962,7 @@ static libspdm_return_t receive_message(
  * a device error.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case1(void **state)
+static void req_psk_finish_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1036,7 +1036,7 @@ void libspdm_test_requester_psk_finish_case1(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and
  * session is established.
  **/
-void libspdm_test_requester_psk_finish_case2(void **state)
+static void req_psk_finish_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1137,7 +1137,7 @@ void libspdm_test_requester_psk_finish_case2(void **state)
  * GET_CAPABILITIES and NEGOTIATE_ALGORITHMS had not been exchanged.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_psk_finish_case3(void **state)
+static void req_psk_finish_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1234,7 +1234,7 @@ void libspdm_test_requester_psk_finish_case3(void **state)
  * indicating InvalidParameters.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case4(void **state)
+static void req_psk_finish_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1332,7 +1332,7 @@ void libspdm_test_requester_psk_finish_case4(void **state)
  * indicating the Busy status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case5(void **state)
+static void req_psk_finish_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1431,7 +1431,7 @@ void libspdm_test_requester_psk_finish_case5(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and session
  * is established.
  **/
-void libspdm_test_requester_psk_finish_case6(void **state)
+static void req_psk_finish_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1534,7 +1534,7 @@ void libspdm_test_requester_psk_finish_case6(void **state)
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR, and the
  * communication is reset to expect a new GET_VERSION message.
  **/
-void libspdm_test_requester_psk_finish_case7(void **state)
+static void req_psk_finish_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1633,7 +1633,7 @@ void libspdm_test_requester_psk_finish_case7(void **state)
  * indicating the ResponseNotReady status of the responder.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case8(void **state)
+static void req_psk_finish_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1732,7 +1732,7 @@ void libspdm_test_requester_psk_finish_case8(void **state)
  * Expected behavior: client returns a Status of RETURN_SUCCESS and session
  * is established.
  **/
-void libspdm_test_requester_psk_finish_case9(void **state)
+static void req_psk_finish_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1841,7 +1841,7 @@ void libspdm_test_requester_psk_finish_case9(void **state)
  * Busy (0x03), ResponseNotReady (0x42), and RequestResync (0x43).
  * Expected behavior: client returns a status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case10(void **state) {
+static void req_psk_finish_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1935,7 +1935,7 @@ void libspdm_test_requester_psk_finish_case10(void **state) {
     free(data);
 }
 
-void libspdm_test_requester_psk_finish_case11(void **state)
+static void req_psk_finish_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2058,7 +2058,7 @@ void libspdm_test_requester_psk_finish_case11(void **state)
  * PSK_FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_psk_finish_case12(void **state)
+static void req_psk_finish_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2156,7 +2156,7 @@ void libspdm_test_requester_psk_finish_case12(void **state)
  * code, but all other field correct.
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR.
  **/
-void libspdm_test_requester_psk_finish_case13(void **state)
+static void req_psk_finish_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2255,7 +2255,7 @@ void libspdm_test_requester_psk_finish_case13(void **state)
  * return a correct PSK_FINISH_RSP message.
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED.
  **/
-void libspdm_test_requester_psk_finish_case14(void **state)
+static void req_psk_finish_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2352,7 +2352,7 @@ void libspdm_test_requester_psk_finish_case14(void **state)
  * Test 15 the requester is setup correctly, but receives an ERROR with SPDM_ERROR_CODE_DECRYPT_ERROR.
  * Expected behavior: client returns a Status of INVALID_SESSION_ID  and free the session ID.
  **/
-void libspdm_test_requester_psk_finish_case15(void **state)
+static void req_psk_finish_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2450,7 +2450,7 @@ void libspdm_test_requester_psk_finish_case15(void **state)
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a PSK_FINISH_RSP message is
  * received, buffer F appends the exchanged PSK_FINISH and PSK_FINISH_RSP messages.
  **/
-void libspdm_test_requester_psk_finish_case16(void **state)
+static void req_psk_finish_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2553,7 +2553,7 @@ void libspdm_test_requester_psk_finish_case16(void **state)
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a PSK_FINISH_RSP message is
  * received.
  **/
-void libspdm_test_requester_psk_finish_case17(void **state)
+static void req_psk_finish_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2638,39 +2638,39 @@ int libspdm_req_psk_finish_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case1),
+        cmocka_unit_test(req_psk_finish_case1),
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case2),
+        cmocka_unit_test(req_psk_finish_case2),
         /* connection_state check failed*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case3),
+        cmocka_unit_test(req_psk_finish_case3),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case4),
+        cmocka_unit_test(req_psk_finish_case4),
         /* Always SPDM_ERROR_CODE_BUSY*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case5),
+        cmocka_unit_test(req_psk_finish_case5),
         /* SPDM_ERROR_CODE_BUSY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case6),
+        cmocka_unit_test(req_psk_finish_case6),
         /* Error response: SPDM_ERROR_CODE_REQUEST_RESYNCH*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case7),
+        cmocka_unit_test(req_psk_finish_case7),
         /* Always SPDM_ERROR_CODE_RESPONSE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case8),
+        cmocka_unit_test(req_psk_finish_case8),
         /* SPDM_ERROR_CODE_RESPONSE_NOT_READY + Successful response*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case9),
+        cmocka_unit_test(req_psk_finish_case9),
         /* Unexpected errors*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case10),
+        cmocka_unit_test(req_psk_finish_case10),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case11),
+        cmocka_unit_test(req_psk_finish_case11),
         /* No correct setup*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case12),
+        cmocka_unit_test(req_psk_finish_case12),
         /* Wrong response code*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case13),
+        cmocka_unit_test(req_psk_finish_case13),
         /* Uninitialized session*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case14),
+        cmocka_unit_test(req_psk_finish_case14),
         /* Error response: SPDM_ERROR_CODE_DECRYPT_ERROR*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case15),
+        cmocka_unit_test(req_psk_finish_case15),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case16),
+        cmocka_unit_test(req_psk_finish_case16),
         /* SPDM 1.4 with OpaqueData */
-        cmocka_unit_test(libspdm_test_requester_psk_finish_case17),
+        cmocka_unit_test(req_psk_finish_case17),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -313,7 +313,7 @@ static libspdm_return_t receive_message(
  * Test 1: message could not be sent
  * Expected Behavior: get a RETURN_DEVICE_ERROR return code
  **/
-void libspdm_test_requester_set_certificate_case1(void **state)
+static void req_set_certificate_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -347,7 +347,7 @@ void libspdm_test_requester_set_certificate_case1(void **state)
  * Test 2: Successful response to set certificate for slot 0
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_set_certificate_case2(void **state)
+static void req_set_certificate_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -381,7 +381,7 @@ void libspdm_test_requester_set_certificate_case2(void **state)
  * Test 3: Unsuccessful response to set certificate for slot 0, because cert_chain is NULL.
  * Expected Behavior: get a LIBSPDM_STATUS_INVALID_PARAMETER return code
  **/
-void libspdm_test_requester_set_certificate_case3(void **state)
+static void req_set_certificate_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -407,7 +407,7 @@ void libspdm_test_requester_set_certificate_case3(void **state)
  * Test 5: Successful response to set certificate for slot 1 in secure session
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_set_certificate_case5(void **state)
+static void req_set_certificate_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -466,7 +466,7 @@ void libspdm_test_requester_set_certificate_case5(void **state)
  * Test 6: Successful response to set certificate for slot 0 with a reset required
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_set_certificate_case6(void **state)
+static void req_set_certificate_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -501,7 +501,7 @@ void libspdm_test_requester_set_certificate_case6(void **state)
  * Test 7: Successful response to erase certificate for slot 0
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_set_certificate_case7(void **state)
+static void req_set_certificate_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -528,7 +528,7 @@ void libspdm_test_requester_set_certificate_case7(void **state)
  * Test 8: Illegal combination of MULTI_KEY_CONN_RSP = true, Erase = false, and SetCertModel = 0.
  * Expected Behavior: function returns LIBSPDM_STATUS_INVALID_PARAMETER.
  **/
-void libspdm_test_requester_set_certificate_case8(void **state)
+static void req_set_certificate_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -564,7 +564,7 @@ void libspdm_test_requester_set_certificate_case8(void **state)
  * Test 9: Set MULTI_KEY_CONN_RSP = true, Erase = false, and SetCertModel = DeviceCert.
  * Expected Behavior: function returns LIBSPDM_STATUS_SUCCESS.
  **/
-void libspdm_test_requester_set_certificate_case9(void **state)
+static void req_set_certificate_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -600,19 +600,19 @@ int libspdm_req_set_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* SendRequest failed*/
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case1),
+        cmocka_unit_test(req_set_certificate_case1),
         /* Successful response to set certificate*/
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case2),
+        cmocka_unit_test(req_set_certificate_case2),
         /* Set null cert_chain for slot 0*/
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case3),
+        cmocka_unit_test(req_set_certificate_case3),
         /* Successful response to set certificate for slot 1 in secure session*/
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case5),
+        cmocka_unit_test(req_set_certificate_case5),
         /* Successful response to set certificate with a reset required */
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case6),
+        cmocka_unit_test(req_set_certificate_case6),
         /* Successful response to erase certificate*/
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case7),
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case8),
-        cmocka_unit_test(libspdm_test_requester_set_certificate_case9),
+        cmocka_unit_test(req_set_certificate_case7),
+        cmocka_unit_test(req_set_certificate_case8),
+        cmocka_unit_test(req_set_certificate_case9),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/set_key_pair_info.c
+++ b/unit_test/test_spdm_requester/set_key_pair_info.c
@@ -125,7 +125,7 @@ static libspdm_return_t receive_message(
  * Test 1: Successful response to set key pair info
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_requester_set_key_pair_info_case1(void **state)
+static void req_set_key_pair_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -172,7 +172,7 @@ void libspdm_test_requester_set_key_pair_info_case1(void **state)
  * Test 2: Fail case, The response version is incorrect .
  * Expected Behavior: returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-void libspdm_test_requester_set_key_pair_info_case2(void **state)
+static void req_set_key_pair_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -211,7 +211,7 @@ void libspdm_test_requester_set_key_pair_info_case2(void **state)
  * Test 3: Fail case, The response code is incorrect
  * Expected Behavior: returns a status of LIBSPDM_STATUS_INVALID_MSG_FIELD.
  **/
-void libspdm_test_requester_set_key_pair_info_case3(void **state)
+static void req_set_key_pair_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -250,7 +250,7 @@ void libspdm_test_requester_set_key_pair_info_case3(void **state)
  * Test 4: Successful reset required error code
  * Expected Behavior: get a RESET_REQURED_PEER return code
  **/
-void libspdm_test_requester_set_key_pair_info_case4(void **state)
+static void req_set_key_pair_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -291,13 +291,13 @@ int libspdm_req_set_key_pair_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Successful response to set key pair info, key_pair_id is 1*/
-        cmocka_unit_test(libspdm_test_requester_set_key_pair_info_case1),
+        cmocka_unit_test(req_set_key_pair_info_case1),
         /* The response version is incorrect */
-        cmocka_unit_test(libspdm_test_requester_set_key_pair_info_case2),
+        cmocka_unit_test(req_set_key_pair_info_case2),
         /* The response code is incorrect */
-        cmocka_unit_test(libspdm_test_requester_set_key_pair_info_case3),
+        cmocka_unit_test(req_set_key_pair_info_case3),
         /* Successful response with reset required error code */
-        cmocka_unit_test(libspdm_test_requester_set_key_pair_info_case4),
+        cmocka_unit_test(req_set_key_pair_info_case4),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/subscribe_event_types.c
+++ b/unit_test/test_spdm_requester/subscribe_event_types.c
@@ -160,7 +160,7 @@ static libspdm_return_t receive_message(
  * Test 1: Successful response to subscribe event types that clears all subscriptions.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS.
  **/
-static void libspdm_test_requester_subscribe_event_types_case1(void **state)
+static void req_subscribe_event_types_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -187,7 +187,7 @@ static void libspdm_test_requester_subscribe_event_types_case1(void **state)
  *         types.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS.
  **/
-static void libspdm_test_requester_subscribe_event_types_case2(void **state)
+static void req_subscribe_event_types_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -218,7 +218,7 @@ static void libspdm_test_requester_subscribe_event_types_case2(void **state)
  *         types using the AllEventTypes attribute.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS.
  **/
-static void libspdm_test_requester_subscribe_event_types_case3(void **state)
+static void req_subscribe_event_types_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -255,9 +255,9 @@ int libspdm_req_subscribe_event_types_test(void)
     };
 
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case1),
-        cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case2),
-        cmocka_unit_test(libspdm_test_requester_subscribe_event_types_case3)
+        cmocka_unit_test(req_subscribe_event_types_case1),
+        cmocka_unit_test(req_subscribe_event_types_case2),
+        cmocka_unit_test(req_subscribe_event_types_case3)
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_requester/vendor_defined_request.c
+++ b/unit_test/test_spdm_requester/vendor_defined_request.c
@@ -182,7 +182,7 @@ static libspdm_return_t receive_message(
  * Test 1: Sending a vendor defined request
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
  **/
-static void libspdm_test_requester_vendor_cmds_case1(void **state)
+static void req_vendor_defined_request_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -233,7 +233,7 @@ static void libspdm_test_requester_vendor_cmds_case1(void **state)
  * Test 2: Sending a vendor defined request with LargeReq supported
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
  **/
-static void libspdm_test_requester_vendor_cmds_case2(void **state)
+static void req_vendor_defined_request_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -288,8 +288,8 @@ static void libspdm_test_requester_vendor_cmds_case2(void **state)
 int libspdm_req_vendor_defined_request_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_requester_vendor_cmds_case1),
-        cmocka_unit_test(libspdm_test_requester_vendor_cmds_case2),
+        cmocka_unit_test(req_vendor_defined_request_case1),
+        cmocka_unit_test(req_vendor_defined_request_case2),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
Rename Requester unit test case names so that they conform to https://github.com/DMTF/libspdm/blob/main/doc/internal/unit_test_template.md.