### PR TITLE
libspdm: enable OSSL_STORE API support

### DIFF
--- a/os_stub/openssllib/CMakeLists.txt
+++ b/os_stub/openssllib/CMakeLists.txt
@@ -840,6 +840,22 @@ target_sources(openssllib
         openssl_gen/der_wrap_gen.c
         openssl_gen/params_idx.c
         rand_pool.c
-        ossl_store.c
         timer_wrapper.c
 )
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    target_sources(openssllib PRIVATE
+        ossl_store.c
+    )
+else()
+    target_sources(openssllib PRIVATE
+        openssl/crypto/store/store_err.c
+        openssl/crypto/store/store_init.c
+        openssl/crypto/store/store_lib.c
+        openssl/crypto/store/store_register.c
+        openssl/crypto/store/store_result.c
+        openssl/crypto/store/store_strings.c
+        openssl/providers/implementations/storemgmt/file_store.c
+        openssl/providers/implementations/storemgmt/file_store_any2obj.c
+    )
+endif()

--- a/os_stub/openssllib/include/crt_support.h
+++ b/os_stub/openssllib/include/crt_support.h
@@ -240,7 +240,10 @@ typedef char *LIBSPDM_VA_LIST;
 /* Basic types mapping*/
 
 typedef size_t u_int;
-#if defined(__GNUC__) && !defined(__MINGW64__)
+#if defined(__APPLE__)
+#include <machine/types.h>
+typedef __darwin_time_t time_t;
+#elif defined(__GNUC__) && !defined(__MINGW64__)
 typedef size_t time_t; /* time_t is 4 bytes for 32bit machine and 8 bytes for 64bit machine */
 #endif
 typedef uint8_t __uint8_t;
@@ -248,7 +251,16 @@ typedef uint8_t sa_family_t;
 typedef uint8_t u_char;
 typedef uint32_t uid_t;
 typedef uint32_t gid_t;
+
+#if defined(__APPLE__)
+typedef __darwin_off_t off_t;
+#else
 typedef long off_t;
+#endif
+
+typedef unsigned int _dev_t;
+
+typedef unsigned short _ino_t;
 
 /* file operations are not required for EFI building,
  * so FILE is mapped to void * to pass build*/


### PR DESCRIPTION
This change enables proper integration of the OSSL_STORE API within openssllib. The CMakeLists.txt has been updated to include the necessary source files, and the dummy oss_store.c implementation only used in Windows for now until fixed LIBSPDM_OPENSSL_STDINT_WORKAROUND.

OSSL_STORE provide functionality to retrieve a keys and certs from a repository of any kind, addressable as a filename or as a URI from multiple kind of support hardware, like normal storage drive and/or secure vault like TPM.

https://docs.openssl.org/3.0/man7/ossl_store