### PR TITLE
os_stub/openssllib: Allow building with older OpenSSL versions

### DIFF
--- a/os_stub/openssllib/openssl_gen/openssl/bio.h
+++ b/os_stub/openssllib/openssl_gen/openssl/bio.h
@@ -993,6 +993,14 @@ int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy) (BIO *));
 int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
                                long (*callback_ctrl) (BIO *, int,
                                                       BIO_info_cb *));
+
+/*
+ * Support OpenSSL versions below 3.5.
+ */
+# ifndef OSSL_DEPRECATEDIN_3_5
+#  define OSSL_DEPRECATEDIN_3_5
+# endif
+
 # ifndef OPENSSL_NO_DEPRECATED_3_5
 OSSL_DEPRECATEDIN_3_5 int (*BIO_meth_get_write(const BIO_METHOD *biom)) (BIO *, const char *,
                                                                          int);

--- a/os_stub/openssllib/openssl_gen/openssl/x509.h
+++ b/os_stub/openssllib/openssl_gen/openssl/x509.h
@@ -892,6 +892,18 @@ ASN1_BIT_STRING *X509_get0_pubkey_bitstr(const X509 *x);
 
 #define X509_REQ_VERSION_1 0
 
+/*
+ * Define OSSL_FUTURE_CONST if it isn't defind, this can be removed
+ * once OSSL_FUTURE_CONST is removed in OpenSSL.
+ */
+#ifndef OSSL_FUTURE_CONST
+# if OPENSSL_VERSION_MAJOR >= 4
+#  define OSSL_FUTURE_CONST const
+# else
+#  define OSSL_FUTURE_CONST
+# endif
+#endif
+
 long X509_REQ_get_version(const X509_REQ *req);
 int X509_REQ_set_version(X509_REQ *x, long version);
 X509_NAME *X509_REQ_get_subject_name(const X509_REQ *req);


### PR DESCRIPTION
Not everyone is using OpenSSL 3.5, so let's ensure we support older versions (tested against OpenSSL 3.2.6)