### PR TITLE
Remove `ia32` from CodeQL build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,6 @@ jobs:
           - openssl
         arch:
           - x64
-          - ia32
         target:
           - Debug
           - Release


### PR DESCRIPTION
Fix #3388.

It is causing build breaks and, in the larger scheme of things, does not provide much value with respect to CodeQL.

https://github.com/steven-bellock/libspdm/actions/runs/22147224813 shows that CodeQL builds are passing.