### PR TITLE
Replace the three URLs which are unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@
 | [ARM_DS2022](https://developer.arm.com/downloads/-/arm-development-studio-downloads) |  -   |  -  | armclang | armclang |    -    |    -    |    -    |
 | [ARM_GNU](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) |  -   |  -  | arm-none-linux-gnueabihf-gcc | aarch64-none-linux-gnu-gcc |    -    |    -    |    -    |
 | [ARM_GNU_BARE_METAL](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) |  -   |  -  | arm-none-eabi | aarch64-none-elf |    -    |    -    |    -    |
-| [ARM_GCC](https://packages.ubuntu.com/bionic/gcc-arm-linux-gnueabi) |  -   |  -  | arm-linux-gnueabi-gcc |    -    |    -    |    -    |    -    |
-| [AARCH64_GCC](https://packages.ubuntu.com/bionic/gcc-aarch64-linux-gnu) |  -   |  -  |  -  | aarch64-linux-gnu-gcc |    -    |    -    |    -    |
+| [ARM_GCC](https://pkgs.org/download/gcc-arm-linux-gnueabi) |  -   |  -  | arm-linux-gnueabi-gcc |    -    |    -    |    -    |    -    |
+| [AARCH64_GCC](https://pkgs.org/download/gcc-aarch64-linux-gnu) |  -   |  -  |  -  | aarch64-linux-gnu-gcc |    -    |    -    |    -    |
 | [RISCV_GNU](https://github.com/riscv/riscv-gnu-toolchain) |  -   |  -  |  -  |    -    | riscv32-unknown-linux-gnu-gcc | riscv64-unknown-linux-gnu-gcc |    -    |
-| [RISCV64_GCC](https://packages.ubuntu.com/bionic/gcc-riscv64-linux-gnu) |  -   |  -  |  -  |    -    |    -    | riscv64-linux-gnu-gcc |    -    |
+| [RISCV64_GCC](https://pkgs.org/download/gcc-riscv64-linux-gnu) |  -   |  -  |  -  |    -    |    -    | riscv64-linux-gnu-gcc |    -    |
 | [RISCV_XPACK](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack) |  -   |  -  |  -  |    -    | riscv-none-elf-gcc | riscv-none-elf-gcc |    -    |
 | [RISCV_NONE](https://archlinux.org/packages/extra/x86_64/riscv64-elf-gcc/) |  -   |  -  |  -  |    -    | riscv64-elf-gcc | riscv64-elf-gcc |    -    |
 | [LOONGARCH64_GNU](https://github.com/loongson/build-tools/) |  -   |  -  |  -  |    -    | - | - | loongarch64-unknown-linux-gnu-gcc |

--- a/doc/build.md
+++ b/doc/build.md
@@ -56,11 +56,12 @@ c) [ARM GNU bare metal](https://developer.arm.com/downloads/-/arm-gnu-toolchain-
       source ~/.bashrc
       ```
 
-d) [ARM GCC](https://packages.ubuntu.com/bionic/gcc-arm-linux-gnueabi) for ARM only
-  - `sudo apt-get install gcc-arm-linux-gnueabi`
+d) [ARM GCC](https://pkgs.org/download/gcc-arm-linux-gnueabi) for ARM only
+  - Ubuntu, Debian:`sudo apt-get install gcc-arm-linux-gnueabi`
 
-e) [AARCH64 GCC](https://packages.ubuntu.com/bionic/gcc-aarch64-linux-gnu) for AARCH64 only
-  - `sudo apt-get install gcc-aarch64-linux-gnu`
+e) [AARCH64 GCC](https://pkgs.org/download/gcc-aarch64-linux-gnu) for AARCH64 only
+  - Ubuntu, Debian:`sudo apt-get install gcc-aarch64-linux-gnu`
+  - Fedora:`sudo dnf install gcc-aarch64-linux-gnu`
 
 #### Compiler for RISCV32/RISCV64 (Choose one)
 
@@ -94,8 +95,9 @@ b) [RISCV GNU](https://github.com/riscv-collab/riscv-gnu-toolchain)
       sudo ln -s /opt/riscv32/bin/* /usr/bin
       ```
 
-c) [RISCV64 GCC](https://packages.ubuntu.com/bionic/gcc-riscv64-linux-gnu) for RISCV64 only
-  - `sudo apt-get install gcc-riscv64-linux-gnu`
+c) [RISCV64 GCC](https://pkgs.org/download/gcc-riscv64-linux-gnu) for RISCV64 only
+  - Ubuntu, Debian:`sudo apt-get install gcc-riscv64-linux-gnu`
+  - Fedora:`sudo dnf install gcc-riscv64-linux-gnu`
 
 d) [RISCV NONE](https://archlinux.org/packages/extra/x86_64/riscv64-elf-gcc/)
   - Use a [GCC](https://gcc.gnu.org/) compiler configured for building


### PR DESCRIPTION
Outdated URLs are replaced due to they are unreachable. New URLs list package links for the mainstream distributions, and will remain long-term valid.