### PR TITLE
Rename non-existent `RETURN_SUCCESS` in unit test documentation

### DIFF
--- a/unit_test/include/library/spdm_transport_test_lib.h
+++ b/unit_test/include/library/spdm_transport_test_lib.h
@@ -63,9 +63,6 @@ typedef struct {
  * @param  transport_message             A pointer to a destination buffer to store the transport message.
  *                                      On input, it shall be msg_buf_ptr from sender buffer.
  *                                      On output, it will point to acquired sender buffer.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_transport_test_encode_message(
     void *spdm_context, const uint32_t *session_id, bool is_app_message,
@@ -97,10 +94,6 @@ libspdm_return_t libspdm_transport_test_encode_message(
  *                                      On input, it shall point to the scratch buffer in spdm_context.
  *                                      On output, for normal message, it will point to the original receiver buffer.
  *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
- *
- * @retval RETURN_SUCCESS               The message is decoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
- * @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
  **/
 libspdm_return_t libspdm_transport_test_decode_message(
     void *spdm_context, uint32_t **session_id,

--- a/unit_test/spdm_transport_test_lib/common.c
+++ b/unit_test/spdm_transport_test_lib/common.c
@@ -17,9 +17,6 @@
  * @param  message                      A pointer to a source buffer to store the message.
  * @param  transport_message_size         size in bytes of the transport message data buffer.
  * @param  transport_message             A pointer to a destination buffer to store the transport message.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_test_encode_message(const uint32_t *session_id,
                                              bool need_alignment,
@@ -38,9 +35,6 @@ libspdm_return_t libspdm_test_encode_message(const uint32_t *session_id,
  * @param  transport_message             A pointer to a source buffer to store the transport message.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_test_decode_message(uint32_t **session_id,
                                              bool need_alignment,
@@ -74,9 +68,6 @@ libspdm_return_t libspdm_test_decode_message(uint32_t **session_id,
  * @param  transport_message       A pointer to a destination buffer to store the transport message.
  *                                 On input, it shall be msg_buf_ptr from sender buffer.
  *                                 On output, it will point to acquired sender buffer.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_transport_test_encode_message(
     void *spdm_context, const uint32_t *session_id, bool is_app_message,
@@ -195,10 +186,6 @@ libspdm_return_t libspdm_transport_test_encode_message(
  *                                 On input, it shall point to the scratch buffer in spdm_context.
  *                                 On output, for normal message, it will point to the original receiver buffer.
  *                                 On output, for secured message, it will point to the scratch buffer in spdm_context.
- *
- * @retval RETURN_SUCCESS               The message is decoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
- * @retval RETURN_UNSUPPORTED           The transport_message is unsupported.
  **/
 libspdm_return_t libspdm_transport_test_decode_message(
     void *spdm_context, uint32_t **session_id,

--- a/unit_test/spdm_transport_test_lib/test.c
+++ b/unit_test/spdm_transport_test_lib/test.c
@@ -66,9 +66,6 @@ spdm_version_number_t libspdm_test_get_secured_spdm_version(
  * @param  message                      A pointer to a source buffer to store the message.
  * @param  transport_message_size         size in bytes of the transport message data buffer.
  * @param  transport_message             A pointer to a destination buffer to store the transport message.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_test_encode_message(const uint32_t *session_id,
                                              bool need_alignment,
@@ -129,9 +126,6 @@ libspdm_return_t libspdm_test_encode_message(const uint32_t *session_id,
  * @param  transport_message             A pointer to a source buffer to store the transport message.
  * @param  message_size                  size in bytes of the message data buffer.
  * @param  message                      A pointer to a destination buffer to store the message.
- *
- * @retval RETURN_SUCCESS               The message is encoded successfully.
- * @retval RETURN_INVALID_PARAMETER     The message is NULL or the message_size is zero.
  **/
 libspdm_return_t libspdm_test_decode_message(uint32_t **session_id,
                                              bool need_alignment,

--- a/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
+++ b/unit_test/test_size/test_size_of_spdm_requester/spdm_requester_authentication.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -21,10 +21,6 @@
  * @param  cert_chain                    A pointer to a destination buffer to store the certificate chain.
  * @param  measurement_hash_type          The type of the measurement hash.
  * @param  measurement_hash              A pointer to a destination buffer to store the measurement hash.
- *
- * @retval RETURN_SUCCESS               The authentication is got successfully.
- * @retval RETURN_DEVICE_ERROR          A device error occurs when communicates with the device.
- * @retval RETURN_SECURITY_VIOLATION    Any verification fails.
  **/
 libspdm_return_t
 spdm_authentication(void *context, uint8_t *slot_mask,

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -101,13 +101,10 @@ size_t libspdm_get_multi_element_opaque_data_supported_version_data_size(
  *
  * @param  data_out_size[in]                 size in bytes of the data_out.
  *                                           On input, it means the size in bytes of data_out buffer.
- *                                           On output, it means the size in bytes of copied data_out buffer if RETURN_SUCCESS is returned,
+ *                                           On output, it means the size in bytes of copied data_out buffer if LIBSPDM_STATUS_SUCCESS is returned,
  *                                           and means the size in bytes of desired data_out buffer if RETURN_BUFFER_TOO_SMALL is returned.
  * @param  data_out[in]                      A pointer to the destination buffer to store the opaque data supported version.
  * @param  element_num[in]                   in this test function, the element number < 9 is right. because element id is changed with element_index
- *
- * @retval RETURN_SUCCESS               The opaque data supported version is built successfully.
- * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 libspdm_return_t
 libspdm_build_multi_element_opaque_data_supported_version_test(libspdm_context_t *spdm_context,
@@ -264,13 +261,10 @@ size_t libspdm_get_multi_element_opaque_data_version_selection_data_size(
  *
  * @param  data_out_size[in]                 size in bytes of the data_out.
  *                                           On input, it means the size in bytes of data_out buffer.
- *                                           On output, it means the size in bytes of copied data_out buffer if RETURN_SUCCESS is returned,
+ *                                           On output, it means the size in bytes of copied data_out buffer if LIBSPDM_STATUS_SUCCESS is returned,
  *                                           and means the size in bytes of desired data_out buffer if RETURN_BUFFER_TOO_SMALL is returned.
  * @param  data_out[in]                      A pointer to the destination buffer to store the opaque data selection version.
  * @param  element_num[in]                   in this test function, the element number < 9 is right. because element id is changed with element_index
- *
- * @retval RETURN_SUCCESS               The opaque data selection version is built successfully.
- * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
  **/
 libspdm_return_t
 libspdm_build_opaque_data_version_selection_data_test(const libspdm_context_t *spdm_context,
@@ -895,7 +889,7 @@ void libspdm_test_verify_peer_cert_chain_buffer_case8(void **state)
  * Test 9: test set data for root cert.
  *
  * case                                              Expected Behavior
- * there is null root cert;                          return RETURN_SUCCESS, and the root cert is set successfully.
+ * there is null root cert;                          return LIBSPDM_STATUS_SUCCESS, and the root cert is set successfully.
  * there is full root cert;                          return RETURN_OUT_OF_RESOURCES.
  **/
 static void libspdm_test_set_data_case9(void **state)

--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -2065,7 +2065,7 @@ static void req_challenge_case1(void **state)
  * (param1=0) and do not request measurements (param2=0).
  * The received CHALLENGE_AUTH message correctly responds to the challenge, with
  * no opaque data and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case2(void **state)
 {
@@ -2369,7 +2369,7 @@ static void req_challenge_case5(void **state)
  * Test 6: the requester is setup correctly (see Test 2), but, on the first try,
  * receiving a Busy ERROR message, and on retry, receiving a correct CHALLENGE_AUTH
  * message to the challenge, with no opaque data and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case6(void **state)
 {
@@ -2590,7 +2590,7 @@ static void req_challenge_case8(void **state)
  * receiving a ResponseNotReady ERROR message, and on retry, receiving a correct
  * CHALLENGE_AUTH message to the challenge, with no opaque data and a signature
  * on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case9(void **state)
 {
@@ -2992,7 +2992,7 @@ static void req_challenge_case15(void **state) {
  * (param1=0) and do not request measurements (param2=0).
  * The received CHALLENGE_AUTH message correctly responds to the challenge, opaque
  * data with bytes from the string "libspdm", and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case16(void **state) {
     libspdm_return_t status;
@@ -3139,7 +3139,7 @@ static void req_challenge_case17(void **state) {
  * (param1=0) and request TCB measurements (param2=1).
  * The received CHALLENGE_AUTH message correctly responds to the challenge, with
  * no opaque data and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case18(void **state) {
     libspdm_return_t status;
@@ -3209,7 +3209,7 @@ static void req_challenge_case18(void **state) {
  * (param1=0) and request TCB measurements (param2=1).
  * The received CHALLENGE_AUTH message correctly responds to the challenge, with
  * no opaque data and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case19(void **state) {
     libspdm_return_t status;
@@ -3422,7 +3422,7 @@ static void req_challenge_case21(void **state) {
 /**
  * Test 22: a request message is successfully sent and a response message is successfully received.
  * Buffer C already has arbitrary data.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a CHALLENGE_AUTH message is
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a CHALLENGE_AUTH message is
  * received, buffer C appends the exchanged CHALLENGE and CHALLENGE_AUTH messages.
  **/
 static void req_challenge_case22(void **state)
@@ -3515,7 +3515,7 @@ static void req_challenge_case22(void **state)
  * (param1=0) and do not request measurements (param2=0).
  * The received CHALLENGE_AUTH message correctly responds to the challenge, with
  * no opaque data and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case23(void **state)
 {
@@ -3617,7 +3617,7 @@ static void req_challenge_case23(void **state)
 
 /**
  * Test 24: Challenge using provisioned public key (slot_id 0xFF)
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case24(void **state)
 {
@@ -3728,7 +3728,7 @@ static void req_challenge_case25(void **state) {
  * - it has flags indicating that the previous messages were sent
  * The received CHALLENGE_AUTH message correctly responds to the challenge, opaque
  * data with bytes from the string "libspdm", and a signature on the sent nonce.
- * Expected behavior: client returns a status of RETURN_SUCCESS.
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case26(void **state) {
     libspdm_return_t status;
@@ -3797,7 +3797,7 @@ static void req_challenge_case26(void **state) {
 
 /**
  * Test 27: Successful case , With the correct challenge context field
- * Expected Behavior: client returns a status of RETURN_SUCCESS.
+ * Expected Behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_challenge_case27(void **state)
 {

--- a/unit_test/test_spdm_requester/encap_challenge_auth.c
+++ b/unit_test/test_spdm_requester/encap_challenge_auth.c
@@ -367,7 +367,7 @@ static void req_encap_challenge_auth_case6(void **state)
 /**
  * Test 7: receiving a correct CHALLENGE message from the requester with context field
  * no opaque data, no measurements, and slot number 0.
- * Expected behavior:  get a RETURN_SUCCESS return code, correct context field
+ * Expected behavior:  get a LIBSPDM_STATUS_SUCCESS return code, correct context field
  **/
 static void req_encap_challenge_auth_case7(void **state)
 {

--- a/unit_test/test_spdm_requester/encap_endpoint_info.c
+++ b/unit_test/test_spdm_requester/encap_endpoint_info.c
@@ -66,7 +66,7 @@ size_t m_libspdm_get_endpoint_info_request4_size =
 
 /**
  * Test 1: Successful response to get endpoint_info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_encap_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -178,7 +178,7 @@ static void req_encap_endpoint_info_case1(void **state)
 
 /**
  * Test 2: Successful response to get endpoint_info with signature, slot_id == 0x1
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_encap_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -289,7 +289,7 @@ static void req_encap_endpoint_info_case2(void **state)
 
 /**
  * Test 3: Successful response to get endpoint_info with signature, slot_id == 0xF
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_encap_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -383,7 +383,7 @@ static void req_encap_endpoint_info_case3(void **state)
 
 /**
  * Test 4: Successful response to get endpoint_info without signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct response message size and fields
  **/
 static void req_encap_endpoint_info_case4(void **state)
@@ -432,7 +432,7 @@ static void req_encap_endpoint_info_case4(void **state)
 
 /**
  * Test 5: Successful response to get session-based endpoint_info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_encap_e size,
  *                    correct response message size and fields
  *                    correct signature verification

--- a/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_endpoint_info_err.c
@@ -2167,7 +2167,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case14(void **state)
 
 /**
  * Test 15: Error case, request no signature but slot id not 0
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void libspdm_test_requester_get_endpoint_info_err_case15(void **state)
 {
@@ -2206,7 +2206,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case15(void **state)
 
 /**
  * Test 16: Error case, request no signature but responder's slot id not 0
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void libspdm_test_requester_get_endpoint_info_err_case16(void **state)
 {
@@ -2245,7 +2245,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case16(void **state)
 
 /**
  * Test 17: Error case, request no signature and response with wrong ep_info_length
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void libspdm_test_requester_get_endpoint_info_err_case17(void **state)
 {
@@ -2284,7 +2284,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case17(void **state)
 
 /**
  * Test 18: Error case, request no signature but response with signature
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void libspdm_test_requester_get_endpoint_info_err_case18(void **state)
 {
@@ -2413,7 +2413,7 @@ static void libspdm_test_requester_get_endpoint_info_err_case19(void **state)
 
 /**
  * Test 20: Error case, input buffer ep_info_length too small.
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void libspdm_test_requester_get_endpoint_info_err_case20(void **state)
 {

--- a/unit_test/test_spdm_requester/error_test/get_measurements_err.c
+++ b/unit_test/test_spdm_requester/error_test/get_measurements_err.c
@@ -4077,7 +4077,7 @@ static void libspdm_test_requester_get_measurements_err_case21(void **state)
 
 /**
  * Test 22: request a large number of unsigned measurements before requesting a signature
- * Expected Behavior: RETURN_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
+ * Expected Behavior: LIBSPDM_STATUS_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
  **/
 static void libspdm_test_requester_get_measurements_err_case22(void **state)
 {

--- a/unit_test/test_spdm_requester/finish.c
+++ b/unit_test/test_spdm_requester/finish.c
@@ -1653,7 +1653,7 @@ static void req_finish_case1(void **state)
 /**
  * Test 2: receiving a correct FINISH_RSP message with only MAC (no
  * mutual authentication) and 'handshake in the clear'.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_finish_case2(void **state)
@@ -2049,7 +2049,7 @@ static void req_finish_case5(void **state)
  * Test 6: the requester is setup correctly (see Test 2), but, on the first try,
  * receiving a Busy ERROR message, and on retry, receiving a correct FINISH_RSP
  * message with only MAC (no mutual authentication).
- * Expected behavior: client returns a Status of RETURN_SUCCESS.
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_finish_case6(void **state)
 {
@@ -2346,7 +2346,7 @@ static void req_finish_case8(void **state)
  * Test 9: the requester is setup correctly (see Test 2), but, on the first try,
  * receiving a ResponseNotReady ERROR message, and on retry, receiving a correct
  * FINISH_RSP message with only MAC (no mutual authentication).
- * Expected behavior: client returns a Status of RETURN_SUCCESS.
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_finish_case9(void **state)
 {
@@ -3055,7 +3055,7 @@ static void req_finish_case15(void **state)
 /**
  * Test 16: receiving a correct FINISH_RSP message with a correct MAC,
  * mutual authentication and 'handshake in the clear'.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_finish_case16(void **state)
@@ -3597,7 +3597,7 @@ static void req_finish_case21(void **state)
 /**
  * Test 22: a FINISH request message is successfully sent and a FINISH_RSP response message is
  * successfully received.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a FINISH_RSP message is
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a FINISH_RSP message is
  * received, buffer F appends the exchanged FINISH and FINISH_RSP
  **/
 static void req_finish_case22(void **state)
@@ -3714,7 +3714,7 @@ static void req_finish_case22(void **state)
 
 /**
  * Test 23: receiving a correct FINISH_RSP message using slot_id 0xFF
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_finish_case23(void **state)
@@ -3802,7 +3802,7 @@ static void req_finish_case23(void **state)
 
 /**
  * Test 24: Set HANDSHAKE_IN_THE_CLEAR_CAP to 0 , The ResponderVerifyData field is absent.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_finish_case24(void **state)
@@ -3911,7 +3911,7 @@ static void req_finish_case24(void **state)
 
 /**
  * Test 25: SPDM version 1.4, with OpaqueData
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_finish_case25(void **state)

--- a/unit_test/test_spdm_requester/get_certificate.c
+++ b/unit_test/test_spdm_requester/get_certificate.c
@@ -3782,7 +3782,7 @@ static void req_get_certificate_case22(void **state)
 /**
  * Test 23: request messages are successfully sent and response messages are successfully
  * received. Buffer B already has arbitrary data.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and CERTIFICATE messages are
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and CERTIFICATE messages are
  * received, buffer B appends the exchanged GET_CERTIFICATE and CERTIFICATE messages.
  **/
 static void req_get_certificate_case23(void **state)

--- a/unit_test/test_spdm_requester/get_csr.c
+++ b/unit_test/test_spdm_requester/get_csr.c
@@ -343,7 +343,7 @@ static void req_get_csr_case1(void **state)
 
 /**
  * Test 2: Successful response to get csr
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_get_csr_case2(void **state)
 {
@@ -378,7 +378,7 @@ static void req_get_csr_case2(void **state)
 /**
  * Test 3: Successful response to get csr,
  * with a reset required
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_get_csr_case3(void **state)
 {
@@ -422,7 +422,7 @@ static void req_get_csr_case3(void **state)
 
 /**
  * Test 4: Send correct req_info and opaque_data
- * Expected Behavior: get a RETURN_SUCCESS return code and determine if req_info and opaque_data are correct
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code and determine if req_info and opaque_data are correct
  **/
 static void req_get_csr_case4(void **state)
 {

--- a/unit_test/test_spdm_requester/get_digests.c
+++ b/unit_test/test_spdm_requester/get_digests.c
@@ -1427,7 +1427,7 @@ static void req_get_digests_case22(void **state)
 /**
  * Test 23: a request message is successfully sent and a response message is successfully received.
  * Buffer B already has arbitrary data.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is
  * received, buffer B appends the exchanged GET_DIGESTS and DIGESTS messages.
  **/
 static void req_get_digests_case23(void **state)

--- a/unit_test/test_spdm_requester/get_endpoint_info.c
+++ b/unit_test/test_spdm_requester/get_endpoint_info.c
@@ -641,7 +641,7 @@ static libspdm_return_t receive_message(
 
 /**
  * Test 1: Successful response to get a endpoint info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void req_get_endpoint_info_case1(void **state)
 {
@@ -738,7 +738,7 @@ static void req_get_endpoint_info_case1(void **state)
 /**
  * Test 2: Successful response to get a endpoint info with signature,
  *         after getting SPDM_ERROR_CODE_BUSY on first attempt
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void req_get_endpoint_info_case2(void **state)
 {
@@ -836,7 +836,7 @@ static void req_get_endpoint_info_case2(void **state)
 /**
  * Test 3: Successful response to get a endpoint info with signature,
  *         after getting SPDM_ERROR_CODE_RESPONSE_NOT_READY on first attempt
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void req_get_endpoint_info_case3(void **state)
 {
@@ -937,7 +937,7 @@ static void req_get_endpoint_info_case3(void **state)
 
 /**
  * Test 4: Successful response to get a endpoint info with signature with slot_id = 1
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void req_get_endpoint_info_case4(void **state)
 {
@@ -1034,7 +1034,7 @@ static void req_get_endpoint_info_case4(void **state)
 /**
  * Test 5: Successful response to get a endpoint info with signature
  *         Using provisioned public key (slot_id = 0xF)
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_e
  **/
 static void req_get_endpoint_info_case5(void **state)
 {
@@ -1109,7 +1109,7 @@ static void req_get_endpoint_info_case5(void **state)
 
 /**
  * Test 6: Successful response to get a endpoint info without signature
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_get_endpoint_info_case6(void **state)
 {
@@ -1148,7 +1148,7 @@ static void req_get_endpoint_info_case6(void **state)
 
 /**
  * Test 7: Successful response to get a session based endpoint info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_e
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty session_transcript.message_e
  **/
 static void req_get_endpoint_info_case7(void **state)
 {

--- a/unit_test/test_spdm_requester/get_measurements.c
+++ b/unit_test/test_spdm_requester/get_measurements.c
@@ -3367,7 +3367,7 @@ static void req_get_measurements_case1(void **state)
 
 /**
  * Test 2: Successful response to get a measurement with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_m
  **/
 static void req_get_measurements_case2(void **state)
 {
@@ -3701,7 +3701,7 @@ static void req_get_measurements_case5(void **state)
 
 /**
  * Test 6: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_BUSY on first attempt
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_m
  **/
 static void req_get_measurements_case6(void **state)
 {
@@ -3935,7 +3935,7 @@ static void req_get_measurements_case8(void **state)
 
 /**
  * Test 9: Successfully get one measurement block (signed), after getting SPDM_ERROR_CODE_RESPONSE_NOT_READY on first attempt
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty transcript.message_m
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty transcript.message_m
  **/
 static void req_get_measurements_case9(void **state)
 {
@@ -4011,7 +4011,7 @@ static void req_get_measurements_case9(void **state)
 
 /**
  * Test 10: Successful response to get total number of measurements, without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct number_of_blocks, correct transcript.message_m.buffer_size
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct number_of_blocks, correct transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case10(void **state)
 {
@@ -4089,7 +4089,7 @@ static void req_get_measurements_case10(void **state)
 
 /**
  * Test 11: Successful response to get a measurement block, without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case11(void **state)
 {
@@ -4488,7 +4488,7 @@ static void req_get_measurements_case15(void **state)
 
 /**
  * Test 16: SlotID verificaton, the response's SlotID should match the request
- * Expected Behavior: get a RETURN_SUCCESS return code if the fields match, RETURN_DEVICE_ERROR otherwise. Either way, transcript.message_m should be empty
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code if the fields match, RETURN_DEVICE_ERROR otherwise. Either way, transcript.message_m should be empty
  **/
 static void req_get_measurements_case16(void **state)
 {
@@ -4906,7 +4906,7 @@ static void req_get_measurements_case21(void **state)
 
 /**
  * Test 22: request a large number of unsigned measurements before requesting a signature
- * Expected Behavior: RETURN_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
+ * Expected Behavior: LIBSPDM_STATUS_SUCCESS return code and correct transcript.message_m.buffer_size while transcript.message_m has room; RETURN_DEVICE_ERROR otherwise
  **/
 static void req_get_measurements_case22(void **state)
 {
@@ -5008,7 +5008,7 @@ static void req_get_measurements_case22(void **state)
 
 /**
  * Test 23: Successful response to get a measurement block, without signature. response contains opaque data
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case23(void **state)
 {
@@ -5172,7 +5172,7 @@ static void req_get_measurements_case24(void **state)
 
 /**
  * Test 25: Successful response to get a measurement block, with signature. response contains opaque data
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m.buffer_size
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case25(void **state)
 {
@@ -5494,7 +5494,7 @@ static void req_get_measurements_case28(void **state)
 
 /**
  * Test 29: request measurement without signature, but response opaque data is 1 byte longer than informed
- * Expected Behavior: extra byte should just be ignored. Get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
+ * Expected Behavior: extra byte should just be ignored. Get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case29(void **state)
 {
@@ -5596,7 +5596,7 @@ static void req_get_measurements_case31(void **state)
 
 /**
  * Test 32: Successful response to get all measurement blocks, without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m.buffer_size
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m.buffer_size
  **/
 static void req_get_measurements_case32(void **state)
 {
@@ -5771,7 +5771,7 @@ static void req_get_measurements_case33(void **state) {
 
 /**
  * Test 34: Successful response to get a session based measurement with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty session_transcript.message_m
  **/
 static void req_get_measurements_case34(void **state)
 {
@@ -6166,7 +6166,7 @@ static void req_get_measurements_case38(void **state)
 
 /**
  * Test 39: Exercise the libspdm_get_measurement_ex function.
- * Expected Behavior: client returns a status of RETURN_SUCCESS.
+ * Expected Behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_get_measurements_case39(void **state)
 {
@@ -6264,7 +6264,7 @@ static void req_get_measurements_case39(void **state)
 
 /**
  * Test 40: Successful case , correct measuerments context field , without signature
- * Expected Behavior: client returns a status of RETURN_SUCCESS.
+ * Expected Behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void req_get_measurements_case40(void **state)
 {

--- a/unit_test/test_spdm_requester/get_version.c
+++ b/unit_test/test_spdm_requester/get_version.c
@@ -726,7 +726,7 @@ static void req_get_version_case15(void **state)
 /**
  * Test 16: receiving a correct VERSION message with available version 1.0 and 1.1.
  * Buffers A, B and C already have arbitrary data.
- * Expected behavior: client returns a status of RETURN_SUCCESS, buffers A, B and C
+ * Expected behavior: client returns a status of LIBSPDM_STATUS_SUCCESS, buffers A, B and C
  * should be first reset, and then buffer A receives only the exchanged GET_VERSION
  * and VERSION messages.
  **/

--- a/unit_test/test_spdm_requester/key_update.c
+++ b/unit_test/test_spdm_requester/key_update.c
@@ -3626,7 +3626,7 @@ static void req_key_update_case1(void **state)
 /**
  * Test 2: receiving a correct UPDATE_KEY_ACK message for updating
  * only the request data key.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, the
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
 static void req_key_update_case2(void **state)
@@ -3829,7 +3829,7 @@ static void req_key_update_case5(void **state)
  * key, on the first try, receiving a Busy ERROR message, and on retry,
  * receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY behavior is
  * not altered.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, the
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
 static void req_key_update_case6(void **state)
@@ -3983,7 +3983,7 @@ static void req_key_update_case8(void **state)
  * key, on the first try, receiving a ResponseNotReady ERROR message, and on
  * retry, receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY
  * behavior is not altered.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, the
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, the
  * request data key is updated, but not the response data key.
  **/
 static void req_key_update_case9(void **state)
@@ -4574,7 +4574,7 @@ static void req_key_update_case18(void **state)
  * verifying key, on the first try, receiving a Busy ERROR message,
  * and on retry, receiving a correct KEY_UPDATE_ACK message. The
  * VERIFY_KEY behavior is not altered.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, the
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, the
  * request data key is not rollbacked.
  **/
 static void req_key_update_case19(void **state)
@@ -4733,7 +4733,7 @@ static void req_key_update_case21(void **state)
  * Test 22: the requester is setup correctly (see Test 2), but, when verifying
  * key, on the first try, receiving a ResponseNotReady ERROR message, and on
  * retry, receiving a correct KEY_UPDATE_ACK message.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, the
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, the
  * request data key is not rollbacked.
  **/
 static void req_key_update_case22(void **state)
@@ -5049,7 +5049,7 @@ static void req_key_update_case26(void **state)
 /**
  * Test 27: receiving a correct UPDATE_KEY_ACK message for updating
  * both the request data key and the response data key.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, and
  * the request data key and response data key are updated.
  **/
 static void req_key_update_case27(void **state)
@@ -5246,7 +5246,7 @@ static void req_key_update_case29(void **state)
  * all keys, on the first try, receiving a Busy ERROR message, and on retry,
  * receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY behavior is
  * not altered.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, and
  * the request data key and response data key are updated.
  **/
 static void req_key_update_case30(void **state)
@@ -5450,7 +5450,7 @@ static void req_key_update_case32(void **state)
  * all keys, on the first try, receiving a ResponseNotReady ERROR message, and
  * on retry, receiving a correct KEY_UPDATE_ACK message. The VERIFY_KEY
  * behavior is not altered.
- * Expected behavior: client returns a Status of RETURN_SUCCESS, and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS, and
  * the request data key and response data key are updated.
  **/
 static void req_key_update_case33(void **state)

--- a/unit_test/test_spdm_requester/psk_finish.c
+++ b/unit_test/test_spdm_requester/psk_finish.c
@@ -1033,7 +1033,7 @@ static void req_psk_finish_case1(void **state)
 
 /**
  * Test 2: receiving a correct PSK_FINISH_RSP message.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and
  * session is established.
  **/
 static void req_psk_finish_case2(void **state)
@@ -1428,7 +1428,7 @@ static void req_psk_finish_case5(void **state)
  * Test 6: the requester is setup correctly, but, on the first try, receiving
  * a Busy ERROR message, and, on retry, receiving a correct PSK_FINISH_RSP
  * message.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and session
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and session
  * is established.
  **/
 static void req_psk_finish_case6(void **state)
@@ -1729,7 +1729,7 @@ static void req_psk_finish_case8(void **state)
  * Test 9: the requester is setup correctly, but, on the first try, receiving
  * a ResponseNotReady ERROR message, and, on retry, receiving a correct
  * PSK_FINISH_RSP message.
- * Expected behavior: client returns a Status of RETURN_SUCCESS and session
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS and session
  * is established.
  **/
 static void req_psk_finish_case9(void **state)
@@ -2447,7 +2447,7 @@ static void req_psk_finish_case15(void **state)
 
 /**
  * Test 16: a request message is successfully sent and a response message is successfully received.
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a PSK_FINISH_RSP message is
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a PSK_FINISH_RSP message is
  * received, buffer F appends the exchanged PSK_FINISH and PSK_FINISH_RSP messages.
  **/
 static void req_psk_finish_case16(void **state)
@@ -2550,7 +2550,7 @@ static void req_psk_finish_case16(void **state)
 
 /**
  * Test 17: SPDM version 1.4, with OpaqueData
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a PSK_FINISH_RSP message is
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a PSK_FINISH_RSP message is
  * received.
  **/
 static void req_psk_finish_case17(void **state)

--- a/unit_test/test_spdm_requester/set_certificate.c
+++ b/unit_test/test_spdm_requester/set_certificate.c
@@ -345,7 +345,7 @@ static void req_set_certificate_case1(void **state)
 
 /**
  * Test 2: Successful response to set certificate for slot 0
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_set_certificate_case2(void **state)
 {
@@ -405,7 +405,7 @@ static void req_set_certificate_case3(void **state)
 
 /**
  * Test 5: Successful response to set certificate for slot 1 in secure session
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_set_certificate_case5(void **state)
 {
@@ -464,7 +464,7 @@ static void req_set_certificate_case5(void **state)
 
 /**
  * Test 6: Successful response to set certificate for slot 0 with a reset required
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_set_certificate_case6(void **state)
 {
@@ -499,7 +499,7 @@ static void req_set_certificate_case6(void **state)
 
 /**
  * Test 7: Successful response to erase certificate for slot 0
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_set_certificate_case7(void **state)
 {

--- a/unit_test/test_spdm_requester/set_key_pair_info.c
+++ b/unit_test/test_spdm_requester/set_key_pair_info.c
@@ -123,7 +123,7 @@ static libspdm_return_t receive_message(
 
 /**
  * Test 1: Successful response to set key pair info
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void req_set_key_pair_info_case1(void **state)
 {

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -2792,7 +2792,7 @@ static void rsp_algorithms_case30(void **state)
 
 /**
  * Test 31: NEGOTIATE_ALGORITHMS message received with MEL correct
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void rsp_algorithms_case31(void **state)
 {
@@ -2860,7 +2860,7 @@ static void rsp_algorithms_case31(void **state)
 
 /**
  * Test 32: NEGOTIATE_ALGORITHMS message received with MEAS correct
- * Expected Behavior: get a RETURN_SUCCESS return code
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code
  **/
 static void rsp_algorithms_case32(void **state)
 {

--- a/unit_test/test_spdm_responder/challenge_auth.c
+++ b/unit_test/test_spdm_responder/challenge_auth.c
@@ -1060,7 +1060,7 @@ static void rsp_challenge_auth_case17(void **state)
 /**
  * Test 18: Successfully reply to V1.3 to get CHALLENGE message with context field
  * no opaque data, no measurements, and slot number 0.
- * Expected Behavior: get a RETURN_SUCCESS return code, correct context field
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct context field
  **/
 static void rsp_challenge_auth_case18(void **state)
 {

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -373,7 +373,7 @@ static void rsp_encap_challenge_case5(void **state)
 
 /**
  * Test 6: Successful case , With the correct challenge context field
- * Expected Behavior: client returns a status of RETURN_SUCCESS.
+ * Expected Behavior: client returns a status of LIBSPDM_STATUS_SUCCESS.
  **/
 static void rsp_encap_challenge_case6(void **state)
 {

--- a/unit_test/test_spdm_responder/encap_get_digests.c
+++ b/unit_test/test_spdm_responder/encap_get_digests.c
@@ -15,7 +15,7 @@ static uint8_t m_libspdm_local_certificate_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
 
 /**
  * Test 1: Response message received successfully
- * Expected Behavior: requester returns the status RETURN_SUCCESS and a DIGESTS message is received
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS and a DIGESTS message is received
  **/
 static void rsp_encap_get_digests_case1(void **state)
 {
@@ -237,7 +237,7 @@ static void rsp_encap_get_digests_case5(void **state)
 
 /**
  * Test 6: a response message is successfully sent , Set multi_key_conn_req to check if it responds correctly
- * Expected Behavior: requester returns the status RETURN_SUCCESS
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS
  **/
 static void rsp_encap_get_digests_case6(void **state)
 {
@@ -339,7 +339,7 @@ static void rsp_encap_get_digests_case6(void **state)
 /**
  * Test 7: a response message is successfully sent ,
  * Check KeyPairID CertificateInfo and KeyUsageMask
- * Expected Behavior: requester returns the status RETURN_SUCCESS
+ * Expected Behavior: requester returns the status LIBSPDM_STATUS_SUCCESS
  **/
 static void rsp_encap_get_digests_case7(void **state)
 {

--- a/unit_test/test_spdm_responder/encap_get_endpoint_info.c
+++ b/unit_test/test_spdm_responder/encap_get_endpoint_info.c
@@ -30,7 +30,7 @@ libspdm_return_t get_endpoint_info_callback (
 
 /**
  * Test 1: Normal case, request a endpoint info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct endpoint_info
  *                    and an empty transcript.message_encap_e
  **/
 static void rsp_encap_get_endpoint_info_case1(void **state)
@@ -203,7 +203,7 @@ static void rsp_encap_get_endpoint_info_case1(void **state)
 
 /**
  * Test 2: Normal case, request a endpoint info with signature, req_slot_id = 0xFF
- * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct endpoint_info
  *                    and an empty transcript.message_encap_e
  **/
 static void rsp_encap_get_endpoint_info_case2(void **state)
@@ -297,7 +297,7 @@ static void rsp_encap_get_endpoint_info_case2(void **state)
 
 /**
  * Test 3: Normal case, request a endpoint info without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct endpoint_info
  **/
 static void rsp_encap_get_endpoint_info_case3(void **state)
 {
@@ -360,7 +360,7 @@ static void rsp_encap_get_endpoint_info_case3(void **state)
 
 /**
  * Test 4: Normal case, request a endpoint info with signature within session
- * Expected Behavior: get a RETURN_SUCCESS return code, correct endpoint_info
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct endpoint_info
  *                    and an empty session_transcript.message_encap_e
  **/
 static void rsp_encap_get_endpoint_info_case4(void **state)

--- a/unit_test/test_spdm_responder/encap_key_update.c
+++ b/unit_test/test_spdm_responder/encap_key_update.c
@@ -43,7 +43,7 @@ static void libspdm_set_standard_key_update_test_state(libspdm_context_t *spdm_c
 /**
  * Test 1: receiving a correct UPDATE_KEY_ACK message for updating
  * only the request data key.
- * Expected behavior: client returns a Status of RETURN_SUCCESS,Communication needs to continue.
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS,Communication needs to continue.
  **/
 static void rsp_encap_key_update_case1(void **state)
 {
@@ -88,7 +88,7 @@ static void rsp_encap_key_update_case1(void **state)
 /**
  * Test 2: receiving a correct UPDATE_KEY_ACK message for updating
  * only the request data key.
- * Expected behavior: client returns a Status of RETURN_SUCCESS,Communication needs to continue.
+ * Expected behavior: client returns a Status of LIBSPDM_STATUS_SUCCESS,Communication needs to continue.
  **/
 static void rsp_encap_key_update_case2(void **state)
 {

--- a/unit_test/test_spdm_responder/endpoint_info.c
+++ b/unit_test/test_spdm_responder/endpoint_info.c
@@ -67,7 +67,7 @@ size_t m_libspdm_get_endpoint_info_request4_size =
 
 /**
  * Test 1: Successful response to get endpoint_info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -185,7 +185,7 @@ static void rsp_endpoint_info_case1(void **state)
 
 /**
  * Test 2: Successful response to get endpoint_info with signature, slot_id == 0xF
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -283,7 +283,7 @@ static void rsp_endpoint_info_case2(void **state)
 /**
  * Test 3: Successful response to get endpoint_info with signature,
  *          multi_key_conn_rsp is set, slot_id = 0x1
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_e size,
  *                    correct response message size and fields
  *                    correct signature verification
@@ -405,7 +405,7 @@ static void rsp_endpoint_info_case3(void **state)
 
 /**
  * Test 4: Successful response to get endpoint_info without signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct response message size and fields
  **/
 static void rsp_endpoint_info_case4(void **state)
@@ -465,7 +465,7 @@ static void rsp_endpoint_info_case4(void **state)
 
 /**
  * Test 5: Successful response to get session-based endpoint_info with signature
- * Expected Behavior: get a RETURN_SUCCESS return code,
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code,
  *                    correct transcript.message_e size,
  *                    correct response message size and fields
  *                    correct signature verification

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -119,7 +119,7 @@ extern size_t libspdm_secret_lib_meas_opaque_data_size;
 
 /**
  * Test 1: Successful response to get a number of measurements without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
 static void rsp_measurements_case1(void **state)
 {
@@ -409,7 +409,7 @@ static void rsp_measurements_case6(void **state)
 
 /**
  * Test 7: Successful response to get a number of measurements with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
 static void rsp_measurements_case7(void **state)
 {
@@ -528,7 +528,7 @@ static void rsp_measurements_case7(void **state)
 
 /**
  * Test 8: Successful response to get one measurement with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
 static void rsp_measurements_case8(void **state)
 {
@@ -584,7 +584,7 @@ static void rsp_measurements_case8(void **state)
 
 /**
  * Test 9: Error case, Bad request size (sizeof(spdm_message_header_t)x) to get measurement number with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case9(void **state)
 {
@@ -636,7 +636,7 @@ static void rsp_measurements_case9(void **state)
 
 /**
  * Test 10: Successful response to get one measurement without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
 static void rsp_measurements_case10(void **state)
 {
@@ -696,7 +696,7 @@ static void rsp_measurements_case10(void **state)
 
 /**
  * Test 11: Successful response to get all measurements with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
 static void rsp_measurements_case11(void **state)
 {
@@ -765,7 +765,7 @@ static void rsp_measurements_case11(void **state)
 
 /**
  * Test 12: Successful response to get all measurements without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct transcript.message_m size, and correct response message size and fields
  **/
 static void rsp_measurements_case12(void **state)
 {
@@ -855,7 +855,7 @@ static void rsp_measurements_case13(void **state)
 
 /**
  * Test 14: Error case, signature was required, but there is no nonce and/or slotID
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case14(void **state)
 {
@@ -924,7 +924,7 @@ static void rsp_measurements_case14(void **state)
 
 /**
  * Test 15: Error case, meas_cap = 01b, but signature was requested (request message includes nonce and slotID)
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case15(void **state)
 {
@@ -978,7 +978,7 @@ static void rsp_measurements_case15(void **state)
 
 /**
  * Test 16: Error case, meas_cap = 01b, but signature was requested (request message does not include nonce and slotID)
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case16(void **state)
 {
@@ -1030,7 +1030,7 @@ static void rsp_measurements_case16(void **state)
 
 /**
  * Test 17: Error case, meas_cap = 00
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case17(void **state)
 {
@@ -1084,7 +1084,7 @@ static void rsp_measurements_case17(void **state)
 
 /**
  * Test 18: Successful response to get one measurement with signature, SlotId different from default
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
 static void rsp_measurements_case18(void **state)
 {
@@ -1155,7 +1155,7 @@ static void rsp_measurements_case18(void **state)
 
 /**
  * Test 19: Error case, invalid SlotId parameter (SlotId >= SPDM_MAX_SLOT_COUNT)
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case19(void **state)
 {
@@ -1208,7 +1208,7 @@ static void rsp_measurements_case19(void **state)
 
 /**
  * Test 21: Error case, request a measurement index not found
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m size, and Error message as response
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m size, and Error message as response
  **/
 static void rsp_measurements_case21(void **state)
 {
@@ -1259,7 +1259,7 @@ static void rsp_measurements_case21(void **state)
 
 /**
  * Test 22: request a large number of measurements before requesting a signed response
- * Expected Behavior: while transcript.message_m is not full, get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: while transcript.message_m is not full, get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  *                    if transcript.message_m has no more room, an error response is expected
  **/
 static void rsp_measurements_case22(void **state)
@@ -1343,7 +1343,7 @@ static void rsp_measurements_case22(void **state)
 
 /**
  * Test 23: Successful response to get a session based measurement with signature
- * Expected Behavior: get a RETURN_SUCCESS return code, with an empty session_transcript.message_m
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, with an empty session_transcript.message_m
  **/
 static void rsp_measurements_case23(void **state)
 {
@@ -1744,7 +1744,7 @@ static void rsp_measurements_case27(void **state)
 
 /**
  * Test 28: Successful response to get all measurements with signature using slot_id 0xFF
- * Expected Behavior: get a RETURN_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, empty transcript.message_m, and correct response message size and fields
  **/
 static void rsp_measurements_case28(void **state)
 {
@@ -2584,7 +2584,7 @@ static void rsp_measurements_case34(void** state)
 
 /**
  * Test 35: Successful response V1.3 to get a number of measurements without signature
- * Expected Behavior: get a RETURN_SUCCESS return code, correct context field
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct context field
  **/
 static void rsp_measurements_case35(void **state)
 {

--- a/unit_test/test_spdm_responder/set_key_pair_info_ack.c
+++ b/unit_test/test_spdm_responder/set_key_pair_info_ack.c
@@ -12,7 +12,7 @@
 
 /**
  * Test 1: Successful response to set key pair info with key pair id 4
- * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, and correct response message size and fields
  **/
 static void rsp_set_key_pair_info_ack_case1(void **state)
 {
@@ -127,7 +127,7 @@ static void rsp_set_key_pair_info_ack_case1(void **state)
 
 /**
  * Test 2: Successful response to set key pair info with key pair id 4: need reset
- * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, and correct response message size and fields
  **/
 static void rsp_set_key_pair_info_ack_case2(void **state)
 {
@@ -505,7 +505,7 @@ static void rsp_set_key_pair_info_ack_case3(void **state)
 
 /**
  * Test 4: Successful response to set key pair info with key pair id 4: need reset, spdm 1.4
- * Expected Behavior: get a RETURN_SUCCESS return code, and correct response message size and fields
+ * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, and correct response message size and fields
  **/
 static void rsp_set_key_pair_info_ack_case4(void **state)
 {


### PR DESCRIPTION
Rename the non-existent `RETURN_SUCCESS` to `LIBSPDM_STATUS_SUCCESS` in unit test files, or delete it.