### PR TITLE
Add session_id to the measurement HAL API.

### DIFF
--- a/include/hal/library/responder/measlib.h
+++ b/include/hal/library/responder/measlib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -71,6 +71,7 @@
  **/
 extern libspdm_return_t libspdm_measurement_collection(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,
@@ -116,6 +117,7 @@ extern libspdm_return_t libspdm_measurement_collection(
  **/
 extern bool libspdm_measurement_opaque_data(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,

--- a/library/spdm_responder_lib/libspdm_rsp_measurements.c
+++ b/library/spdm_responder_lib/libspdm_rsp_measurements.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -103,6 +103,7 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
     uint8_t *fill_response_ptr;
     size_t request_context_size;
     const void *request_context;
+    const uint32_t *session_id_ptr;
 
     spdm_request = request;
 
@@ -111,7 +112,9 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
 
     if (!spdm_context->last_spdm_request_session_id_valid) {
         session_info = NULL;
+        session_id_ptr = NULL;
     } else {
+        session_id_ptr = &spdm_context->last_spdm_request_session_id;
         session_info = libspdm_get_session_info_via_session_id(
             spdm_context,
             spdm_context->last_spdm_request_session_id);
@@ -277,6 +280,7 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
 
     status = libspdm_measurement_collection(
         spdm_context,
+        session_id_ptr,
         spdm_context->connection_info.version,
         spdm_context->connection_info.algorithm.measurement_spec,
         spdm_context->connection_info.algorithm.measurement_hash_algo,
@@ -325,6 +329,7 @@ libspdm_return_t libspdm_get_response_measurements(libspdm_context_t *spdm_conte
 
         ret = libspdm_measurement_opaque_data(
             spdm_context,
+            session_id_ptr,
             spdm_context->connection_info.version,
             spdm_context->connection_info.algorithm.measurement_spec,
             spdm_context->connection_info.algorithm.measurement_hash_algo,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -21,6 +21,7 @@
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
 libspdm_return_t libspdm_measurement_collection(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,
@@ -38,6 +39,7 @@ libspdm_return_t libspdm_measurement_collection(
 
 bool libspdm_measurement_opaque_data(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,

--- a/os_stub/spdm_device_secret_lib_sample/meas.c
+++ b/os_stub/spdm_device_secret_lib_sample/meas.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2024-2025 DMTF. All rights reserved.
+ *  Copyright 2024-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -382,6 +382,7 @@ uint64_t g_measurement_request_context;
 
 libspdm_return_t libspdm_measurement_collection(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,
@@ -624,6 +625,7 @@ size_t libspdm_secret_lib_meas_opaque_data_size;
 
 bool libspdm_measurement_opaque_data(
     void *spdm_context,
+    const uint32_t *session_id,
     spdm_version_number_t spdm_version,
     uint8_t measurement_specification,
     uint32_t measurement_hash_algo,
@@ -695,6 +697,7 @@ bool libspdm_generate_measurement_summary_hash(
         device_measurement_size = sizeof(device_measurement);
         status = libspdm_measurement_collection(
             spdm_context,
+            NULL,
             spdm_version, measurement_specification,
             measurement_hash_algo,
             0xFF, /* Get all measurements*/

--- a/unit_test/test_spdm_responder/measurements.c
+++ b/unit_test/test_spdm_responder/measurements.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -1719,6 +1719,7 @@ static void rsp_measurements_case27(void **state)
 
     libspdm_measurement_collection(
         spdm_context,
+        NULL,
         spdm_context->connection_info.version,
         spdm_context->connection_info.algorithm.measurement_spec,
         spdm_context->connection_info.algorithm.measurement_hash_algo,
@@ -1733,6 +1734,7 @@ static void rsp_measurements_case27(void **state)
 
     libspdm_measurement_opaque_data(
         spdm_context,
+        NULL,
         spdm_context->connection_info.version,
         spdm_context->connection_info.algorithm.measurement_spec,
         spdm_context->connection_info.algorithm.measurement_hash_algo,


### PR DESCRIPTION
The integrator can track the content_change based on session.

Fix https://github.com/DMTF/libspdm/issues/3452