### PR TITLE
extract key schedule logic to spdm_crypt_lib for FIPS CAVP test

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -1580,6 +1580,99 @@ bool libspdm_kem_decapsulate(uint32_t kem_alg, void *context,
                              size_t peer_cipher_text_size,
                              uint8_t *shared_secret,
                              size_t *shared_secret_size);
+
+/**
+ * This function concatenates binary data, which is used as info in HKDF expand later.
+ *
+ * @param  label        An ascii string label for the libspdm_bin_concat.
+ * @param  label_size   The size in bytes of the ASCII string label, not including NULL terminator.
+ * @param  context      A pre-defined hash value as the context for the libspdm_bin_concat.
+ * @param  length       16 bits length for the libspdm_bin_concat.
+ * @param  hash_size    The size in bytes of the context hash.
+ * @param  out_bin      The buffer to store the output binary.
+ * @param  out_bin_size The size in bytes for the out_bin.
+ **/
+void libspdm_bin_concat(spdm_version_number_t spdm_version,
+                        const char *label, size_t label_size,
+                        const uint8_t *context, uint16_t length,
+                        size_t hash_size, uint8_t *out_bin,
+                        size_t *out_bin_size);
+
+/**
+ * This function generates SPDM HandshakeKey.
+ *
+ * @param spdm_version                   The SPDM version number.
+ * @param shared_secret                  Pointer to the input shared secret used for key derivation.
+ * @param shared_secret_size             Size of the input shared secret in bytes.
+ * @param shared_secret_use_psk          Indicates whether to use PSK as shared secret for key generation.
+ * @param psk_hint                       Pointer to the PSK hint used for PSK key derivation.
+ * @param psk_hint_size                  Size of the PSK hint in bytes.
+ * @param use_psk_hint                   Indicates whether to use PSK hint for PSK key generation.
+ * @param base_hash_algo                 The base hash algorithm identifier to use for key derivation.
+ * @param th1_hash_data                  Pointer to the TH1 hash data used in the key derivation process.
+ * @param handshake_secret               Pointer to the buffer that will receive the generated handshake secret.
+ * @param handshake_secret_size          On input, the size of the handshake_secret buffer.
+ *                                       On output, the actual size of the generated handshake secret.
+ * @param request_handshake_secret       Pointer to the buffer that will receive the generated request handshake secret.
+ * @param request_handshake_secret_size  On input, the size of the request_handshake_secret buffer.
+ *                                       On output, the actual size of the generated handshake secret.
+ * @param response_handshake_secret      Pointer to the buffer that will receive the generated response handshake secret.
+ * @param response_handshake_secret_size On input, the size of the response_handshake_secret buffer.
+ *                                       On output, the actual size of the generated handshake secret.
+ *
+ * @retval true   Handshake keys were generated successfully.
+ * @retval false  An error occurred during key generation.
+ */
+bool libspdm_generate_handshake_key (
+    spdm_version_number_t spdm_version,
+    const uint8_t *shared_secret, size_t shared_secret_size,
+    bool shared_secret_use_psk,
+    const uint8_t *psk_hint, size_t psk_hint_size,
+    bool use_psk_hint,
+    uint32_t base_hash_algo,
+    const uint8_t *th1_hash_data,
+    uint8_t *handshake_secret, size_t *handshake_secret_size,
+    uint8_t *request_handshake_secret, size_t *request_handshake_secret_size,
+    uint8_t *response_handshake_secret, size_t *response_handshake_secret_size);
+
+/**
+ * This function generates SPDM DataKey.
+ *
+ * @param spdm_version                   The SPDM version number.
+ * @param handshake_secret               Pointer to the input handshake secret used for key derivation.
+ * @param handshake_secret_size          Size of the input handshake secret in bytes.
+ * @param psk_hint                       Pointer to the PSK hint used for PSK key derivation.
+ * @param psk_hint_size                  Size of the PSK hint in bytes.
+ * @param use_psk_hint                   Indicates whether to use PSK hint for PSK key generation.
+ * @param base_hash_algo                 The base hash algorithm identifier to use for key derivation.
+ * @param th2_hash_data                  Pointer to the TH2 hash data used in the key derivation process.
+ * @param master_secret                  Pointer to the buffer that will receive the generated master secret.
+ * @param master_secret_size             On input, the size of the master_secret buffer.
+ *                                       On output, the actual size of the generated master secret.
+ * @param request_data_secret            Pointer to the buffer that will receive the generated request data secret.
+ * @param request_data_secret_size       On input, the size of the request_data_secret buffer.
+ *                                       On output, the actual size of the generated data secret.
+ * @param response_data_secret           Pointer to the buffer that will receive the generated response data secret.
+ * @param response_data_secret_size      On input, the size of the response_data_secret buffer.
+ *                                       On output, the actual size of the generated data secret.
+ * @param export_master_secret           Pointer to the buffer that will receive the generated export master secret.
+ * @param export_master_secret_size      On input, the size of the export_master_secret buffer.
+ *                                       On output, the actual size of the generated export master secret.
+ *
+ * @retval true   Handshake keys were generated successfully.
+ * @retval false  An error occurred during key generation.
+ */
+bool libspdm_generate_data_key (
+    spdm_version_number_t spdm_version,
+    const uint8_t *handshake_secret, size_t handshake_secret_size,
+    const uint8_t *psk_hint, size_t psk_hint_size,
+    bool use_psk_hint,
+    uint32_t base_hash_algo,
+    const uint8_t *th2_hash_data,
+    uint8_t *master_secret, size_t *master_secret_size,
+    uint8_t *request_data_secret, size_t *request_data_secret_size,
+    uint8_t *response_data_secret, size_t *response_data_secret_size,
+    uint8_t *export_master_secret, size_t *export_master_secret_size);
 
 #if LIBSPDM_FIPS_MODE
 /*run all of the self-tests and returns the results.*/

