### PR TITLE
Support multiple make jobs on Darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
           cmake -E env CFLAGS="${{ matrix.configurations }} -DLIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG=3" cmake -DARCH=${{ matrix.arch }} -DTOOLCHAIN=${{ matrix.toolchain }} -DTARGET=${{ matrix.target }} -DCRYPTO=${{ matrix.crypto }} ..
           make copy_sample_key
           make copy_seed
-          make # process killed with multicore
+          make -j$(sysctl -n hw.logicalcpu)
       - name: Build - Windows
         if: matrix.os == 'windows-latest' && matrix.toolchain != 'GCC'
         run: |


### PR DESCRIPTION
In CI/CD this reduces build and test time from approximately 9 minutes to 6.75 minutes.