### PR TITLE
Expand Responder event error testing

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_event_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_event_ack.c
@@ -37,7 +37,7 @@ libspdm_return_t libspdm_get_response_send_event(libspdm_context_t *spdm_context
     if (libspdm_get_connection_version(spdm_context) < SPDM_MESSAGE_VERSION_13) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNSUPPORTED_REQUEST,
-                                               SPDM_KEY_UPDATE,
+                                               SPDM_SEND_EVENT,
                                                response_size, response);
     }
 

--- a/os_stub/spdm_device_secret_lib_sample/event.c
+++ b/os_stub/spdm_device_secret_lib_sample/event.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2024 DMTF. All rights reserved.
+ *  Copyright 2024-2025 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -24,6 +24,8 @@ bool g_event_all_subscribe = false;
 bool g_event_all_unsubscribe = false;
 uint32_t g_event_count = 1;
 bool g_generate_event_list_error = false;
+bool g_event_get_types_error = false;
+bool g_event_subscribe_error = false;
 
 #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
 bool libspdm_event_get_types(
@@ -34,6 +36,10 @@ bool libspdm_event_get_types(
     uint32_t *supported_event_groups_list_len,
     uint8_t *event_group_count)
 {
+    if (g_event_get_types_error) {
+        return false;
+    }
+
     *supported_event_groups_list_len = g_supported_event_groups_list_len;
 
     for (uint32_t index = 0; index < *supported_event_groups_list_len; index++)
@@ -55,6 +61,10 @@ bool libspdm_event_subscribe(
     uint32_t subscribe_list_len,
     const void *subscribe_list)
 {
+    if (g_event_subscribe_error) {
+        return false;
+    }
+
     switch (subscribe_type) {
     case LIBSPDM_EVENT_SUBSCRIBE_ALL:
         if ((subscribe_list_len != 0) || (subscribe_list != NULL)) {

--- a/unit_test/test_spdm_responder/error_test/event_ack_err.c
+++ b/unit_test/test_spdm_responder/error_test/event_ack_err.c
@@ -27,6 +27,7 @@ typedef struct {
 
 static expected_event_t m_expected_event[4];
 static uint32_t m_event_counter;
+static bool m_process_event_error = false;
 
 static libspdm_return_t process_event(void *spdm_context,
                                       uint32_t session_id,
@@ -38,6 +39,10 @@ static libspdm_return_t process_event(void *spdm_context,
                                       uint16_t event_detail_len,
                                       const void *event_detail)
 {
+    if (m_process_event_error) {
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
+
     printf("Event Received\n");
     printf("Event Instance ID = [0x%x]\n", event_instance_id);
     printf("SVH ID = [0x%x], SVH VendorIDLen = [0x%x]\n", svh_id, svh_vendor_id_len);
@@ -122,7 +127,7 @@ static void rsp_event_ack_err_case1(void **state)
     libspdm_context_t *spdm_context;
     spdm_send_event_request_t *send_event;
     size_t request_size;
-    spdm_event_ack_response_t *event_ack;
+    spdm_error_response_t *spdm_response;
     size_t response_size =  sizeof(m_spdm_response_buffer);
     uint8_t event_data_size;
     spdm_dmtf_event_type_event_lost_t event_lost;
@@ -156,15 +161,15 @@ static void rsp_event_ack_err_case1(void **state)
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
-    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
-    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(event_ack->header.param2, 0);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
 
     assert_int_equal(m_event_counter, 0);
 }
@@ -180,7 +185,7 @@ static void rsp_event_ack_err_case2(void **state)
     libspdm_context_t *spdm_context;
     spdm_send_event_request_t *send_event;
     size_t request_size;
-    spdm_event_ack_response_t *event_ack;
+    spdm_error_response_t *spdm_response;
     size_t response_size =  sizeof(m_spdm_response_buffer);
     uint8_t event_data_size[2];
     spdm_dmtf_event_type_event_lost_t event_lost;
@@ -234,15 +239,15 @@ static void rsp_event_ack_err_case2(void **state)
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
-    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
-    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(event_ack->header.param2, 0);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
 
     assert_int_equal(m_event_counter, 0);
 }
@@ -258,7 +263,7 @@ static void rsp_event_ack_err_case3(void **state)
     libspdm_context_t *spdm_context;
     spdm_send_event_request_t *send_event;
     size_t request_size;
-    spdm_event_ack_response_t *event_ack;
+    spdm_error_response_t *spdm_response;
     size_t response_size =  sizeof(m_spdm_response_buffer);
     uint8_t event_data_size;
     spdm_dmtf_event_type_event_lost_t event_lost;
@@ -292,15 +297,15 @@ static void rsp_event_ack_err_case3(void **state)
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
-    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
-    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(event_ack->header.param2, 0);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
 
     assert_int_equal(m_event_counter, 0);
 }
@@ -316,7 +321,7 @@ static void rsp_event_ack_err_case4(void **state)
     libspdm_context_t *spdm_context;
     spdm_send_event_request_t *send_event;
     size_t request_size;
-    spdm_event_ack_response_t *event_ack;
+    spdm_error_response_t *spdm_response;
     size_t response_size =  sizeof(m_spdm_response_buffer);
     uint8_t event_data_size;
     spdm_dmtf_event_type_event_lost_t event_lost;
@@ -350,15 +355,234 @@ static void rsp_event_ack_err_case4(void **state)
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
-    event_ack = (spdm_event_ack_response_t *)m_spdm_response_buffer;
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 
     assert_int_equal(response_size, sizeof(spdm_error_response_t));
-    assert_int_equal(event_ack->header.spdm_version, SPDM_MESSAGE_VERSION_13);
-    assert_int_equal(event_ack->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(event_ack->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
-    assert_int_equal(event_ack->header.param2, 0);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 5: Negotiated SPDM version does not support SEND_EVENT request message.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_UNSUPPORTED_REQUEST.
+ **/
+static void rsp_event_ack_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_error_response_t *spdm_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x05;
+
+    set_standard_state(spdm_context);
+
+    /* SPDM 1.2 does not support SEND_EVENT request message. */
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t);
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_SEND_EVENT);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 6: SPDM version field in SEND_EVENT request message does not match the
+ *         connection's negotiated version.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_VERSION_MISMATCH.
+ **/
+static void rsp_event_ack_err_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_error_response_t *spdm_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x06;
+
+    set_standard_state(spdm_context);
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_14 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    /* Value is not equal to the negotiated SPDM version (1.4). */
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t);
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_14);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_VERSION_MISMATCH);
+    assert_int_equal(spdm_response->header.param2, 0);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 7: Requester does not support EVENT_CAP.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_UNSUPPORTED_REQUEST.
+ **/
+static void rsp_event_ack_err_case7(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_error_response_t *spdm_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x07;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+
+    /* Requester sends SEND_EVENT but does not support EVENT_CAP. */
+    spdm_context->connection_info.capability.flags &=
+        ~SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EVENT_CAP;
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t);
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_SEND_EVENT);
+
+    assert_int_equal(m_event_counter, 0);
+}
+
+/**
+ * Test 8: Call to process_event returns an error.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_INVALID_REQUEST.
+ **/
+static void rsp_event_ack_err_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_send_event_request_t *send_event;
+    size_t request_size;
+    spdm_error_response_t *spdm_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+    uint8_t event_data_size;
+    spdm_dmtf_event_type_event_lost_t event_lost;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x8;
+
+    set_standard_state(spdm_context);
+
+    send_event = (spdm_send_event_request_t *)m_spdm_request_buffer;
+
+    send_event->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    send_event->header.request_response_code = SPDM_SEND_EVENT;
+    send_event->header.param1 = 0;
+    send_event->header.param2 = 0;
+    send_event->event_count = 1;
+
+    event_lost.last_acked_event_inst_id = 0xffeeddcc;
+    event_lost.last_lost_event_inst_id = 0x55667788;
+
+    generate_dmtf_event_data(send_event + 1, &event_data_size, 0x11223344,
+                             SPDM_DMTF_EVENT_TYPE_EVENT_LOST, &event_lost);
+
+    m_event_counter = 0;
+
+    request_size = sizeof(spdm_send_event_request_t) + event_data_size;
+
+    /* Induce error in process_request. */
+    m_process_event_error = true;
+
+    status = libspdm_get_response_send_event(
+        spdm_context, request_size, m_spdm_request_buffer,
+        &response_size, m_spdm_response_buffer);
+
+    m_process_event_error = false;
+
+    spdm_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
 
     assert_int_equal(m_event_counter, 0);
 }
