### PR TITLE
Remove unnecessary SHA macro check for RSAPSS FIPS test.

### DIFF
--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_pss.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_pss.c
@@ -18,7 +18,7 @@ bool libspdm_fips_selftest_rsa_pss(void *fips_selftest_context)
 {
     bool result = true;
 
-#if (LIBSPDM_RSA_PSS_SUPPORT) && (LIBSPDM_SHA256_SUPPORT)
+#if LIBSPDM_RSA_PSS_SUPPORT
     libspdm_fips_selftest_context_t *context = fips_selftest_context;
     LIBSPDM_ASSERT(fips_selftest_context != NULL);
 
@@ -201,7 +201,7 @@ update:
         context->self_test_result &= ~LIBSPDM_FIPS_SELF_TEST_RSA_PSS;
     }
 
-#endif/*(LIBSPDM_RSA_PSS_SUPPORT) && (LIBSPDM_SHA256_SUPPORT)*/
+#endif/*LIBSPDM_RSA_PSS_SUPPORT*/
 
     return result;
 }


### PR DESCRIPTION
It also align with RSASSA and ECDSA FIPS test.