### PR TITLE
libspdm: fix Yocto build failure for shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project("libspdm" C)
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.md CMAKE_INPUT_PROJECT_VERSION)
 string(REPLACE " " "_" CMAKE_PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
-string(REGEX REPLACE "[ ]*[A-Za-z]+[ ]*[A-Za-z ]+" "" PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
+string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" PROJECT_VERSION ${CMAKE_INPUT_PROJECT_VERSION})
 
 #
 # Build Configuration Macro Definition
@@ -1191,12 +1191,19 @@ else()
             )
         elseif(CRYPTO STREQUAL "openssl")
             set(CRYPTO_DEPS "-lssl -lcrypto")
+	    if((TOOLCHAIN STREQUAL "NONE") AND (ENABLE_BINARY_BUILD STREQUAL "0"))
+                target_link_libraries(${LIB_NAME}_crypto
+                    PUBLIC openssllib
+                    PUBLIC cryptlib_openssl
+                )
+            else()
+                target_link_libraries(${LIB_NAME}_crypto
+                    PUBLIC ssl
+                    PUBLIC crypto
+                )
+            endif()
             # Always link to the OpenSSL library built from source (openssllib target)
             # openssllib will be STATIC when TOOLCHAIN=NONE, SHARED otherwise
-            target_link_libraries(${LIB_NAME}_crypto
-                PUBLIC openssllib
-                PUBLIC cryptlib_openssl
-            )
         endif()
 
         target_link_libraries(${LIB_NAME}

--- a/os_stub/cryptlib_openssl/CMakeLists.txt
+++ b/os_stub/cryptlib_openssl/CMakeLists.txt
@@ -11,9 +11,6 @@ target_include_directories(cryptlib_openssl
         ${LIBSPDM_DIR}/os_stub/openssllib/include
 )
 
-# Ensure OpenSSL is built before cryptlib_openssl
-add_dependencies(cryptlib_openssl openssllib)
-
 target_sources(cryptlib_openssl
     PRIVATE
         cipher/aead_aes_gcm.c

--- a/os_stub/openssllib/include/crt_support.h
+++ b/os_stub/openssllib/include/crt_support.h
@@ -214,7 +214,7 @@ typedef char *LIBSPDM_VA_LIST;
 
 typedef size_t u_int;
 #if defined(__GNUC__) && !defined(__MINGW64__)
-typedef size_t time_t; /* time_t is 4 bytes for 32bit machine and 8 bytes for 64bit machine */
+typedef long long time_t; /* time_t is 8 bytes for 32bit machine and 64bit machine */
 #endif
 typedef uint8_t __uint8_t;
 typedef uint8_t sa_family_t;


### PR DESCRIPTION
Fixes build errors when compiling shared libspdm libraries using
the BUILD_LINUX_SHARED_LIB option in Yocto for OpenSSL.

This commit fixes the following:
 1. When ENABLE_BINARY_BUILD is set, always use the existing OpenSSL
   binaries from the build environment.
 2. Conflicting data type error for time_t
