### PR TITLE
large response size could be less than `DataTransferSize` when size of `CHUNK_SEND_ACK` exceeds `DataTransferSize`

### DIFF
--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -107,6 +107,7 @@ libspdm_return_t libspdm_handle_error_response_main(
  *                                       On output, the large response size after being retrieved in chunks.
  * @param  response                      The error response on input. Large response on output.
  * @param  response_capacity             The maximum capacity of the response buffer.
+ * @param  response_from_chunk           Indicates the response message is from chunking mechanism or not.
  *
  * @retval libspdm_return_t              An error value or success.
  **/
@@ -115,7 +116,8 @@ libspdm_return_t libspdm_handle_error_large_response(
     const uint32_t* session_id,
     size_t* inout_response_size,
     void* inout_response,
-    size_t response_capacity);
+    size_t response_capacity,
+    bool response_from_chunk);
 
 /**
  * This function sends GET_VERSION and receives VERSION.

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -729,6 +729,7 @@ libspdm_return_t libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
     spdm_message_header_t *spdm_response;
     size_t response_capacity;
     libspdm_chunk_info_t *send_info;
+    bool response_from_chunk = false;
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP */
 
     if ((session_id != NULL) &&
@@ -757,6 +758,7 @@ libspdm_return_t libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
                          send_info->large_message, send_info->large_message_size);
         *response_size = send_info->large_message_size;
         response_capacity = send_info->large_message_capacity;
+        response_from_chunk = true;
 
         /* This response may either be an actual response or ERROR_LARGE_RESPONSE,
          * the latter which should be handled in the large response handler. */
@@ -788,7 +790,7 @@ libspdm_return_t libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
         && spdm_response->param1 == SPDM_ERROR_CODE_LARGE_RESPONSE) {
         status = libspdm_handle_error_large_response(
             spdm_context, session_id,
-            response_size, (void *)spdm_response, response_capacity);
+            response_size, (void *)spdm_response, response_capacity, response_from_chunk);
 
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             goto receive_done;


### PR DESCRIPTION
fix #3189