### PR TITLE
Move `local_used_cert_chain_slot_id` to `session_info`

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -150,11 +150,6 @@ typedef struct {
     libspdm_peer_used_cert_chain_t peer_used_cert_chain[SPDM_MAX_SLOT_COUNT];
     uint8_t peer_used_cert_chain_slot_id;
 
-    /* Local Used CertificateChain (for responder, or requester in mut auth) */
-    const uint8_t *local_used_cert_chain_buffer;
-    size_t local_used_cert_chain_buffer_size;
-    uint8_t local_used_cert_chain_slot_id;
-
     /* Specifies whether the cached negotiated state should be invalidated. (responder only)
      * This is a "sticky" bit wherein if it is set to 1 then it cannot be set to 0. */
     uint8_t end_session_attributes;
@@ -477,6 +472,8 @@ typedef struct {
     /* Register for the last KEY_UPDATE token and operation (responder only)*/
     spdm_key_update_request_t last_key_update_request;
     void *secured_message_context;
+    /* Only present in session info as it is currently only used within a secure session. */
+    uint8_t local_used_cert_chain_slot_id;
 } libspdm_session_info_t;
 
 #define LIBSPDM_MAX_ENCAP_REQUEST_OP_CODE_SEQUENCE_COUNT 3

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -879,11 +879,9 @@ bool libspdm_get_peer_cert_chain_data(void *spdm_context,
  * @param  spdm_context            A pointer to the SPDM context.
  * @param  cert_chain_buffer       Certificate chain buffer including spdm_cert_chain_t header.
  * @param  cert_chain_buffer_size  Size in bytes of the certificate chain buffer.
- *
- * @retval true  Local used certificate chain buffer including spdm_cert_chain_t header is returned.
- * @retval false Local used certificate chain buffer including spdm_cert_chain_t header is not found.
  **/
-bool libspdm_get_local_cert_chain_buffer(void *spdm_context,
+void libspdm_get_local_cert_chain_buffer(void *spdm_context,
+                                         uint8_t slot_id,
                                          const void **cert_chain_buffer,
                                          size_t *cert_chain_buffer_size);
 
@@ -898,6 +896,7 @@ bool libspdm_get_local_cert_chain_buffer(void *spdm_context,
  * @retval false Local used certificate chain data without spdm_cert_chain_t header is not found.
  **/
 bool libspdm_get_local_cert_chain_data(void *spdm_context,
+                                       uint8_t slot_id,
                                        const void **cert_chain_data,
                                        size_t *cert_chain_data_size);
 

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1999,19 +1999,19 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
                                          hash_size);
                     }
                 } else {
-                    slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+                    slot_id = spdm_session_info->local_used_cert_chain_slot_id;
                     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
                     if (slot_id == 0xFF) {
                         result = libspdm_get_local_public_key_buffer(
                             spdm_context, (const void **)&cert_chain_buffer,
                             &cert_chain_buffer_size);
+                        if (!result) {
+                            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+                        }
                     } else {
-                        result = libspdm_get_local_cert_chain_buffer(
-                            spdm_context, (const void **)&cert_chain_buffer,
+                        libspdm_get_local_cert_chain_buffer(
+                            spdm_context, slot_id, (const void **)&cert_chain_buffer,
                             &cert_chain_buffer_size);
-                    }
-                    if (!result) {
-                        return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                     }
 
                     result = libspdm_hash_all(
@@ -2145,21 +2145,22 @@ libspdm_return_t libspdm_append_message_f(libspdm_context_t *spdm_context,
 
             if (!spdm_session_info->use_psk && (spdm_session_info->mut_auth_requested != 0)) {
                 if (is_requester) {
-                    slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+                    slot_id = spdm_session_info->local_used_cert_chain_slot_id;
                     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
                     if (slot_id == 0xFF) {
                         result = libspdm_get_local_public_key_buffer(
                             spdm_context,
                             (const void **)&mut_cert_chain_buffer,
                             &mut_cert_chain_buffer_size);
+                        if (!result) {
+                            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+                        }
                     } else {
-                        result = libspdm_get_local_cert_chain_buffer(
+                        libspdm_get_local_cert_chain_buffer(
                             spdm_context,
+                            slot_id,
                             (const void **)&mut_cert_chain_buffer,
                             &mut_cert_chain_buffer_size);
-                    }
-                    if (!result) {
-                        return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                     }
 
                     result = libspdm_hash_all(
@@ -3253,8 +3254,6 @@ void libspdm_reset_context(void *spdm_context)
     libspdm_zero_mem(&context->connection_info.algorithm, sizeof(libspdm_device_algorithm_t));
     libspdm_zero_mem(&context->last_spdm_error, sizeof(libspdm_error_struct_t));
     libspdm_zero_mem(&context->encap_context, sizeof(libspdm_encap_context_t));
-    context->connection_info.local_used_cert_chain_buffer_size = 0;
-    context->connection_info.local_used_cert_chain_buffer = NULL;
     context->connection_info.multi_key_conn_req = false;
     context->connection_info.multi_key_conn_rsp = false;
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -115,19 +115,20 @@ bool libspdm_get_peer_cert_chain_data(void *spdm_context,
  * @retval true  Local used certificate chain buffer including spdm_cert_chain_t header is returned.
  * @retval false Local used certificate chain buffer including spdm_cert_chain_t header is not found.
  **/
-bool libspdm_get_local_cert_chain_buffer(void *spdm_context,
+void libspdm_get_local_cert_chain_buffer(void *spdm_context,
+                                         uint8_t slot_id,
                                          const void **cert_chain_buffer,
                                          size_t *cert_chain_buffer_size)
 {
     libspdm_context_t *context;
 
     context = spdm_context;
-    if (context->connection_info.local_used_cert_chain_buffer_size != 0) {
-        *cert_chain_buffer = context->connection_info.local_used_cert_chain_buffer;
-        *cert_chain_buffer_size = context->connection_info.local_used_cert_chain_buffer_size;
-        return true;
-    }
-    return false;
+
+    LIBSPDM_ASSERT(context->local_context.local_cert_chain_provision[slot_id] != NULL);
+    LIBSPDM_ASSERT(context->local_context.local_cert_chain_provision_size != 0);
+
+    *cert_chain_buffer = context->local_context.local_cert_chain_provision[slot_id];
+    *cert_chain_buffer_size = context->local_context.local_cert_chain_provision_size[slot_id];
 }
 
 /**
@@ -141,25 +142,22 @@ bool libspdm_get_local_cert_chain_buffer(void *spdm_context,
  * @retval false Local used certificate chain data without spdm_cert_chain_t header is not found.
  **/
 bool libspdm_get_local_cert_chain_data(void *spdm_context,
+                                       uint8_t slot_id,
                                        const void **cert_chain_data,
                                        size_t *cert_chain_data_size)
 {
     libspdm_context_t *context;
-    bool result;
     size_t hash_size;
 
     context = spdm_context;
 
-    result = libspdm_get_local_cert_chain_buffer(context, cert_chain_data,
-                                                 cert_chain_data_size);
-    if (!result) {
-        return false;
-    }
+    libspdm_get_local_cert_chain_buffer(context, slot_id, cert_chain_data, cert_chain_data_size);
 
     hash_size = libspdm_get_hash_size(context->connection_info.algorithm.base_hash_algo);
 
     *cert_chain_data = (const uint8_t *)*cert_chain_data + sizeof(spdm_cert_chain_t) + hash_size;
     *cert_chain_data_size = *cert_chain_data_size - (sizeof(spdm_cert_chain_t) + hash_size);
+
     return true;
 }
 

--- a/library/spdm_common_lib/libspdm_com_crypto_service_session.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service_session.c
@@ -471,16 +471,17 @@ bool libspdm_calculate_th1_hash(libspdm_context_t *spdm_context,
                     &cert_chain_buffer_size);
             }
         } else {
-            slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+            slot_id = session_info->local_used_cert_chain_slot_id;
             LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
             if (slot_id == 0xFF) {
                 result = libspdm_get_local_public_key_buffer(
                     spdm_context, (const void **)&cert_chain_buffer,
                     &cert_chain_buffer_size);
             } else {
-                result = libspdm_get_local_cert_chain_buffer(
-                    spdm_context, (const void **)&cert_chain_buffer,
+                libspdm_get_local_cert_chain_buffer(
+                    spdm_context, slot_id, (const void **)&cert_chain_buffer,
                     &cert_chain_buffer_size);
+                result = true;
             }
         }
         if (!result) {
@@ -563,16 +564,17 @@ bool libspdm_calculate_th2_hash(libspdm_context_t *spdm_context,
                     &cert_chain_buffer_size);
             }
         } else {
-            slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+            slot_id = session_info->local_used_cert_chain_slot_id;
             LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
             if (slot_id == 0xFF) {
                 result = libspdm_get_local_public_key_buffer(
                     spdm_context, (const void **)&cert_chain_buffer,
                     &cert_chain_buffer_size);
             } else {
-                result = libspdm_get_local_cert_chain_buffer(
-                    spdm_context, (const void **)&cert_chain_buffer,
+                libspdm_get_local_cert_chain_buffer(
+                    spdm_context, slot_id, (const void **)&cert_chain_buffer,
                     &cert_chain_buffer_size);
+                result = true;
             }
         }
         if (!result) {
@@ -580,16 +582,17 @@ bool libspdm_calculate_th2_hash(libspdm_context_t *spdm_context,
         }
         if (session_info->mut_auth_requested != 0) {
             if (is_requester) {
-                slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+                slot_id = session_info->local_used_cert_chain_slot_id;
                 LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
                 if (slot_id == 0xFF) {
                     result = libspdm_get_local_public_key_buffer(
                         spdm_context, (const void **)&mut_cert_chain_buffer,
                         &mut_cert_chain_buffer_size);
                 } else {
-                    result = libspdm_get_local_cert_chain_buffer(
-                        spdm_context, (const void **)&mut_cert_chain_buffer,
+                    libspdm_get_local_cert_chain_buffer(
+                        spdm_context, slot_id, (const void **)&mut_cert_chain_buffer,
                         &mut_cert_chain_buffer_size);
+                    result = true;
                 }
             } else {
                 slot_id = spdm_context->connection_info.peer_used_cert_chain_slot_id;

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -32,14 +32,15 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
     LIBSPDM_ASSERT(hmac_size == hash_size);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+    slot_id = session_info->local_used_cert_chain_slot_id;
     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
     if (slot_id == 0xFF) {
         result = libspdm_get_local_public_key_buffer(
             spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
     } else {
-        result = libspdm_get_local_cert_chain_buffer(
-            spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
+        libspdm_get_local_cert_chain_buffer(
+            spdm_context, slot_id, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
+        result = true;
     }
     if (!result) {
         return false;
@@ -136,17 +137,17 @@ bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
 #endif
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+    slot_id = session_info->local_used_cert_chain_slot_id;
     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
     if (slot_id == 0xFF) {
         result = libspdm_get_local_public_key_buffer(
             spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
+        if (!result) {
+           return false;
+        }
     } else {
-        result = libspdm_get_local_cert_chain_buffer(
-            spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
-    }
-    if (!result) {
-        return false;
+        libspdm_get_local_cert_chain_buffer(
+            spdm_context, slot_id, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
     }
 
     slot_id = spdm_context->connection_info.peer_used_cert_chain_slot_id;
@@ -323,17 +324,17 @@ bool libspdm_generate_finish_rsp_hmac(libspdm_context_t *spdm_context,
     hash_size = libspdm_get_hash_size(spdm_context->connection_info.algorithm.base_hash_algo);
 
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-    slot_id = spdm_context->connection_info.local_used_cert_chain_slot_id;
+    slot_id = session_info->local_used_cert_chain_slot_id;
     LIBSPDM_ASSERT((slot_id < SPDM_MAX_SLOT_COUNT) || (slot_id == 0xFF));
     if (slot_id == 0xFF) {
         result = libspdm_get_local_public_key_buffer(
             spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
+        if (!result) {
+            return false;
+        }
     } else {
-        result = libspdm_get_local_cert_chain_buffer(
-            spdm_context, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
-    }
-    if (!result) {
-        return false;
+        libspdm_get_local_cert_chain_buffer(
+            spdm_context, slot_id, (const void **)&cert_chain_buffer, &cert_chain_buffer_size);
     }
 
     if (session_info->mut_auth_requested != 0) {

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_end_session/end_session.c
@@ -59,9 +59,6 @@ void libspdm_test_responder_end_session(void **State)
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size;
 
     libspdm_reset_message_a(spdm_context);
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_finish_rsp/finish_rsp.c
@@ -95,8 +95,6 @@ void libspdm_test_responder_finish_case1(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -105,6 +103,7 @@ void libspdm_test_responder_finish_case1(void **State)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, true);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(session_info->secured_message_context,
@@ -315,8 +314,6 @@ void libspdm_test_responder_finish_case7(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -325,6 +322,7 @@ void libspdm_test_responder_finish_case7(void **State)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, true);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(session_info->secured_message_context,
@@ -397,8 +395,6 @@ void libspdm_test_responder_finish_case8(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -430,6 +426,7 @@ void libspdm_test_responder_finish_case8(void **State)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, true);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(session_info->secured_message_context,

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_heartbeat_ack/heartbeat_ack.c
@@ -60,9 +60,6 @@ void libspdm_test_responder_heartbeat_case1(void **State)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -176,9 +173,6 @@ void libspdm_test_responder_heartbeat_case4(void **State)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_exchange_rsp/psk_exchange_rsp.c
@@ -73,8 +73,6 @@ void libspdm_test_responder_psk_exchange_case1(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -140,8 +138,6 @@ void libspdm_test_responder_psk_exchange_case2(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -195,8 +191,6 @@ void libspdm_test_responder_psk_exchange_case3(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -272,8 +266,6 @@ void libspdm_test_responder_psk_exchange_case4(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -351,9 +343,6 @@ void libspdm_test_responder_psk_exchange_case5(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
-
 
     libspdm_reset_message_a(spdm_context);
 
@@ -428,8 +417,6 @@ void libspdm_test_responder_psk_exchange_case6(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -506,8 +493,6 @@ void libspdm_test_responder_psk_exchange_case7(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     libspdm_reset_message_a(spdm_context);
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_psk_finish_rsp/psk_finish_rsp.c
@@ -75,8 +75,6 @@ void libspdm_test_responder_psk_finish_rsp_case1(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -147,8 +145,6 @@ void libspdm_test_responder_psk_finish_rsp_case2(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -237,8 +233,7 @@ void libspdm_test_responder_psk_finish_rsp_case3(void **State)
                                                     NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
+
     libspdm_reset_message_a(spdm_context);
 
     session_id = 0xFFFFFFFF;

--- a/unit_test/test_spdm_responder/end_session_ack.c
+++ b/unit_test/test_spdm_responder/end_session_ack.c
@@ -68,9 +68,6 @@ static void rsp_end_session_ack_case1(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -139,9 +136,6 @@ static void rsp_end_session_ack_case2(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -215,9 +209,6 @@ static void rsp_end_session_ack_case3(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -293,9 +284,6 @@ static void rsp_end_session_ack_case4(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -366,8 +354,6 @@ static void rsp_end_session_ack_case5(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -445,9 +431,6 @@ static void rsp_end_session_ack_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -519,9 +502,6 @@ static void rsp_end_session_ack_case7(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -604,8 +584,6 @@ static void rsp_end_session_ack_case8(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 

--- a/unit_test/test_spdm_responder/finish_rsp.c
+++ b/unit_test/test_spdm_responder/finish_rsp.c
@@ -138,9 +138,6 @@ void rsp_finish_rsp_case1(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -149,6 +146,7 @@ void rsp_finish_rsp_case1(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -260,9 +258,6 @@ void rsp_finish_rsp_case3(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -271,6 +266,7 @@ void rsp_finish_rsp_case3(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -377,9 +373,6 @@ void rsp_finish_rsp_case4(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -388,6 +381,7 @@ void rsp_finish_rsp_case4(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -497,9 +491,6 @@ void rsp_finish_rsp_case5(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -508,6 +499,7 @@ void rsp_finish_rsp_case5(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -623,9 +615,6 @@ void rsp_finish_rsp_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -634,6 +623,7 @@ void rsp_finish_rsp_case6(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -732,9 +722,6 @@ void rsp_finish_rsp_case7(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -743,6 +730,7 @@ void rsp_finish_rsp_case7(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -875,9 +863,6 @@ void rsp_finish_rsp_case8(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -911,6 +896,7 @@ void rsp_finish_rsp_case8(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1038,9 +1024,6 @@ void rsp_finish_rsp_case9(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1049,6 +1032,7 @@ void rsp_finish_rsp_case9(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1154,9 +1138,6 @@ void rsp_finish_rsp_case10(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1165,6 +1146,7 @@ void rsp_finish_rsp_case10(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1264,9 +1246,6 @@ void rsp_finish_rsp_case11(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1275,6 +1254,7 @@ void rsp_finish_rsp_case11(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1362,9 +1342,6 @@ void rsp_finish_rsp_case12(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1373,6 +1350,7 @@ void rsp_finish_rsp_case12(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1475,9 +1453,6 @@ void rsp_finish_rsp_case14(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1486,6 +1461,7 @@ void rsp_finish_rsp_case14(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1598,9 +1574,6 @@ void rsp_finish_rsp_case15(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -1620,6 +1593,7 @@ void rsp_finish_rsp_case15(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1759,9 +1733,6 @@ void rsp_finish_rsp_case16(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -1781,6 +1752,7 @@ void rsp_finish_rsp_case16(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -1902,8 +1874,6 @@ void rsp_finish_rsp_case17(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1912,6 +1882,7 @@ void rsp_finish_rsp_case17(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2035,7 +2006,6 @@ void rsp_finish_rsp_case18(void **state)
 
     spdm_context->encap_context.req_slot_id = 0xFF;
     spdm_context->connection_info.peer_used_cert_chain_slot_id = 0xFF;
-    spdm_context->connection_info.local_used_cert_chain_slot_id = 0xFF;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -2053,6 +2023,7 @@ void rsp_finish_rsp_case18(void **state)
         session_info->secured_message_context,
         LIBSPDM_SESSION_STATE_HANDSHAKING);
     session_info->mut_auth_requested = 1;
+    session_info->local_used_cert_chain_slot_id = 0xFF;
 
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
@@ -2174,9 +2145,6 @@ void rsp_finish_rsp_case19(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -2210,6 +2178,7 @@ void rsp_finish_rsp_case19(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2344,9 +2313,6 @@ void rsp_finish_rsp_case20(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED_WITH_ENCAP_REQUEST;
@@ -2380,6 +2346,7 @@ void rsp_finish_rsp_case20(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2509,9 +2476,6 @@ void rsp_finish_rsp_case21(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -2520,6 +2484,7 @@ void rsp_finish_rsp_case21(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2631,9 +2596,6 @@ void rsp_finish_rsp_case22(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
     g_key_exchange_start_mut_auth = SPDM_KEY_EXCHANGE_RESPONSE_MUT_AUTH_REQUESTED;
@@ -2667,6 +2629,7 @@ void rsp_finish_rsp_case22(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2799,9 +2762,6 @@ void rsp_finish_rsp_case23(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_LITTLE_ONLY;
 
@@ -2837,6 +2797,7 @@ void rsp_finish_rsp_case23(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -2969,9 +2930,6 @@ void rsp_finish_rsp_case24(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_BIG_ONLY;
 
@@ -3007,6 +2965,7 @@ void rsp_finish_rsp_case24(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -3140,9 +3099,6 @@ void rsp_finish_rsp_case25(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_BIG_OR_LITTLE;
 
@@ -3178,6 +3134,7 @@ void rsp_finish_rsp_case25(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -3309,9 +3266,6 @@ void rsp_finish_rsp_case26(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_LITTLE_ONLY;
 
@@ -3347,6 +3301,7 @@ void rsp_finish_rsp_case26(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -3483,9 +3438,6 @@ void rsp_finish_rsp_case27(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_BIG_ONLY;
 
@@ -3521,6 +3473,7 @@ void rsp_finish_rsp_case27(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -3657,9 +3610,6 @@ void rsp_finish_rsp_case28(void** state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
     spdm_context->spdm_10_11_verify_signature_endian =
         LIBSPDM_SPDM_10_11_VERIFY_SIGNATURE_ENDIAN_LITTLE_ONLY;
 
@@ -3695,6 +3645,7 @@ void rsp_finish_rsp_case28(void** state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     libspdm_set_mem(m_dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key(
@@ -3827,9 +3778,6 @@ void rsp_finish_rsp_case29(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -3846,7 +3794,7 @@ void rsp_finish_rsp_case29(void **state)
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
-
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
 
@@ -3947,9 +3895,6 @@ void rsp_finish_rsp_case30(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -3967,6 +3912,7 @@ void rsp_finish_rsp_case30(void **state)
     libspdm_session_info_init(spdm_context, session_info, session_id,
                               SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
 
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
     hmac_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
 

--- a/unit_test/test_spdm_responder/heartbeat_ack.c
+++ b/unit_test/test_spdm_responder/heartbeat_ack.c
@@ -54,8 +54,6 @@ static void rsp_heartbeat_ack_case1(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -124,9 +122,6 @@ static void rsp_heartbeat_ack_case2(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -201,9 +196,6 @@ static void rsp_heartbeat_ack_case3(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -277,9 +269,6 @@ static void rsp_heartbeat_ack_case4(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -357,9 +346,6 @@ static void rsp_heartbeat_ack_case5(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -442,9 +428,6 @@ static void rsp_heartbeat_ack_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -516,9 +499,6 @@ static void rsp_heartbeat_ack_case7(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);

--- a/unit_test/test_spdm_responder/psk_exchange_rsp.c
+++ b/unit_test/test_spdm_responder/psk_exchange_rsp.c
@@ -156,9 +156,6 @@ static void rsp_psk_exchange_rsp_case1(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -246,9 +243,6 @@ static void rsp_psk_exchange_rsp_case2(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -327,9 +321,6 @@ static void rsp_psk_exchange_rsp_case3(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -410,9 +401,6 @@ static void rsp_psk_exchange_rsp_case4(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -496,9 +484,6 @@ static void rsp_psk_exchange_rsp_case5(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -587,9 +572,6 @@ static void rsp_psk_exchange_rsp_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -667,9 +649,6 @@ static void rsp_psk_exchange_rsp_case7(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -771,8 +750,6 @@ static void rsp_psk_exchange_rsp_case8(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -863,8 +840,6 @@ static void rsp_psk_exchange_rsp_case9(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -963,9 +938,6 @@ static void rsp_psk_exchange_rsp_case10(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -1088,9 +1060,6 @@ static void rsp_psk_exchange_rsp_case11(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1207,9 +1176,6 @@ static void rsp_psk_exchange_rsp_case12(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1307,9 +1273,6 @@ static void rsp_psk_exchange_rsp_case13(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1396,9 +1359,6 @@ static void rsp_psk_exchange_rsp_case14(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -1487,9 +1447,6 @@ static void rsp_psk_exchange_rsp_case15(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -1582,9 +1539,6 @@ static void rsp_psk_exchange_rsp_case16(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1670,9 +1624,6 @@ static void rsp_psk_exchange_rsp_case17(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);

--- a/unit_test/test_spdm_responder/psk_finish_rsp.c
+++ b/unit_test/test_spdm_responder/psk_finish_rsp.c
@@ -107,9 +107,6 @@ static void rsp_psk_finish_rsp_case1(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -210,9 +207,6 @@ static void rsp_psk_finish_rsp_case2(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -317,9 +311,6 @@ static void rsp_psk_finish_rsp_case3(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -428,9 +419,6 @@ static void rsp_psk_finish_rsp_case4(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -542,9 +530,6 @@ static void rsp_psk_finish_rsp_case5(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -663,9 +648,6 @@ static void rsp_psk_finish_rsp_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -765,9 +747,6 @@ static void rsp_psk_finish_rsp_case7(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     libspdm_reset_message_a(spdm_context);
@@ -894,9 +873,6 @@ static void rsp_psk_finish_rsp_case8(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
 
@@ -1004,9 +980,6 @@ static void rsp_psk_finish_rsp_case9(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
 
@@ -1111,9 +1084,6 @@ static void rsp_psk_finish_rsp_case10(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
 
@@ -1210,9 +1180,6 @@ static void rsp_psk_finish_rsp_case11(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
@@ -1314,9 +1281,6 @@ static void rsp_psk_finish_rsp_case12(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
-        data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
         data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
@@ -1426,9 +1390,6 @@ static void rsp_psk_finish_rsp_case13(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size =
-        data_size1;
 
     spdm_context->transcript.message_a.buffer_size = 0;
 
@@ -1529,8 +1490,6 @@ static void rsp_psk_finish_rsp_case14(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 
@@ -1632,8 +1591,6 @@ static void rsp_psk_finish_rsp_case15(void **state)
                                                     &data_size1, NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data1;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size1;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data1;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size1;
 
     libspdm_reset_message_a(spdm_context);
 

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -745,14 +745,13 @@ static void rsp_respond_if_ready_case6(void **state) {
                                                      NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     session_id = 0xFFFFFFFF;
     spdm_context->latest_session_id = session_id;
     session_info = &spdm_context->session_info[0];
     libspdm_session_info_init (spdm_context, session_info, session_id,
                                SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT, false);
+    session_info->local_used_cert_chain_slot_id = 0;
     hash_size = libspdm_get_hash_size (m_libspdm_use_hash_algo);
     libspdm_set_mem (dummy_buffer, hash_size, (uint8_t)(0xFF));
     libspdm_secured_message_set_request_finished_key (session_info->secured_message_context,
@@ -860,8 +859,6 @@ static void rsp_respond_if_ready_case7(void **state) {
                                                      NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     m_libspdm_psk_exchange_request.psk_hint_length =
         (uint16_t)sizeof(LIBSPDM_TEST_PSK_HINT_STRING);
@@ -949,7 +946,7 @@ static void rsp_respond_if_ready_case8(void **state) {
     spdm_test_context->case_id = 0x8;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
 
-    /*state for the the original request (FINISH)*/
+    /*state for the the original request (PSK_FINISH)*/
     spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
     spdm_context->local_context.capability.flags = 0;
     spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP;
@@ -973,8 +970,6 @@ static void rsp_respond_if_ready_case8(void **state) {
                                                      NULL, NULL);
     spdm_context->local_context.local_cert_chain_provision[0] = data;
     spdm_context->local_context.local_cert_chain_provision_size[0] = data_size;
-    spdm_context->connection_info.local_used_cert_chain_buffer = data;
-    spdm_context->connection_info.local_used_cert_chain_buffer_size = data_size;
 
     session_id = 0xFFFFFFFF;
     spdm_context->latest_session_id = session_id;


### PR DESCRIPTION
Fix #3405 and move `local_used_cert_chain_slot_id` from `connection_info` to `session_info`.