### PR TITLE
Expand Requester event error testing

### DIFF
--- a/unit_test/test_spdm_requester/error_test/encap_supported_event_types_err.c
+++ b/unit_test/test_spdm_requester/error_test/encap_supported_event_types_err.c
@@ -16,6 +16,7 @@ static const uint32_t m_session_id = 0xffffffff;
 
 extern uint32_t g_supported_event_groups_list_len;
 extern uint8_t g_event_group_count;
+extern bool g_event_get_types_error;
 
 static void set_standard_state(libspdm_context_t *spdm_context)
 {
@@ -54,6 +55,8 @@ static void set_standard_state(libspdm_context_t *spdm_context)
     libspdm_secured_message_set_session_state(
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_ESTABLISHED);
+
+    g_event_get_types_error = false;
 }
 
 /**
@@ -121,7 +124,7 @@ static void test_encap_supported_event_types_err_case2(void **state)
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
-    spdm_test_context->case_id = 0x01;
+    spdm_test_context->case_id = 0x02;
 
     set_standard_state(spdm_context);
 
@@ -152,11 +155,155 @@ static void test_encap_supported_event_types_err_case2(void **state)
     assert_int_equal(error_response->header.param2, 0);
 }
 
+/**
+ * Test 3: Connection version does not support GET_SUPPORTED_EVENT_TYPES.
+ * Expected Behavior: Requester returns SPDM_ERROR_CODE_UNSUPPORTED_REQUEST.
+ **/
+static void test_encap_supported_event_types_err_case3(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t *get_supported_event_types;
+    size_t request_size = sizeof(spdm_get_supported_event_types_request_t);
+    spdm_error_response_t *error_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x03;
+
+    set_standard_state(spdm_context);
+
+    /* SPDM 1.2 does not support GET_SUPPORTED_EVENT_TYPES. */
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    get_supported_event_types = (spdm_get_supported_event_types_request_t *)m_spdm_request_buffer;
+
+    get_supported_event_types->header.spdm_version = SPDM_MESSAGE_VERSION_12;
+    get_supported_event_types->header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    get_supported_event_types->header.param1 = 0;
+    get_supported_event_types->header.param2 = 0;
+
+    status = libspdm_get_encap_supported_event_types(spdm_context,
+                                                     request_size,
+                                                     m_spdm_request_buffer,
+                                                     &response_size,
+                                                     m_spdm_response_buffer);
+
+    error_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(error_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
+    assert_int_equal(error_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(error_response->header.param2, SPDM_GET_SUPPORTED_EVENT_TYPES);
+}
+
+/**
+ * Test 4: Message SPDMVersion does not match the connection's version.
+ * Expected Behavior: Requester returns SPDM_ERROR_CODE_VERSION_MISMATCH.
+ **/
+static void test_encap_supported_event_types_err_case4(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t *get_supported_event_types;
+    size_t request_size = sizeof(spdm_get_supported_event_types_request_t);
+    spdm_error_response_t *error_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x04;
+
+    set_standard_state(spdm_context);
+
+    get_supported_event_types = (spdm_get_supported_event_types_request_t *)m_spdm_request_buffer;
+
+    /* SPDMVersion does not match the connection's negotiated version. */
+    get_supported_event_types->header.spdm_version = SPDM_MESSAGE_VERSION_14;
+    get_supported_event_types->header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    get_supported_event_types->header.param1 = 0;
+    get_supported_event_types->header.param2 = 0;
+
+    status = libspdm_get_encap_supported_event_types(spdm_context,
+                                                     request_size,
+                                                     m_spdm_request_buffer,
+                                                     &response_size,
+                                                     m_spdm_response_buffer);
+
+    error_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(error_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(error_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_VERSION_MISMATCH);
+    assert_int_equal(error_response->header.param2, 0);
+}
+
+/**
+ * Test 5: Call to libspdm_event_get_types fails.
+ * Expected Behavior: Requester returns SPDM_ERROR_CODE_UNSPECIFIED.
+ **/
+static void test_encap_supported_event_types_err_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    spdm_get_supported_event_types_request_t *get_supported_event_types;
+    size_t request_size = sizeof(spdm_get_supported_event_types_request_t);
+    spdm_error_response_t *error_response;
+    size_t response_size =  sizeof(m_spdm_response_buffer);
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x05;
+
+    set_standard_state(spdm_context);
+
+    get_supported_event_types = (spdm_get_supported_event_types_request_t *)m_spdm_request_buffer;
+
+    get_supported_event_types->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    get_supported_event_types->header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+    get_supported_event_types->header.param1 = 0;
+    get_supported_event_types->header.param2 = 0;
+
+    g_event_get_types_error = true;
+
+    status = libspdm_get_encap_supported_event_types(spdm_context,
+                                                     request_size,
+                                                     m_spdm_request_buffer,
+                                                     &response_size,
+                                                     m_spdm_response_buffer);
+
+    g_event_get_types_error = false;
+
+    error_response = (spdm_error_response_t *)m_spdm_response_buffer;
+
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    assert_int_equal(error_response->header.spdm_version, SPDM_MESSAGE_VERSION_13);
+    assert_int_equal(error_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_UNSPECIFIED);
+    assert_int_equal(error_response->header.param2, 0);
+}
+
 int libspdm_req_encap_supported_event_types_error_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(test_encap_supported_event_types_err_case1),
         cmocka_unit_test(test_encap_supported_event_types_err_case2),
+        cmocka_unit_test(test_encap_supported_event_types_err_case3),
+        cmocka_unit_test(test_encap_supported_event_types_err_case4),
+        cmocka_unit_test(test_encap_supported_event_types_err_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/error_test/send_event_err.c
+++ b/unit_test/test_spdm_requester/error_test/send_event_err.c
@@ -21,15 +21,98 @@ static struct m_test_params {
 static libspdm_return_t send_message(
     void *spdm_context, size_t request_size, const void *request, uint64_t timeout)
 {
-    assert_true(false);
-    return LIBSPDM_STATUS_SEND_FAIL;
+    libspdm_test_context_t *spdm_test_context = libspdm_get_test_context();
+
+    switch (spdm_test_context->case_id) {
+    case 0x4:
+    case 0x6:
+    case 0x7:
+    case 0x8:
+    case 0x9:
+        return LIBSPDM_STATUS_SUCCESS;
+    case 0x5:
+        return LIBSPDM_STATUS_SEND_FAIL;
+    default:
+        assert_true(false);
+        return LIBSPDM_STATUS_SEND_FAIL;
+    }
 }
 
 static libspdm_return_t receive_message(
     void *spdm_context, size_t *response_size, void **response, uint64_t timeout)
 {
-    assert_true(false);
-    return LIBSPDM_STATUS_RECEIVE_FAIL;
+    libspdm_test_context_t *spdm_test_context = libspdm_get_test_context();
+    spdm_event_ack_response_t *spdm_response;
+    size_t spdm_response_size;
+    size_t transport_header_size;
+    uint32_t session_id;
+    libspdm_session_info_t *session_info;
+    uint8_t *scratch_buffer;
+    size_t scratch_buffer_size;
+
+    transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+    spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+    session_id = m_session_id;
+    session_info = libspdm_get_session_info_via_session_id(spdm_context, session_id);
+    LIBSPDM_ASSERT((session_info != NULL));
+
+    transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+    spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+    spdm_response_size = sizeof(spdm_event_ack_response_t);
+    libspdm_zero_mem(spdm_response, spdm_response_size);
+
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_EVENT_ACK;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = 0;
+
+    switch (spdm_test_context->case_id) {
+    case 0x7:
+        /* Invalid response message size. */
+        spdm_response_size++;
+        break;
+    case 0x8:
+        /* Invalid RequestResponseCode to SEND_EVENT request. */
+        spdm_response->header.request_response_code = SPDM_KEY_UPDATE_ACK;
+        break;
+    case 0x9:
+        /* Invalid SPDMVersion field value. */
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_14;
+        break;
+    default:
+        break;
+    }
+
+    /* For secure message, message is in sender buffer, we need copy it to scratch buffer.
+     * transport_message is always in sender buffer. */
+    libspdm_get_scratch_buffer(spdm_context, (void **)&scratch_buffer, &scratch_buffer_size);
+    libspdm_copy_mem(scratch_buffer + transport_header_size,
+                     scratch_buffer_size - transport_header_size,
+                     spdm_response, spdm_response_size);
+
+    spdm_response = (void *)(scratch_buffer + transport_header_size);
+
+    libspdm_transport_test_encode_message(spdm_context, &session_id,
+                                          false, false, spdm_response_size,
+                                          spdm_response, response_size, response);
+
+    /* Workaround: Use single context to encode message and then decode message. */
+    ((libspdm_secured_message_context_t *)(session_info->secured_message_context))->
+    application_secret.response_data_sequence_number--;
+
+    switch (spdm_test_context->case_id) {
+    case 0x6:
+        return LIBSPDM_STATUS_RECEIVE_FAIL;
+    case 0x7:
+    case 0x8:
+    case 0x9:
+        return LIBSPDM_STATUS_SUCCESS;
+    default:
+        assert_true(false);
+        return LIBSPDM_STATUS_RECEIVE_FAIL;
+    }
 }
 
 static void set_standard_state(libspdm_context_t *spdm_context)
@@ -77,7 +160,7 @@ static void set_standard_state(libspdm_context_t *spdm_context)
 
 /**
  * Test 1: Requester has not set EVENT_CAP.
- * Expected behavior: returns with LIBSPDM_STATUS_SUCCESS.
+ * Expected behavior: returns with LIBSPDM_STATUS_UNSUPPORTED_CAP.
  **/
 static void req_send_event_err_case1(void **state)
 {
@@ -110,7 +193,7 @@ static void req_send_event_err_case1(void **state)
 
 /**
  * Test 2: Connection version does not support SEND_EVENT.
- * Expected behavior: returns with LIBSPDM_STATUS_SUCCESS.
+ * Expected behavior: returns with LIBSPDM_STATUS_UNSUPPORTED_CAP.
  **/
 static void req_send_event_err_case2(void **state)
 {
@@ -141,11 +224,231 @@ static void req_send_event_err_case2(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
 }
 
+/**
+ * Test 3: Unable to acquire send buffer.
+ * Expected behavior: returns with LIBSPDM_STATUS_ACQUIRE_FAIL.
+ **/
+static void req_send_event_err_case3(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x3;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    /* Induce error when acquiring send buffer. */
+    libspdm_force_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    libspdm_release_error(LIBSPDM_ERR_ACQUIRE_SENDER_BUFFER);
+
+    assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
+}
+
+/**
+ * Test 4: Unable to acquire receive buffer.
+ * Expected behavior: returns with LIBSPDM_STATUS_ACQUIRE_FAIL.
+ **/
+static void req_send_event_err_case4(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x4;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    /* Induce error when acquiring receive buffer. */
+    libspdm_force_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    libspdm_release_error(LIBSPDM_ERR_ACQUIRE_RECEIVER_BUFFER);
+
+    assert_int_equal(status, LIBSPDM_STATUS_ACQUIRE_FAIL);
+}
+
+/**
+ * Test 5: Unable to send message.
+ * Expected behavior: returns with LIBSPDM_STATUS_SEND_FAIL.
+ **/
+static void req_send_event_err_case5(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    assert_int_equal(status, LIBSPDM_STATUS_SEND_FAIL);
+}
+
+/**
+ * Test 6: Unable to receive message.
+ * Expected behavior: returns with LIBSPDM_STATUS_RECEIVE_FAIL.
+ **/
+static void req_send_event_err_case6(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x6;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    assert_int_equal(status, LIBSPDM_STATUS_RECEIVE_FAIL);
+}
+
+/**
+ * Test 7: Invalid size of EVENT_ACK response.
+ * Expected behavior: returns with LIBSPDM_STATUS_INVALID_MSG_SIZE.
+ **/
+static void req_send_event_err_case7(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x7;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
+}
+
+/**
+ * Test 8: Invalid RequestResponseCode in response.
+ * Expected behavior: returns with LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ **/
+static void req_send_event_err_case8(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x8;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
+
+/**
+ * Test 9: Invalid SPDMVersion in response.
+ * Expected behavior: returns with LIBSPDM_STATUS_INVALID_MSG_FIELD.
+ **/
+static void req_send_event_err_case9(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    libspdm_return_t status;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x9;
+
+    set_standard_state(spdm_context);
+
+    m_test_params.event_count = 3;
+    m_test_params.events_list_size = 100;
+
+    for (int unsigned index = 0; index < m_test_params.events_list_size; index++) {
+        m_test_params.events_list[index] = (uint8_t)index;
+    }
+
+    status = libspdm_send_event(spdm_context, m_session_id, m_test_params.event_count,
+                                m_test_params.events_list_size, m_test_params.events_list);
+
+    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+}
+
 int libspdm_req_send_event_error_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         cmocka_unit_test(req_send_event_err_case1),
         cmocka_unit_test(req_send_event_err_case2),
+        cmocka_unit_test(req_send_event_err_case3),
+        cmocka_unit_test(req_send_event_err_case4),
+        cmocka_unit_test(req_send_event_err_case5),
+        cmocka_unit_test(req_send_event_err_case6),
+        cmocka_unit_test(req_send_event_err_case7),
+        cmocka_unit_test(req_send_event_err_case8),
+        cmocka_unit_test(req_send_event_err_case9),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/test_spdm_requester.c
+++ b/unit_test/test_spdm_requester/test_spdm_requester.c
@@ -267,6 +267,12 @@ int main(void)
     if (libspdm_req_encap_supported_event_types_error_test() != 0) {
         return_value = 1;
     }
+    if (libspdm_req_encap_subscribe_event_types_ack_test() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_req_encap_subscribe_event_types_ack_error_test() != 0) {
+        return_value = 1;
+    }
     if (libspdm_req_send_event_test() != 0) {
         return_value = 1;
     }


### PR DESCRIPTION
This also fixes #3269, which was discovered in the course of adding these test cases.

These test cases were guided by the following coverage reports:
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_requester_lib/libspdm_req_encap_subscribe_event_types_ack.c.gcov.html
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_requester_lib/libspdm_req_encap_supported_event_types.c.gcov.html
- https://dmtf.github.io/libspdm/coverage_log/library/spdm_requester_lib/libspdm_req_send_event.c.gcov.html