@@ -370,6 +594,10 @@ int libspdm_rsp_event_ack_error_test(void)
         cmocka_unit_test(rsp_event_ack_err_case2),
         cmocka_unit_test(rsp_event_ack_err_case3),
         cmocka_unit_test(rsp_event_ack_err_case4),
+        cmocka_unit_test(rsp_event_ack_err_case5),
+        cmocka_unit_test(rsp_event_ack_err_case6),
+        cmocka_unit_test(rsp_event_ack_err_case7),
+        cmocka_unit_test(rsp_event_ack_err_case8),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/error_test/subscribe_event_types_ack_err.c
+++ b/unit_test/test_spdm_responder/error_test/subscribe_event_types_ack_err.c
@@ -9,6 +9,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
 
+extern bool g_event_subscribe_error;
+
 static void set_standard_state(libspdm_context_t *spdm_context)
 {
     libspdm_session_info_t *session_info;
@@ -51,6 +53,8 @@ static void set_standard_state(libspdm_context_t *spdm_context)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    g_event_subscribe_error = false;
 }
 
 /**
@@ -66,7 +70,7 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case1(void **st
     size_t spdm_request_size;
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     size_t response_size = sizeof(response);
-    spdm_subscribe_event_types_ack_response_t *spdm_response;
+    spdm_error_response_t *spdm_response;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -87,7 +91,7 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case1(void **st
     status = libspdm_get_response_subscribe_event_types_ack(spdm_context,
                                                             spdm_request_size, &spdm_request,
                                                             &response_size, response);
-    spdm_response = (spdm_subscribe_event_types_ack_response_t *)response;
+    spdm_response = (spdm_error_response_t *)response;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
@@ -109,11 +113,11 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case2(void **st
     size_t spdm_request_size;
     uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
     size_t response_size = sizeof(response);
-    spdm_subscribe_event_types_ack_response_t *spdm_response;
+    spdm_error_response_t *spdm_response;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 1;
+    spdm_test_context->case_id = 2;
 
     set_standard_state(spdm_context);
     spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
@@ -130,7 +134,7 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case2(void **st
     status = libspdm_get_response_subscribe_event_types_ack(spdm_context,
                                                             spdm_request_size, &spdm_request,
                                                             &response_size, response);
-    spdm_response = (spdm_subscribe_event_types_ack_response_t *)response;
+    spdm_response = (spdm_error_response_t *)response;
 
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
@@ -139,11 +143,153 @@ static void libspdm_test_responder_subscribe_event_types_ack_err_case2(void **st
     assert_int_equal(spdm_response->header.param2, SPDM_SUBSCRIBE_EVENT_TYPES);
 }
 
+/**
+ * Test 3: SPDM version field in SUBSCRIBE_EVENT_TYPES request message does not match the
+ *         connection's negotiated version.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_VERSION_MISMATCH.
+ **/
+static void libspdm_test_responder_subscribe_event_types_ack_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_subscribe_event_types_request_t spdm_request;
+    size_t spdm_request_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 3;
+
+    set_standard_state(spdm_context);
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    /* Value is not equal to the negotiated SPDM version (1.3). */
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_14;
+    spdm_request.header.request_response_code = SPDM_SUBSCRIBE_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    spdm_request_size = sizeof(spdm_message_header_t);
+
+    status = libspdm_get_response_subscribe_event_types_ack(spdm_context,
+                                                            spdm_request_size, &spdm_request,
+                                                            &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_VERSION_MISMATCH);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 4: Invalid combination of SubscribeEventGroupCount (!= 0) and SubscribeListLen (== 0).
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_INVALID_REQUEST.
+ **/
+static void libspdm_test_responder_subscribe_event_types_ack_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_subscribe_event_types_request_t spdm_request;
+    size_t spdm_request_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 4;
+
+    set_standard_state(spdm_context);
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_request.header.request_response_code = SPDM_SUBSCRIBE_EVENT_TYPES;
+    spdm_request.header.param1 = 1;
+    spdm_request.header.param2 = 0;
+    /* If SubscribeEventGroupCount is non-zero then SubscribeListLen must be greater than zero. */
+    spdm_request.subscribe_list_len = 0;
+
+    spdm_request_size = sizeof(spdm_request);
+
+    status = libspdm_get_response_subscribe_event_types_ack(spdm_context,
+                                                            spdm_request_size, &spdm_request,
+                                                            &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 5: Call to libspdm_event_subscribe fails.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_INVALID_REQUEST.
+ **/
+static void libspdm_test_responder_subscribe_event_types_ack_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_subscribe_event_types_request_t spdm_request;
+    size_t spdm_request_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 5;
+
+    set_standard_state(spdm_context);
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_request.header.request_response_code = SPDM_SUBSCRIBE_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    spdm_request_size = sizeof(spdm_message_header_t);
+
+    g_event_subscribe_error = true;
+
+    status = libspdm_get_response_subscribe_event_types_ack(spdm_context,
+                                                            spdm_request_size, &spdm_request,
+                                                            &response_size, response);
+
+    /* Induce an error in the call to libspdm_event_subscribe. */
+    g_event_subscribe_error = false;
+
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
 int libspdm_rsp_subscribe_event_types_ack_error_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case1),
