### PR TITLE
Rename Responder unit test case names

### DIFF
--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -958,7 +958,7 @@ spdm_negotiate_algorithms_request_t m_libspdm_negotiate_algorithms_request30 = {
 size_t m_libspdm_negotiate_algorithms_request30_size =
     sizeof(m_libspdm_negotiate_algorithms_request30);
 
-void libspdm_test_responder_algorithms_case1(void **state)
+static void rsp_algorithms_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -989,7 +989,7 @@ void libspdm_test_responder_algorithms_case1(void **state)
                      SPDM_ALGORITHMS);
 }
 
-void libspdm_test_responder_algorithms_case2(void **state)
+static void rsp_algorithms_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1023,7 +1023,7 @@ void libspdm_test_responder_algorithms_case2(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case3(void **state)
+static void rsp_algorithms_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1059,7 +1059,7 @@ void libspdm_test_responder_algorithms_case3(void **state)
                      LIBSPDM_RESPONSE_STATE_BUSY);
 }
 
-void libspdm_test_responder_algorithms_case4(void **state)
+static void rsp_algorithms_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1096,7 +1096,7 @@ void libspdm_test_responder_algorithms_case4(void **state)
                      LIBSPDM_RESPONSE_STATE_NEED_RESYNC);
 }
 
-void libspdm_test_responder_algorithms_case6(void **state)
+static void rsp_algorithms_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1131,7 +1131,7 @@ void libspdm_test_responder_algorithms_case6(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case7(void **state) {
+static void rsp_algorithms_case7(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1198,7 +1198,7 @@ void libspdm_test_responder_algorithms_case7(void **state) {
                       spdm_context->local_context.algorithm.key_schedule);
 }
 
-void libspdm_test_responder_algorithms_case8(void **state) {
+static void rsp_algorithms_case8(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1258,7 +1258,7 @@ void libspdm_test_responder_algorithms_case8(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case9(void **state) {
+static void rsp_algorithms_case9(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1318,7 +1318,7 @@ void libspdm_test_responder_algorithms_case9(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case10(void **state) {
+static void rsp_algorithms_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1378,7 +1378,7 @@ void libspdm_test_responder_algorithms_case10(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case11(void **state) {
+static void rsp_algorithms_case11(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1438,7 +1438,7 @@ void libspdm_test_responder_algorithms_case11(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case12(void **state) {
+static void rsp_algorithms_case12(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1498,7 +1498,7 @@ void libspdm_test_responder_algorithms_case12(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case13(void **state) {
+static void rsp_algorithms_case13(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1558,7 +1558,7 @@ void libspdm_test_responder_algorithms_case13(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case14(void **state) {
+static void rsp_algorithms_case14(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1592,7 +1592,7 @@ void libspdm_test_responder_algorithms_case14(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case15(void **state) {
+static void rsp_algorithms_case15(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1649,7 +1649,7 @@ void libspdm_test_responder_algorithms_case15(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case16(void **state) {
+static void rsp_algorithms_case16(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1706,7 +1706,7 @@ void libspdm_test_responder_algorithms_case16(void **state) {
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case17(void **state) {
+static void rsp_algorithms_case17(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1763,7 +1763,7 @@ void libspdm_test_responder_algorithms_case17(void **state) {
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case18(void **state) {
+static void rsp_algorithms_case18(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1820,7 +1820,7 @@ void libspdm_test_responder_algorithms_case18(void **state) {
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case19(void **state) {
+static void rsp_algorithms_case19(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1878,7 +1878,7 @@ void libspdm_test_responder_algorithms_case19(void **state) {
 }
 
 /* When both of requester and responder support multiple algorithms, then defaults to choose the strongest available algorithm*/
-void libspdm_test_responder_algorithms_case20(void **state) {
+static void rsp_algorithms_case20(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1965,7 +1965,7 @@ void libspdm_test_responder_algorithms_case20(void **state) {
                       spdm_context->connection_info.algorithm.key_schedule);
 }
 
-void libspdm_test_responder_algorithms_case21(void **state) {
+static void rsp_algorithms_case21(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
     libspdm_context_t *spdm_context;
@@ -2051,7 +2051,7 @@ void libspdm_test_responder_algorithms_case21(void **state) {
                         m_libspdm_negotiate_algorithm_request3_size, response, response_size);
 }
 
-void libspdm_test_responder_algorithms_case22(void **state)
+static void rsp_algorithms_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2122,7 +2122,7 @@ void libspdm_test_responder_algorithms_case22(void **state)
                       spdm_context->local_context.algorithm.key_schedule);
 }
 
-void libspdm_test_responder_algorithms_case23(void **state)
+static void rsp_algorithms_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2243,7 +2243,7 @@ void libspdm_test_responder_algorithms_case23(void **state)
                      SPDM_ALGORITHMS_OPAQUE_DATA_FORMAT_1);
 }
 
-void libspdm_test_responder_algorithms_case24(void **state)
+static void rsp_algorithms_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2309,7 +2309,7 @@ void libspdm_test_responder_algorithms_case24(void **state)
     assert_int_equal(spdm_response->measurement_specification_sel, 0);
 }
 
-void libspdm_test_responder_algorithms_case25(void **state)
+static void rsp_algorithms_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2372,7 +2372,7 @@ void libspdm_test_responder_algorithms_case25(void **state)
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case26(void **state)
+static void rsp_algorithms_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2435,7 +2435,7 @@ void libspdm_test_responder_algorithms_case26(void **state)
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case27(void **state)
+static void rsp_algorithms_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2498,7 +2498,7 @@ void libspdm_test_responder_algorithms_case27(void **state)
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case28(void **state)
+static void rsp_algorithms_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2561,7 +2561,7 @@ void libspdm_test_responder_algorithms_case28(void **state)
     assert_int_equal (spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_algorithms_case29(void **state)
+static void rsp_algorithms_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
@@ -2634,7 +2634,7 @@ void libspdm_test_responder_algorithms_case29(void **state)
  * | 10b           | 1                        | true               |
  *  ----------------------------------------------------------------
  **/
-void libspdm_test_responder_algorithms_case30(void **state)
+static void rsp_algorithms_case30(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2794,7 +2794,7 @@ void libspdm_test_responder_algorithms_case30(void **state)
  * Test 31: NEGOTIATE_ALGORITHMS message received with MEL correct
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_responder_algorithms_case31(void **state)
+static void rsp_algorithms_case31(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2862,7 +2862,7 @@ void libspdm_test_responder_algorithms_case31(void **state)
  * Test 32: NEGOTIATE_ALGORITHMS message received with MEAS correct
  * Expected Behavior: get a RETURN_SUCCESS return code
  **/
-void libspdm_test_responder_algorithms_case32(void **state)
+static void rsp_algorithms_case32(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2935,67 +2935,67 @@ int libspdm_rsp_algorithms_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case1),
+        cmocka_unit_test(rsp_algorithms_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case2),
+        cmocka_unit_test(rsp_algorithms_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case3),
+        cmocka_unit_test(rsp_algorithms_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case4),
+        cmocka_unit_test(rsp_algorithms_case4),
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case6),
+        cmocka_unit_test(rsp_algorithms_case6),
         /* Success case V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case7),
+        cmocka_unit_test(rsp_algorithms_case7),
         /* No match for base_asym_algo*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case8),
+        cmocka_unit_test(rsp_algorithms_case8),
         /* No match for base_hash_algo*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case9),
+        cmocka_unit_test(rsp_algorithms_case9),
         /* No match for dhe_named_group*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case10),
+        cmocka_unit_test(rsp_algorithms_case10),
         /* No match for aead_cipher_suite*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case11),
+        cmocka_unit_test(rsp_algorithms_case11),
         /* No match for req_base_asym_alg*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case12),
+        cmocka_unit_test(rsp_algorithms_case12),
         /* No match for key_schedule*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case13),
+        cmocka_unit_test(rsp_algorithms_case13),
         /* Spdm length greater than 64 bytes for V1.0*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case14),
+        cmocka_unit_test(rsp_algorithms_case14),
         /* Spdm length greater than 128 bytes for V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case15),
+        cmocka_unit_test(rsp_algorithms_case15),
         /* Multiple repeated Alg structs for V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case16),
+        cmocka_unit_test(rsp_algorithms_case16),
         /* param1 is smaller than the number of Alg structs for V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case17),
+        cmocka_unit_test(rsp_algorithms_case17),
         /* param1 is bigger than the number of  Alg structs for V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case18),
+        cmocka_unit_test(rsp_algorithms_case18),
         /* Invalid  Alg structs + valid Alg Structs for V1.1*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case19),
+        cmocka_unit_test(rsp_algorithms_case19),
         /* When support multiple algorithms, then defaults to choose the strongest available algorithm*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case20),
+        cmocka_unit_test(rsp_algorithms_case20),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case21),
+        cmocka_unit_test(rsp_algorithms_case21),
         /* Success case V1.2*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case22),
+        cmocka_unit_test(rsp_algorithms_case22),
         /* Version 1.2 Check other_params_support */
-        cmocka_unit_test(libspdm_test_responder_algorithms_case23),
+        cmocka_unit_test(rsp_algorithms_case23),
         /* No support for MEASUREMENT from requester*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case24),
+        cmocka_unit_test(rsp_algorithms_case24),
         /* Invalid (Redundant) alg_type value*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case25),
+        cmocka_unit_test(rsp_algorithms_case25),
         /* Invalid (Decreasing) alg_type value*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case26),
+        cmocka_unit_test(rsp_algorithms_case26),
         /* Invalid (smaller than DHE) alg_type value*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case27),
+        cmocka_unit_test(rsp_algorithms_case27),
         /* Invalid (bigger than KEY_SCHEDULE) alg_type value*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case28),
+        cmocka_unit_test(rsp_algorithms_case28),
         /* Invalid AlgStruct, contains an AlgSupported=0 (Non-supported)*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case29),
+        cmocka_unit_test(rsp_algorithms_case29),
         /* MULTI_KEY_CONN_REQ and MULTI_KEY_CONN_RSP value validation*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case30),
+        cmocka_unit_test(rsp_algorithms_case30),
         /* Success Case , set MELspecificationSel*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case31),
+        cmocka_unit_test(rsp_algorithms_case31),
         /* Success Case , set MeasurementSpecification*/
-        cmocka_unit_test(libspdm_test_responder_algorithms_case32),
+        cmocka_unit_test(rsp_algorithms_case32),
     };
 
     m_libspdm_negotiate_algorithms_request1.base_asym_algo = m_libspdm_use_asym_algo;

--- a/unit_test/test_spdm_responder/capabilities.c
+++ b/unit_test/test_spdm_responder/capabilities.c
@@ -487,7 +487,7 @@ spdm_get_capabilities_request_t m_libspdm_get_capabilities_request28 = {
 };
 size_t m_libspdm_get_capabilities_request28_size = sizeof(m_libspdm_get_capabilities_request28);
 
-void libspdm_test_responder_capabilities_case1(void **state)
+static void rsp_capabilities_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -523,7 +523,7 @@ void libspdm_test_responder_capabilities_case1(void **state)
 #endif
 }
 
-void libspdm_test_responder_capabilities_case2(void **state)
+static void rsp_capabilities_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -558,7 +558,7 @@ void libspdm_test_responder_capabilities_case2(void **state)
 #endif
 }
 
-void libspdm_test_responder_capabilities_case3(void **state)
+static void rsp_capabilities_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -591,7 +591,7 @@ void libspdm_test_responder_capabilities_case3(void **state)
                      LIBSPDM_RESPONSE_STATE_BUSY);
 }
 
-void libspdm_test_responder_capabilities_case4(void **state)
+static void rsp_capabilities_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -625,7 +625,7 @@ void libspdm_test_responder_capabilities_case4(void **state)
                      LIBSPDM_RESPONSE_STATE_NEED_RESYNC);
 }
 
-void libspdm_test_responder_capabilities_case6(void **state)
+static void rsp_capabilities_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -661,7 +661,7 @@ void libspdm_test_responder_capabilities_case6(void **state)
  * Test 7: Requester sets a CTExponent value that is larger than LIBSPDM_MAX_CT_EXPONENT.
  * Expected behavior: returns with error code SPDM_ERROR_CODE_INVALID_REQUEST.
  **/
-void libspdm_test_responder_capabilities_case7(void **state)
+static void rsp_capabilities_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -690,7 +690,7 @@ void libspdm_test_responder_capabilities_case7(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case8(void **state)
+static void rsp_capabilities_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -720,7 +720,7 @@ void libspdm_test_responder_capabilities_case8(void **state)
                      SPDM_CAPABILITIES);
 }
 
-void libspdm_test_responder_capabilities_case9(void **state)
+static void rsp_capabilities_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -750,19 +750,19 @@ void libspdm_test_responder_capabilities_case9(void **state)
                      SPDM_CAPABILITIES);
 }
 
-void libspdm_test_responder_capabilities_case10(void **state)
+static void rsp_capabilities_case10(void **state)
 {
 }
 
-void libspdm_test_responder_capabilities_case11(void **state)
+static void rsp_capabilities_case11(void **state)
 {
 }
 
-void libspdm_test_responder_capabilities_case12(void **state)
+static void rsp_capabilities_case12(void **state)
 {
 }
 
-void libspdm_test_responder_capabilities_case13(void **state)
+static void rsp_capabilities_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -793,7 +793,7 @@ void libspdm_test_responder_capabilities_case13(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case14(void **state)
+static void rsp_capabilities_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -824,7 +824,7 @@ void libspdm_test_responder_capabilities_case14(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case15(void **state)
+static void rsp_capabilities_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -855,7 +855,7 @@ void libspdm_test_responder_capabilities_case15(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case16(void **state)
+static void rsp_capabilities_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -886,7 +886,7 @@ void libspdm_test_responder_capabilities_case16(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case17(void **state)
+static void rsp_capabilities_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -917,7 +917,7 @@ void libspdm_test_responder_capabilities_case17(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case18(void **state)
+static void rsp_capabilities_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -950,7 +950,7 @@ void libspdm_test_responder_capabilities_case18(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case19(void **state)
+static void rsp_capabilities_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -981,7 +981,7 @@ void libspdm_test_responder_capabilities_case19(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case20(void **state)
+static void rsp_capabilities_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1012,11 +1012,11 @@ void libspdm_test_responder_capabilities_case20(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case21(void **state)
+static void rsp_capabilities_case21(void **state)
 {
 }
 
-void libspdm_test_responder_capabilities_case22(void **state)
+static void rsp_capabilities_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1046,7 +1046,7 @@ void libspdm_test_responder_capabilities_case22(void **state)
                      SPDM_CAPABILITIES);
 }
 
-void libspdm_test_responder_capabilities_case23(void **state)
+static void rsp_capabilities_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1090,7 +1090,7 @@ void libspdm_test_responder_capabilities_case23(void **state)
                         response, response_size);
 }
 
-void libspdm_test_responder_capabilities_case24(void **state)
+static void rsp_capabilities_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1123,7 +1123,7 @@ void libspdm_test_responder_capabilities_case24(void **state)
     assert_int_equal(spdm_response->max_spdm_msg_size, LIBSPDM_MAX_SPDM_MSG_SIZE);
 }
 
-void libspdm_test_responder_capabilities_case25(void **state)
+static void rsp_capabilities_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1154,7 +1154,7 @@ void libspdm_test_responder_capabilities_case25(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case26(void **state)
+static void rsp_capabilities_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1185,7 +1185,7 @@ void libspdm_test_responder_capabilities_case26(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
-void libspdm_test_responder_capabilities_case27(void **state)
+static void rsp_capabilities_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1218,7 +1218,7 @@ void libspdm_test_responder_capabilities_case27(void **state)
                      SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MULTI_KEY_CAP_ONLY);
 }
 
-void libspdm_test_responder_capabilities_case28(void **state)
+static void rsp_capabilities_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1278,59 +1278,59 @@ int libspdm_rsp_capabilities_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case1),
+        cmocka_unit_test(rsp_capabilities_case1),
         /* Success case where request size is larger than actual message. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case2),
+        cmocka_unit_test(rsp_capabilities_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case3),
+        cmocka_unit_test(rsp_capabilities_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case4),
+        cmocka_unit_test(rsp_capabilities_case4),
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case6),
+        cmocka_unit_test(rsp_capabilities_case6),
         /* Invalid requester capabilities flag (random flag)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case7),
+        cmocka_unit_test(rsp_capabilities_case7),
         /* V1.1 Success case, all possible flags set*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case8),
+        cmocka_unit_test(rsp_capabilities_case8),
         /* Requester capabilities flag bit 0 is set. reserved value should ne ignored*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case9),
+        cmocka_unit_test(rsp_capabilities_case9),
         /* Can be populated with new test. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case10),
+        cmocka_unit_test(rsp_capabilities_case10),
         /* Can be populated with new test. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case11),
+        cmocka_unit_test(rsp_capabilities_case11),
         /* Can be populated with new test. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case12),
+        cmocka_unit_test(rsp_capabilities_case12),
         /* pub_key_id_cap and cert_cap set (flags are mutually exclusive)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case13),
+        cmocka_unit_test(rsp_capabilities_case13),
         /* encrypt_cap set and key_ex_cap and psk_cap cleared (encrypt_cap demands key_ex_cap or psk_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case14),
+        cmocka_unit_test(rsp_capabilities_case14),
         /* mac_cap set and key_ex_cap and psk_cap cleared (mac_cap demands key_ex_cap or psk_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case15),
+        cmocka_unit_test(rsp_capabilities_case15),
         /* key_ex_cap set and encrypt_cap and mac_cap cleared (key_ex_cap demands encrypt_cap or mac_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case16),
+        cmocka_unit_test(rsp_capabilities_case16),
         /* psk_cap set and encrypt_cap and mac_cap cleared (psk_cap demands encrypt_cap or mac_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case17),
+        cmocka_unit_test(rsp_capabilities_case17),
         /* encap_cap cleared and MUT_AUTH set (MUT_AUTH demands encap_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case18),
+        cmocka_unit_test(rsp_capabilities_case18),
         /* cert_cap set and pub_key_id_cap set (pub_key_id_cap demands cert_cap to be cleared)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case19),
+        cmocka_unit_test(rsp_capabilities_case19),
         /* key_ex_cap cleared and handshake_in_the_clear_cap set (handshake_in_the_clear_cap demands key_ex_cap to be set)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case20),
+        cmocka_unit_test(rsp_capabilities_case20),
         /* Open test case */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case21),
+        cmocka_unit_test(rsp_capabilities_case21),
         /* cert_cap cleared and pub_key_id_cap set (pub_key_id_cap demands cert_cap to be cleared)*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case22),
+        cmocka_unit_test(rsp_capabilities_case22),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case23),
+        cmocka_unit_test(rsp_capabilities_case23),
         /* V1.2 Success case, all possible flags set*/
-        cmocka_unit_test(libspdm_test_responder_capabilities_case24),
+        cmocka_unit_test(rsp_capabilities_case24),
         /* CHUNK_CAP == 0 and data_transfer_size != max_spdm_msg_size should result in error. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case25),
+        cmocka_unit_test(rsp_capabilities_case25),
         /* MaxSPDMmsgSize is less than DataTransferSize, then should result in error. */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case26),
+        cmocka_unit_test(rsp_capabilities_case26),
         /* Success Case , capability supports MULTI_KEY_CAP */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case27),
+        cmocka_unit_test(rsp_capabilities_case27),
         /* Success Case, GET_CAPABILITIES with param1[0] set and CHUNK_CAP enabled */
-        cmocka_unit_test(libspdm_test_responder_capabilities_case28),
+        cmocka_unit_test(rsp_capabilities_case28),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -47,7 +47,7 @@ size_t m_libspdm_get_certificate_request5_size = sizeof(m_libspdm_get_certificat
  * Test 1: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the certificate chain
  * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case1(void **state)
+static void rsp_certificate_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -107,7 +107,7 @@ void libspdm_test_responder_certificate_case1(void **state)
  * Test 2:
  * Expected Behavior:
  **/
-void libspdm_test_responder_certificate_case2(void **state)
+static void rsp_certificate_case2(void **state)
 {
 }
 
@@ -115,7 +115,7 @@ void libspdm_test_responder_certificate_case2(void **state)
  * Test 3: Force response_state = LIBSPDM_RESPONSE_STATE_BUSY when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
  **/
-void libspdm_test_responder_certificate_case3(void **state)
+static void rsp_certificate_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -165,7 +165,7 @@ void libspdm_test_responder_certificate_case3(void **state)
  * Test 4: Force response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  **/
-void libspdm_test_responder_certificate_case4(void **state)
+static void rsp_certificate_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -217,7 +217,7 @@ void libspdm_test_responder_certificate_case4(void **state)
  * Test 5: Force response_state = LIBSPDM_RESPONSE_STATE_NOT_READY when asked GET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_RESPONSE_NOT_READY and correct error_data
  **/
-void libspdm_test_responder_certificate_case5(void **state)
+static void rsp_certificate_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -273,7 +273,7 @@ void libspdm_test_responder_certificate_case5(void **state)
  * Test 6: simulate wrong connection_state when asked GET_CERTIFICATE (missing SPDM_GET_DIGESTS_RECEIVE_FLAG and SPDM_GET_CAPABILITIES_RECEIVE_FLAG)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNEXPECTED_REQUEST
  **/
-void libspdm_test_responder_certificate_case6(void **state)
+static void rsp_certificate_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -323,7 +323,7 @@ void libspdm_test_responder_certificate_case6(void **state)
  * Test 7: request length at the boundary of maximum integer values, while keeping offset 0
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case7(void **state)
+static void rsp_certificate_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -398,7 +398,7 @@ void libspdm_test_responder_certificate_case7(void **state)
  * Test 8: request offset at the boundary of maximum integer values, while keeping length 0
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case8(void **state)
+static void rsp_certificate_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -494,7 +494,7 @@ void libspdm_test_responder_certificate_case8(void **state)
  * Test 9: request offset and length at the boundary of maximum integer values
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case9(void **state)
+static void rsp_certificate_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -625,7 +625,7 @@ void libspdm_test_responder_certificate_case9(void **state)
  * Test 10: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of long certificate chains, with the largest valid offset
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case10(void **state)
+static void rsp_certificate_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -741,7 +741,7 @@ void libspdm_test_responder_certificate_case10(void **state)
  * Test 11: request LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of a short certificate chain (fits in 1 message)
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case11(void **state)
+static void rsp_certificate_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -856,7 +856,7 @@ void libspdm_test_responder_certificate_case11(void **state)
  * Test 12: request a whole certificate chain byte by byte
  * Expected Behavior: generate correctly formed Certificate messages, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case12(void **state)
+static void rsp_certificate_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -961,7 +961,7 @@ void libspdm_test_responder_certificate_case12(void **state)
  * CERTIFICATE response message, and buffer B receives the exchanged
  * GET_CERTIFICATE and CERTIFICATE messages.
  **/
-void libspdm_test_responder_certificate_case13(void **state)
+static void rsp_certificate_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1028,7 +1028,7 @@ void libspdm_test_responder_certificate_case13(void **state)
  * Test 14: request the first LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN bytes of the certificate chain in a session
  * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case14(void **state)
+static void rsp_certificate_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1101,7 +1101,7 @@ void libspdm_test_responder_certificate_case14(void **state)
  * Test 15: Produce a CERTIFICATE response that is meant to be chunked.
  *          LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN is ignored when chunking is enabled.
  **/
-void libspdm_test_responder_certificate_case15(void **state)
+static void rsp_certificate_case15(void **state)
 {
     libspdm_return_t status;
     bool ret;
@@ -1179,7 +1179,7 @@ void libspdm_test_responder_certificate_case15(void **state)
  * Expected Behavior: portion length should be 0 and remainder length should be the size of the
  *                    certificate chain.
  **/
-void libspdm_test_responder_certificate_case16(void **state)
+static void rsp_certificate_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1226,7 +1226,7 @@ void libspdm_test_responder_certificate_case16(void **state)
  * Test 17: SlotID in GET_CERTIFICATE request message is 9, but it should be between 0 and 7 inclusive.
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST.
  **/
-void libspdm_test_responder_certificate_case17(void **state)
+static void rsp_certificate_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1275,7 +1275,7 @@ void libspdm_test_responder_certificate_case17(void **state)
  * GET_CERTIFICATE request shall be ignored by the Responder
  * Expected Behavior: generate a correctly formed Certificate message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_certificate_case18(void **state)
+static void rsp_certificate_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1329,7 +1329,7 @@ void libspdm_test_responder_certificate_case18(void **state)
  * Test 19: Attempt to retrieve a certificate chain from a slot that needs to be reset.
  * Expected Behavior: Responder responds with ResetRequired.
  **/
-void libspdm_test_responder_certificate_case19(void **state)
+static void rsp_certificate_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1378,43 +1378,43 @@ int libspdm_rsp_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case1),
+        cmocka_unit_test(rsp_certificate_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case2),
+        cmocka_unit_test(rsp_certificate_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case3),
+        cmocka_unit_test(rsp_certificate_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case4),
+        cmocka_unit_test(rsp_certificate_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case5),
+        cmocka_unit_test(rsp_certificate_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case6),
+        cmocka_unit_test(rsp_certificate_case6),
         /* Tests varying length*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case7),
+        cmocka_unit_test(rsp_certificate_case7),
         /* Tests varying offset*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case8),
+        cmocka_unit_test(rsp_certificate_case8),
         /* Tests varying length and offset*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case9),
+        cmocka_unit_test(rsp_certificate_case9),
         /* Tests large certificate chains*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case10),
+        cmocka_unit_test(rsp_certificate_case10),
         /* Certificate fits in one single message*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case11),
+        cmocka_unit_test(rsp_certificate_case11),
         /* Requests byte by byte*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case12),
+        cmocka_unit_test(rsp_certificate_case12),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case13),
+        cmocka_unit_test(rsp_certificate_case13),
         /* Success Case in a session*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case14),
+        cmocka_unit_test(rsp_certificate_case14),
         /* Produce a CERTIFICATE response that is meant to be chunked. */
-        cmocka_unit_test(libspdm_test_responder_certificate_case15),
-        cmocka_unit_test(libspdm_test_responder_certificate_case16),
+        cmocka_unit_test(rsp_certificate_case15),
+        cmocka_unit_test(rsp_certificate_case16),
         /* Bad SlotID in request message */
-        cmocka_unit_test(libspdm_test_responder_certificate_case17),
+        cmocka_unit_test(rsp_certificate_case17),
         /* check request attributes and response attributes*/
-        cmocka_unit_test(libspdm_test_responder_certificate_case18),
-        cmocka_unit_test(libspdm_test_responder_certificate_case19),
+        cmocka_unit_test(rsp_certificate_case18),
+        cmocka_unit_test(rsp_certificate_case19),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -59,7 +59,7 @@ extern size_t libspdm_secret_lib_challenge_opaque_data_size;
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case1(void **state)
+static void rsp_challenge_auth_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -126,7 +126,7 @@ void libspdm_test_responder_challenge_auth_case1(void **state)
  * Test 2:
  * Expected behavior:
  **/
-void libspdm_test_responder_challenge_auth_case2(void **state)
+static void rsp_challenge_auth_case2(void **state)
 {
 }
 
@@ -136,7 +136,7 @@ void libspdm_test_responder_challenge_auth_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Busy state.
  **/
-void libspdm_test_responder_challenge_auth_case3(void **state)
+static void rsp_challenge_auth_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -201,7 +201,7 @@ void libspdm_test_responder_challenge_auth_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the NeedResynch state.
  **/
-void libspdm_test_responder_challenge_auth_case4(void **state)
+static void rsp_challenge_auth_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -268,7 +268,7 @@ void libspdm_test_responder_challenge_auth_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the ResponseNotReady state.
  **/
-void libspdm_test_responder_challenge_auth_case5(void **state)
+static void rsp_challenge_auth_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -332,7 +332,7 @@ void libspdm_test_responder_challenge_auth_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void libspdm_test_responder_challenge_auth_case6(void **state)
+static void rsp_challenge_auth_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -396,7 +396,7 @@ void libspdm_test_responder_challenge_auth_case6(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case7(void **state) {
+static void rsp_challenge_auth_case7(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -450,7 +450,7 @@ void libspdm_test_responder_challenge_auth_case7(void **state) {
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void libspdm_test_responder_challenge_auth_case8(void **state) {
+static void rsp_challenge_auth_case8(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -504,7 +504,7 @@ void libspdm_test_responder_challenge_auth_case8(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case9(void **state) {
+static void rsp_challenge_auth_case9(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -570,7 +570,7 @@ void libspdm_test_responder_challenge_auth_case9(void **state) {
  * Expected behavior: the responder rejects the request, and produces an ERROR message
  * indicating the UnexpectedRequest.
  **/
-void libspdm_test_responder_challenge_auth_case10(void **state) {
+static void rsp_challenge_auth_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -631,7 +631,7 @@ void libspdm_test_responder_challenge_auth_case10(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case11(void **state) {
+static void rsp_challenge_auth_case11(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -688,7 +688,7 @@ void libspdm_test_responder_challenge_auth_case11(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case12(void **state) {
+static void rsp_challenge_auth_case12(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -747,7 +747,7 @@ void libspdm_test_responder_challenge_auth_case12(void **state) {
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case13(void **state) {
+static void rsp_challenge_auth_case13(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -807,7 +807,7 @@ void libspdm_test_responder_challenge_auth_case13(void **state) {
  * Expected behavior: the responder refuses the CHALLENGE message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_challenge_auth_case14(void **state) {
+static void rsp_challenge_auth_case14(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -863,7 +863,7 @@ void libspdm_test_responder_challenge_auth_case14(void **state) {
  * CHALLENGE_AUTH response message, and buffer C receives the exchanged CHALLENGE
  * and CHALLENGE_AUTH (without signature) messages.
  **/
-void libspdm_test_responder_challenge_auth_case15(void **state)
+static void rsp_challenge_auth_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -935,7 +935,7 @@ void libspdm_test_responder_challenge_auth_case15(void **state)
  * Test 16: Receive a CHALLENGE request within a secure session.
  * Expected behavior: the Responder replies with error UnexpectedRequest as that is not legal.
  **/
-void libspdm_test_responder_challenge_auth_case16(void **state)
+static void rsp_challenge_auth_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -995,7 +995,7 @@ void libspdm_test_responder_challenge_auth_case16(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * CHALLENGE_AUTH response message.
  **/
-void libspdm_test_responder_challenge_auth_case17(void **state)
+static void rsp_challenge_auth_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1062,7 +1062,7 @@ void libspdm_test_responder_challenge_auth_case17(void **state)
  * no opaque data, no measurements, and slot number 0.
  * Expected Behavior: get a RETURN_SUCCESS return code, correct context field
  **/
-void libspdm_test_responder_challenge_auth_case18(void **state)
+static void rsp_challenge_auth_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1144,7 +1144,7 @@ void libspdm_test_responder_challenge_auth_case18(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the invalid state.
  **/
-void libspdm_test_responder_challenge_auth_case19(void **state)
+static void rsp_challenge_auth_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1221,36 +1221,36 @@ int libspdm_rsp_challenge_auth_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case1),
+        cmocka_unit_test(rsp_challenge_auth_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case2),
+        cmocka_unit_test(rsp_challenge_auth_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case3),
+        cmocka_unit_test(rsp_challenge_auth_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case4),
+        cmocka_unit_test(rsp_challenge_auth_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case5),
+        cmocka_unit_test(rsp_challenge_auth_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case6),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case7),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case8),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case9),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case10),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case11),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case12),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case13),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case14),
+        cmocka_unit_test(rsp_challenge_auth_case6),
+        cmocka_unit_test(rsp_challenge_auth_case7),
+        cmocka_unit_test(rsp_challenge_auth_case8),
+        cmocka_unit_test(rsp_challenge_auth_case9),
+        cmocka_unit_test(rsp_challenge_auth_case10),
+        cmocka_unit_test(rsp_challenge_auth_case11),
+        cmocka_unit_test(rsp_challenge_auth_case12),
+        cmocka_unit_test(rsp_challenge_auth_case13),
+        cmocka_unit_test(rsp_challenge_auth_case14),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case15),
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case16),
+        cmocka_unit_test(rsp_challenge_auth_case15),
+        cmocka_unit_test(rsp_challenge_auth_case16),
         /* using provisioned public key (slot_id 0xFF) */
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case17),
+        cmocka_unit_test(rsp_challenge_auth_case17),
         /* Success Case: V1.3 get a correct context field */
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case18),
+        cmocka_unit_test(rsp_challenge_auth_case18),
         /* The key usage bit mask is not set, failed Case*/
-        cmocka_unit_test(libspdm_test_responder_challenge_auth_case19),
+        cmocka_unit_test(rsp_challenge_auth_case19),
 
     };
 

--- a/unit_test/test_spdm_responder/chunk_response.c
+++ b/unit_test/test_spdm_responder/chunk_response.c
@@ -17,7 +17,7 @@
  * Expected Behavior: Returns ERROR response message
  * with SPDM_ERROR_CODE_UNEXPECTED_REQUEST error code.
  **/
-void libspdm_test_responder_chunk_get_rsp_case1(void** state)
+static void rsp_chunk_response_case1(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -68,7 +68,7 @@ void libspdm_test_responder_chunk_get_rsp_case1(void** state)
  * Test 2: Responder receives a CHUNK_GET request with bad response state.
  * Expected Behavior: Returns ERROR response message with an error code.
  **/
-void libspdm_test_responder_chunk_get_rsp_case2(void** state)
+static void rsp_chunk_response_case2(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -128,7 +128,7 @@ void libspdm_test_responder_chunk_get_rsp_case2(void** state)
  * Expected Behavior: Returns ERROR response message
  * with SPDM_ERROR_CODE_UNEXPECTED_REQUEST error code.
  **/
-void libspdm_test_responder_chunk_get_rsp_case3(void** state)
+static void rsp_chunk_response_case3(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -186,7 +186,7 @@ void libspdm_test_responder_chunk_get_rsp_case3(void** state)
  * Expected Behavior: Returns ERROR response message
  * with SPDM_ERROR_CODE_INVALID_REQUEST error code.
  **/
-void libspdm_test_responder_chunk_get_rsp_case4(void** state)
+static void rsp_chunk_response_case4(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -243,7 +243,7 @@ void libspdm_test_responder_chunk_get_rsp_case4(void** state)
  * Expected Behavior: Returns ERROR response message
  * with SPDM_ERROR_CODE_VERSION_MISMATCH error code.
  **/
-void libspdm_test_responder_chunk_get_rsp_case5(void** state)
+static void rsp_chunk_response_case5(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -297,7 +297,7 @@ void libspdm_test_responder_chunk_get_rsp_case5(void** state)
 /**
  * Test 6: Responder has no chunk saved to get.
  **/
-void libspdm_test_responder_chunk_get_rsp_case6(void** state)
+static void rsp_chunk_response_case6(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -354,7 +354,7 @@ void libspdm_test_responder_chunk_get_rsp_case6(void** state)
 /**
  * Test 7: Responder has handle that does not match request.
  **/
-void libspdm_test_responder_chunk_get_rsp_case7(void** state)
+static void rsp_chunk_response_case7(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -427,7 +427,7 @@ void libspdm_test_responder_chunk_get_rsp_case7(void** state)
 /**
  * Test 8: Responder has earlier sequence number than request .
  **/
-void libspdm_test_responder_chunk_get_rsp_case8(void** state)
+static void rsp_chunk_response_case8(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -499,7 +499,7 @@ void libspdm_test_responder_chunk_get_rsp_case8(void** state)
 /**
  * Test 9: Responder has later sequence number than request.
  **/
-void libspdm_test_responder_chunk_get_rsp_case9(void** state)
+static void rsp_chunk_response_case9(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -572,7 +572,7 @@ void libspdm_test_responder_chunk_get_rsp_case9(void** state)
 /**
  * Test 10: Successful request of first chunk.
  **/
-void libspdm_test_responder_chunk_get_rsp_case10(void** state)
+static void rsp_chunk_response_case10(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -678,7 +678,7 @@ void libspdm_test_responder_chunk_get_rsp_case10(void** state)
 /**
  * Test 11: Successful request of middle chunk.
  **/
-void libspdm_test_responder_chunk_get_rsp_case11(void** state)
+static void rsp_chunk_response_case11(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -782,7 +782,7 @@ void libspdm_test_responder_chunk_get_rsp_case11(void** state)
 /**
  * Test 12: Successful request of last chunk where size is exactly max chunk size
  **/
-void libspdm_test_responder_chunk_get_rsp_case12(void** state)
+static void rsp_chunk_response_case12(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -886,7 +886,7 @@ void libspdm_test_responder_chunk_get_rsp_case12(void** state)
 /**
  * Test 13: Successful request of last chunk where size is exactly 1.
  **/
-void libspdm_test_responder_chunk_get_rsp_case13(void** state)
+static void rsp_chunk_response_case13(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1000,7 +1000,7 @@ void libspdm_test_responder_chunk_get_rsp_case13(void** state)
 /**
  * Test 14: Responder has response exceed chunk seq no
  **/
-void libspdm_test_responder_chunk_get_rsp_case14(void** state)
+static void rsp_chunk_response_case14(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1093,7 +1093,7 @@ void libspdm_test_responder_chunk_get_rsp_case14(void** state)
 /**
  * Test 15: Successful request of first chunk, spdm 1.4.
  **/
-void libspdm_test_responder_chunk_get_rsp_case15(void** state)
+static void rsp_chunk_response_case15(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1199,7 +1199,7 @@ void libspdm_test_responder_chunk_get_rsp_case15(void** state)
 /**
  * Test 16: Successful request of middle chunk, spdm 1.4.
  **/
-void libspdm_test_responder_chunk_get_rsp_case16(void** state)
+static void rsp_chunk_response_case16(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1303,7 +1303,7 @@ void libspdm_test_responder_chunk_get_rsp_case16(void** state)
 /**
  * Test 17: Successful request of last chunk where size is exactly max chunk size
  **/
-void libspdm_test_responder_chunk_get_rsp_case17(void** state)
+static void rsp_chunk_response_case17(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1407,7 +1407,7 @@ void libspdm_test_responder_chunk_get_rsp_case17(void** state)
 /**
  * Test 18: Successful request of last chunk where size is exactly 1.
  **/
-void libspdm_test_responder_chunk_get_rsp_case18(void** state)
+static void rsp_chunk_response_case18(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1522,41 +1522,41 @@ int libspdm_rsp_chunk_response_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Responder has no response flag chunk cap */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case1),
+        cmocka_unit_test(rsp_chunk_response_case1),
         /* Responder has response state != NORMAL */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case2),
+        cmocka_unit_test(rsp_chunk_response_case2),
         /* Responder has connection state <= NOT_START */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case3),
+        cmocka_unit_test(rsp_chunk_response_case3),
         /* Request has wrong size */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case4),
+        cmocka_unit_test(rsp_chunk_response_case4),
         /* Request has wrong SPDM version */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case5),
+        cmocka_unit_test(rsp_chunk_response_case5),
         /* Responder has no chunk saved to get */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case6),
+        cmocka_unit_test(rsp_chunk_response_case6),
         /* Responder has handle that does not match request */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case7),
+        cmocka_unit_test(rsp_chunk_response_case7),
         /* Responder has earlier sequence number than request */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case8),
+        cmocka_unit_test(rsp_chunk_response_case8),
         /* Responder has later sequence number than request*/
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case9),
+        cmocka_unit_test(rsp_chunk_response_case9),
         /* Successful request of first chunk */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case10),
+        cmocka_unit_test(rsp_chunk_response_case10),
         /* Successful request of middle chunk */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case11),
+        cmocka_unit_test(rsp_chunk_response_case11),
         /* Successful request of last chunk, where size is exactly max chunk size */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case12),
+        cmocka_unit_test(rsp_chunk_response_case12),
         /* Successful request of last chunk where chunk size is exactly 1 byte */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case13),
+        cmocka_unit_test(rsp_chunk_response_case13),
         /* Responder has response exceed chunk seq no */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case14),
+        cmocka_unit_test(rsp_chunk_response_case14),
         /* Successful request of first chunk, spdm 1.4*/
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case15),
+        cmocka_unit_test(rsp_chunk_response_case15),
         /* Successful request of middle chunk, spdm 1.4 */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case16),
+        cmocka_unit_test(rsp_chunk_response_case16),
         /* Successful request of last chunk, where size is exactly max chunk size, spdm 1.4 */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case17),
+        cmocka_unit_test(rsp_chunk_response_case17),
         /* Successful request of last chunk where chunk size is exactly 1 byte, spdm 1.4 */
-        cmocka_unit_test(libspdm_test_responder_chunk_get_rsp_case18),
+        cmocka_unit_test(rsp_chunk_response_case18),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/csr.c
+++ b/unit_test/test_spdm_responder/csr.c
@@ -312,7 +312,7 @@ bool libspdm_check_csr_basic_constraints(uint8_t *csr, uint16_t csr_len, bool is
  * Test 1: receives a valid GET_CSR request message from Requester
  * Expected Behavior: produces a valid CSR response message with device_cert mode
  **/
-void libspdm_test_responder_csr_case1(void **state)
+static void rsp_csr_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -395,7 +395,7 @@ void libspdm_test_responder_csr_case1(void **state)
  * Test 2: Wrong GET_CSR message size (larger than expected)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void libspdm_test_responder_csr_case2(void **state)
+static void rsp_csr_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -456,7 +456,7 @@ void libspdm_test_responder_csr_case2(void **state)
  * Test 3: receives a valid GET_CSR request message from Requester with non-null right req_info
  * Expected Behavior: produces a valid CSR response message
  **/
-void libspdm_test_responder_csr_case3(void **state)
+static void rsp_csr_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -532,7 +532,7 @@ void libspdm_test_responder_csr_case3(void **state)
  * Test 4: receives a valid GET_CSR request message from Requester with non-null opaque_data
  * Expected Behavior: produces a valid CSR response message
  **/
-void libspdm_test_responder_csr_case4(void **state)
+static void rsp_csr_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -595,7 +595,7 @@ void libspdm_test_responder_csr_case4(void **state)
  * Test 5: receives a valid GET_CSR request message from Requester with non-null wrong req_info
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void libspdm_test_responder_csr_case5(void **state)
+static void rsp_csr_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -662,7 +662,7 @@ void libspdm_test_responder_csr_case5(void **state)
  * Expected Behavior: the first get_csr: responder return need reset;
  *                    the second get_csr after device reset: get the cached valid csr;
  **/
-void libspdm_test_responder_csr_case6(void **state)
+static void rsp_csr_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -778,7 +778,7 @@ void libspdm_test_responder_csr_case6(void **state)
  * Test 7: receives a valid GET_CSR request message from Requester with non-null right req_info and opaque_data
  * Expected Behavior: produces a valid CSR response message
  **/
-void libspdm_test_responder_csr_case7(void **state)
+static void rsp_csr_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -858,7 +858,7 @@ void libspdm_test_responder_csr_case7(void **state)
  * Test 8: receives a invalid GET_CSR request message from Requester With chaotic req_info and opaque_data
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void libspdm_test_responder_csr_case8(void **state)
+static void rsp_csr_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -926,7 +926,7 @@ void libspdm_test_responder_csr_case8(void **state)
  * the OpaqueDataFmt1 bit is selected in OtherParamsSelection of ALGORITHMS ,
  * Expected Behavior: produces a valid CSR response message
  **/
-void libspdm_test_responder_csr_case9(void **state)
+static void rsp_csr_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1041,7 +1041,7 @@ void libspdm_test_responder_csr_case9(void **state)
  * the OpaqueDataFmt1 bit is selected in OtherParamsSelection of ALGORITHMS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void libspdm_test_responder_csr_case10(void **state)
+static void rsp_csr_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1158,7 +1158,7 @@ void libspdm_test_responder_csr_case10(void **state)
  * Test 11: receives a valid GET_CSR request message from Requester
  * Expected Behavior: produces a valid CSR response message with alias_cert mode
  **/
-void libspdm_test_responder_csr_case11(void **state)
+static void rsp_csr_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1233,7 +1233,7 @@ void libspdm_test_responder_csr_case11(void **state)
  * Expected Behavior: the first get_csr: responder return need reset;
  *                    the second get_csr without device reset: responder return need reset;
  **/
-void libspdm_test_responder_csr_case12(void **state)
+static void rsp_csr_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1350,7 +1350,7 @@ void libspdm_test_responder_csr_case12(void **state)
  * Expected Behavior: the first get_csr with csr_tracking_tag 0: responder return need reset and available csr_tracking_tag;
  *                    After reset, the second get_csr with returned available csr_tracking_tag: after device reset: get the cached valid csr;
  **/
-void libspdm_test_responder_csr_case13(void **state)
+static void rsp_csr_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1486,7 +1486,7 @@ void libspdm_test_responder_csr_case13(void **state)
  *                    After reset, then send get_csr with csr_tracking_tag 0 six times: responder return need reset and available csr_tracking_tag;
  *                    Then send get_csr with csr_tracking_tag 0: responder return busy error;
  **/
-void libspdm_test_responder_csr_case14(void **state)
+static void rsp_csr_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1655,7 +1655,7 @@ void libspdm_test_responder_csr_case14(void **state)
  *                    After reset, then send get_csr with unmatched csr_tracking_tag：responder return unexpected error;
  *                    After reset, then send get_csr with csr_tracking_tag 0, and overwrite is set：responder return need reset and available csr_tracking_tag;
  **/
-void libspdm_test_responder_csr_case15(void **state)
+static void rsp_csr_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1905,7 +1905,7 @@ void libspdm_test_responder_csr_case15(void **state)
  * Test 16: Illegal combination of MULTI_KEY_CONN_RSP = true and CSRCertModel = 0.
  * Expected Behavior: produces SPDM_ERROR_CODE_INVALID_REQUEST message.
  **/
-void libspdm_test_responder_csr_case16(void **state)
+static void rsp_csr_case16(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_CSR_CAP_EX
     libspdm_return_t status;
@@ -1983,36 +1983,36 @@ int libspdm_rsp_csr_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case for csr response with device_cert mode */
-        cmocka_unit_test(libspdm_test_responder_csr_case1),
+        cmocka_unit_test(rsp_csr_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_csr_case2),
+        cmocka_unit_test(rsp_csr_case2),
         /* Success Case for csr response with non-null right req_info */
-        cmocka_unit_test(libspdm_test_responder_csr_case3),
+        cmocka_unit_test(rsp_csr_case3),
         /* Success Case for csr response with non-null opaque_data */
-        cmocka_unit_test(libspdm_test_responder_csr_case4),
+        cmocka_unit_test(rsp_csr_case4),
         /* Failed Case for csr response with non-null wrong req_info */
-        cmocka_unit_test(libspdm_test_responder_csr_case5),
+        cmocka_unit_test(rsp_csr_case5),
         /* Responder need reset to gen csr, the second send after device reset*/
-        cmocka_unit_test(libspdm_test_responder_csr_case6),
+        cmocka_unit_test(rsp_csr_case6),
         /* Success Case for csr response with non-null right req_info and opaque_data */
-        cmocka_unit_test(libspdm_test_responder_csr_case7),
+        cmocka_unit_test(rsp_csr_case7),
         /* Failed Case for csr response  With chaotic req_info and opaque_data */
-        cmocka_unit_test(libspdm_test_responder_csr_case8),
+        cmocka_unit_test(rsp_csr_case8),
         /* the OpaqueDataFmt1 bit is selected in OtherParamsSelection of ALGORITHMS*/
-        cmocka_unit_test(libspdm_test_responder_csr_case9),
+        cmocka_unit_test(rsp_csr_case9),
         /* Failed Case  OpaqueDataFmt1, When AlignPadding is not zero*/
-        cmocka_unit_test(libspdm_test_responder_csr_case10),
+        cmocka_unit_test(rsp_csr_case10),
         /* Success Case for csr response with alias_cert mode */
-        cmocka_unit_test(libspdm_test_responder_csr_case11),
+        cmocka_unit_test(rsp_csr_case11),
         /* Responder need reset to gen csr, the second send without device reset*/
-        cmocka_unit_test(libspdm_test_responder_csr_case12),
+        cmocka_unit_test(rsp_csr_case12),
         /* Success Case: Responder need reset to gen csr for SPDM1.3, the second send with matched csr_tracking_tag after device reset*/
-        cmocka_unit_test(libspdm_test_responder_csr_case13),
+        cmocka_unit_test(rsp_csr_case13),
         /* Failed Case: Responder need reset to gen csr for SPDM1.3, test for busy error*/
-        cmocka_unit_test(libspdm_test_responder_csr_case14),
+        cmocka_unit_test(rsp_csr_case14),
         /* Failed Case: Responder need reset to gen csr for SPDM1.3, test for unmatched csr_tracking_tag and overwrite*/
-        cmocka_unit_test(libspdm_test_responder_csr_case15),
-        cmocka_unit_test(libspdm_test_responder_csr_case16),
+        cmocka_unit_test(rsp_csr_case15),
+        cmocka_unit_test(rsp_csr_case16),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -31,7 +31,7 @@ static uint8_t m_libspdm_local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
  * Test 1: receives a valid GET_DIGESTS request message from Requester
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void libspdm_test_responder_digests_case1(void **state)
+static void rsp_digests_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -88,7 +88,7 @@ void libspdm_test_responder_digests_case1(void **state)
  * Test 2:
  * Expected Behavior:
  **/
-void libspdm_test_responder_digests_case2(void **state)
+static void rsp_digests_case2(void **state)
 {
 }
 
@@ -97,7 +97,7 @@ void libspdm_test_responder_digests_case2(void **state)
  * request message (is busy) and may be able to process the request message if it is sent again in the future
  * Expected Behavior: produces an ERROR response message with error code = Busy
  **/
-void libspdm_test_responder_digests_case3(void **state)
+static void rsp_digests_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -146,7 +146,7 @@ void libspdm_test_responder_digests_case3(void **state)
  * Test 4: receives a valid GET_DIGESTS request message from Requester, but Responder needs the Requester to reissue GET_VERSION to resynchronize
  * Expected Behavior: produces an ERROR response message with error code = RequestResynch
  **/
-void libspdm_test_responder_digests_case4(void **state)
+static void rsp_digests_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -197,7 +197,7 @@ void libspdm_test_responder_digests_case4(void **state)
  * Test 5: receives a valid GET_DIGESTS request message from Requester, but Responder cannot produce the response message in time
  * Expected Behavior: produces an ERROR response message with error code = ResponseNotReady
  **/
-void libspdm_test_responder_digests_case5(void **state)
+static void rsp_digests_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -251,7 +251,7 @@ void libspdm_test_responder_digests_case5(void **state)
  * meaning that steps GET_CAPABILITIES-CAPABILITIES and NEGOTIATE_ALGORITHMS-ALGORITHMS of the protocol were not previously completed
  * Expected Behavior: produces an ERROR response message with error code = UnexpectedRequest
  **/
-void libspdm_test_responder_digests_case6(void **state)
+static void rsp_digests_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -299,7 +299,7 @@ void libspdm_test_responder_digests_case6(void **state)
  * Test 7: receives a valid GET_DIGESTS request message from Requester, but there is no local certificate chain, i.e. there is no digest to send
  * Expected Behavior: produces an ERROR response message with error code = Unspecified
  **/
-void libspdm_test_responder_digests_case7(void **state)
+static void rsp_digests_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -348,7 +348,7 @@ void libspdm_test_responder_digests_case7(void **state)
  * Test 08: receives a valid GET_DIGESTS request message from Requester in a session
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void libspdm_test_responder_digests_case8(void **state)
+static void rsp_digests_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -418,7 +418,7 @@ void libspdm_test_responder_digests_case8(void **state)
  * Test 9: receives a valid GET_DIGESTS request message from Requester , set multi_key_conn_rsp to check if it responds correctly
  * Expected Behavior: produces a valid DIGESTS response message
  **/
-void libspdm_test_responder_digests_case9(void **state)
+static void rsp_digests_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -505,7 +505,7 @@ void libspdm_test_responder_digests_case9(void **state)
  * Check KeyPairID CertificateInfo and KeyUsageMask
  * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS
  **/
-void libspdm_test_responder_digests_case10(void **state)
+static void rsp_digests_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -599,7 +599,7 @@ void libspdm_test_responder_digests_case10(void **state)
  * Test 11: GET_DIGESTS is sent when at least one certificate slot is in the reset state.
  * Expected Behavior: Responder responds with ResetRequired.
  **/
-void libspdm_test_responder_digests_case11(void **state)
+static void rsp_digests_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -643,28 +643,28 @@ int libspdm_rsp_digests_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_digests_case1),
+        cmocka_unit_test(rsp_digests_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_digests_case2),
+        cmocka_unit_test(rsp_digests_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_digests_case3),
+        cmocka_unit_test(rsp_digests_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_digests_case4),
+        cmocka_unit_test(rsp_digests_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_digests_case5),
+        cmocka_unit_test(rsp_digests_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_digests_case6),
+        cmocka_unit_test(rsp_digests_case6),
         /* No digest to send*/
-        cmocka_unit_test(libspdm_test_responder_digests_case7),
+        cmocka_unit_test(rsp_digests_case7),
         /* Success Case in a session*/
-        cmocka_unit_test(libspdm_test_responder_digests_case8),
+        cmocka_unit_test(rsp_digests_case8),
         /* Set multi_key_conn_rsp to check if it responds correctly */
-        cmocka_unit_test(libspdm_test_responder_digests_case9),
+        cmocka_unit_test(rsp_digests_case9),
         /* Check KeyPairID CertificateInfo and KeyUsageMask*/
-        cmocka_unit_test(libspdm_test_responder_digests_case10),
-        cmocka_unit_test(libspdm_test_responder_digests_case11),
+        cmocka_unit_test(rsp_digests_case10),
+        cmocka_unit_test(rsp_digests_case11),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -12,7 +12,7 @@
 
 static uint8_t m_requester_context[SPDM_REQ_CONTEXT_SIZE];
 
-void libspdm_test_responder_encap_challenge_case1(void **state)
+static void rsp_encap_challenge_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -101,7 +101,7 @@ void libspdm_test_responder_encap_challenge_case1(void **state)
     free(data);
 }
 
-void libspdm_test_responder_encap_challenge_case2(void **state)
+static void rsp_encap_challenge_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -169,7 +169,7 @@ void libspdm_test_responder_encap_challenge_case2(void **state)
 }
 
 
-void libspdm_test_responder_encap_challenge_case3(void **state)
+static void rsp_encap_challenge_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -236,7 +236,7 @@ void libspdm_test_responder_encap_challenge_case3(void **state)
     free(data);
 }
 
-void libspdm_test_responder_encap_challenge_case4(void **state)
+static void rsp_encap_challenge_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -303,7 +303,7 @@ void libspdm_test_responder_encap_challenge_case4(void **state)
     free(data);
 }
 
-void libspdm_test_responder_encap_challenge_case5(void **state)
+static void rsp_encap_challenge_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -375,7 +375,7 @@ void libspdm_test_responder_encap_challenge_case5(void **state)
  * Test 6: Successful case , With the correct challenge context field
  * Expected Behavior: client returns a status of RETURN_SUCCESS.
  **/
-void libspdm_test_responder_encap_challenge_case6(void **state)
+static void rsp_encap_challenge_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -474,17 +474,17 @@ void libspdm_test_responder_encap_challenge_case6(void **state)
 int libspdm_rsp_encap_challenge_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case1),
+        cmocka_unit_test(rsp_encap_challenge_case1),
         /* Error response: SPDM_ERROR*/
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case2),
+        cmocka_unit_test(rsp_encap_challenge_case2),
         /* Error request_response_code  : SPDM_CERTIFICATE */
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case3),
+        cmocka_unit_test(rsp_encap_challenge_case3),
         /* Error spdm_response_size */
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case4),
+        cmocka_unit_test(rsp_encap_challenge_case4),
         /* Success Case, use provisioned public key (slot 0xFF) */
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case5),
+        cmocka_unit_test(rsp_encap_challenge_case5),
         /* Success Case, V1.3 With the correct challenge context field */
-        cmocka_unit_test(libspdm_test_responder_encap_challenge_case6),
+        cmocka_unit_test(rsp_encap_challenge_case6),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_certificate.c
+++ b/unit_test/test_spdm_responder/encap_get_certificate.c
@@ -26,7 +26,7 @@ size_t m_spdm_get_certificate_response2_size = sizeof(m_spdm_get_certificate_res
  * Test 1: Normal case, request a certificate chain
  * Expected Behavior: receives a valid certificate chain with the correct number of Certificate messages
  **/
-void test_spdm_responder_encap_get_certificate_case1(void **state)
+static void rsp_encap_get_certificate_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -124,7 +124,7 @@ void test_spdm_responder_encap_get_certificate_case1(void **state)
  * Test 2: force responder to send an ERROR message with code SPDM_ERROR_CODE_INVALID_REQUEST
  * Expected Behavior: get a RETURN_DEVICE_ERROR, with no CERTIFICATE messages received (checked in transcript.message_b buffer)
  **/
-void test_spdm_responder_encap_get_certificate_case2(void **state)
+static void rsp_encap_get_certificate_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -186,7 +186,7 @@ void test_spdm_responder_encap_get_certificate_case2(void **state)
  * total_responder_cert_chain_buffer_length.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_responder_encap_get_certificate_case3(void **state)
+static void rsp_encap_get_certificate_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -285,7 +285,7 @@ void test_spdm_responder_encap_get_certificate_case3(void **state)
  * Test 4: Fail case, request a certificate chain, responder return portion_length > spdm_request.length.
  * Expected Behavior:returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_responder_encap_get_certificate_case4(void **state)
+static void rsp_encap_get_certificate_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -384,7 +384,7 @@ void test_spdm_responder_encap_get_certificate_case4(void **state)
  * Expected Behavior: CertModel is GenericCert model and slot 0 , returns a status of RETURN_DEVICE_ERROR.
  * Expected Behavior: CertModel Value of 0 and certificate chain is valid, returns a status of RETURN_DEVICE_ERROR.
  **/
-void test_spdm_responder_encap_get_certificate_case5(void **state)
+static void rsp_encap_get_certificate_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -595,18 +595,18 @@ int spdm_rsp_encap_get_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case1),
+        cmocka_unit_test(rsp_encap_get_certificate_case1),
         /* Bad request size ,remaining length is 0*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case2),
+        cmocka_unit_test(rsp_encap_get_certificate_case2),
         /* Error response: SPDM_ERROR_CODE_INVALID_REQUEST*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case2),
+        cmocka_unit_test(rsp_encap_get_certificate_case2),
         /* Fail response: spdm_request.offset + spdm_response.portion_length + spdm_response.remainder_length !=
          * total_responder_cert_chain_buffer_length.*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case3),
+        cmocka_unit_test(rsp_encap_get_certificate_case3),
         /* Fail response: responder return portion_length > spdm_request.length*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case4),
+        cmocka_unit_test(rsp_encap_get_certificate_case4),
         /* check request attributes and response attributes*/
-        cmocka_unit_test(test_spdm_responder_encap_get_certificate_case5),
+        cmocka_unit_test(rsp_encap_get_certificate_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_digests.c
+++ b/unit_test/test_spdm_responder/encap_get_digests.c
@@ -17,7 +17,7 @@ static uint8_t m_libspdm_local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
  * Test 1: Response message received successfully
  * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is received
  **/
-void test_spdm_responder_encap_get_digests_case1(void **state)
+static void rsp_encap_get_digests_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -71,7 +71,7 @@ void test_spdm_responder_encap_get_digests_case1(void **state)
  * Test 2: Error response message with error code busy
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_responder_encap_get_digests_case2(void **state)
+static void rsp_encap_get_digests_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -112,7 +112,7 @@ void test_spdm_responder_encap_get_digests_case2(void **state)
  * Test 3: Error response message with error code busy response seize incorrect
  * Expected Behavior:  Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_responder_encap_get_digests_case3(void **state)
+static void rsp_encap_get_digests_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -151,7 +151,7 @@ void test_spdm_responder_encap_get_digests_case3(void **state)
  * Test 4: The code of the request_response_code  summary in the response message is different
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_responder_encap_get_digests_case4(void **state)
+static void rsp_encap_get_digests_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -202,7 +202,7 @@ void test_spdm_responder_encap_get_digests_case4(void **state)
  * CERTIFICATE response messages
  * Expected Behavior: requester returns the status RETURN_DEVICE_ERROR, with no DIGESTS message received
  **/
-void test_spdm_responder_encap_get_digests_case5(void **state)
+static void rsp_encap_get_digests_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -239,7 +239,7 @@ void test_spdm_responder_encap_get_digests_case5(void **state)
  * Test 6: a response message is successfully sent , Set multi_key_conn_req to check if it responds correctly
  * Expected Behavior: requester returns the status RETURN_SUCCESS
  **/
-void test_spdm_responder_encap_get_digests_case6(void **state)
+static void rsp_encap_get_digests_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -341,7 +341,7 @@ void test_spdm_responder_encap_get_digests_case6(void **state)
  * Check KeyPairID CertificateInfo and KeyUsageMask
  * Expected Behavior: requester returns the status RETURN_SUCCESS
  **/
-void test_spdm_responder_encap_get_digests_case7(void **state)
+static void rsp_encap_get_digests_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -477,19 +477,19 @@ int spdm_rsp_encap_get_digests_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case1),
+        cmocka_unit_test(rsp_encap_get_digests_case1),
         /* Error response: SPDM_ERROR*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case2),
+        cmocka_unit_test(rsp_encap_get_digests_case2),
         /* Error response: RETURN_DEVICE_ERROR*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case3),
+        cmocka_unit_test(rsp_encap_get_digests_case3),
         /* request_response_code wrong in response*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case4),
+        cmocka_unit_test(rsp_encap_get_digests_case4),
         /* capability flags check failed*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case5),
+        cmocka_unit_test(rsp_encap_get_digests_case5),
         /* Set multi_key_conn_req to check if it responds correctly */
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case6),
+        cmocka_unit_test(rsp_encap_get_digests_case6),
         /* Check KeyPairID CertificateInfo and KeyUsageMask*/
-        cmocka_unit_test(test_spdm_responder_encap_get_digests_case7),
+        cmocka_unit_test(rsp_encap_get_digests_case7),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_endpoint_info.c
+++ b/unit_test/test_spdm_responder/encap_get_endpoint_info.c
@@ -33,7 +33,7 @@ libspdm_return_t get_endpoint_info_callback (
  * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
  *                    and an empty transcript.message_encap_e
  **/
-void libspdm_test_responder_encap_get_endpoint_info_case1(void **state)
+static void rsp_encap_get_endpoint_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -206,7 +206,7 @@ void libspdm_test_responder_encap_get_endpoint_info_case1(void **state)
  * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
  *                    and an empty transcript.message_encap_e
  **/
-void libspdm_test_responder_encap_get_endpoint_info_case2(void **state)
+static void rsp_encap_get_endpoint_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -299,7 +299,7 @@ void libspdm_test_responder_encap_get_endpoint_info_case2(void **state)
  * Test 3: Normal case, request a endpoint info without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
  **/
-void libspdm_test_responder_encap_get_endpoint_info_case3(void **state)
+static void rsp_encap_get_endpoint_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -363,7 +363,7 @@ void libspdm_test_responder_encap_get_endpoint_info_case3(void **state)
  * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
  *                    and an empty session_transcript.message_encap_e
  **/
-void libspdm_test_responder_encap_get_endpoint_info_case4(void **state)
+static void rsp_encap_get_endpoint_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -507,13 +507,13 @@ int libspdm_rsp_encap_get_endpoint_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success requeset endpoint info with signature */
-        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case1),
+        cmocka_unit_test(rsp_encap_get_endpoint_info_case1),
         /* Success requeset endpoint info with signature, req_slot_id = 0xFF */
-        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case2),
+        cmocka_unit_test(rsp_encap_get_endpoint_info_case2),
         /* Success requeset endpoint info without signature */
-        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case3),
+        cmocka_unit_test(rsp_encap_get_endpoint_info_case3),
         /* Success requeset endpoint info with signature in a session */
-        cmocka_unit_test(libspdm_test_responder_encap_get_endpoint_info_case4),
+        cmocka_unit_test(rsp_encap_get_endpoint_info_case4),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_key_update.c
+++ b/unit_test/test_spdm_responder/encap_key_update.c
@@ -45,7 +45,7 @@ static void libspdm_set_standard_key_update_test_state(libspdm_context_t *spdm_c
  * only the request data key.
  * Expected behavior: client returns a Status of RETURN_SUCCESS,Communication needs to continue.
  **/
-void libspdm_test_responder_encap_key_update_case1(void **state)
+static void rsp_encap_key_update_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -90,7 +90,7 @@ void libspdm_test_responder_encap_key_update_case1(void **state)
  * only the request data key.
  * Expected behavior: client returns a Status of RETURN_SUCCESS,Communication needs to continue.
  **/
-void libspdm_test_responder_encap_key_update_case2(void **state)
+static void rsp_encap_key_update_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -134,7 +134,7 @@ void libspdm_test_responder_encap_key_update_case2(void **state)
  * only the request data key. last_spdm_request_session_id_valid invalid
  * Expected behavior: client returns a Status of RETURN_UNSUPPORTED,No further communication is required.
  **/
-void libspdm_test_responder_encap_key_update_case3(void **state)
+static void rsp_encap_key_update_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -170,7 +170,7 @@ void libspdm_test_responder_encap_key_update_case3(void **state)
  * Expected behavior: client returns a Status of RETURN_SECURITY_VIOLATION, and
  * no keys should be updated.
  **/
-void libspdm_test_responder_encap_key_update_case4(void **state)
+static void rsp_encap_key_update_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -206,7 +206,7 @@ void libspdm_test_responder_encap_key_update_case4(void **state)
  * Test 5: spdm_response message is correct but does not match last_encap_request_header error message
  * Expected behavior: client returns a Status of RETURN_DEVICE_ERROR
  **/
-void libspdm_test_responder_encap_key_update_case5(void **state)
+static void rsp_encap_key_update_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -248,15 +248,15 @@ int libspdm_rsp_encap_key_update_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Successful response*/
-        cmocka_unit_test(libspdm_test_responder_encap_key_update_case1),
+        cmocka_unit_test(rsp_encap_key_update_case1),
         /* Successful response,No further communication is required.*/
-        cmocka_unit_test(libspdm_test_responder_encap_key_update_case2),
+        cmocka_unit_test(rsp_encap_key_update_case2),
         /* last_spdm_request_session_id_valid : false */
-        cmocka_unit_test(libspdm_test_responder_encap_key_update_case3),
+        cmocka_unit_test(rsp_encap_key_update_case3),
         /* Error response: RETURN_SECURITY_VIOLATION */
-        cmocka_unit_test(libspdm_test_responder_encap_key_update_case4),
+        cmocka_unit_test(rsp_encap_key_update_case4),
         /* Error response: RETURN_DEVICE_ERROR */
-        cmocka_unit_test(libspdm_test_responder_encap_key_update_case5),
+        cmocka_unit_test(rsp_encap_key_update_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_send_event.c
+++ b/unit_test/test_spdm_responder/encap_send_event.c
@@ -61,7 +61,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
 /**
  * Test 1: Responder forms the expected SEND_EVENT request message with one event.
  **/
-static void test_responder_encap_send_event_case1(void **state)
+static void rsp_encap_send_event_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -100,7 +100,7 @@ static void test_responder_encap_send_event_case1(void **state)
 /**
  * Test 2: Responder processes the encapsulated EVENT_ACK response.
  **/
-static void test_responder_encap_send_event_case2(void **state)
+static void rsp_encap_send_event_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -133,8 +133,8 @@ static void test_responder_encap_send_event_case2(void **state)
 int libspdm_rsp_encap_send_event_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(test_responder_encap_send_event_case1),
-        cmocka_unit_test(test_responder_encap_send_event_case2),
+        cmocka_unit_test(rsp_encap_send_event_case1),
+        cmocka_unit_test(rsp_encap_send_event_case2),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/end_session_ack.c
+++ b/unit_test/test_spdm_responder/end_session_ack.c
@@ -26,7 +26,7 @@ spdm_end_session_request_t m_libspdm_end_session_request3 = {
 };
 size_t m_libspdm_end_session_request3_size = sizeof(m_libspdm_end_session_request1);
 
-void libspdm_test_responder_end_session_case1(void **state)
+static void rsp_end_session_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -98,7 +98,7 @@ void libspdm_test_responder_end_session_case1(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_end_session_case2(void **state)
+static void rsp_end_session_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -173,7 +173,7 @@ void libspdm_test_responder_end_session_case2(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_end_session_case3(void **state)
+static void rsp_end_session_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -250,7 +250,7 @@ void libspdm_test_responder_end_session_case3(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_end_session_case4(void **state)
+static void rsp_end_session_ack_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -329,7 +329,7 @@ void libspdm_test_responder_end_session_case4(void **state)
 }
 
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
-void libspdm_test_responder_end_session_case5(void **state)
+static void rsp_end_session_ack_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -402,7 +402,7 @@ void libspdm_test_responder_end_session_case5(void **state)
 }
 #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
 
-void libspdm_test_responder_end_session_case6(void **state)
+static void rsp_end_session_ack_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -478,7 +478,7 @@ void libspdm_test_responder_end_session_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_end_session_case7(void **state)
+static void rsp_end_session_ack_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -570,7 +570,7 @@ void libspdm_test_responder_end_session_case7(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_end_session_case8(void **state)
+static void rsp_end_session_ack_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -638,23 +638,23 @@ int libspdm_rsp_end_session_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case1),
+        cmocka_unit_test(rsp_end_session_ack_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case2),
+        cmocka_unit_test(rsp_end_session_ack_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case3),
+        cmocka_unit_test(rsp_end_session_ack_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case4),
+        cmocka_unit_test(rsp_end_session_ack_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case5),
+        cmocka_unit_test(rsp_end_session_ack_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case6),
+        cmocka_unit_test(rsp_end_session_ack_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_end_session_case7),
+        cmocka_unit_test(rsp_end_session_ack_case7),
         /* Success Case with end_session_attribute set */
-        cmocka_unit_test(libspdm_test_responder_end_session_case8),
+        cmocka_unit_test(rsp_end_session_ack_case8),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/endpoint_info.c
+++ b/unit_test/test_spdm_responder/endpoint_info.c
@@ -72,7 +72,7 @@ size_t m_libspdm_get_endpoint_info_request4_size =
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_responder_endpoint_info_case1(void **state)
+static void rsp_endpoint_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -190,7 +190,7 @@ void libspdm_test_responder_endpoint_info_case1(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_responder_endpoint_info_case2(void **state)
+static void rsp_endpoint_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -288,7 +288,7 @@ void libspdm_test_responder_endpoint_info_case2(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_responder_endpoint_info_case3(void **state)
+static void rsp_endpoint_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -408,7 +408,7 @@ void libspdm_test_responder_endpoint_info_case3(void **state)
  * Expected Behavior: get a RETURN_SUCCESS return code,
  *                    correct response message size and fields
  **/
-void libspdm_test_responder_endpoint_info_case4(void **state)
+static void rsp_endpoint_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -470,7 +470,7 @@ void libspdm_test_responder_endpoint_info_case4(void **state)
  *                    correct response message size and fields
  *                    correct signature verification
  **/
-void libspdm_test_responder_endpoint_info_case5(void **state)
+static void rsp_endpoint_info_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -595,11 +595,11 @@ void libspdm_test_responder_endpoint_info_case5(void **state)
 int libspdm_rsp_endpoint_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_endpoint_info_case1),
-        cmocka_unit_test(libspdm_test_responder_endpoint_info_case2),
-        cmocka_unit_test(libspdm_test_responder_endpoint_info_case3),
-        cmocka_unit_test(libspdm_test_responder_endpoint_info_case4),
-        cmocka_unit_test(libspdm_test_responder_endpoint_info_case5),
+        cmocka_unit_test(rsp_endpoint_info_case1),
+        cmocka_unit_test(rsp_endpoint_info_case2),
+        cmocka_unit_test(rsp_endpoint_info_case3),
+        cmocka_unit_test(rsp_endpoint_info_case4),
+        cmocka_unit_test(rsp_endpoint_info_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/finish_rsp.c
+++ b/unit_test/test_spdm_responder/finish_rsp.c
@@ -86,7 +86,7 @@ void libspdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case1(void **state)
+void rsp_finish_rsp_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -197,7 +197,7 @@ void libspdm_test_responder_finish_case1(void **state)
  * Test 2:
  * Expected behavior:
  **/
-void libspdm_test_responder_finish_case2(void **state)
+void rsp_finish_rsp_case2(void **state)
 {
 }
 
@@ -207,7 +207,7 @@ void libspdm_test_responder_finish_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state.
  **/
-void libspdm_test_responder_finish_case3(void **state)
+void rsp_finish_rsp_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -324,7 +324,7 @@ void libspdm_test_responder_finish_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state.
  **/
-void libspdm_test_responder_finish_case4(void **state)
+void rsp_finish_rsp_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -443,7 +443,7 @@ void libspdm_test_responder_finish_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the ResponseNotReady state.
  **/
-void libspdm_test_responder_finish_case5(void **state)
+void rsp_finish_rsp_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -570,7 +570,7 @@ void libspdm_test_responder_finish_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest.
  **/
-void libspdm_test_responder_finish_case6(void **state)
+void rsp_finish_rsp_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -680,7 +680,7 @@ void libspdm_test_responder_finish_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_finish_case7(void **state)
+void rsp_finish_rsp_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -816,7 +816,7 @@ void libspdm_test_responder_finish_case7(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case8(void **state)
+void rsp_finish_rsp_case8(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -981,7 +981,7 @@ void libspdm_test_responder_finish_case8(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the UnsupportedRequest.
  **/
-void libspdm_test_responder_finish_case9(void **state)
+void rsp_finish_rsp_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1098,7 +1098,7 @@ void libspdm_test_responder_finish_case9(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the UnsupportedRequest.
  **/
-void libspdm_test_responder_finish_case10(void **state)
+void rsp_finish_rsp_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1213,7 +1213,7 @@ void libspdm_test_responder_finish_case10(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_finish_case11(void **state)
+void rsp_finish_rsp_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1309,7 +1309,7 @@ void libspdm_test_responder_finish_case11(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_finish_case12(void **state)
+void rsp_finish_rsp_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1409,7 +1409,7 @@ void libspdm_test_responder_finish_case12(void **state)
  * Test 13:
  * Expected behavior:
  **/
-void libspdm_test_responder_finish_case13(void **state)
+void rsp_finish_rsp_case13(void **state)
 {
 }
 
@@ -1419,7 +1419,7 @@ void libspdm_test_responder_finish_case13(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_finish_case14(void **state)
+void rsp_finish_rsp_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1535,7 +1535,7 @@ void libspdm_test_responder_finish_case14(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_finish_case15(void **state)
+void rsp_finish_rsp_case15(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -1691,7 +1691,7 @@ void libspdm_test_responder_finish_case15(void **state)
  * Expected behavior: the responder refuses the FINISH message and produces
  * an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_finish_case16(void **state)
+void rsp_finish_rsp_case16(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -1846,7 +1846,7 @@ void libspdm_test_responder_finish_case16(void **state)
  * Expected behavior: the responder accepts the request and produces a valid FINISH
  * response message, and buffer F receives the exchanged FINISH and FINISH_RSP messages.
  **/
-void libspdm_test_responder_finish_case17(void **state)
+void rsp_finish_rsp_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1956,7 +1956,7 @@ void libspdm_test_responder_finish_case17(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case18(void **state)
+void rsp_finish_rsp_case18(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -2101,7 +2101,7 @@ void libspdm_test_responder_finish_case18(void **state)
  * SlotID in FINISH request message is 10, but it shall be 0xFF or between 0 and 7 inclusive.
  * Expected behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST.
  **/
-void libspdm_test_responder_finish_case19(void **state)
+void rsp_finish_rsp_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2267,7 +2267,7 @@ void libspdm_test_responder_finish_case19(void **state)
  * SlotID in FINISH request message is 3, but it shall match the value 0 in final ENCAPSULATED_RESPONSE_ACK.EncapsulatedRequest.
  * Expected behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST.
  **/
-void libspdm_test_responder_finish_case20(void **state)
+void rsp_finish_rsp_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2435,7 +2435,7 @@ void libspdm_test_responder_finish_case20(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case21(void **state)
+void rsp_finish_rsp_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2550,7 +2550,7 @@ void libspdm_test_responder_finish_case21(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case22(void **state)
+void rsp_finish_rsp_case22(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -2715,7 +2715,7 @@ void libspdm_test_responder_finish_case22(void **state)
  * Big-Endian Sign. Little-Endian Verify.
  * Expecting signature to fail.
  **/
-void libspdm_test_responder_finish_case23(void** state)
+void rsp_finish_rsp_case23(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2880,7 +2880,7 @@ void libspdm_test_responder_finish_case23(void** state)
  * Big-Endian Sign. Big-Endian Verify.
  * Expecting signature to PASS.
  **/
-void libspdm_test_responder_finish_case24(void** state)
+void rsp_finish_rsp_case24(void** state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -3047,7 +3047,7 @@ void libspdm_test_responder_finish_case24(void** state)
  * Big Endian Sign. Big or Little Endian Verify.
  * Expecting signature to PASS.
  **/
-void libspdm_test_responder_finish_case25(void** state)
+void rsp_finish_rsp_case25(void** state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -3212,7 +3212,7 @@ void libspdm_test_responder_finish_case25(void** state)
  * Sign as Little Endian, Verify as Little.
  * Expecting signature to PASS.
  **/
-void libspdm_test_responder_finish_case26(void** state)
+void rsp_finish_rsp_case26(void** state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -3383,7 +3383,7 @@ void libspdm_test_responder_finish_case26(void** state)
  * Sign as Little Endian, Verify as Big.
  * Expecting signature to FAIL.
  **/
-void libspdm_test_responder_finish_case27(void** state)
+void rsp_finish_rsp_case27(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -3552,7 +3552,7 @@ void libspdm_test_responder_finish_case27(void** state)
  * Sign as Little Endian, Verify as Big Or Little.
  * Expecting signature to PASS.
  **/
-void libspdm_test_responder_finish_case28(void** state)
+void rsp_finish_rsp_case28(void** state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_MUT_AUTH_CAP
     libspdm_return_t status;
@@ -3724,7 +3724,7 @@ void libspdm_test_responder_finish_case28(void** state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message, and The ResponderVerifyData field is absent.
  **/
-void libspdm_test_responder_finish_case29(void **state)
+void rsp_finish_rsp_case29(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3844,7 +3844,7 @@ void libspdm_test_responder_finish_case29(void **state)
  * Expected behavior: the responder accepts the request and produces a valid
  * FINISH_RSP response message.
  **/
-void libspdm_test_responder_finish_case30(void **state)
+void rsp_finish_rsp_case30(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -3969,63 +3969,63 @@ int libspdm_rsp_finish_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_finish_case1),
+        cmocka_unit_test(rsp_finish_rsp_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_finish_case2),
+        cmocka_unit_test(rsp_finish_rsp_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_finish_case3),
+        cmocka_unit_test(rsp_finish_rsp_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_finish_case4),
+        cmocka_unit_test(rsp_finish_rsp_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: LIBSPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_finish_case5),
+        cmocka_unit_test(rsp_finish_rsp_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_finish_case6),
+        cmocka_unit_test(rsp_finish_rsp_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_finish_case7),
+        cmocka_unit_test(rsp_finish_rsp_case7),
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_finish_case8),
+        cmocka_unit_test(rsp_finish_rsp_case8),
         /* Unsupported KEY_EX capabilities*/
-        cmocka_unit_test(libspdm_test_responder_finish_case9),
+        cmocka_unit_test(rsp_finish_rsp_case9),
         /* Uninitialized session*/
-        cmocka_unit_test(libspdm_test_responder_finish_case10),
+        cmocka_unit_test(rsp_finish_rsp_case10),
         /* Incorrect MAC*/
-        cmocka_unit_test(libspdm_test_responder_finish_case11),
-        cmocka_unit_test(libspdm_test_responder_finish_case12),
+        cmocka_unit_test(rsp_finish_rsp_case11),
+        cmocka_unit_test(rsp_finish_rsp_case12),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_finish_case13),
-        cmocka_unit_test(libspdm_test_responder_finish_case14),
+        cmocka_unit_test(rsp_finish_rsp_case13),
+        cmocka_unit_test(rsp_finish_rsp_case14),
         /* Incorrect signature*/
-        cmocka_unit_test(libspdm_test_responder_finish_case15),
-        cmocka_unit_test(libspdm_test_responder_finish_case16),
+        cmocka_unit_test(rsp_finish_rsp_case15),
+        cmocka_unit_test(rsp_finish_rsp_case16),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_finish_case17),
+        cmocka_unit_test(rsp_finish_rsp_case17),
         /* Success Case, enable mutual authentication and use slot_id 0xFF */
-        cmocka_unit_test(libspdm_test_responder_finish_case18),
+        cmocka_unit_test(rsp_finish_rsp_case18),
         /* Invalid SlotID in FINISH request message when mutual authentication */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case19, libspdm_unit_test_group_setup),
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case20, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case19, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case20, libspdm_unit_test_group_setup),
         /* If FINISH.Param1 != 0x01, then FINISH.Param2 is reserved, shall be ignored when read */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case21, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case21, libspdm_unit_test_group_setup),
         /* If KEY_EXCHANGE_RSP.MutAuthRequested equals neither 0x02 nor 0x04, FINISH.Param2 no need match ENCAPSULATED_RESPONSE_ACK.EncapsulatedRequest */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case22, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case22, libspdm_unit_test_group_setup),
         /* Big Endian Sign - Little Endian Verify */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case23, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case23, libspdm_unit_test_group_setup),
         /* Big Endian Sign - Big Endian Verify */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case24, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case24, libspdm_unit_test_group_setup),
         /* Big Endian Sign - Big or Little Endian Verify */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case25, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case25, libspdm_unit_test_group_setup),
         /* Little Endian Sign - Little Endian Verify*/
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case26, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case26, libspdm_unit_test_group_setup),
         /* Little Endian Sign - Big Endian Verify */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case27, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case27, libspdm_unit_test_group_setup),
         /* Little Endian Sign - Big or Little Endian Verify */
-        cmocka_unit_test_setup(libspdm_test_responder_finish_case28, libspdm_unit_test_group_setup),
+        cmocka_unit_test_setup(rsp_finish_rsp_case28, libspdm_unit_test_group_setup),
         /* The requester and responder have not set HANDSHAKE_IN_THE_CLEAR*/
-        cmocka_unit_test(libspdm_test_responder_finish_case29),
+        cmocka_unit_test(rsp_finish_rsp_case29),
         /* SPDM 1.4 with OpaqueData */
-        cmocka_unit_test(libspdm_test_responder_finish_case30),
+        cmocka_unit_test(rsp_finish_rsp_case30),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/heartbeat_ack.c
+++ b/unit_test/test_spdm_responder/heartbeat_ack.c
@@ -21,7 +21,7 @@ spdm_heartbeat_request_t m_libspdm_heartbeat_request2 = {
 size_t m_libspdm_heartbeat_request2_size = LIBSPDM_MAX_SPDM_MSG_SIZE;
 
 
-void libspdm_test_responder_heartbeat_case1(void **state)
+static void rsp_heartbeat_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -83,7 +83,7 @@ void libspdm_test_responder_heartbeat_case1(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_heartbeat_case2(void **state)
+static void rsp_heartbeat_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -158,7 +158,7 @@ void libspdm_test_responder_heartbeat_case2(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_heartbeat_case3(void **state)
+static void rsp_heartbeat_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -235,7 +235,7 @@ void libspdm_test_responder_heartbeat_case3(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_heartbeat_case4(void **state)
+static void rsp_heartbeat_ack_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -314,7 +314,7 @@ void libspdm_test_responder_heartbeat_case4(void **state)
 }
 
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
-void libspdm_test_responder_heartbeat_case5(void **state)
+static void rsp_heartbeat_ack_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -399,7 +399,7 @@ void libspdm_test_responder_heartbeat_case5(void **state)
 }
 #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
 
-void libspdm_test_responder_heartbeat_case6(void **state)
+static void rsp_heartbeat_ack_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -475,7 +475,7 @@ void libspdm_test_responder_heartbeat_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_heartbeat_case7(void **state)
+static void rsp_heartbeat_ack_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -571,7 +571,7 @@ void libspdm_test_responder_heartbeat_case7(void **state)
  *         HEARTBEAT request anyways.
  * Expected behavior: Responder returns UnexpectedRequest ERROR message.
  **/
-void libspdm_test_responder_heartbeat_case8(void **state)
+static void rsp_heartbeat_ack_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -629,22 +629,22 @@ int libspdm_rsp_heartbeat_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case1),
+        cmocka_unit_test(rsp_heartbeat_ack_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case2),
+        cmocka_unit_test(rsp_heartbeat_ack_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case3),
+        cmocka_unit_test(rsp_heartbeat_ack_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case4),
+        cmocka_unit_test(rsp_heartbeat_ack_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case5),
+        cmocka_unit_test(rsp_heartbeat_ack_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case6),
+        cmocka_unit_test(rsp_heartbeat_ack_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case7),
-        cmocka_unit_test(libspdm_test_responder_heartbeat_case8),
+        cmocka_unit_test(rsp_heartbeat_ack_case7),
+        cmocka_unit_test(rsp_heartbeat_ack_case8),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/key_exchange_rsp.c
+++ b/unit_test/test_spdm_responder/key_exchange_rsp.c
@@ -91,7 +91,7 @@ size_t m_libspdm_key_exchange_request10_size = sizeof(m_libspdm_key_exchange_req
 extern bool g_event_all_subscribe;
 extern bool g_event_all_unsubscribe;
 
-void libspdm_test_responder_key_exchange_case1(void **state)
+static void rsp_key_exchange_rsp_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -175,7 +175,7 @@ void libspdm_test_responder_key_exchange_case1(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case2(void **state)
+static void rsp_key_exchange_rsp_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -258,7 +258,7 @@ void libspdm_test_responder_key_exchange_case2(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case3(void **state)
+static void rsp_key_exchange_rsp_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -343,7 +343,7 @@ void libspdm_test_responder_key_exchange_case3(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case4(void **state)
+static void rsp_key_exchange_rsp_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -430,7 +430,7 @@ void libspdm_test_responder_key_exchange_case4(void **state)
 }
 
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
-void libspdm_test_responder_key_exchange_case5(void **state)
+static void rsp_key_exchange_rsp_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -523,7 +523,7 @@ void libspdm_test_responder_key_exchange_case5(void **state)
 }
 #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
 
-void libspdm_test_responder_key_exchange_case6(void **state)
+static void rsp_key_exchange_rsp_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -607,7 +607,7 @@ void libspdm_test_responder_key_exchange_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case7(void **state)
+static void rsp_key_exchange_rsp_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -710,7 +710,7 @@ void libspdm_test_responder_key_exchange_case7(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case8(void **state)
+static void rsp_key_exchange_rsp_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -827,7 +827,7 @@ void libspdm_test_responder_key_exchange_case8(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case9(void **state)
+static void rsp_key_exchange_rsp_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -949,7 +949,7 @@ void libspdm_test_responder_key_exchange_case9(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case10(void **state)
+static void rsp_key_exchange_rsp_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1039,7 +1039,7 @@ void libspdm_test_responder_key_exchange_case10(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case11(void **state)
+static void rsp_key_exchange_rsp_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1133,7 +1133,7 @@ void libspdm_test_responder_key_exchange_case11(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case14(void **state)
+static void rsp_key_exchange_rsp_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1231,7 +1231,7 @@ void libspdm_test_responder_key_exchange_case14(void **state)
     free(data2);
 }
 
-void libspdm_test_responder_key_exchange_case15(void **state)
+static void rsp_key_exchange_rsp_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1334,7 +1334,7 @@ void libspdm_test_responder_key_exchange_case15(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case16(void **state)
+static void rsp_key_exchange_rsp_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1432,7 +1432,7 @@ void libspdm_test_responder_key_exchange_case16(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case17(void **state)
+static void rsp_key_exchange_rsp_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1524,7 +1524,7 @@ void libspdm_test_responder_key_exchange_case17(void **state)
  * Test 18: SlotID in KEY_EXCHANGE request message is 9, but it should be 0xFF or between 0 and 7 inclusive.
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST.
  **/
-void libspdm_test_responder_key_exchange_case18(void **state)
+static void rsp_key_exchange_rsp_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1609,7 +1609,7 @@ void libspdm_test_responder_key_exchange_case18(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case19(void **state)
+static void rsp_key_exchange_rsp_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1740,7 +1740,7 @@ void libspdm_test_responder_key_exchange_case19(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_key_exchange_case20(void **state)
+static void rsp_key_exchange_rsp_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1842,7 +1842,7 @@ void libspdm_test_responder_key_exchange_case20(void **state)
  * Test 21: The key usage bit mask is not set, the SlotID fields in KEY_EXCHANGE and KEY_EXCHANGE_RSP shall not specify this certificate slot
  * Expected Behavior: get a SPDM_ERROR_CODE_INVALID_REQUEST return code
  **/
-void libspdm_test_responder_key_exchange_case21(void **state)
+static void rsp_key_exchange_rsp_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1940,7 +1940,7 @@ void libspdm_test_responder_key_exchange_case21(void **state)
  * Test 21: The Requester subscribes to all events supported by the Responder.
  * Expected Behavior: Responder successfully subscribes the Requester to all events.
  **/
-static void libspdm_test_responder_key_exchange_case22(void **state)
+static void rsp_key_exchange_rsp_case22(void **state)
 {
 #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
     libspdm_return_t status;
@@ -2030,7 +2030,7 @@ static void libspdm_test_responder_key_exchange_case22(void **state)
 #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 }
 
-void libspdm_test_responder_key_exchange_case23(void **state)
+static void rsp_key_exchange_rsp_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2112,7 +2112,7 @@ void libspdm_test_responder_key_exchange_case23(void **state)
 }
 
 
-void libspdm_test_responder_key_exchange_case24(void **state)
+static void rsp_key_exchange_rsp_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2197,49 +2197,49 @@ int libspdm_rsp_key_exchange_rsp_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case1),
+        cmocka_unit_test(rsp_key_exchange_rsp_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case2),
+        cmocka_unit_test(rsp_key_exchange_rsp_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case3),
+        cmocka_unit_test(rsp_key_exchange_rsp_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case4),
+        cmocka_unit_test(rsp_key_exchange_rsp_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case5),
+        cmocka_unit_test(rsp_key_exchange_rsp_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case6),
+        cmocka_unit_test(rsp_key_exchange_rsp_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case7),
+        cmocka_unit_test(rsp_key_exchange_rsp_case7),
         /* TCB measurement hash requested */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case8),
+        cmocka_unit_test(rsp_key_exchange_rsp_case8),
         /* All measurement hash requested */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case9),
+        cmocka_unit_test(rsp_key_exchange_rsp_case9),
         /* Reserved value in Measurement summary. Error + Invalid */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case10),
+        cmocka_unit_test(rsp_key_exchange_rsp_case10),
         /* TCB measurement hash requested, measurement flag not set */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case11),
+        cmocka_unit_test(rsp_key_exchange_rsp_case11),
         /* Request previously provisioned public key, slot 0xFF */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case14),
+        cmocka_unit_test(rsp_key_exchange_rsp_case14),
         /* HANDSHAKE_IN_THE_CLEAR set for requester and responder */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case15),
+        cmocka_unit_test(rsp_key_exchange_rsp_case15),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case16),
+        cmocka_unit_test(rsp_key_exchange_rsp_case16),
         /* Successful response V1.2*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case17),
+        cmocka_unit_test(rsp_key_exchange_rsp_case17),
         /* Invalid SlotID in KEY_EXCHANGE request message*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case18),
+        cmocka_unit_test(rsp_key_exchange_rsp_case18),
         /* Only OpaqueDataFmt1 is supported, Bytes not aligned*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case19),
+        cmocka_unit_test(rsp_key_exchange_rsp_case19),
         /* OpaqueData only supports OpaqueDataFmt1, Success Case */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case20),
+        cmocka_unit_test(rsp_key_exchange_rsp_case20),
         /* The key usage bit mask is not set, failed Case*/
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case21),
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case22),
+        cmocka_unit_test(rsp_key_exchange_rsp_case21),
+        cmocka_unit_test(rsp_key_exchange_rsp_case22),
         /* The Responder requires mutual authentication, but the Requester does not support it */
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case23),
-        cmocka_unit_test(libspdm_test_responder_key_exchange_case24),
+        cmocka_unit_test(rsp_key_exchange_rsp_case23),
+        cmocka_unit_test(rsp_key_exchange_rsp_case24),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/key_pair_info.c
+++ b/unit_test/test_spdm_responder/key_pair_info.c
@@ -20,7 +20,7 @@ size_t m_libspdm_get_key_pair_info_request1_size = sizeof(m_libspdm_get_key_pair
  * Test 1: Successful response to get key pair info with key pair id 4
  * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, and correct response message size and fields
  **/
-void libspdm_test_responder_key_pair_info_case1(void **state)
+static void rsp_key_pair_info_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -71,7 +71,7 @@ void libspdm_test_responder_key_pair_info_case1(void **state)
  * KeyPairID is set to 0.
  * Expected Behavior:  Generate error response message
  **/
-void libspdm_test_responder_key_pair_info_case2(void **state)
+static void rsp_key_pair_info_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -115,7 +115,7 @@ void libspdm_test_responder_key_pair_info_case2(void **state)
  * Test 3: The key_pair_id is greater than the total key pairs
  * Expected Behavior:  Generate error response message
  **/
-void libspdm_test_responder_key_pair_info_case3(void **state)
+static void rsp_key_pair_info_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -157,7 +157,7 @@ void libspdm_test_responder_key_pair_info_case3(void **state)
  * Test 4: not set KEY_PAIR_INFO
  * Expected Behavior:  Generate error response message
  **/
-void libspdm_test_responder_key_pair_info_case4(void **state)
+static void rsp_key_pair_info_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -200,13 +200,13 @@ int libspdm_rsp_key_pair_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case to get key pair info*/
-        cmocka_unit_test(libspdm_test_responder_key_pair_info_case1),
+        cmocka_unit_test(rsp_key_pair_info_case1),
         /* The KeyPairID is at least 1 , KeyPairID is set to 0.*/
-        cmocka_unit_test(libspdm_test_responder_key_pair_info_case2),
+        cmocka_unit_test(rsp_key_pair_info_case2),
         /* KeyPairID > total_key_pairs*/
-        cmocka_unit_test(libspdm_test_responder_key_pair_info_case3),
+        cmocka_unit_test(rsp_key_pair_info_case3),
         /* capability not set KEY_PAIR_INFO*/
-        cmocka_unit_test(libspdm_test_responder_key_pair_info_case4),
+        cmocka_unit_test(rsp_key_pair_info_case4),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/key_update_ack.c
+++ b/unit_test/test_spdm_responder/key_update_ack.c
@@ -173,7 +173,7 @@ static void libspdm_compute_secret_update(spdm_version_number_t spdm_version,
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case1(void **state)
+static void rsp_key_update_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -243,7 +243,7 @@ void libspdm_test_responder_key_update_case1(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void libspdm_test_responder_key_update_case2(void **state)
+static void rsp_key_update_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -306,7 +306,7 @@ void libspdm_test_responder_key_update_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state. No keys are updated.
  **/
-void libspdm_test_responder_key_update_case3(void **state)
+static void rsp_key_update_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -373,7 +373,7 @@ void libspdm_test_responder_key_update_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state. No keys are updated.
  **/
-void libspdm_test_responder_key_update_case4(void **state)
+static void rsp_key_update_ack_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -443,7 +443,7 @@ void libspdm_test_responder_key_update_case4(void **state)
  * ERROR message indicating the ResponseNotReady state. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case5(void **state)
+static void rsp_key_update_ack_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -520,7 +520,7 @@ void libspdm_test_responder_key_update_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest. No keys are updated.
  **/
-void libspdm_test_responder_key_update_case6(void **state)
+static void rsp_key_update_ack_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -581,7 +581,7 @@ void libspdm_test_responder_key_update_case6(void **state)
                         m_rsp_secret_buffer, secured_message_context->hash_size);
 }
 
-void libspdm_test_responder_key_update_case7(void **state)
+static void rsp_key_update_ack_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -672,7 +672,7 @@ void libspdm_test_responder_key_update_case7(void **state)
  * produces an ERROR message indicating the UnsupportedRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case8(void **state)
+static void rsp_key_update_ack_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -742,7 +742,7 @@ void libspdm_test_responder_key_update_case8(void **state)
  * Expected behavior: the responder refuses the KEY_UPDATE message and produces
  * an ERROR message indicating the UnsupportedRequest. No keys are updated.
  **/
-void libspdm_test_responder_key_update_case9(void **state)
+static void rsp_key_update_ack_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -811,7 +811,7 @@ void libspdm_test_responder_key_update_case9(void **state)
  * KEY_UPDATE_ACK response message, and both the request data key and the
  * response data key are updated.
  **/
-void libspdm_test_responder_key_update_case10(void **state)
+static void rsp_key_update_ack_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -885,7 +885,7 @@ void libspdm_test_responder_key_update_case10(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void libspdm_test_responder_key_update_case11(void **state)
+static void rsp_key_update_ack_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -949,7 +949,7 @@ void libspdm_test_responder_key_update_case11(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case12(void **state)
+static void rsp_key_update_ack_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1036,7 +1036,7 @@ void libspdm_test_responder_key_update_case12(void **state)
  * produces an ERROR message indicating the InvalidRequest. The request
  * data key is not rolled back to before the UpdateKey.
  **/
-void libspdm_test_responder_key_update_case13(void **state)
+static void rsp_key_update_ack_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1122,7 +1122,7 @@ void libspdm_test_responder_key_update_case13(void **state)
  * KEY_UPDATE_ACK response message, and both the request data key and the
  * response data key are updated.
  **/
-void libspdm_test_responder_key_update_case14(void **state)
+static void rsp_key_update_ack_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1225,7 +1225,7 @@ void libspdm_test_responder_key_update_case14(void **state)
  * request data key nor the response data key are rolled back to before
  * the UpdateAllKeys.
  **/
-void libspdm_test_responder_key_update_case15(void **state)
+static void rsp_key_update_ack_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1327,7 +1327,7 @@ void libspdm_test_responder_key_update_case15(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case16(void **state)
+static void rsp_key_update_ack_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1392,7 +1392,7 @@ void libspdm_test_responder_key_update_case16(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case17(void **state)
+static void rsp_key_update_ack_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1469,7 +1469,7 @@ void libspdm_test_responder_key_update_case17(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case18(void **state)
+static void rsp_key_update_ack_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1562,7 +1562,7 @@ void libspdm_test_responder_key_update_case18(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case19(void **state)
+static void rsp_key_update_ack_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1618,7 +1618,7 @@ void libspdm_test_responder_key_update_case19(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case20(void **state)
+static void rsp_key_update_ack_case20(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1673,7 +1673,7 @@ void libspdm_test_responder_key_update_case20(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case21(void **state)
+static void rsp_key_update_ack_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1747,7 +1747,7 @@ void libspdm_test_responder_key_update_case21(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case22(void **state)
+static void rsp_key_update_ack_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1825,7 +1825,7 @@ void libspdm_test_responder_key_update_case22(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case23(void **state)
+static void rsp_key_update_ack_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1882,7 +1882,7 @@ void libspdm_test_responder_key_update_case23(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case24(void **state)
+static void rsp_key_update_ack_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -1954,7 +1954,7 @@ void libspdm_test_responder_key_update_case24(void **state)
  * Expected behavior: the responder accepts the request, produces a valid
  * KEY_UPDATE_ACK response message, and the request data key is updated.
  **/
-void libspdm_test_responder_key_update_case25(void **state)
+static void rsp_key_update_ack_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -2030,7 +2030,7 @@ void libspdm_test_responder_key_update_case25(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys are
  * updated.
  **/
-void libspdm_test_responder_key_update_case26(void **state)
+static void rsp_key_update_ack_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -2099,7 +2099,7 @@ void libspdm_test_responder_key_update_case26(void **state)
  * produces an ERROR message indicating the InvalidRequest. No keys
  * are updated.
  **/
-void libspdm_test_responder_key_update_case27(void **state)
+static void rsp_key_update_ack_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t            *spdm_test_context;
@@ -2160,61 +2160,61 @@ int libspdm_rsp_key_update_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case -- UpdateKey*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case1),
+        cmocka_unit_test(rsp_key_update_ack_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case2),
+        cmocka_unit_test(rsp_key_update_ack_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case3),
+        cmocka_unit_test(rsp_key_update_ack_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case4),
+        cmocka_unit_test(rsp_key_update_ack_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case5),
+        cmocka_unit_test(rsp_key_update_ack_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case6),
+        cmocka_unit_test(rsp_key_update_ack_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case7),
+        cmocka_unit_test(rsp_key_update_ack_case7),
         /* Unsupported KEY_UPD capabilities*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case8),
+        cmocka_unit_test(rsp_key_update_ack_case8),
         /* Uninitialized session*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case9),
+        cmocka_unit_test(rsp_key_update_ack_case9),
         /* Success Case -- UpdateAllKeys*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case10),
+        cmocka_unit_test(rsp_key_update_ack_case10),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case11),
+        cmocka_unit_test(rsp_key_update_ack_case11),
         /* UpdateKey + VerifyNewKey: Success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case12),
+        cmocka_unit_test(rsp_key_update_ack_case12),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case13),
+        cmocka_unit_test(rsp_key_update_ack_case13),
         /* UpdateALLKeys + VerifyNewKey: Success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case14),
+        cmocka_unit_test(rsp_key_update_ack_case14),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case15),
+        cmocka_unit_test(rsp_key_update_ack_case15),
         /* Uninitialized key update*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case16),
+        cmocka_unit_test(rsp_key_update_ack_case16),
         /* UpdateKey + UpdateKey: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case17),
+        cmocka_unit_test(rsp_key_update_ack_case17),
         /* UpdateKey + UpdateAllKeys: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case18),
+        cmocka_unit_test(rsp_key_update_ack_case18),
         /* UpdateALLKeys + UpdateKey: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case19),
+        cmocka_unit_test(rsp_key_update_ack_case19),
         /* UpdateALLKeys + UpdateALLKeys: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case20),
+        cmocka_unit_test(rsp_key_update_ack_case20),
         /* VerifyNewKey + UpdateKey: success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case21),
+        cmocka_unit_test(rsp_key_update_ack_case21),
         /* VerifyNewKey + UpdateAllKeys: success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case22),
+        cmocka_unit_test(rsp_key_update_ack_case22),
         /* VerifyNewKey + VerifyNewKey: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case23),
+        cmocka_unit_test(rsp_key_update_ack_case23),
         /* other command + UpdateKey: success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case24),
+        cmocka_unit_test(rsp_key_update_ack_case24),
         /* other command + UpdateAllKeys: success*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case25),
+        cmocka_unit_test(rsp_key_update_ack_case25),
         /* other command + VerifyNewKey: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case26),
+        cmocka_unit_test(rsp_key_update_ack_case26),
         /* Invalid operation,other key_update operation: failed*/
-        cmocka_unit_test(libspdm_test_responder_key_update_case27),
+        cmocka_unit_test(rsp_key_update_ack_case27),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/measurement_extension_log.c
+++ b/unit_test/test_spdm_responder/measurement_extension_log.c
@@ -45,7 +45,7 @@ size_t m_libspdm_get_measurement_extension_log_request4_size =
  * Test 1: request the first LIBSPDM_MAX_MEL_BLOCK_LEN bytes of the MEL
  * Expected Behavior: generate a correctly formed MEL message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_measurement_extension_log_case1(void **state)
+static void rsp_measurement_extension_log_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -107,7 +107,7 @@ void libspdm_test_responder_measurement_extension_log_case1(void **state)
  * Test 2: request.length is less than the MEL len
  * Expected Behavior: generate a correctly formed MEL message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_measurement_extension_log_case2(void **state)
+static void rsp_measurement_extension_log_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -172,7 +172,7 @@ void libspdm_test_responder_measurement_extension_log_case2(void **state)
  * Test 3: When the request.length is greater than LIBSPDM_MAX_MEL_BLOCK_LEN.
  * Expected Behavior: generate a correctly formed MEL message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_measurement_extension_log_case3(void **state)
+static void rsp_measurement_extension_log_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -234,7 +234,7 @@ void libspdm_test_responder_measurement_extension_log_case3(void **state)
  * Test 4: request.offset > spdm mel len , wrong request message
  * Expected Behavior: Generate error response message
  **/
-void libspdm_test_responder_measurement_extension_log_case4(void **state)
+static void rsp_measurement_extension_log_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -293,7 +293,7 @@ void libspdm_test_responder_measurement_extension_log_case4(void **state)
  * Test 5: A correct and not zero request.offset.
  * Expected Behavior: generate a correctly formed MEL message, including its portion_length and remainder_length fields
  **/
-void libspdm_test_responder_measurement_extension_log_case5(void **state)
+static void rsp_measurement_extension_log_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -359,15 +359,15 @@ int libspdm_rsp_measurement_extension_log_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case1),
+        cmocka_unit_test(rsp_measurement_extension_log_case1),
         /* Success Case, request.length < total MEL len*/
-        cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case2),
+        cmocka_unit_test(rsp_measurement_extension_log_case2),
         /* Success Case, request.length > LIBSPDM_MAX_MEL_BLOCK_LEN*/
-        cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case3),
+        cmocka_unit_test(rsp_measurement_extension_log_case3),
         /* failed Case,  request.offset > total MEL len*/
-        cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case4),
+        cmocka_unit_test(rsp_measurement_extension_log_case4),
         /* Success Case, request.offset < total MEL len*/
-        cmocka_unit_test(libspdm_test_responder_measurement_extension_log_case5),
+        cmocka_unit_test(rsp_measurement_extension_log_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -121,7 +121,7 @@ extern size_t libspdm_secret_lib_meas_opaque_data_size;
  * Test 1: Successful response to get a number of measurements without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case1(void **state)
+static void rsp_measurements_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -177,7 +177,7 @@ void libspdm_test_responder_measurements_case1(void **state)
  * Test 2:
  * Expected Behavior:
  **/
-void libspdm_test_responder_measurements_case2(void **state)
+static void rsp_measurements_case2(void **state)
 {
 }
 
@@ -185,7 +185,7 @@ void libspdm_test_responder_measurements_case2(void **state)
  * Test 3: Force response_state = SPDM_RESPONSE_STATE_BUSY when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
  **/
-void libspdm_test_responder_measurements_case3(void **state)
+static void rsp_measurements_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -239,7 +239,7 @@ void libspdm_test_responder_measurements_case3(void **state)
  * Test 4: Force response_state = SPDM_RESPONSE_STATE_NEED_RESYNC when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  **/
-void libspdm_test_responder_measurements_case4(void **state)
+static void rsp_measurements_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -295,7 +295,7 @@ void libspdm_test_responder_measurements_case4(void **state)
  * Test 5: Force response_state = SPDM_RESPONSE_STATE_NOT_READY when asked GET_MEASUREMENTS
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_RESPONSE_NOT_READY
  **/
-void libspdm_test_responder_measurements_case5(void **state)
+static void rsp_measurements_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -358,7 +358,7 @@ void libspdm_test_responder_measurements_case5(void **state)
  *        (missing SPDM_GET_DIGESTS_RECEIVE_FLAG, SPDM_GET_CAPABILITIES_RECEIVE_FLAG and SPDM_NEGOTIATE_ALGORITHMS_RECEIVE_FLAG)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_UNEXPECTED_REQUEST
  **/
-void libspdm_test_responder_measurements_case6(void **state)
+static void rsp_measurements_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -411,7 +411,7 @@ void libspdm_test_responder_measurements_case6(void **state)
  * Test 7: Successful response to get a number of measurements with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case7(void **state)
+static void rsp_measurements_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -530,7 +530,7 @@ void libspdm_test_responder_measurements_case7(void **state)
  * Test 8: Successful response to get one measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case8(void **state)
+static void rsp_measurements_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -586,7 +586,7 @@ void libspdm_test_responder_measurements_case8(void **state)
  * Test 9: Error case, Bad request size (sizeof(spdm_message_header_t)x) to get measurement number with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case9(void **state)
+static void rsp_measurements_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -638,7 +638,7 @@ void libspdm_test_responder_measurements_case9(void **state)
  * Test 10: Successful response to get one measurement without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case10(void **state)
+static void rsp_measurements_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -698,7 +698,7 @@ void libspdm_test_responder_measurements_case10(void **state)
  * Test 11: Successful response to get all measurements with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case11(void **state)
+static void rsp_measurements_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -767,7 +767,7 @@ void libspdm_test_responder_measurements_case11(void **state)
  * Test 12: Successful response to get all measurements without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case12(void **state)
+static void rsp_measurements_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -849,7 +849,7 @@ void libspdm_test_responder_measurements_case12(void **state)
  * Test 13:
  * Expected Behavior:
  **/
-void libspdm_test_responder_measurements_case13(void **state)
+static void rsp_measurements_case13(void **state)
 {
 }
 
@@ -857,7 +857,7 @@ void libspdm_test_responder_measurements_case13(void **state)
  * Test 14: Error case, signature was required, but there is no nonce and/or slotID
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case14(void **state)
+static void rsp_measurements_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -926,7 +926,7 @@ void libspdm_test_responder_measurements_case14(void **state)
  * Test 15: Error case, meas_cap = 01b, but signature was requested (request message includes nonce and slotID)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case15(void **state)
+static void rsp_measurements_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -980,7 +980,7 @@ void libspdm_test_responder_measurements_case15(void **state)
  * Test 16: Error case, meas_cap = 01b, but signature was requested (request message does not include nonce and slotID)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case16(void **state)
+static void rsp_measurements_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1032,7 +1032,7 @@ void libspdm_test_responder_measurements_case16(void **state)
  * Test 17: Error case, meas_cap = 00
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case17(void **state)
+static void rsp_measurements_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1086,7 +1086,7 @@ void libspdm_test_responder_measurements_case17(void **state)
  * Test 18: Successful response to get one measurement with signature, SlotId different from default
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case18(void **state)
+static void rsp_measurements_case18(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1157,7 +1157,7 @@ void libspdm_test_responder_measurements_case18(void **state)
  * Test 19: Error case, invalid SlotId parameter (SlotId >= SPDM_MAX_SLOT_COUNT)
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case19(void **state)
+static void rsp_measurements_case19(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1210,7 +1210,7 @@ void libspdm_test_responder_measurements_case19(void **state)
  * Test 21: Error case, request a measurement index not found
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
-void libspdm_test_responder_measurements_case21(void **state)
+static void rsp_measurements_case21(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1262,7 +1262,7 @@ void libspdm_test_responder_measurements_case21(void **state)
  * Expected Behavior: while transcript.message_m is not full, get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  *                    if transcript.message_m has no more room, an error response is expected
  **/
-void libspdm_test_responder_measurements_case22(void **state)
+static void rsp_measurements_case22(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1345,7 +1345,7 @@ void libspdm_test_responder_measurements_case22(void **state)
  * Test 23: Successful response to get a session based measurement with signature
  * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
  **/
-void libspdm_test_responder_measurements_case23(void **state)
+static void rsp_measurements_case23(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1415,7 +1415,7 @@ void libspdm_test_responder_measurements_case23(void **state)
  * MEASUREMENTS response message, and buffer M appends the exchanged GET_MEASUREMENTS and MEASUREMENTS
  * messages.
  **/
-void libspdm_test_responder_measurements_case24(void **state)
+static void rsp_measurements_case24(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1497,7 +1497,7 @@ void libspdm_test_responder_measurements_case24(void **state)
 #endif
 }
 
-void libspdm_test_responder_measurements_case25(void **state)
+static void rsp_measurements_case25(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1551,7 +1551,7 @@ void libspdm_test_responder_measurements_case25(void **state)
 #endif
 }
 
-void libspdm_test_responder_measurements_case26(void **state)
+static void rsp_measurements_case26(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1622,7 +1622,7 @@ void libspdm_test_responder_measurements_case26(void **state)
     free(data);
 }
 
-void libspdm_test_responder_measurements_case27(void **state)
+static void rsp_measurements_case27(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1746,7 +1746,7 @@ void libspdm_test_responder_measurements_case27(void **state)
  * Test 28: Successful response to get all measurements with signature using slot_id 0xFF
  * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
-void libspdm_test_responder_measurements_case28(void **state)
+static void rsp_measurements_case28(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1824,7 +1824,7 @@ void libspdm_test_responder_measurements_case28(void **state)
  *
  * Expected Behavior: Failing signature verification
  **/
-void libspdm_test_responder_measurements_case29(void** state)
+static void rsp_measurements_case29(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -1949,7 +1949,7 @@ void libspdm_test_responder_measurements_case29(void** state)
  *
  * Expected Behavior: Failing signature verification
  **/
-void libspdm_test_responder_measurements_case30(void** state)
+static void rsp_measurements_case30(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2074,7 +2074,7 @@ void libspdm_test_responder_measurements_case30(void** state)
  *
  * Expected Behavior: Passing signature verification
  **/
-void libspdm_test_responder_measurements_case31(void** state)
+static void rsp_measurements_case31(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2199,7 +2199,7 @@ void libspdm_test_responder_measurements_case31(void** state)
  *
  * Expected Behavior: Failing signature verification
  **/
-void libspdm_test_responder_measurements_case32(void** state)
+static void rsp_measurements_case32(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2329,7 +2329,7 @@ void libspdm_test_responder_measurements_case32(void** state)
  *
  * Expected Behavior: Failing signature verification
  **/
-void libspdm_test_responder_measurements_case33(void** state)
+static void rsp_measurements_case33(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2460,7 +2460,7 @@ void libspdm_test_responder_measurements_case33(void** state)
  *
  * Expected Behavior: Passing signature verification
  **/
-void libspdm_test_responder_measurements_case34(void** state)
+static void rsp_measurements_case34(void** state)
 {
     libspdm_return_t status;
     libspdm_test_context_t* spdm_test_context;
@@ -2586,7 +2586,7 @@ void libspdm_test_responder_measurements_case34(void** state)
  * Test 35: Successful response V1.3 to get a number of measurements without signature
  * Expected Behavior: get a RETURN_SUCCESS return code, correct context field
  **/
-void libspdm_test_responder_measurements_case35(void **state)
+static void rsp_measurements_case35(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2653,7 +2653,7 @@ void libspdm_test_responder_measurements_case35(void **state)
  * Test 36: The key usage bit mask is not set, the SlotID fields in GET_MEASUREMENTS and MEASUREMENTS shall not specify this certificate slot
  * Expected Behavior: get a SPDM_ERROR_CODE_INVALID_REQUEST return code
  **/
-void libspdm_test_responder_measurements_case36(void **state)
+static void rsp_measurements_case36(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -2737,77 +2737,77 @@ int libspdm_rsp_measurements_test(void)
 
     const struct CMUnitTest test_cases[] = {
         /* Success Case to get measurement number without signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case1),
+        cmocka_unit_test(rsp_measurements_case1),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case2),
+        cmocka_unit_test(rsp_measurements_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case3),
+        cmocka_unit_test(rsp_measurements_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case4),
+        cmocka_unit_test(rsp_measurements_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case5),
+        cmocka_unit_test(rsp_measurements_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case6),
+        cmocka_unit_test(rsp_measurements_case6),
         /* Success Case to get measurement number with signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case7),
+        cmocka_unit_test(rsp_measurements_case7),
         /* Success Case to get one measurement with signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case8),
+        cmocka_unit_test(rsp_measurements_case8),
         /* Bad request size to get one measurement with signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case9),
+        cmocka_unit_test(rsp_measurements_case9),
         /* Success Case to get one measurement without signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case10),
+        cmocka_unit_test(rsp_measurements_case10),
         /* Success Case to get all measurements with signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case11),
+        cmocka_unit_test(rsp_measurements_case11),
         /* Success Case to get all measurements without signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case12),
+        cmocka_unit_test(rsp_measurements_case12),
         /* Can be populated with new test.*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case13),
+        cmocka_unit_test(rsp_measurements_case13),
         /* Error Case: sig required, but no nonce and/or SlotID*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case14),
+        cmocka_unit_test(rsp_measurements_case14),
         /* Error Case: sig required, but meas_cap = 01b (including nonce and SlotId on request)*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case15),
+        cmocka_unit_test(rsp_measurements_case15),
         /* Error Case: sig required, but meas_cap = 01b (not including nonce and SlotId on request)*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case16),
+        cmocka_unit_test(rsp_measurements_case16),
         /* Error Case: meas_cap = 00b*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case17),
+        cmocka_unit_test(rsp_measurements_case17),
         /* Success Case: SlotId different from default*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case18),
+        cmocka_unit_test(rsp_measurements_case18),
         /* Bad SlotId parameter (>= SPDM_MAX_SLOT_COUNT)*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case19),
+        cmocka_unit_test(rsp_measurements_case19),
         /* Error Case: request a measurement out of bounds*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case21),
+        cmocka_unit_test(rsp_measurements_case21),
         /* Large number of requests before requiring a signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case22),
+        cmocka_unit_test(rsp_measurements_case22),
         /* Successful response to get a session based measurement with signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case23),
+        cmocka_unit_test(rsp_measurements_case23),
         /* Buffer verification */
-        cmocka_unit_test(libspdm_test_responder_measurements_case24),
+        cmocka_unit_test(rsp_measurements_case24),
         /* Success Case V1.2 to get one measurement without signature*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case25),
+        cmocka_unit_test(rsp_measurements_case25),
         /* Successful response V1.2 to get one measurement with signature and without opqaue data*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case26),
+        cmocka_unit_test(rsp_measurements_case26),
         /* Successful response V1.2 to get one measurement with signature and with opqaue data*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case27),
+        cmocka_unit_test(rsp_measurements_case27),
         /* Success Case to get measurement with signature using slot_id 0xFF */
-        cmocka_unit_test(libspdm_test_responder_measurements_case28),
+        cmocka_unit_test(rsp_measurements_case28),
         /* Error Case: Big Endian Signature. Little Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case29),
+        cmocka_unit_test(rsp_measurements_case29),
         /* Success Case: Big Endian Signature. Big Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case30),
+        cmocka_unit_test(rsp_measurements_case30),
         /* Success Case: Big Endian Signature. Big or Little Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case31),
+        cmocka_unit_test(rsp_measurements_case31),
         /* Success Case: Little Endian Signature. Little Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case32),
+        cmocka_unit_test(rsp_measurements_case32),
         /* Error Case: Little Endian Signature. Big Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case33),
+        cmocka_unit_test(rsp_measurements_case33),
         /* Success Case: Little Endian Signature. Big or Little Endian Verify */
-        cmocka_unit_test(libspdm_test_responder_measurements_case34),
+        cmocka_unit_test(rsp_measurements_case34),
         /* Success Case: V1.3 get a correct context field */
-        cmocka_unit_test(libspdm_test_responder_measurements_case35),
+        cmocka_unit_test(rsp_measurements_case35),
         /* The key usage bit mask is not set, failed Case*/
-        cmocka_unit_test(libspdm_test_responder_measurements_case36),
+        cmocka_unit_test(rsp_measurements_case36),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/psk_exchange_rsp.c
+++ b/unit_test/test_spdm_responder/psk_exchange_rsp.c
@@ -112,7 +112,7 @@ libspdm_psk_exchange_request_mine_t_noPSKHINT_noOPAQUE m_libspdm_psk_exchange_re
 };
 size_t m_libspdm_psk_exchange_request9_size = sizeof(m_libspdm_psk_exchange_request9);
 
-void libspdm_test_responder_psk_exchange_case1(void **state)
+static void rsp_psk_exchange_rsp_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -204,7 +204,7 @@ void libspdm_test_responder_psk_exchange_case1(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case2(void **state)
+static void rsp_psk_exchange_rsp_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -285,7 +285,7 @@ void libspdm_test_responder_psk_exchange_case2(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case3(void **state)
+static void rsp_psk_exchange_rsp_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -368,7 +368,7 @@ void libspdm_test_responder_psk_exchange_case3(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case4(void **state)
+static void rsp_psk_exchange_rsp_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -453,7 +453,7 @@ void libspdm_test_responder_psk_exchange_case4(void **state)
 }
 
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
-void libspdm_test_responder_psk_exchange_case5(void **state)
+static void rsp_psk_exchange_rsp_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -544,7 +544,7 @@ void libspdm_test_responder_psk_exchange_case5(void **state)
 }
 #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
 
-void libspdm_test_responder_psk_exchange_case6(void **state)
+static void rsp_psk_exchange_rsp_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -626,7 +626,7 @@ void libspdm_test_responder_psk_exchange_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case7(void **state)
+static void rsp_psk_exchange_rsp_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -729,7 +729,7 @@ void libspdm_test_responder_psk_exchange_case7(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case8(void **state)
+static void rsp_psk_exchange_rsp_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -822,7 +822,7 @@ void libspdm_test_responder_psk_exchange_case8(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case9(void **state)
+static void rsp_psk_exchange_rsp_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -908,7 +908,7 @@ void libspdm_test_responder_psk_exchange_case9(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case10(void **state)
+static void rsp_psk_exchange_rsp_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1032,7 +1032,7 @@ void libspdm_test_responder_psk_exchange_case10(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case11(void **state)
+static void rsp_psk_exchange_rsp_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1156,7 +1156,7 @@ void libspdm_test_responder_psk_exchange_case11(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case12(void **state)
+static void rsp_psk_exchange_rsp_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1253,7 +1253,7 @@ void libspdm_test_responder_psk_exchange_case12(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case13(void **state)
+static void rsp_psk_exchange_rsp_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1348,7 +1348,7 @@ void libspdm_test_responder_psk_exchange_case13(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case14(void **state)
+static void rsp_psk_exchange_rsp_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1439,7 +1439,7 @@ void libspdm_test_responder_psk_exchange_case14(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case15(void **state)
+static void rsp_psk_exchange_rsp_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1533,7 +1533,7 @@ void libspdm_test_responder_psk_exchange_case15(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case16(void **state)
+static void rsp_psk_exchange_rsp_case16(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1622,7 +1622,7 @@ void libspdm_test_responder_psk_exchange_case16(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_exchange_case17(void **state)
+static void rsp_psk_exchange_rsp_case17(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1724,41 +1724,41 @@ int libspdm_rsp_psk_exchange_rsp_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case1),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case2),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case3),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case4),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case5),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case6),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case7),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case7),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case8),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case8),
         /* Successful response V1.2*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case9),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case9),
         /* TCB measurement hash requested */
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case10),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case10),
         /* All measurement hash requested */
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case11),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case11),
         /* Reserved value in Measurement summary. Error + Invalid */
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case12),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case12),
         /* TCB measurement hash requested, measurement flag not set */
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case13),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case13),
         /* No PSKHint*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case14),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case14),
         /* No OpaqueData*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case15),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case15),
         /* No PSKHint and no OpaqueData*/
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case16),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case16),
         /* OpaqueData only supports OpaqueDataFmt1, Success Case */
-        cmocka_unit_test(libspdm_test_responder_psk_exchange_case17),
+        cmocka_unit_test(rsp_psk_exchange_rsp_case17),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/psk_finish_rsp.c
+++ b/unit_test/test_spdm_responder/psk_finish_rsp.c
@@ -60,7 +60,7 @@ static void libspdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid
  * PSK_FINISH_RSP response message.
  **/
-void libspdm_test_responder_psk_finish_case1(void **state)
+static void rsp_psk_finish_rsp_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -165,7 +165,7 @@ void libspdm_test_responder_psk_finish_case1(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_psk_finish_case2(void **state)
+static void rsp_psk_finish_rsp_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -270,7 +270,7 @@ void libspdm_test_responder_psk_finish_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the Busy state.
  **/
-void libspdm_test_responder_psk_finish_case3(void **state)
+static void rsp_psk_finish_rsp_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -381,7 +381,7 @@ void libspdm_test_responder_psk_finish_case3(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the NeedResynch state.
  **/
-void libspdm_test_responder_psk_finish_case4(void **state)
+static void rsp_psk_finish_rsp_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -494,7 +494,7 @@ void libspdm_test_responder_psk_finish_case4(void **state)
  * Expected behavior: the responder accepts the request, but produces an
  * ERROR message indicating the ResponseNotReady state.
  **/
-void libspdm_test_responder_psk_finish_case5(void **state)
+static void rsp_psk_finish_rsp_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -615,7 +615,7 @@ void libspdm_test_responder_psk_finish_case5(void **state)
  * Expected behavior: the responder rejects the request, and produces an
  * ERROR message indicating the UnexpectedRequest.
  **/
-void libspdm_test_responder_psk_finish_case6(void **state)
+static void rsp_psk_finish_rsp_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -719,7 +719,7 @@ void libspdm_test_responder_psk_finish_case6(void **state)
     free(data1);
 }
 
-void libspdm_test_responder_psk_finish_case7(void **state)
+static void rsp_psk_finish_rsp_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -847,7 +847,7 @@ void libspdm_test_responder_psk_finish_case7(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the UnsupportedRequest.
  **/
-void libspdm_test_responder_psk_finish_case8(void **state)
+static void rsp_psk_finish_rsp_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -957,7 +957,7 @@ void libspdm_test_responder_psk_finish_case8(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_psk_finish_case9(void **state)
+static void rsp_psk_finish_rsp_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1066,7 +1066,7 @@ void libspdm_test_responder_psk_finish_case9(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_psk_finish_case10(void **state)
+static void rsp_psk_finish_rsp_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1164,7 +1164,7 @@ void libspdm_test_responder_psk_finish_case10(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the DecryptError.
  **/
-void libspdm_test_responder_psk_finish_case11(void **state)
+static void rsp_psk_finish_rsp_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1268,7 +1268,7 @@ void libspdm_test_responder_psk_finish_case11(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_psk_finish_case12(void **state)
+static void rsp_psk_finish_rsp_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1379,7 +1379,7 @@ void libspdm_test_responder_psk_finish_case12(void **state)
  * Expected behavior: the responder refuses the PSK_FINISH message and
  * produces an ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_psk_finish_case13(void **state)
+static void rsp_psk_finish_rsp_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1488,7 +1488,7 @@ void libspdm_test_responder_psk_finish_case13(void **state)
  * Expected behavior: the responder accepts the request and produces a valid PSK_FINISH
  * response message, and buffer F receives the exchanged PSK_FINISH and PSK_FINISH_RSP messages.
  **/
-void libspdm_test_responder_psk_finish_case14(void **state)
+static void rsp_psk_finish_rsp_case14(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1591,7 +1591,7 @@ void libspdm_test_responder_psk_finish_case14(void **state)
  * Expected behavior: the responder accepts the request and produces a valid PSK_FINISH
  * response message.
  **/
-void libspdm_test_responder_psk_finish_case15(void **state)
+static void rsp_psk_finish_rsp_case15(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1691,35 +1691,35 @@ int libspdm_rsp_psk_finish_rsp_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case1),
+        cmocka_unit_test(rsp_psk_finish_rsp_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case2),
+        cmocka_unit_test(rsp_psk_finish_rsp_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case3),
+        cmocka_unit_test(rsp_psk_finish_rsp_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case4),
+        cmocka_unit_test(rsp_psk_finish_rsp_case4),
         #if LIBSPDM_RESPOND_IF_READY_SUPPORT
         /* response_state: SPDM_RESPONSE_STATE_NOT_READY*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case5),
+        cmocka_unit_test(rsp_psk_finish_rsp_case5),
         #endif /* LIBSPDM_RESPOND_IF_READY_SUPPORT */
         /* connection_state Check*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case6),
+        cmocka_unit_test(rsp_psk_finish_rsp_case6),
         /* Buffer reset*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case7),
+        cmocka_unit_test(rsp_psk_finish_rsp_case7),
         /* Unsupported PSK capabilities*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case8),
+        cmocka_unit_test(rsp_psk_finish_rsp_case8),
         /* Uninitialized session*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case9),
+        cmocka_unit_test(rsp_psk_finish_rsp_case9),
         /* Incorrect MAC*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case10),
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case11),
+        cmocka_unit_test(rsp_psk_finish_rsp_case10),
+        cmocka_unit_test(rsp_psk_finish_rsp_case11),
         /* Incorrect MAC size*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case12),
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case13),
+        cmocka_unit_test(rsp_psk_finish_rsp_case12),
+        cmocka_unit_test(rsp_psk_finish_rsp_case13),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case14),
+        cmocka_unit_test(rsp_psk_finish_rsp_case14),
         /* SPDM 1.4 with OpaqueData */
-        cmocka_unit_test(libspdm_test_responder_psk_finish_case15),
+        cmocka_unit_test(rsp_psk_finish_rsp_case15),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -285,7 +285,7 @@ static void libspdm_secured_message_set_request_finished_key(
  * Expected behavior: the responder accepts the request and produces a valid DIGESTS
  * response message.
  **/
-void libspdm_test_responder_respond_if_ready_case1(void **state) {
+static void rsp_respond_if_ready_case1(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -353,7 +353,7 @@ void libspdm_test_responder_respond_if_ready_case1(void **state) {
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 
-void libspdm_test_responder_respond_if_ready_case2(void **state) {
+static void rsp_respond_if_ready_case2(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -427,7 +427,7 @@ void libspdm_test_responder_respond_if_ready_case2(void **state) {
  * response message.
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-void libspdm_test_responder_respond_if_ready_case3(void **state) {
+static void rsp_respond_if_ready_case3(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -511,7 +511,7 @@ void libspdm_test_responder_respond_if_ready_case3(void **state) {
 
 extern size_t libspdm_secret_lib_meas_opaque_data_size;
 
-void libspdm_test_responder_respond_if_ready_case4(void **state) {
+static void rsp_respond_if_ready_case4(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -580,7 +580,7 @@ void libspdm_test_responder_respond_if_ready_case4(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-void libspdm_test_responder_respond_if_ready_case5(void **state) {
+static void rsp_respond_if_ready_case5(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -695,7 +695,7 @@ void libspdm_test_responder_respond_if_ready_case5(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
 
-void libspdm_test_responder_respond_if_ready_case6(void **state) {
+static void rsp_respond_if_ready_case6(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -820,7 +820,7 @@ void libspdm_test_responder_respond_if_ready_case6(void **state) {
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
 
-void libspdm_test_responder_respond_if_ready_case7(void **state) {
+static void rsp_respond_if_ready_case7(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -929,7 +929,7 @@ void libspdm_test_responder_respond_if_ready_case7(void **state) {
  * response message.
  **/
 #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
-void libspdm_test_responder_respond_if_ready_case8(void **state) {
+static void rsp_respond_if_ready_case8(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1048,7 +1048,7 @@ void libspdm_test_responder_respond_if_ready_case8(void **state) {
  * Test 9:
  * Expected behavior:
  **/
-void libspdm_test_responder_respond_if_ready_case9(void **state) {
+static void rsp_respond_if_ready_case9(void **state) {
 }
 
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
@@ -1060,7 +1060,7 @@ void libspdm_test_responder_respond_if_ready_case9(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Busy state.
  **/
-void libspdm_test_responder_respond_if_ready_case10(void **state) {
+static void rsp_respond_if_ready_case10(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1123,7 +1123,7 @@ void libspdm_test_responder_respond_if_ready_case10(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the NeedResynch state.
  **/
-void libspdm_test_responder_respond_if_ready_case11(void **state) {
+static void rsp_respond_if_ready_case11(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1187,7 +1187,7 @@ void libspdm_test_responder_respond_if_ready_case11(void **state) {
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the ResponseNotReady state, with the same token as the request.
  **/
-void libspdm_test_responder_respond_if_ready_case12(void **state) {
+static void rsp_respond_if_ready_case12(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1256,7 +1256,7 @@ void libspdm_test_responder_respond_if_ready_case12(void **state) {
  * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_respond_if_ready_case13(void **state) {
+static void rsp_respond_if_ready_case13(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1317,7 +1317,7 @@ void libspdm_test_responder_respond_if_ready_case13(void **state) {
  * Expected behavior: the responder refuses the RESPOND_IF_READY message and produces an
  * ERROR message indicating the InvalidRequest.
  **/
-void libspdm_test_responder_respond_if_ready_case14(void **state) {
+static void rsp_respond_if_ready_case14(void **state) {
     libspdm_return_t status;
     libspdm_test_context_t    *spdm_test_context;
     libspdm_context_t  *spdm_context;
@@ -1375,35 +1375,35 @@ int libspdm_rsp_respond_if_ready_test(void) {
     const struct CMUnitTest test_cases[] = {
         /* Success Case*/
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case1),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case2),
+        cmocka_unit_test(rsp_respond_if_ready_case1),
+        cmocka_unit_test(rsp_respond_if_ready_case2),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case3),
+        cmocka_unit_test(rsp_respond_if_ready_case3),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHAL_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case4),
+        cmocka_unit_test(rsp_respond_if_ready_case4),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case5),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case6),
+        cmocka_unit_test(rsp_respond_if_ready_case5),
+        cmocka_unit_test(rsp_respond_if_ready_case6),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_KEY_EX_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case7),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case8),
+        cmocka_unit_test(rsp_respond_if_ready_case7),
+        cmocka_unit_test(rsp_respond_if_ready_case8),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP*/
 
     #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case9),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case10),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case11),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case12),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case13),
-        cmocka_unit_test(libspdm_test_responder_respond_if_ready_case14),
+        cmocka_unit_test(rsp_respond_if_ready_case9),
+        cmocka_unit_test(rsp_respond_if_ready_case10),
+        cmocka_unit_test(rsp_respond_if_ready_case11),
+        cmocka_unit_test(rsp_respond_if_ready_case12),
+        cmocka_unit_test(rsp_respond_if_ready_case13),
+        cmocka_unit_test(rsp_respond_if_ready_case14),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     };

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -24,7 +24,7 @@ extern bool g_set_cert_is_busy;
  * Test 1: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:0 with device_cert model
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case1(void **state)
+static void rsp_set_certificate_rsp_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -157,7 +157,7 @@ void libspdm_test_responder_set_certificate_rsp_case1(void **state)
  * Test 2: Wrong SET_CERTIFICATE message size (larger than expected)
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_INVALID_REQUEST
  **/
-void libspdm_test_responder_set_certificate_rsp_case2(void **state)
+static void rsp_set_certificate_rsp_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -231,7 +231,7 @@ void libspdm_test_responder_set_certificate_rsp_case2(void **state)
  * Test 3: Force response_state = LIBSPDM_RESPONSE_STATE_BUSY when asked SET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_BUSY
  **/
-void libspdm_test_responder_set_certificate_rsp_case3(void **state)
+static void rsp_set_certificate_rsp_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -308,7 +308,7 @@ void libspdm_test_responder_set_certificate_rsp_case3(void **state)
  * Test 4: Force response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC when asked SET_CERTIFICATE
  * Expected Behavior: generate an ERROR_RESPONSE with code SPDM_ERROR_CODE_REQUEST_RESYNCH
  **/
-void libspdm_test_responder_set_certificate_rsp_case4(void **state)
+static void rsp_set_certificate_rsp_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -384,7 +384,7 @@ void libspdm_test_responder_set_certificate_rsp_case4(void **state)
  * Test 5: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:1 with session
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case5(void **state)
+static void rsp_set_certificate_rsp_case5(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -470,7 +470,7 @@ void libspdm_test_responder_set_certificate_rsp_case5(void **state)
  * Test 6: receives a valid SET_CERTIFICATE request message from Requester with need_reset
  * Expected Behavior: The Responder return need reset
  **/
-void libspdm_test_responder_set_certificate_rsp_case6(void **state)
+static void rsp_set_certificate_rsp_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -545,7 +545,7 @@ void libspdm_test_responder_set_certificate_rsp_case6(void **state)
  * Test 7: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:0 with alias_cert model
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case7(void **state)
+static void rsp_set_certificate_rsp_case7(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -621,7 +621,7 @@ void libspdm_test_responder_set_certificate_rsp_case7(void **state)
  * Test 8: receives a SET_CERTIFICATE request message to set cert in slot_id:1 without session and with trusted environment
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case8(void **state)
+static void rsp_set_certificate_rsp_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -696,7 +696,7 @@ void libspdm_test_responder_set_certificate_rsp_case8(void **state)
  * Test 9: receives a SET_CERTIFICATE request message to set cert in slot_id:1 without session and without trusted environment
  * Expected Behavior: produces a valid ERROR response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case9(void **state)
+static void rsp_set_certificate_rsp_case9(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -774,7 +774,7 @@ void libspdm_test_responder_set_certificate_rsp_case9(void **state)
  * Test 10: receives a valid SET_CERTIFICATE request message from Requester to erase cert in slot_id:1 with session
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case10(void **state)
+static void rsp_set_certificate_rsp_case10(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -893,7 +893,7 @@ void libspdm_test_responder_set_certificate_rsp_case10(void **state)
  * Test 11: receives a valid SET_CERTIFICATE request message from Requester to set cert in slot_id:1 with key_pair_id
  * Expected Behavior: produces a valid SET_CERTIFICATE_RSP response message
  **/
-void libspdm_test_responder_set_certificate_rsp_case11(void **state)
+static void rsp_set_certificate_rsp_case11(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -970,7 +970,7 @@ void libspdm_test_responder_set_certificate_rsp_case11(void **state)
  * Test 12: Illegal combination of MULTI_KEY_CONN_RSP = true, Erase = false, and SetCertModel = 0.
  * Expected Behavior: produces SPDM_ERROR_CODE_INVALID_REQUEST message.
  **/
-void libspdm_test_responder_set_certificate_rsp_case12(void **state)
+static void rsp_set_certificate_rsp_case12(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1044,7 +1044,7 @@ void libspdm_test_responder_set_certificate_rsp_case12(void **state)
  * Test 13: The Responder cannot complete request due to busy response when writing to NVM.
  * Expected Behavior: The Responder returns a Busy error response.
  **/
-void libspdm_test_responder_set_certificate_rsp_case13(void **state)
+static void rsp_set_certificate_rsp_case13(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -1117,29 +1117,29 @@ int libspdm_rsp_set_certificate_rsp_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case for set_certificate to slot_id:0 with device_cert mode*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case1),
+        cmocka_unit_test(rsp_set_certificate_rsp_case1),
         /* Bad request size*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case2),
+        cmocka_unit_test(rsp_set_certificate_rsp_case2),
         /* response_state: LIBSPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case3),
+        cmocka_unit_test(rsp_set_certificate_rsp_case3),
         /* response_state: LIBSPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case4),
+        cmocka_unit_test(rsp_set_certificate_rsp_case4),
         /* Success Case for set_certificate to slot_id:1 with session*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case5),
+        cmocka_unit_test(rsp_set_certificate_rsp_case5),
         /* Responder requires a reset to complete the SET_CERTIFICATE request */
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case6),
+        cmocka_unit_test(rsp_set_certificate_rsp_case6),
         /* Success Case for set_certificate to slot_id:0 with alias_cert mode*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case7),
+        cmocka_unit_test(rsp_set_certificate_rsp_case7),
         /* Success Case for set_certificate to slot_id:1 without session and with trusted environment */
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case8),
+        cmocka_unit_test(rsp_set_certificate_rsp_case8),
         /* Error Case for set_certificate to slot_id:1 without session and without trusted environment */
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case9),
+        cmocka_unit_test(rsp_set_certificate_rsp_case9),
         /* Success Case for erase certificate to slot_id:1 with session*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case10),
+        cmocka_unit_test(rsp_set_certificate_rsp_case10),
         /* Success Case for set_certificate to slot_id:1 with key_pair_id*/
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case11),
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case12),
-        cmocka_unit_test(libspdm_test_responder_set_certificate_rsp_case13),
+        cmocka_unit_test(rsp_set_certificate_rsp_case11),
+        cmocka_unit_test(rsp_set_certificate_rsp_case12),
+        cmocka_unit_test(rsp_set_certificate_rsp_case13),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/set_key_pair_info_ack.c
+++ b/unit_test/test_spdm_responder/set_key_pair_info_ack.c
@@ -14,7 +14,7 @@
  * Test 1: Successful response to set key pair info with key pair id 4
  * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
  **/
-void libspdm_test_responder_set_key_pair_info_ack_case1(void **state)
+static void rsp_set_key_pair_info_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -129,7 +129,7 @@ void libspdm_test_responder_set_key_pair_info_ack_case1(void **state)
  * Test 2: Successful response to set key pair info with key pair id 4: need reset
  * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
  **/
-void libspdm_test_responder_set_key_pair_info_ack_case2(void **state)
+static void rsp_set_key_pair_info_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -287,7 +287,7 @@ void libspdm_test_responder_set_key_pair_info_ack_case2(void **state)
 /**
  * Test 2: The collection of multiple sub-cases.
  **/
-void libspdm_test_responder_set_key_pair_info_ack_case3(void **state)
+static void rsp_set_key_pair_info_ack_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -507,7 +507,7 @@ void libspdm_test_responder_set_key_pair_info_ack_case3(void **state)
  * Test 4: Successful response to set key pair info with key pair id 4: need reset, spdm 1.4
  * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
  **/
-void libspdm_test_responder_set_key_pair_info_ack_case4(void **state)
+static void rsp_set_key_pair_info_ack_case4(void **state)
 {
     /* reference case 2 */
     libspdm_return_t status;
@@ -680,13 +680,13 @@ int libspdm_rsp_set_key_pair_info_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success Case to set key pair info*/
-        cmocka_unit_test(libspdm_test_responder_set_key_pair_info_ack_case1),
+        cmocka_unit_test(rsp_set_key_pair_info_ack_case1),
         /* Success Case to set key pair info with reset*/
-        cmocka_unit_test(libspdm_test_responder_set_key_pair_info_ack_case2),
+        cmocka_unit_test(rsp_set_key_pair_info_ack_case2),
         /* The collection of multiple sub-cases.*/
-        cmocka_unit_test(libspdm_test_responder_set_key_pair_info_ack_case3),
+        cmocka_unit_test(rsp_set_key_pair_info_ack_case3),
         /* Success Case to set key pair info with reset, spdm 1.4*/
-        cmocka_unit_test(libspdm_test_responder_set_key_pair_info_ack_case4),
+        cmocka_unit_test(rsp_set_key_pair_info_ack_case4),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/subscribe_event_types_ack.c
+++ b/unit_test/test_spdm_responder/subscribe_event_types_ack.c
@@ -60,7 +60,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
  * Test 1: Successful response to subscribe event types that clears all events.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS with the expected values.
  **/
-static void libspdm_test_responder_subscribe_event_types_ack_case1(void **state)
+static void rsp_subscribe_event_types_ack_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -103,7 +103,7 @@ static void libspdm_test_responder_subscribe_event_types_ack_case1(void **state)
  * Test 2: Successful response to subscribe event types that subscribes to two events.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS with the expected values.
  **/
-static void libspdm_test_responder_subscribe_event_types_ack_case2(void **state)
+static void rsp_subscribe_event_types_ack_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -158,8 +158,8 @@ int libspdm_rsp_subscribe_event_types_ack_test(void)
     };
 
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_case1),
-        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_case2)
+        cmocka_unit_test(rsp_subscribe_event_types_ack_case1),
+        cmocka_unit_test(rsp_subscribe_event_types_ack_case2)
     };
 
     libspdm_setup_test_context(&test_context);

--- a/unit_test/test_spdm_responder/supported_event_types.c
+++ b/unit_test/test_spdm_responder/supported_event_types.c
@@ -60,7 +60,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
  * Test 1: Successful response to get supported event types.
  * Expected Behavior: Returns LIBSPDM_STATUS_SUCCESS with the expected values.
  **/
-static void libspdm_test_responder_supported_event_types_case1(void **state)
+static void rsp_supported_event_types_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -106,7 +106,7 @@ static void libspdm_test_responder_supported_event_types_case1(void **state)
 int libspdm_rsp_supported_event_types_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_supported_event_types_case1),
+        cmocka_unit_test(rsp_supported_event_types_case1),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/vendor_defined_response.c
+++ b/unit_test/test_spdm_responder/vendor_defined_response.c
@@ -92,7 +92,7 @@ static libspdm_return_t libspdm_vendor_response_func_test(
  * Test 1: Sending a vendor defined request using the internal response handler
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
  **/
-static void libspdm_test_responder_vendor_cmds_case1(void **state)
+static void rsp_vendor_defined_response_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -162,7 +162,7 @@ static void libspdm_test_responder_vendor_cmds_case1(void **state)
  * Test 2: Sending a vendor defined request using the internal response handler with Large VDM support
  * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS and expected response
  **/
-static void libspdm_test_responder_vendor_cmds_case2(void **state)
+static void rsp_vendor_defined_response_case2(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -242,12 +242,11 @@ static void libspdm_test_responder_vendor_cmds_case2(void **state)
     assert_int_equal(response.header.param1, SPDM_VENDOR_DEFINED_RESPONSE_LARGE_RESP);
 }
 
-
 int libspdm_rsp_vendor_defined_response_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_vendor_cmds_case1),
-        cmocka_unit_test(libspdm_test_responder_vendor_cmds_case2),
+        cmocka_unit_test(rsp_vendor_defined_response_case1),
+        cmocka_unit_test(rsp_vendor_defined_response_case2),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/version.c
+++ b/unit_test/test_spdm_responder/version.c
@@ -47,7 +47,7 @@ size_t m_libspdm_get_version_request4_size = sizeof(m_libspdm_get_version_reques
  * Expected behavior: the responder accepts the request, produces a valid VERSION
  * response message, and then resets the connection state.
  **/
-void libspdm_test_responder_version_case1(void **state)
+static void rsp_version_case1(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -82,7 +82,7 @@ void libspdm_test_responder_version_case1(void **state)
  * Test 2:
  * Expected behavior:
  **/
-void libspdm_test_responder_version_case2(void **state)
+static void rsp_version_case2(void **state)
 {
 }
 
@@ -92,7 +92,7 @@ void libspdm_test_responder_version_case2(void **state)
  * Expected behavior: the responder accepts the request, but produces an ERROR message
  * indicating the Buse state.
  **/
-void libspdm_test_responder_version_case3(void **state)
+static void rsp_version_case3(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -128,7 +128,7 @@ void libspdm_test_responder_version_case3(void **state)
  * Expected behavior: the requester resets the communication upon receiving the GET_VERSION
  * message, fulfilling the resynchronization. A valid VERSION message is produced.
  **/
-void libspdm_test_responder_version_case4(void **state)
+static void rsp_version_case4(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -165,7 +165,7 @@ void libspdm_test_responder_version_case4(void **state)
  * Expected behavior: the responder refuses the GET_VERSION message, produces an
  * ERROR message indicating the VersionMismatch, and will not reset the connection state.
  **/
-void libspdm_test_responder_version_case6(void **state)
+static void rsp_version_case6(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -199,7 +199,7 @@ void libspdm_test_responder_version_case6(void **state)
 /**
  * Test 7: can be populated with new test.
  **/
-void libspdm_test_responder_version_case7(void **state)
+static void rsp_version_case7(void **state)
 {
 }
 
@@ -210,7 +210,7 @@ void libspdm_test_responder_version_case7(void **state)
  * response message, buffers A, B and C should be first reset, and then buffer A
  * receives only the exchanged GET_VERSION and VERSION messages.
  **/
-void libspdm_test_responder_version_case8(void **state)
+static void rsp_version_case8(void **state)
 {
     libspdm_return_t status;
     libspdm_test_context_t *spdm_test_context;
@@ -259,19 +259,19 @@ void libspdm_test_responder_version_case8(void **state)
 int libspdm_rsp_version_test(void)
 {
     const struct CMUnitTest test_cases[] = {
-        cmocka_unit_test(libspdm_test_responder_version_case1),
+        cmocka_unit_test(rsp_version_case1),
         /* Invalid request*/
-        cmocka_unit_test(libspdm_test_responder_version_case2),
+        cmocka_unit_test(rsp_version_case2),
         /* response_state: SPDM_RESPONSE_STATE_BUSY*/
-        cmocka_unit_test(libspdm_test_responder_version_case3),
+        cmocka_unit_test(rsp_version_case3),
         /* response_state: SPDM_RESPONSE_STATE_NEED_RESYNC*/
-        cmocka_unit_test(libspdm_test_responder_version_case4),
+        cmocka_unit_test(rsp_version_case4),
         /* Invalid request*/
-        cmocka_unit_test(libspdm_test_responder_version_case6),
+        cmocka_unit_test(rsp_version_case6),
         /* Invalid request*/
-        cmocka_unit_test(libspdm_test_responder_version_case7),
+        cmocka_unit_test(rsp_version_case7),
         /* Buffer verification*/
-        cmocka_unit_test(libspdm_test_responder_version_case8),
+        cmocka_unit_test(rsp_version_case8),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
Rename Responder unit test case names so that they conform to https://github.com/DMTF/libspdm/blob/main/doc/internal/unit_test_template.md.