--- a/include/library/spdm_secured_message_lib.h
+++ b/include/library/spdm_secured_message_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -152,23 +152,6 @@ void libspdm_clear_handshake_secret(void *spdm_secured_message_context);
  * @param spdm_secured_message_context  A pointer to the SPDM secured message context.
  **/
 void libspdm_clear_master_secret(void *spdm_secured_message_context);
-
-/**
- * This function concatenates binary data, which is used as info in HKDF expand later.
- *
- * @param  label        An ascii string label for the libspdm_bin_concat.
- * @param  label_size   The size in bytes of the ASCII string label, not including NULL terminator.
- * @param  context      A pre-defined hash value as the context for the libspdm_bin_concat.
- * @param  length       16 bits length for the libspdm_bin_concat.
- * @param  hash_size    The size in bytes of the context hash.
- * @param  out_bin      The buffer to store the output binary.
- * @param  out_bin_size The size in bytes for the out_bin.
- **/
-void libspdm_bin_concat(spdm_version_number_t spdm_version,
-                        const char *label, size_t label_size,
-                        const uint8_t *context, uint16_t length,
-                        size_t hash_size, uint8_t *out_bin,
-                        size_t *out_bin_size);
 
 typedef enum {
     LIBSPDM_KEY_UPDATE_OPERATION_CREATE_UPDATE,

--- a/library/spdm_crypt_lib/CMakeLists.txt
+++ b/library/spdm_crypt_lib/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(spdm_crypt_lib
         libspdm_crypt_rng.c
         libspdm_crypt_pqc_asym.c
         libspdm_crypt_pqc_kem.c
+        libspdm_crypt_key_schedule.c
         fips/libspdm_selftest.c
         fips/libspdm_selftest_hmac.c
         fips/libspdm_selftest_aes_gcm.c

--- a/library/spdm_crypt_lib/libspdm_crypt_key_schedule.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_key_schedule.c
@@ -1,0 +1,326 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+#include "internal/libspdm_crypt_lib.h"
+#include "internal/libspdm_common_lib.h"
+
+void libspdm_bin_concat(spdm_version_number_t spdm_version,
+                        const char *label, size_t label_size,
+                        const uint8_t *context, uint16_t length,
+                        size_t hash_size, uint8_t *out_bin,
+                        size_t *out_bin_size)
+{
+    size_t final_size;
+
+    /* The correct version characters (1.1 or 1.2) will replace the x.x. */
+    #define LIBSPDM_BIN_CONCAT_LABEL "spdmx.x "
+
+    final_size = sizeof(uint16_t) + sizeof(LIBSPDM_BIN_CONCAT_LABEL) - 1 + label_size;
+    if (context != NULL) {
+        final_size += hash_size;
+    }
+
+    LIBSPDM_ASSERT(*out_bin_size >= final_size);
+
+    *out_bin_size = final_size;
+
+    libspdm_copy_mem(out_bin, *out_bin_size, &length, sizeof(uint16_t));
+    libspdm_copy_mem(out_bin + sizeof(uint16_t), *out_bin_size - sizeof(uint16_t),
+                     LIBSPDM_BIN_CONCAT_LABEL, sizeof(LIBSPDM_BIN_CONCAT_LABEL) - 1);
+
+    /* Patch the version. */
+    out_bin[6] = (char)('0' + ((spdm_version >> 12) & 0xF));
+    out_bin[8] = (char)('0' + ((spdm_version >> 8) & 0xF));
+    libspdm_copy_mem(out_bin + sizeof(uint16_t) + sizeof(LIBSPDM_BIN_CONCAT_LABEL) - 1,
+                     *out_bin_size - (sizeof(uint16_t) + sizeof(LIBSPDM_BIN_CONCAT_LABEL) - 1),
+                     label, label_size);
+
+    if (context != NULL) {
+        libspdm_copy_mem(out_bin + sizeof(uint16_t) + sizeof(LIBSPDM_BIN_CONCAT_LABEL) -
+                         1 + label_size,
+                         *out_bin_size - (sizeof(uint16_t) + sizeof(LIBSPDM_BIN_CONCAT_LABEL) -
+                                          1 + label_size), context, hash_size);
+    }
+
+    #undef LIBSPDM_BIN_CONCAT_LABEL
+}
+
+bool libspdm_generate_handshake_key (
+    spdm_version_number_t spdm_version,
+    const uint8_t *shared_secret, size_t shared_secret_size,
+    bool shared_secret_use_psk,
+    const uint8_t *psk_hint, size_t psk_hint_size,
+    bool use_psk_hint,
+    uint32_t base_hash_algo,
+    const uint8_t *th1_hash_data,
+    uint8_t *handshake_secret, size_t *handshake_secret_size,
+    uint8_t *request_handshake_secret, size_t *request_handshake_secret_size,
+    uint8_t *response_handshake_secret, size_t *response_handshake_secret_size)
+{
+    bool status = false;
+    size_t hash_size;
+    uint8_t bin_str1[128];
+    size_t bin_str1_size;
+    uint8_t bin_str2[128];
+    size_t bin_str2_size;
+    uint8_t salt0[LIBSPDM_MAX_HASH_SIZE];
+
+    if (!use_psk_hint) {
+        if (shared_secret == NULL || shared_secret_size == 0) {
+            return false;
+        }
+    }
+
+    hash_size = libspdm_get_hash_size(base_hash_algo);
+
+    if (*handshake_secret_size < hash_size ||
+        *request_handshake_secret_size < hash_size ||
+        *response_handshake_secret_size < hash_size) {
+        return false;
+    }
+    *handshake_secret_size = hash_size;
+    *request_handshake_secret_size = hash_size;
+    *response_handshake_secret_size = hash_size;
+
+    bin_str1_size = sizeof(bin_str1);
+    libspdm_bin_concat(spdm_version,
+                       SPDM_BIN_STR_1_LABEL, sizeof(SPDM_BIN_STR_1_LABEL) - 1,
+                       th1_hash_data, (uint16_t)hash_size, hash_size,
+                       bin_str1, &bin_str1_size);
+
+    bin_str2_size = sizeof(bin_str2);
+    libspdm_bin_concat(spdm_version,
+                       SPDM_BIN_STR_2_LABEL, sizeof(SPDM_BIN_STR_2_LABEL) - 1,
+                       th1_hash_data, (uint16_t)hash_size, hash_size,
+                       bin_str2, &bin_str2_size);
+
+    #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
+    if (use_psk_hint) {
+        status = libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_version,
+            base_hash_algo,
+            psk_hint, psk_hint_size,
+            bin_str1, bin_str1_size,
+            request_handshake_secret, hash_size);
+
+        if (!status) {
+            return false;
+        }
+
+        status = libspdm_psk_handshake_secret_hkdf_expand(
+            spdm_version,
+            base_hash_algo,
+            psk_hint, psk_hint_size,
+            bin_str2, bin_str2_size,
+            response_handshake_secret, hash_size);
+
+        if (!status) {
+            return false;
+        }
+
+    }
+    #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
+
+    if (!use_psk_hint) {
+        libspdm_zero_mem(salt0, sizeof(salt0));
+        #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
+        if ((shared_secret_use_psk) &&
+            ((spdm_version >> SPDM_VERSION_NUMBER_SHIFT_BIT) >= SPDM_MESSAGE_VERSION_13)) {
+            libspdm_set_mem(salt0, hash_size, 0xff);
+        }
+        #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
+
+        status = libspdm_hkdf_extract(
+            base_hash_algo,
+            shared_secret, shared_secret_size,
+            salt0, hash_size,
+            handshake_secret, hash_size);
+        if (!status) {
+            return false;
+        }
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo,
+            handshake_secret,
+            hash_size, bin_str1, bin_str1_size,
+            request_handshake_secret, hash_size);
+
+        if (!status) {
+            return false;
+        }
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo,
+            handshake_secret,
+            hash_size, bin_str2, bin_str2_size,
+            response_handshake_secret, hash_size);
+
+        if (!status) {
+            return false;
+        }
+    }
+
+    return status;
+}
+
+bool libspdm_generate_data_key (
+    spdm_version_number_t spdm_version,
+    const uint8_t *handshake_secret, size_t handshake_secret_size,
+    const uint8_t *psk_hint, size_t psk_hint_size,
+    bool use_psk_hint,
+    uint32_t base_hash_algo,
+    const uint8_t *th2_hash_data,
+    uint8_t *master_secret, size_t *master_secret_size,
+    uint8_t *request_data_secret, size_t *request_data_secret_size,
+    uint8_t *response_data_secret, size_t *response_data_secret_size,
+    uint8_t *export_master_secret, size_t *export_master_secret_size)
+{
+    bool status = false;
+    size_t hash_size;
+    uint8_t salt1[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t bin_str0[128];
+    size_t bin_str0_size;
+    uint8_t bin_str3[128];
+    size_t bin_str3_size;
+    uint8_t bin_str4[128];
+    size_t bin_str4_size;
+    uint8_t bin_str8[128];
+    size_t bin_str8_size;
+    uint8_t zero_filled_buffer[LIBSPDM_MAX_HASH_SIZE];
+
+    if (!use_psk_hint) {
+        if (handshake_secret == NULL || handshake_secret_size == 0) {
+            return false;
+        }
+    }
+
+    hash_size = libspdm_get_hash_size(base_hash_algo);
+
+    if (*master_secret_size < hash_size ||
+        *request_data_secret_size < hash_size ||
+        *response_data_secret_size < hash_size ||
+        *export_master_secret_size < hash_size) {
+        return false;
+    }
+    *master_secret_size = hash_size;
+    *request_data_secret_size = hash_size;
+    *response_data_secret_size = hash_size;
+    *export_master_secret_size = hash_size;
+
+    bin_str3_size = sizeof(bin_str3);
+    libspdm_bin_concat(spdm_version,
+                       SPDM_BIN_STR_3_LABEL, sizeof(SPDM_BIN_STR_3_LABEL) - 1,
+                       th2_hash_data, (uint16_t)hash_size, hash_size,
+                       bin_str3, &bin_str3_size);
+
+    bin_str4_size = sizeof(bin_str4);
+    libspdm_bin_concat(spdm_version,
+                       SPDM_BIN_STR_4_LABEL, sizeof(SPDM_BIN_STR_4_LABEL) - 1,
+                       th2_hash_data, (uint16_t)hash_size, hash_size,
+                       bin_str4, &bin_str4_size);
+
+    bin_str8_size = sizeof(bin_str8);
+    libspdm_bin_concat(spdm_version,
+                       SPDM_BIN_STR_8_LABEL, sizeof(SPDM_BIN_STR_8_LABEL) - 1,
+                       th2_hash_data, (uint16_t)hash_size, hash_size,
+                       bin_str8, &bin_str8_size);
+
+    #if LIBSPDM_ENABLE_CAPABILITY_PSK_CAP
+    if (use_psk_hint) {
+        status = libspdm_psk_master_secret_hkdf_expand(
+            spdm_version,
+            base_hash_algo,
+            psk_hint, psk_hint_size,
+            bin_str3, bin_str3_size,
+            request_data_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+
+        status = libspdm_psk_master_secret_hkdf_expand(
+            spdm_version,
+            base_hash_algo,
+            psk_hint, psk_hint_size,
+            bin_str4, bin_str4_size,
+            response_data_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+
+        status = libspdm_psk_master_secret_hkdf_expand(
+            spdm_version,
+            base_hash_algo,
+            psk_hint, psk_hint_size,
+            bin_str8, bin_str8_size,
+            export_master_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+    }
+    #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
+
+    if (!use_psk_hint) {
+        bin_str0_size = sizeof(bin_str0);
+        libspdm_bin_concat(spdm_version,
+                           SPDM_BIN_STR_0_LABEL,
+                           sizeof(SPDM_BIN_STR_0_LABEL) - 1, NULL,
+                           (uint16_t)hash_size, hash_size, bin_str0,
+                           &bin_str0_size);
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo, handshake_secret,
+            hash_size, bin_str0, bin_str0_size, salt1, hash_size);
+        if (!status) {
+            goto cleanup;
+        }
+
+        libspdm_zero_mem(zero_filled_buffer, sizeof(zero_filled_buffer));
+        status = libspdm_hkdf_extract(
+            base_hash_algo,
+            zero_filled_buffer, hash_size, salt1, hash_size,
+            master_secret, hash_size);
+        if (!status) {
+            goto cleanup;
+        }
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo,
+            master_secret, hash_size,
+            bin_str3, bin_str3_size,
+            request_data_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo,
+            master_secret, hash_size,
+            bin_str4, bin_str4_size,
+            response_data_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+
+        status = libspdm_hkdf_expand(
+            base_hash_algo,
+            master_secret, hash_size,
+            bin_str8, bin_str8_size,
+            export_master_secret, hash_size);
+
+        if (!status) {
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    /*zero salt1 for security*/
+    libspdm_zero_mem(salt1, hash_size);
+    return status;
+}


### PR DESCRIPTION
Fix: #3082 

In this PR
- Extract key schedule logic from spdm_secure_message_lib to new APIs in spdm_crypt_lib
  - `libspdm_generate_handshake_key`
  - `libspdm_generate_data_key`

EMU test: https://github.com/DMTF/spdm-emu/pull/462