-        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case2)
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case2),
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case3),
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case4),
+        cmocka_unit_test(libspdm_test_responder_subscribe_event_types_ack_err_case5),
     };
 
     libspdm_test_context_t m_test_context = {

--- a/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
+++ b/unit_test/test_spdm_responder/error_test/supported_event_types_err.c
@@ -9,6 +9,8 @@
 
 #if LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP
 
+extern bool g_event_get_types_error;
+
 static void set_standard_state(libspdm_context_t *spdm_context)
 {
     libspdm_session_info_t *session_info;
@@ -51,6 +53,8 @@ static void set_standard_state(libspdm_context_t *spdm_context)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    g_event_get_types_error = false;
 }
 
 /**
@@ -94,10 +98,180 @@ static void libspdm_test_responder_supported_event_types_err_case1(void **state)
     assert_int_equal(spdm_response->header.param2, SPDM_GET_SUPPORTED_EVENT_TYPES);
 }
 
+/**
+ * Test 2: Negotiated SPDM version does not support GET_SUPPORTED_EVENT_TYPES request message.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_UNSUPPORTED_REQUEST.
+ **/
+static void libspdm_test_responder_supported_event_types_err_case2(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t spdm_request;
+    size_t spdm_request_size = sizeof(spdm_request);
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 2;
+
+    set_standard_state(spdm_context);
+
+    /* Invalid SPDM version for the GET_SUPPORTED_EVENT_TYPES request message. */
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    spdm_request.header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    status = libspdm_get_response_supported_event_types(spdm_context,
+                                                        spdm_request_size, &spdm_request,
+                                                        &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(spdm_response->header.param2, SPDM_GET_SUPPORTED_EVENT_TYPES);
+}
+
+/**
+ * Test 3: Size of GET_SUPPORTED_EVENT_TYPES request message is incorrect.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_INVALID_REQUEST.
+ **/
+static void libspdm_test_responder_supported_event_types_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t spdm_request;
+    size_t spdm_request_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 3;
+
+    set_standard_state(spdm_context);
+
+    /* Incorrect request message size. */
+    spdm_request_size = sizeof(spdm_request) + 1;
+
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_request.header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    status = libspdm_get_response_supported_event_types(spdm_context,
+                                                        spdm_request_size, &spdm_request,
+                                                        &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 4: SPDM version field in GET_SUPPORTED_EVENT_TYPES request message does not match the
+ *         connection's negotiated version.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_VERSION_MISMATCH.
+ **/
+static void libspdm_test_responder_supported_event_types_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t spdm_request;
+    size_t spdm_request_size = sizeof(spdm_request);
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 4;
+
+    set_standard_state(spdm_context);
+
+    /* Value is not equal to the negotiated SPDM version (1.3). */
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_14;
+    spdm_request.header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    status = libspdm_get_response_supported_event_types(spdm_context,
+                                                        spdm_request_size, &spdm_request,
+                                                        &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_VERSION_MISMATCH);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 5: Call to libspdm_event_get_types fails.
+ * Expected Behavior: Responder returns SPDM_ERROR_CODE_UNSPECIFIED.
+ **/
+static void libspdm_test_responder_supported_event_types_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t spdm_request;
+    size_t spdm_request_size = sizeof(spdm_request);
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t response_size = sizeof(response);
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 5;
+
+    set_standard_state(spdm_context);
+
+    /* Induce error in libspdm_event_get_types. */
+    g_event_get_types_error = true;
+
+    spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_request.header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    spdm_request.header.param1 = 0;
+    spdm_request.header.param2 = 0;
+
+    status = libspdm_get_response_supported_event_types(spdm_context,
+                                                        spdm_request_size, &spdm_request,
+                                                        &response_size, response);
+    spdm_response = (spdm_error_response_t *)response;
+
+    g_event_get_types_error = false;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(spdm_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_UNSPECIFIED);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
 int libspdm_rsp_supported_event_types_error_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case1),
+        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case2),
+        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case3),
+        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case4),
+        cmocka_unit_test(libspdm_test_responder_supported_event_types_err_case5),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
This also fixes #3267, which was discovered in the course of adding these test cases.

These test cases were guided by the following coverage reports:
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_responder_lib/libspdm_rsp_event_ack.c.gcov.html
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_responder_lib/libspdm_rsp_subscribe_event_types_ack.c.gcov.html
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_responder_lib/libspdm_rsp_supported_event_types.c.gcov.html