### PR TITLE
Map `SlotID` to `KeyPairID` in unit test

### DIFF
--- a/os_stub/spdm_device_secret_lib_sample/sign.c
+++ b/os_stub/spdm_device_secret_lib_sample/sign.c
@@ -31,6 +31,20 @@ bool libspdm_requester_data_sign(
     void *context;
     bool result;
 
+    const uint8_t version = spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT;
+    const bool multi_key_conn_rsp =
+        ((libspdm_context_t *)spdm_context)->connection_info.multi_key_conn_req;
+
+    if (version < SPDM_MESSAGE_VERSION_13) {
+        LIBSPDM_ASSERT(key_pair_id == 0);
+    } else if (version >= SPDM_MESSAGE_VERSION_13) {
+        if (multi_key_conn_rsp) {
+            LIBSPDM_ASSERT(key_pair_id > 0);
+        } else {
+            LIBSPDM_ASSERT(key_pair_id == 0);
+        }
+    }
+
 #if !LIBSPDM_PRIVATE_KEY_MODE_RAW_KEY_ONLY
     if (g_private_key_mode) {
         void *private_pem;
@@ -156,6 +170,21 @@ bool libspdm_responder_data_sign(
 {
     void *context;
     bool result;
+
+    const uint8_t version = spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT;
+    const bool multi_key_conn_rsp =
+        ((libspdm_context_t *)spdm_context)->connection_info.multi_key_conn_rsp;
+
+    if (version < SPDM_MESSAGE_VERSION_13) {
+        LIBSPDM_ASSERT(key_pair_id == 0);
+    } else if (version >= SPDM_MESSAGE_VERSION_13) {
+        if (multi_key_conn_rsp) {
+            LIBSPDM_ASSERT(key_pair_id > 0);
+        } else {
+            LIBSPDM_ASSERT(key_pair_id == 0);
+        }
+    }
+
 #if !LIBSPDM_PRIVATE_KEY_MODE_RAW_KEY_ONLY
     if (g_private_key_mode) {
         void *private_pem;

--- a/unit_test/test_spdm_responder/endpoint_info.c
+++ b/unit_test/test_spdm_responder/endpoint_info.c
@@ -110,6 +110,7 @@ static void rsp_endpoint_info_case1(void **state)
                                                     m_libspdm_use_asym_algo, &data,
                                                     &data_size, NULL, NULL);
     for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_key_pair_id[i] = 1;
         spdm_context->local_context.local_cert_chain_provision_size[i] = data_size;
         spdm_context->local_context.local_cert_chain_provision[i] = data;
     }
@@ -326,6 +327,7 @@ static void rsp_endpoint_info_case3(void **state)
                                                     m_libspdm_use_asym_algo, &data,
                                                     &data_size, NULL, NULL);
     for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_key_pair_id[i] = 1;
         spdm_context->local_context.local_cert_chain_provision_size[i] = data_size;
         spdm_context->local_context.local_cert_chain_provision[i] = data;
     }
@@ -520,6 +522,7 @@ static void rsp_endpoint_info_case5(void **state)
                                                     m_libspdm_use_asym_algo, &data,
                                                     &data_size, NULL, NULL);
     for (int i = 0; i < SPDM_MAX_SLOT_COUNT; i++) {
+        spdm_context->local_context.local_key_pair_id[i] = 1;
         spdm_context->local_context.local_cert_chain_provision_size[i] = data_size;
         spdm_context->local_context.local_cert_chain_provision[i] = data;
     }


### PR DESCRIPTION
Add assertions in spdm_device_secret_lib_sample to enforce this.

This fixes #3331.