### PR TITLE
Delete redundant Doxygen comments from .c files

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -1240,31 +1240,16 @@ bool libspdm_check_context (void *spdm_context)
 }
 #endif /* LIBSPDM_CHECK_CONTEXT */
 
-/**
- * Reset message A cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_a(libspdm_context_t *spdm_context)
 {
     libspdm_reset_managed_buffer(&spdm_context->transcript.message_a);
 }
 
-/**
- * Reset message D cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_d(libspdm_context_t *spdm_context)
 {
     libspdm_reset_managed_buffer(&spdm_context->transcript.message_d);
 }
 
-/**
- * Reset message B cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_b(libspdm_context_t *spdm_context)
 {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1278,11 +1263,6 @@ void libspdm_reset_message_b(libspdm_context_t *spdm_context)
 #endif
 }
 
-/**
- * Reset message C cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_c(libspdm_context_t *spdm_context)
 {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1296,11 +1276,6 @@ void libspdm_reset_message_c(libspdm_context_t *spdm_context)
 #endif
 }
 
-/**
- * Reset message MutB cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_mut_b(libspdm_context_t *spdm_context)
 {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1314,11 +1289,6 @@ void libspdm_reset_message_mut_b(libspdm_context_t *spdm_context)
 #endif
 }
 
-/**
- * Reset message MutC cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- **/
 void libspdm_reset_message_mut_c(libspdm_context_t *spdm_context)
 {
 #if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
@@ -1332,14 +1302,6 @@ void libspdm_reset_message_mut_c(libspdm_context_t *spdm_context)
 #endif
 }
 
-/**
- * Reset message M cache in SPDM context.
- * If session_info is NULL, this function will use M cache of SPDM context,
- * else will use M cache of SPDM session context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_info                  A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_m(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1374,12 +1336,6 @@ void libspdm_reset_message_m(libspdm_context_t *spdm_context, void *session_info
 #endif /* LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP */
 }
 
-/**
- * Reset message K cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  spdm_session_info              A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_k(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1403,12 +1359,6 @@ void libspdm_reset_message_k(libspdm_context_t *spdm_context, void *session_info
 #endif
 }
 
-/**
- * Reset message EncapD cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  spdm_session_info              A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_encap_d(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1417,12 +1367,6 @@ void libspdm_reset_message_encap_d(libspdm_context_t *spdm_context, void *sessio
     libspdm_reset_managed_buffer(&spdm_session_info->session_transcript.message_encap_d);
 }
 
-/**
- * Reset message F cache in SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  spdm_session_info              A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_f(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1444,14 +1388,6 @@ void libspdm_reset_message_f(libspdm_context_t *spdm_context, void *session_info
 #endif
 }
 
-/**
- * Reset message E cache in SPDM context.
- * If session_info is NULL, this function will use E cache of SPDM context,
- * else will use E cache of SPDM session context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  spdm_session_info              A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_e(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1480,14 +1416,6 @@ void libspdm_reset_message_e(libspdm_context_t *spdm_context, void *session_info
 #endif
 }
 
-/**
- * Reset message encap E cache in SPDM context.
- * If session_info is NULL, this function will use encap E cache of SPDM context,
- * else will use encap E cache of SPDM session context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  spdm_session_info              A pointer to the SPDM session context.
- **/
 void libspdm_reset_message_encap_e(libspdm_context_t *spdm_context, void *session_info)
 {
     libspdm_session_info_t *spdm_session_info;
@@ -1516,13 +1444,6 @@ void libspdm_reset_message_encap_e(libspdm_context_t *spdm_context, void *sessio
 #endif
 }
 
-/**
- * Reset message buffer in SPDM context according to request code.
- *
- * @param  spdm_context                   A pointer to the SPDM context.
- * @param  spdm_session_info             A pointer to the SPDM session context.
- * @param  spdm_request                   The SPDM request code.
- */
 void libspdm_reset_message_buffer_via_request_code(void *context, void *session_info,
                                                    uint8_t request_code)
 {
@@ -2465,15 +2386,6 @@ libspdm_return_t libspdm_append_message_encap_e(libspdm_context_t *spdm_context,
     }
 #endif
 }
-/**
- * This function returns if a given version is supported based upon the GET_VERSION/VERSION.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  version                      The SPDM version.
- *
- * @retval true  the version is supported.
- * @retval false the version is not supported.
- **/
 bool libspdm_is_version_supported(const libspdm_context_t *spdm_context, uint8_t version)
 {
     if (version == (spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT)) {
@@ -2483,29 +2395,11 @@ bool libspdm_is_version_supported(const libspdm_context_t *spdm_context, uint8_t
     return false;
 }
 
-/**
- * This function returns connection version negotiated by GET_VERSION/VERSION.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- *
- * @return the connection version.
- **/
 uint8_t libspdm_get_connection_version(const libspdm_context_t *spdm_context)
 {
     return (uint8_t)(spdm_context->connection_info.version >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
-/**
- * This function returns if a capabilities flag is supported in current SPDM connection.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  is_requester                  Is the function called from a requester.
- * @param  requester_capabilities_flag    The requester capabilities flag to be checked
- * @param  responder_capabilities_flag    The responder capabilities flag to be checked
- *
- * @retval true  the capabilities flag is supported.
- * @retval false the capabilities flag is not supported.
- **/
 bool libspdm_is_capabilities_flag_supported(const libspdm_context_t *spdm_context,
                                             bool is_requester,
                                             uint32_t requester_capabilities_flag,
@@ -2534,17 +2428,6 @@ bool libspdm_is_capabilities_flag_supported(const libspdm_context_t *spdm_contex
     }
 }
 
-/**
- * This function returns if a capabilities extended flag is supported in current SPDM connection.
- *
- * @param  spdm_context                     A pointer to the SPDM context.
- * @param  is_requester                     Is the function called from a requester.
- * @param  requester_capabilities_ext_flag  The requester capabilities extended flag to be checked
- * @param  responder_capabilities_ext_flag  The responder capabilities extended flag to be checked
- *
- * @retval true  the capabilities extended flag is supported.
- * @retval false the capabilities extended flag is not supported.
- **/
 bool libspdm_is_capabilities_ext_flag_supported(const libspdm_context_t *spdm_context,
                                                 bool is_requester,
                                                 uint16_t requester_capabilities_ext_flag,
@@ -2606,15 +2489,6 @@ bool libspdm_is_encap_supported(const libspdm_context_t *spdm_context)
     }
 }
 
-/**
- * Register SPDM device input/output functions.
- *
- * This function must be called after libspdm_init_context, and before any SPDM communication.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  send_message                  The function to send an SPDM transport layer message.
- * @param  receive_message               The function to receive an SPDM transport layer message.
- **/
 void libspdm_register_device_io_func(
     void *spdm_context, libspdm_device_send_message_func send_message,
     libspdm_device_receive_message_func receive_message)
@@ -2626,49 +2500,6 @@ void libspdm_register_device_io_func(
     context->receive_message = receive_message;
 }
 
-/**
- * Register SPDM device buffer management functions.
- *
- * This function must be called after libspdm_init_context, and before any SPDM communication.
- *
- * The sender_buffer_size and receiver_buffer_size must be no smaller than
- * MAX (non-secure Transport Message Header Size +
- *          SPDM_CAPABILITIES.DataTransferSize +
- *          max alignment pad size (transport specific),
- *      secure Transport Message Header Size +
- *          sizeof(spdm_secured_message_a_data_header1_t) +
- *          length of sequence_number (transport specific) +
- *          sizeof(spdm_secured_message_a_data_header2_t) +
- *          sizeof(spdm_secured_message_cipher_header_t) +
- *          App Message Header Size (transport specific) +
- *          SPDM_CAPABILITIES.DataTransferSize +
- *          maximum random data size (transport specific) +
- *          AEAD MAC size (16) +
- *          max alignment pad size (transport specific)).
- *
- * Finally, the SPDM_CAPABILITIES.DataTransferSize will be calculated based upon it.
- *
- *   For MCTP,
- *          Transport Message Header Size = sizeof(mctp_message_header_t)
- *          length of sequence_number = 2
- *          App Message Header Size = sizeof(mctp_message_header_t)
- *          maximum random data size = MCTP_MAX_RANDOM_NUMBER_COUNT
- *          max alignment pad size = 0
- *   For PCI_DOE,
- *          Transport Message Header Size = sizeof(pci_doe_data_object_header_t)
- *          length of sequence_number = 0
- *          App Message Header Size = 0
- *          maximum random data size = 0
- *          max alignment pad size = 3
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  sender_buffer_size            Size in bytes of the sender buffer.
- * @param  receiver_buffer_size          Size in bytes of the receiver buffer.
- * @param  acquire_sender_buffer         The function to acquire transport layer sender buffer.
- * @param  release_sender_buffer         The function to release transport layer sender buffer.
- * @param  acquire_receiver_buffer       The function to acquire transport layer receiver buffer.
- * @param  release_receiver_buffer       The function to release transport layer receiver buffer.
- **/
 void libspdm_register_device_buffer_func(
     void *spdm_context,
     uint32_t sender_buffer_size,
@@ -2705,15 +2536,6 @@ void libspdm_register_device_buffer_func(
     context->local_context.capability.data_transfer_size = receiver_buffer_size;
 }
 
-/**
- * Register SPDM transport layer encode/decode functions for SPDM or APP messages.
- *
- * This function must be called after libspdm_init_context, and before any SPDM communication.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  transport_encode_message       The function to encode an SPDM or APP message to a transport layer message.
- * @param  transport_decode_message       The function to decode an SPDM or APP message from a transport layer message.
- **/
 void libspdm_register_transport_layer_func(
     void *spdm_context,
     uint32_t max_spdm_msg_size,
@@ -2749,20 +2571,6 @@ void libspdm_register_transport_layer_func(
     context->transport_decode_message = transport_decode_message;
 }
 
-/**
- * Register SPDM certificate verification functions for SPDM GET_CERTIFICATE in requester or responder.
- * It is called after GET_CERTIFICATE gets a full certificate chain from peer.
- *
- * If it is NOT registered, the default verification in SPDM lib will be used. It verifies:
- *    1) The integrity of the certificate chain, (Root Cert Hash->Root Cert->Cert Chain), according to X.509.
- *  2) The trust anchor, according LIBSPDM_DATA_PEER_PUBLIC_ROOT_CERT or LIBSPDM_DATA_PEER_PUBLIC_CERT_CHAIN.
- * If it is registered, SPDM lib will use this function to verify the certificate.
- *
- * This function must be called after libspdm_init_context, and before any SPDM communication.
- *
- * @param  context                  A pointer to the SPDM context.
- * @param  verify_spdm_cert_chain   The function to verify an SPDM certificate after GET_CERTIFICATE.
- **/
 void libspdm_register_verify_spdm_cert_chain_func(
     void *spdm_context,
     const libspdm_verify_spdm_cert_chain_func verify_spdm_cert_chain)
@@ -2773,16 +2581,6 @@ void libspdm_register_verify_spdm_cert_chain_func(
     context->local_context.verify_peer_spdm_cert_chain = verify_spdm_cert_chain;
 }
 
-/**
- * Get the size of required scratch buffer.
- *
- * The SPDM Integrator must call libspdm_get_sizeof_required_scratch_buffer to get the size,
- * then allocate enough scratch buffer and call libspdm_set_scratch_buffer().
- *
- * @param  context                  A pointer to the SPDM context.
- *
- * @return the size of required scratch buffer.
- **/
 size_t libspdm_get_sizeof_required_scratch_buffer (void *spdm_context)
 {
     libspdm_context_t *context;
@@ -2795,16 +2593,6 @@ size_t libspdm_get_sizeof_required_scratch_buffer (void *spdm_context)
     return scratch_buffer_size;
 }
 
-/**
- * Set the scratch buffer.
- *
- * This function must be called after libspdm_init_context, and before any SPDM communication.
- *
- * @param  context                  A pointer to the SPDM context.
- * @param  scratch_buffer           Buffer address of the scratch buffer.
- * @param  scratch_buffer_size      Size of the scratch buffer.
- *
- **/
 void libspdm_set_scratch_buffer (
     void *spdm_context,
     void *scratch_buffer,
@@ -2825,14 +2613,6 @@ void libspdm_set_scratch_buffer (
 #endif
 }
 
-/**
- * Get the scratch buffer.
- *
- * @param  context                  A pointer to the SPDM context.
- * @param  scratch_buffer           Buffer address of the scratch buffer.
- * @param  scratch_buffer_size      Size of the scratch buffer.
- *
- **/
 void libspdm_get_scratch_buffer (
     void *spdm_context,
     void **scratch_buffer,
@@ -2884,14 +2664,6 @@ void libspdm_release_sender_buffer (libspdm_context_t *spdm_context)
     spdm_context->sender_buffer = NULL;
 }
 
-/**
- * Get the sender buffer.
- *
- * @param  context                  A pointer to the SPDM context.
- * @param  receiver_buffer            Buffer address of the sender buffer.
- * @param  receiver_buffer_size       Size of the sender buffer.
- *
- **/
 void libspdm_get_sender_buffer (
     libspdm_context_t *spdm_context,
     void **sender_buffer,
@@ -2932,14 +2704,6 @@ void libspdm_release_receiver_buffer (libspdm_context_t *spdm_context)
     spdm_context->receiver_buffer = NULL;
 }
 
-/**
- * Get the receiver buffer.
- *
- * @param  context                  A pointer to the SPDM context.
- * @param  receiver_buffer            Buffer address of the receiver buffer.
- * @param  receiver_buffer_size       Size of the receiver buffer.
- *
- **/
 void libspdm_get_receiver_buffer (
     libspdm_context_t *spdm_context,
     void **receiver_buffer,
@@ -2949,12 +2713,6 @@ void libspdm_get_receiver_buffer (
     *receiver_buffer_size = spdm_context->receiver_buffer_size;
 }
 
-/**
- * Get the last SPDM error struct of an SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  last_spdm_error                Last SPDM error struct of an SPDM context.
- */
 void libspdm_get_last_spdm_error_struct(void *spdm_context, libspdm_error_struct_t *last_spdm_error)
 {
     libspdm_context_t *context;
@@ -2964,12 +2722,6 @@ void libspdm_get_last_spdm_error_struct(void *spdm_context, libspdm_error_struct
                      &context->last_spdm_error,sizeof(libspdm_error_struct_t));
 }
 
-/**
- * Set the last SPDM error struct of an SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  last_spdm_error                Last SPDM error struct of an SPDM context.
- */
 void libspdm_set_last_spdm_error_struct(void *spdm_context, libspdm_error_struct_t *last_spdm_error)
 {
     libspdm_context_t *context;
@@ -3004,11 +2756,6 @@ libspdm_return_t libspdm_init_fips_selftest_context(void *fips_selftest_context,
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Return the size in bytes of the fips_selftest_context.
- *
- * @return the size in bytes of the fips_selftest_context.
- **/
 size_t libspdm_get_fips_selftest_context_size(void)
 {
     size_t size;
@@ -3017,26 +2764,11 @@ size_t libspdm_get_fips_selftest_context_size(void)
     return size;
 }
 
-/**
- * Returns the required buffer size for FIPS self-tests.
- *
- * @retval  The required buffer size in bytes.
- */
 size_t libspdm_get_fips_selftest_buffer_size(void)
 {
     return LIBSPDM_FIPS_REQUIRED_BUFFER_SIZE;
 }
 
-/**
- * import fips_selftest_context to spdm_context;
- *
- * @param[in,out]  spdm_context                A pointer to the spdm_context.
- * @param[in]      fips_selftest_context       A pointer to the fips_selftest_context.
- * @param[in]      fips_selftest_context_size  The size of fips_selftest_context.
- *
- * @retval true   import fips_selftest_context successful.
- * @retval false  spdm_context or fips_selftest_context is null.
- */
 bool libspdm_import_fips_selftest_context_to_spdm_context(void *spdm_context,
                                                           void *fips_selftest_context,
                                                           size_t fips_selftest_context_size)
@@ -3060,16 +2792,6 @@ bool libspdm_import_fips_selftest_context_to_spdm_context(void *spdm_context,
     return true;
 }
 
-/**
- * export fips_selftest_context from spdm_context;
- *
- * @param[in]          spdm_context                A pointer to the spdm_context.
- * @param[in,out]      fips_selftest_context       A pointer to the fips_selftest_context.
- * @param[in]          fips_selftest_context_size  The size of fips_selftest_context.
- *
- * @retval true   export fips_selftest_context successful.
- * @retval false  spdm_context or fips_selftest_context is null.
- */
 bool libspdm_export_fips_selftest_context_from_spdm_context(void *spdm_context,
                                                             void *fips_selftest_context,
                                                             size_t fips_selftest_context_size)
@@ -3258,14 +2980,6 @@ void libspdm_reset_context(void *spdm_context)
     context->current_psk_session_count = 0;
 }
 
-/**
- * Free the memory of contexts within the SPDM context.
- * These are typically contexts whose memory has been allocated by the cryptography library.
- * This function does not free the SPDM context itself.
- *
- * @param[in]  spdm_context         A pointer to the SPDM context.
- *
- */
 void libspdm_deinit_context(void *spdm_context)
 {
     uint32_t session_id;
@@ -3330,14 +3044,6 @@ void libspdm_deinit_context(void *spdm_context)
     }
 }
 
-/**
- * Return the size in bytes of the SPDM context. This includes all
- * secured message context data as well.
- *
- * For just the SPDM context size, use libspdm_get_context_size_without_secured_context.
- *
- * @return the size in bytes of the SPDM context and secured message contexts.
- **/
 size_t libspdm_get_context_size(void)
 {
     size_t size;
@@ -3348,13 +3054,6 @@ size_t libspdm_get_context_size(void)
     return size;
 }
 
-/**
- * Return the size in bytes of just the SPDM context, without secured message context.
- *
- * For the complete context size, use libspdm_get_context_size.
- *
- * @return the size in bytes of the SPDM context.
- **/
 size_t libspdm_get_context_size_without_secured_context(void)
 {
     size_t size;
@@ -3364,25 +3063,11 @@ size_t libspdm_get_context_size_without_secured_context(void)
     return size;
 }
 
-/**
- * Return the SPDMversion field of the version number struct.
- *
- * @param  ver                Spdm version number struct.
- *
- * @return the SPDMversion of the version number struct.
- **/
 uint8_t libspdm_get_version_from_version_number(const spdm_version_number_t ver)
 {
     return (uint8_t)(ver >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
-/**
- * Sort SPDMversion in descending order.
- *
- * @param  spdm_context                A pointer to the SPDM context.
- * @param  ver_set                    A pointer to the version set.
- * @param  ver_num                    Version number.
- */
 void libspdm_version_number_sort(spdm_version_number_t *ver_set, size_t ver_num)
 {
     size_t index;
@@ -3408,19 +3093,6 @@ void libspdm_version_number_sort(spdm_version_number_t *ver_set, size_t ver_num)
     }
 }
 
-/**
- * Negotiate SPDMversion for connection.
- * ver_set is the local version set of requester, res_ver_set is the version set of responder.
- *
- * @param  common_version             A pointer to store the common version.
- * @param  req_ver_set                A pointer to the requester version set.
- * @param  req_ver_num                Version number of requester.
- * @param  res_ver_set                A pointer to the responder version set.
- * @param  res_ver_num                Version number of responder.
- *
- * @retval true                       Negotiation successfully, connect version be saved to common_version.
- * @retval false                      Negotiation failed.
- */
 bool libspdm_negotiate_connection_version(spdm_version_number_t *common_version,
                                           spdm_version_number_t *req_ver_set,
                                           size_t req_ver_num,

--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -1,17 +1,11 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_secured_message_lib.h"
 
-/**
- * This function initializes the session info.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    The SPDM session ID.
- **/
 void libspdm_session_info_init(libspdm_context_t *spdm_context,
                                libspdm_session_info_t *session_info,
                                uint32_t session_id, spdm_version_number_t secured_message_version,
@@ -136,14 +130,6 @@ void libspdm_session_info_set_psk_hint(libspdm_session_info_t *session_info,
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
-/**
- * This function gets the session info via session ID.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    The SPDM session ID.
- *
- * @return session info.
- **/
 void *libspdm_get_session_info_via_session_id(void *spdm_context, uint32_t session_id)
 {
     libspdm_context_t *context;
@@ -171,14 +157,6 @@ void *libspdm_get_session_info_via_session_id(void *spdm_context, uint32_t sessi
     return NULL;
 }
 
-/**
- * This function gets the secured message context via session ID.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    The SPDM session ID.
- *
- * @return secured message context.
- **/
 void *libspdm_get_secured_message_context_via_session_id(void *spdm_context, uint32_t session_id)
 {
     libspdm_session_info_t *session_info;
@@ -191,13 +169,6 @@ void *libspdm_get_secured_message_context_via_session_id(void *spdm_context, uin
     }
 }
 
-/**
- * This function gets the secured message context via session ID.
- *
- * @param  spdm_session_info              A pointer to the SPDM context.
- *
- * @return secured message context.
- **/
 void *libspdm_get_secured_message_context_via_session_info(void *spdm_session_info)
 {
     libspdm_session_info_t *session_info;
@@ -210,14 +181,6 @@ void *libspdm_get_secured_message_context_via_session_info(void *spdm_session_in
     }
 }
 
-/**
- * This function generate a new session ID by concatenating req_session_id and rsp_session_id.
- *
- * @param[in]  req_session_id
- * @param[in]  rsp_session_id
- *
- * @return this new session ID.
- **/
 uint32_t libspdm_generate_session_id(uint16_t req_session_id, uint16_t rsp_session_id)
 {
     uint32_t session_id;
@@ -264,12 +227,6 @@ libspdm_session_info_t *libspdm_assign_session_id(libspdm_context_t *spdm_contex
     return NULL;
 }
 
-/**
- * This function frees a session ID.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    The SPDM session ID.
- **/
 void libspdm_free_session_id(libspdm_context_t *spdm_context, uint32_t session_id)
 {
     libspdm_session_info_t *session_info;

--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -6,15 +6,6 @@
 
 #include "internal/libspdm_common_lib.h"
 
-/**
- * Map slot ID to key pair ID.
- *
- * @param  spdm_context   A pointer to the SPDM context.
- * @param  slot_id        The slot ID.
- * @param  is_requester   Indicate of the key generation for a requester or a responder.
- *
- * @return key pair ID.
- */
 uint8_t libspdm_slot_id_to_key_pair_id (
     void *spdm_context,
     uint8_t slot_id,
@@ -73,16 +64,6 @@ void libspdm_get_peer_cert_chain_data(void *spdm_context,
 }
 #endif /* LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT */
 
-/**
- * This function returns local used certificate chain buffer including spdm_cert_chain_t header.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  cert_chain_buffer              Certificate chain buffer including spdm_cert_chain_t header.
- * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
- *
- * @retval true  Local used certificate chain buffer including spdm_cert_chain_t header is returned.
- * @retval false Local used certificate chain buffer including spdm_cert_chain_t header is not found.
- **/
 void libspdm_get_local_cert_chain_buffer(void *spdm_context,
                                          uint8_t slot_id,
                                          const void **cert_chain_buffer,
@@ -99,16 +80,6 @@ void libspdm_get_local_cert_chain_buffer(void *spdm_context,
     *cert_chain_buffer_size = context->local_context.local_cert_chain_provision_size[slot_id];
 }
 
-/**
- * This function returns local used certificate chain data without spdm_cert_chain_t header.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  cert_chain_data                Certificate chain data without spdm_cert_chain_t header.
- * @param  cert_chain_data_size            size in bytes of the certificate chain data.
- *
- * @retval true  Local used certificate chain data without spdm_cert_chain_t header is returned.
- * @retval false Local used certificate chain data without spdm_cert_chain_t header is not found.
- **/
 bool libspdm_get_local_cert_chain_data(void *spdm_context,
                                        uint8_t slot_id,
                                        const void **cert_chain_data,
@@ -129,16 +100,6 @@ bool libspdm_get_local_cert_chain_data(void *spdm_context,
     return true;
 }
 
-/**
- * This function returns peer public key buffer.
- *
- * @param  spdm_context                 A pointer to the SPDM context.
- * @param  peer_public_key_buffer       Peer public key buffer.
- * @param  peer_public_key_buffer_size  Size in bytes of peer public key buffer.
- *
- * @retval true  Peer public key buffer is returned.
- * @retval false Peer public key buffer is not found.
- **/
 bool libspdm_get_peer_public_key_buffer(void *spdm_context,
                                         const void **peer_public_key_buffer,
                                         size_t *peer_public_key_buffer_size)
@@ -154,16 +115,6 @@ bool libspdm_get_peer_public_key_buffer(void *spdm_context,
     return false;
 }
 
-/**
- * This function returns local public key buffer.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  local_public_key_buffer       Local public key buffer.
- * @param  local_public_key_buffer_size  Size in bytes of local public key buffer.
- *
- * @retval true  Local public key buffer is returned.
- * @retval false Local public key buffer is not found.
- **/
 bool libspdm_get_local_public_key_buffer(void *spdm_context,
                                          const void **local_public_key_buffer,
                                          size_t *local_public_key_buffer_size)
@@ -634,16 +585,6 @@ static bool libspdm_calculate_il1il2_hash(libspdm_context_t *spdm_context,
 }
 #endif /* LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT */
 
-/**
- * This function generates the certificate chain hash.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  slot_id                    The slot index of the certificate chain.
- * @param  signature                    The buffer to store the certificate chain hash.
- *
- * @retval true  certificate chain hash is generated.
- * @retval false certificate chain hash is not generated.
- **/
 bool libspdm_generate_cert_chain_hash(libspdm_context_t *spdm_context,
                                       size_t slot_id, uint8_t *hash)
 {
@@ -654,15 +595,6 @@ bool libspdm_generate_cert_chain_hash(libspdm_context_t *spdm_context,
         spdm_context->local_context.local_cert_chain_provision_size[slot_id], hash);
 }
 
-/**
- * This function generates the public key hash.
- *
- * @param  spdm_context               A pointer to the SPDM context.
- * @param  hash                       The buffer to store the public key hash.
- *
- * @retval true  public key hash is generated.
- * @retval false public key hash is not generated.
- **/
 bool libspdm_generate_public_key_hash(libspdm_context_t *spdm_context,
                                       uint8_t *hash)
 {
@@ -672,13 +604,6 @@ bool libspdm_generate_public_key_hash(libspdm_context_t *spdm_context,
         spdm_context->local_context.local_public_key_provision_size, hash);
 }
 
-/**
- * Get the certificate slot mask
- *
- * @param[in]   context              A pointer to the SPDM context.
- *
- * @retval slot_mask                 get slot mask
- **/
 uint8_t libspdm_get_cert_slot_mask(libspdm_context_t *spdm_context)
 {
     size_t index;
@@ -694,13 +619,6 @@ uint8_t libspdm_get_cert_slot_mask(libspdm_context_t *spdm_context)
     return slot_mask;
 }
 
-/**
- * Get the certificate slot count
- *
- * @param[in]   context              A pointer to the SPDM context.
- *
- * @retval slot_count                get slot count
- **/
 uint8_t libspdm_get_cert_slot_count(libspdm_context_t *spdm_context)
 {
     size_t index;
@@ -717,17 +635,6 @@ uint8_t libspdm_get_cert_slot_count(libspdm_context_t *spdm_context)
 }
 
 #if LIBSPDM_CERT_PARSE_SUPPORT
-/**
- * This function verifies the integrity of peer certificate chain buffer including
- * spdm_cert_chain_t header.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  cert_chain_buffer              Certificate chain buffer including spdm_cert_chain_t header.
- * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
- *
- * @retval true  Peer certificate chain buffer integrity verification passed.
- * @retval false Peer certificate chain buffer integrity verification failed.
- **/
 bool libspdm_verify_peer_cert_chain_buffer_integrity(libspdm_context_t *spdm_context,
                                                      const void *cert_chain_buffer,
                                                      size_t cert_chain_buffer_size)
@@ -768,19 +675,6 @@ bool libspdm_verify_peer_cert_chain_buffer_integrity(libspdm_context_t *spdm_con
     return result;
 }
 
-/**
- * This function verifies peer certificate chain authority.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  cert_chain_buffer              Certificate chain buffer including spdm_cert_chain_t header.
- * @param  cert_chain_buffer_size          size in bytes of the certificate chain buffer.
- * @param  trust_anchor                  A buffer to hold the trust_anchor which is used to validate the peer certificate, if not NULL.
- * @param  trust_anchor_size             A buffer to hold the trust_anchor_size, if not NULL.
- *
- * @retval true  Peer certificate chain buffer authority verification passed.
- *               Or there is no root_cert in local_context.
- * @retval false Peer certificate chain buffer authority verification failed.
- **/
 bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_context,
                                                      const void *cert_chain_buffer,
                                                      size_t cert_chain_buffer_size,
@@ -881,16 +775,6 @@ bool libspdm_verify_peer_cert_chain_buffer_authority(libspdm_context_t *spdm_con
 }
 #endif
 
-/**
- * This function generates the challenge signature based upon m1m2 for authentication.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  is_requester                  Indicate of the signature generation for a requester or a responder.
- * @param  signature                    The buffer to store the challenge signature.
- *
- * @retval true  challenge signature is generated.
- * @retval false challenge signature is not generated.
- **/
 bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
                                                bool is_requester,
                                                uint8_t slot_id,
@@ -995,16 +879,6 @@ bool libspdm_generate_challenge_auth_signature(libspdm_context_t *spdm_context,
     return result;
 }
 
-/**
- * This function verifies the certificate chain hash.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  certificate_chain_hash         The certificate chain hash data buffer.
- * @param  certificate_chain_hash_size     size in bytes of the certificate chain hash data buffer.
- *
- * @retval true  hash verification pass.
- * @retval false hash verification fail.
- **/
 bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
                                            uint8_t slot_id,
                                            const void *certificate_chain_hash,
@@ -1063,16 +937,6 @@ bool libspdm_verify_certificate_chain_hash(libspdm_context_t *spdm_context,
     return true;
 }
 
-/**
- * This function verifies the public key hash.
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  public_key_hash         The public key hash data buffer.
- * @param  public_key_hash_size    size in bytes of the public key hash data buffer.
- *
- * @retval true  hash verification pass.
- * @retval false hash verification fail.
- **/
 bool libspdm_verify_public_key_hash(libspdm_context_t *spdm_context,
                                     const void *public_key_hash,
                                     size_t public_key_hash_size)
@@ -1107,17 +971,6 @@ bool libspdm_verify_public_key_hash(libspdm_context_t *spdm_context,
     return true;
 }
 
-/**
- * This function verifies the challenge signature based upon m1m2.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  is_requester                  Indicate of the signature verification for a requester or a responder.
- * @param  sign_data                     The signature data buffer.
- * @param  sign_data_size                 size in bytes of the signature data buffer.
- *
- * @retval true  signature verification pass.
- * @retval false signature verification fail.
- **/
 bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
                                              bool is_requester,
                                              uint8_t slot_id,
@@ -1333,16 +1186,6 @@ bool libspdm_verify_challenge_auth_signature(libspdm_context_t *spdm_context,
     return true;
 }
 
-/**
- * This function calculate the measurement summary hash size.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  is_requester                  Is the function called from a requester.
- * @param  measurement_summary_hash_type   The type of the measurement summary hash.
- *
- * @return 0 measurement summary hash type is invalid, NO_MEAS hash type or no MEAS capabilities.
- * @return measurement summary hash size according to type.
- **/
 uint32_t
 libspdm_get_measurement_summary_hash_size(libspdm_context_t *spdm_context,
                                           bool is_requester,
@@ -1370,17 +1213,6 @@ libspdm_get_measurement_summary_hash_size(libspdm_context_t *spdm_context,
 }
 
 #if LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP
-/**
- * This function generates the endpoint info signature based upon il1il2 for authentication.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_info                  A pointer to the SPDM session context.
- * @param  is_requester                  Indicate of the signature generation for a requester or a responder.
- * @param  signature                     The buffer to store the endpoint info signature.
- *
- * @retval true  challenge signature is generated.
- * @retval false challenge signature is not generated.
- **/
 bool libspdm_generate_endpoint_info_signature(libspdm_context_t *spdm_context,
                                               libspdm_session_info_t *session_info,
                                               bool is_requester,
@@ -1482,18 +1314,6 @@ bool libspdm_generate_endpoint_info_signature(libspdm_context_t *spdm_context,
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP */
 
-/**
- * This function verifies the endpoint info signature based upon il1il2.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_info                  A pointer to the SPDM session context.
- * @param  is_requester                  Indicate of the signature verification for a requester or a responder.
- * @param  sign_data                     The signature data buffer.
- * @param  sign_data_size                size in bytes of the signature data buffer.
- *
- * @retval true  signature verification pass.
- * @retval false signature verification fail.
- **/
 bool libspdm_verify_endpoint_info_signature(libspdm_context_t *spdm_context,
                                             libspdm_session_info_t *session_info,
                                             bool is_requester,

--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -1,18 +1,11 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_common_lib.h"
 
-/**
- * Return the size in bytes of opaque data version selection.
- *
- * This function should be called in KEY_EXCHANGE/PSK_EXCHANGE response generation.
- *
- * @return the size in bytes of opaque data version selection.
- **/
 size_t libspdm_get_opaque_data_version_selection_data_size(const libspdm_context_t *spdm_context)
 {
     size_t size;
@@ -34,13 +27,6 @@ size_t libspdm_get_opaque_data_version_selection_data_size(const libspdm_context
     return (size + 3) & ~3;
 }
 
-/**
- * Return the size in bytes of opaque data supported version.
- *
- * This function should be called in KEY_EXCHANGE/PSK_EXCHANGE request generation.
- *
- * @return the size in bytes of opaque data supported version.
- **/
 size_t libspdm_get_opaque_data_supported_version_data_size(libspdm_context_t *spdm_context)
 {
     size_t size;
@@ -66,15 +52,6 @@ size_t libspdm_get_opaque_data_supported_version_data_size(libspdm_context_t *sp
     return (size + 3) & ~3;
 }
 
-/**
- * Return the size in bytes of opaque data supported version.
- *
- * This function should be called in libspdm_process_opaque_data_supported_version_data.
- *
- * @param  version_count                 Secure version count.
- *
- * @return the size in bytes of opaque data supported version.
- **/
 size_t libspdm_get_untrusted_opaque_data_supported_version_data_size(
     libspdm_context_t *spdm_context, uint8_t version_count)
 {
@@ -95,21 +72,6 @@ size_t libspdm_get_untrusted_opaque_data_supported_version_data_size(
     return (size + 3) & ~3;
 }
 
-/**
- * Get element from multi element opaque data by element id.
- *
- * This function should be called in
- * libspdm_process_opaque_data_supported_version_data/libspdm_process_opaque_data_version_selection_data.
- *
- * @param[in]  data_in_size                size of multi element opaque data.
- * @param[in]  data_in                     A pointer to the multi element opaque data.
- * @param[in]  element_id                  element id.
- * @param[in]  sm_data_id                  sm_data_id to identify for the Secured Message data type.
- * @param[out] get_element_ptr             pointer to store found element
- *
- * @retval true                            get element successfully
- * @retval false                           get element failed
- **/
 bool libspdm_get_element_from_opaque_data(libspdm_context_t *spdm_context,
                                           size_t data_in_size, const void *data_in,
                                           uint8_t element_id, uint8_t sm_data_id,
@@ -239,15 +201,6 @@ bool libspdm_get_element_from_opaque_data(libspdm_context_t *spdm_context,
     return result;
 }
 
-/**
- *  Process general opaque data check
- *
- * @param  data_in_size                  size in bytes of the data_in.
- * @param  data_in                       A pointer to the buffer to store the opaque data version selection.
- *
- * @retval true                           check opaque data successfully
- * @retval false                          check opaque data failed
- **/
 bool libspdm_process_general_opaque_data_check(libspdm_context_t *spdm_context,
                                                size_t data_in_size,
                                                const void *data_in)

--- a/library/spdm_common_lib/libspdm_com_support.c
+++ b/library/spdm_common_lib/libspdm_com_support.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -136,24 +136,11 @@ void libspdm_internal_dump_hex(const uint8_t *data, size_t size)
 }
 #endif /* LIBSPDM_DEBUG_PRINT_ENABLE */
 
-/**
- * Reads a 24-bit value from memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 24-bit value that may be unaligned.
- *
- * @return The 24-bit value read from buffer.
- **/
 uint32_t libspdm_read_uint24(const uint8_t *buffer)
 {
     return (uint32_t)(buffer[0] | buffer[1] << 8 | buffer[2] << 16);
 }
 
-/**
- * Writes a 24-bit value to memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 24-bit value that may be unaligned.
- * @param  value   24-bit value to write to buffer.
- **/
 void libspdm_write_uint24(uint8_t *buffer, uint32_t value)
 {
     buffer[0] = (uint8_t)(value & 0xFF);
@@ -161,48 +148,22 @@ void libspdm_write_uint24(uint8_t *buffer, uint32_t value)
     buffer[2] = (uint8_t)((value >> 16) & 0xFF);
 }
 
-/**
- * Reads a 16-bit value from memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 16-bit value that may be unaligned.
- *
- * @return The 16-bit value read from buffer.
- **/
 uint16_t libspdm_read_uint16(const uint8_t *buffer)
 {
     return (uint16_t)(buffer[0] | buffer[1] << 8);
 }
 
-/**
- * Writes a 16-bit value to memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 16-bit value that may be unaligned.
- * @param  value   16-bit value to write to buffer.
- **/
 void libspdm_write_uint16(uint8_t *buffer, uint16_t value)
 {
     buffer[0] = (uint8_t)(value & 0xFF);
     buffer[1] = (uint8_t)((value >> 8) & 0xFF);
 }
 
-/**
- * Reads a 32-bit value from memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 32-bit value that may be unaligned.
- *
- * @return The 32-bit value read from buffer.
- **/
 uint32_t libspdm_read_uint32(const uint8_t *buffer)
 {
     return (uint32_t)(buffer[0] | buffer[1] << 8 | buffer[2] << 16 | buffer[3] << 24);
 }
 
-/**
- * Writes a 32-bit value to memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 32-bit value that may be unaligned.
- * @param  value   32-bit value to write to buffer.
- **/
 void libspdm_write_uint32(uint8_t *buffer, uint32_t value)
 {
     buffer[0] = (uint8_t)(value & 0xFF);
@@ -211,13 +172,6 @@ void libspdm_write_uint32(uint8_t *buffer, uint32_t value)
     buffer[3] = (uint8_t)((value >> 24) & 0xFF);
 }
 
-/**
- * Reads a 64-bit value from memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 64-bit value that may be unaligned.
- *
- * @return The 64-bit value read from buffer.
- **/
 uint64_t libspdm_read_uint64(const uint8_t *buffer)
 {
     return (uint64_t)(buffer[0]) |
@@ -230,12 +184,6 @@ uint64_t libspdm_read_uint64(const uint8_t *buffer)
            ((uint64_t)(buffer[7]) << 56);
 }
 
-/**
- * Writes a 64-bit value to memory that may be unaligned.
- *
- * @param  buffer  The pointer to a 64-bit value that may be unaligned.
- * @param  value   64-bit value to write to buffer.
- **/
 void libspdm_write_uint64(uint8_t *buffer, uint64_t value)
 {
     buffer[0] = (uint8_t)(value & 0xFF);
@@ -319,13 +267,6 @@ void libspdm_init_managed_buffer(void *m_buffer, size_t max_buffer_size)
     libspdm_reset_managed_buffer(m_buffer);
 }
 
-/**
- * byte3 - libspdm major version
- * byte2 - libspdm minor version
- * byte1 - libspdm patch version
- * byte0 - libspdm alpha
- *         (office release with tag: 0, release candidate with tag: 1, non official release: 0xFF)
- **/
 uint32_t libspdm_module_version(void)
 {
     return (LIBSPDM_MAJOR_VERSION << 24) |

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_aes_gcm.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * AES_GCM self_test
- **/
 bool libspdm_fips_selftest_aes_gcm(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdh.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * ECDH self_test
- **/
 bool libspdm_fips_selftest_ecdh(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ecdsa.c
@@ -25,9 +25,6 @@ static int libspdm_hardcode_random_number_ecdsa(void *rng_state, unsigned char *
     return 0;
 }
 
-/**
- * ECDSA self_test
- **/
 bool libspdm_fips_selftest_ecdsa(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_eddsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_eddsa.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * EDDSA self_test
- **/
 bool libspdm_fips_selftest_eddsa(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_ffdh.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -9,9 +9,6 @@
 #include "internal/libspdm_fips_lib.h"
 
 #if LIBSPDM_FIPS_MODE
-/**
- * FFDH self_test
- **/
 bool libspdm_fips_selftest_ffdh(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hkdf.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * HKDF KAT test
- **/
 bool libspdm_fips_selftest_hkdf(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_hmac.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * HMAC-SHA256 KAT covers SHA256 KAT.
- **/
 bool libspdm_fips_selftest_hmac_sha256(void *fips_selftest_context)
 {
     bool result = true;
@@ -71,9 +68,6 @@ update:
     return result;
 }
 
-/**
- * HMAC-SHA384 KAT covers SHA384 KAT.
- **/
 bool libspdm_fips_selftest_hmac_sha384(void *fips_selftest_context)
 {
     bool result = true;
@@ -134,9 +128,6 @@ update:
     return result;
 }
 
-/**
- * HMAC-SHA512 KAT covers SHA512 KAT.
- **/
 bool libspdm_fips_selftest_hmac_sha512(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_mldsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_mldsa.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * mldsa self_test
- **/
 bool libspdm_fips_selftest_mldsa(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_mlkem.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_mlkem.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * ML-KEM self_test
- **/
 bool libspdm_fips_selftest_mlkem(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_pss.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_pss.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -11,9 +11,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * RSA_PSS self_test
- **/
 bool libspdm_fips_selftest_rsa_pss(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_rsa_ssa.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * RSA_SSA(RSASSA-PKCS1 v1.5) self_test
- **/
 bool libspdm_fips_selftest_rsa_ssa(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha2.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha2.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * SHA256 KAT: HMAC-SHA256 KAT covers SHA256 KAT.
- **/
 bool libspdm_fips_selftest_sha256(void *fips_selftest_context)
 {
     bool result = true;
@@ -47,9 +44,6 @@ bool libspdm_fips_selftest_sha256(void *fips_selftest_context)
     return result;
 }
 
-/**
- * SHA384 KAT: HMAC-SHA384 KAT covers SHA384 KAT.
- **/
 bool libspdm_fips_selftest_sha384(void *fips_selftest_context)
 {
     bool result = true;
@@ -84,9 +78,6 @@ bool libspdm_fips_selftest_sha384(void *fips_selftest_context)
     return result;
 }
 
-/**
- * SHA512 KAT: HMAC-SHA512 KAT covers SHA512 KAT.
- **/
 bool libspdm_fips_selftest_sha512(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_sha3.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023-2025 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * SHA3_256 KAT
- **/
 bool libspdm_fips_selftest_sha3_256(void *fips_selftest_context)
 {
     bool result = true;
@@ -71,9 +68,6 @@ update:
     return result;
 }
 
-/**
- * SHA3_384 KAT
- **/
 bool libspdm_fips_selftest_sha3_384(void *fips_selftest_context)
 {
     bool result = true;
@@ -134,9 +128,6 @@ update:
     return result;
 }
 
-/**
- * SHA3_512 KAT
- **/
 bool libspdm_fips_selftest_sha3_512(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/fips/libspdm_selftest_slhdsa.c
+++ b/library/spdm_crypt_lib/fips/libspdm_selftest_slhdsa.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,9 +10,6 @@
 
 #if LIBSPDM_FIPS_MODE
 
-/**
- * slhdsa self_test
- **/
 bool libspdm_fips_selftest_slhdsa(void *fips_selftest_context)
 {
     bool result = true;

--- a/library/spdm_crypt_lib/libspdm_crypt_asym.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_asym.c
@@ -94,14 +94,6 @@ static bool libspdm_sm2_dsa_sign_wrap (void *context, size_t hash_nid,
 }
 #endif
 
-/**
- * Get the SPDM signing context string, which is required since SPDM 1.2.
- *
- * @param  spdm_version                         negotiated SPDM version
- * @param  op_code                              the SPDM opcode which requires the signing
- * @param  is_requester                         indicate if the signing is from a requester
- * @param  context_size                         SPDM signing context size
- **/
 const void *libspdm_get_signing_context_string (
     spdm_version_number_t spdm_version,
     uint8_t op_code,
@@ -124,14 +116,6 @@ const void *libspdm_get_signing_context_string (
     return NULL;
 }
 
-/**
- * Create SPDM signing context, which is required since SPDM 1.2.
- *
- * @param  spdm_version                         negotiated SPDM version
- * @param  op_code                              the SPDM opcode which requires the signing
- * @param  is_requester                         indicate if the signing is from a requester
- * @param  spdm_signing_context                 SPDM signing context
- **/
 void libspdm_create_signing_context (
     spdm_version_number_t spdm_version,
     uint8_t op_code,

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -267,19 +267,6 @@ libspdm_get_asym_get_public_key_from_x509(uint32_t base_asym_algo)
     return NULL;
 }
 
-/**
- * Retrieve the asymmetric public key from one DER-encoded X509 certificate,
- * based upon negotiated asymmetric algorithm.
- *
- * @param  base_asym_algo                 SPDM base_asym_algo
- * @param  cert                         Pointer to the DER-encoded X509 certificate.
- * @param  cert_size                     size of the X509 certificate in bytes.
- * @param  context                      Pointer to newly generated asymmetric context which contain the retrieved public key component.
- *                                     Use libspdm_asym_free() function to free the resource.
- *
- * @retval  true   public key was retrieved successfully.
- * @retval  false  Fail to retrieve public key from X509 certificate.
- **/
 bool libspdm_asym_get_public_key_from_x509(uint32_t base_asym_algo,
                                            const uint8_t *cert,
                                            size_t cert_size,
@@ -306,19 +293,6 @@ libspdm_get_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg)
     return libspdm_get_asym_get_public_key_from_x509(req_base_asym_alg);
 }
 
-/**
- * Retrieve the asymmetric public key from one DER-encoded X509 certificate,
- * based upon negotiated requester asymmetric algorithm.
- *
- * @param  req_base_asym_alg               SPDM req_base_asym_alg
- * @param  cert                         Pointer to the DER-encoded X509 certificate.
- * @param  cert_size                     size of the X509 certificate in bytes.
- * @param  context                      Pointer to newly generated asymmetric context which contain the retrieved public key component.
- *                                     Use libspdm_asym_free() function to free the resource.
- *
- * @retval  true   public key was retrieved successfully.
- * @retval  false  Fail to retrieve public key from X509 certificate.
- **/
 bool libspdm_req_asym_get_public_key_from_x509(uint16_t req_base_asym_alg,
                                                const uint8_t *cert,
                                                size_t cert_size,
@@ -1642,21 +1616,6 @@ cleanup:
     return status;
 }
 
-/**
- * Certificate Check for SPDM leaf cert when get_cert command.
- *
- * @param[in]  spdm_version          One of SPDM_MESSAGE_VERSION_* macros.
- * @param[in]  cert                  Pointer to the DER-encoded certificate data.
- * @param[in]  cert_size             The size of certificate data in bytes.
- * @param[in]  base_asym_algo        SPDM base_asym_algo
- * @param[in]  pqc_asym_algo         SPDM pqc_asym_algo
- * @param[in]  base_hash_algo        SPDM base_hash_algo
- * @param[in]  is_requester          Is the function verifying a cert as a requester or responder.
- * @param[in]  cert_model            One of the SPDM_CERTIFICATE_INFO_CERT_MODEL_* macros.
- *
- * @retval  true   Success.
- * @retval  false  Certificate is not valid
- **/
 bool libspdm_x509_certificate_check(
     uint8_t spdm_version,
     const uint8_t *cert, size_t cert_size,
@@ -1686,21 +1645,6 @@ bool libspdm_x509_certificate_check(
     return status;
 }
 
-/**
- * Certificate Check for SPDM leaf cert when set_cert.
- *
- * @param[in]  spdm_version          One of SPDM_MESSAGE_VERSION_* macros.
- * @param[in]  cert                  Pointer to the DER-encoded certificate data.
- * @param[in]  cert_size             The size of certificate data in bytes.
- * @param[in]  base_asym_algo        SPDM base_asym_algo
- * @param[in]  base_hash_algo        SPDM base_hash_algo
- * @param[in]  is_requester          Is the function verifying a cert as a requester or responder.
- * @param[in]  is_device_cert_model  If true, the local endpoint uses the DeviceCert model.
- *                                   If false, the local endpoint uses the AliasCert model.
- *
- * @retval  true   Success.
- * @retval  false  Certificate is not valid.
- **/
 bool libspdm_x509_set_cert_certificate_check(
     uint8_t spdm_version,
     const uint8_t *cert, size_t cert_size,
@@ -1794,25 +1738,6 @@ bool libspdm_is_root_certificate(const uint8_t *cert, size_t cert_size)
     return true;
 }
 
-/**
- * Retrieve the SubjectAltName from SubjectAltName Bytes.
- *
- * @param[in]      buffer           Pointer to subjectAltName oct bytes.
- * @param[in]      len              size of buffer in bytes.
- * @param[out]     name_buffer       buffer to contain the retrieved certificate
- *                                 SubjectAltName. At most name_buffer_size bytes will be
- *                                 written. Maybe NULL in order to determine the size
- *                                 buffer needed.
- * @param[in,out]  name_buffer_size   The size in bytes of the name buffer on input,
- *                                 and the size of buffer returned name on output.
- *                                 If name_buffer is NULL then the amount of space needed
- *                                 in buffer (including the final null) is returned.
- * @param[out]     oid              OID of otherName
- * @param[in,out]  oid_size          the buffersize for required OID
- *
- * @retval true                     get the subjectAltName string successfully
- * @retval failed                   get the subjectAltName string failed
- **/
 bool libspdm_get_dmtf_subject_alt_name_from_bytes(
     uint8_t *buffer, const size_t len, char *name_buffer,
     size_t *name_buffer_size, uint8_t *oid,
@@ -1911,25 +1836,6 @@ bool libspdm_get_dmtf_subject_alt_name_from_bytes(
     return false;
 }
 
-/**
- * Retrieve the SubjectAltName from one X.509 certificate.
- *
- * @param[in]      cert             Pointer to the DER-encoded X509 certificate.
- * @param[in]      cert_size         size of the X509 certificate in bytes.
- * @param[out]     name_buffer       buffer to contain the retrieved certificate
- *                                 SubjectAltName. At most name_buffer_size bytes will be
- *                                 written. Maybe NULL in order to determine the size
- *                                 buffer needed.
- * @param[in,out]  name_buffer_size   The size in bytes of the name buffer on input,
- *                                 and the size of buffer returned name on output.
- *                                 If name_buffer is NULL then the amount of space needed
- *                                 in buffer (including the final null) is returned.
- * @param[out]     oid              OID of otherName
- * @param[in,out]  oid_size          the buffersize for required OID
- *
- * @retval true                     get the subjectAltName string successfully
- * @retval failed                   get the subjectAltName string failed
- **/
 bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const size_t cert_size,
                                        char *name_buffer,
                                        size_t *name_buffer_size,
@@ -1966,21 +1872,6 @@ bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const size_t cert_si
         name_buffer_size, oid, oid_size);
 }
 
-/**
- * This function verifies the integrity of certificate chain data without spdm_cert_chain_t header.
- *
- * @param  spdm_version          One of SPDM_MESSAGE_VERSION_* macros.
- * @param  cert_chain_data       The certificate chain data without spdm_cert_chain_t header.
- * @param  cert_chain_data_size  Size in bytes of the certificate chain data.
- * @param  base_asym_algo        SPDM base_asym_algo
- * @param  pqc_asym_algo         SPDM pqc_asym_algo
- * @param  base_hash_algo        SPDM base_hash_algo
- * @param  is_requester_cert     Is the function verifying requester or responder cert.
- * @param  cert_model            One of the SPDM_CERTIFICATE_INFO_CERT_MODEL_* macros.
- *
- * @retval true  certificate chain data integrity verification pass.
- * @retval false certificate chain data integrity verification fail.
- **/
 bool libspdm_verify_cert_chain_data(
     uint8_t spdm_version,
     uint8_t *cert_chain_data, size_t cert_chain_data_size,
@@ -2034,22 +1925,6 @@ bool libspdm_verify_cert_chain_data(
     return true;
 }
 
-/**
- * This function verifies the integrity of certificate chain buffer including
- * spdm_cert_chain_t header.
- *
- * @param  spdm_version            One of SPDM_MESSAGE_VERSION_* macros.
- * @param  base_hash_algo          SPDM base_hash_algo
- * @param  base_asym_algo          SPDM base_asym_algo
- * @param  pqc_asym_algo           SPDM pqc_asym_algo
- * @param  cert_chain_buffer       The certificate chain buffer including spdm_cert_chain_t header.
- * @param  cert_chain_buffer_size  Size in bytes of the certificate chain buffer.
- * @param  is_requester_cert       Is the function verifying requester or responder cert.
- * @param  cert_model              One of the SPDM_CERTIFICATE_INFO_CERT_MODEL_* macros.
- *
- * @retval true   Certificate chain buffer integrity verification pass.
- * @retval false  Certificate chain buffer integrity verification fail.
- **/
 bool libspdm_verify_certificate_chain_buffer(
     uint8_t spdm_version,
     uint32_t base_hash_algo, uint32_t base_asym_algo, uint32_t pqc_asym_algo,
@@ -2178,20 +2053,6 @@ bool libspdm_get_leaf_cert_public_key_from_cert_chain(uint32_t base_hash_algo,
     return true;
 }
 
-/**
- * Retrieve the asymmetric public key from one DER-encoded X509 certificate,
- * based upon negotiated asymmetric or requester asymmetric algorithm.
- *
- * @param  base_hash_algo        SPDM base_hash_algo.
- * @param  pqc_asym_alg          SPDM pqc_asym_algo or req_pqc_asym_alg.
- * @param  cert_chain_data       Certificate chain data with spdm_cert_chain_t header.
- * @param  cert_chain_data_size  Size in bytes of the certificate chain data.
- * @param  public_key            Pointer to newly generated asymmetric context which contain the
- *                               retrieved public key component.
- *
- * @retval  true   Public key was retrieved successfully.
- * @retval  false  Fail to retrieve public key from X509 certificate.
- **/
 bool libspdm_get_pqc_leaf_cert_public_key_from_cert_chain(uint32_t base_hash_algo,
                                                           uint32_t pqc_asym_alg,
                                                           uint8_t *cert_chain_data,

--- a/library/spdm_crypt_lib/libspdm_crypt_dhe.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_dhe.c
@@ -1,18 +1,11 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_crypt_lib.h"
 
-/**
- * This function returns the SPDM DHE algorithm key size.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- *
- * @return SPDM DHE algorithm key size.
- **/
 uint32_t libspdm_get_dhe_pub_key_size(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {
@@ -63,13 +56,6 @@ uint32_t libspdm_get_dhe_pub_key_size(uint16_t dhe_named_group)
     }
 }
 
-/**
- * This function returns the SPDM DHE shared secret size.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- *
- * @return SPDM DHE shared secret size.
- **/
 uint32_t libspdm_get_dhe_shared_secret_size(uint16_t dhe_named_group)
 {
     switch (dhe_named_group) {

--- a/library/spdm_requester_lib/libspdm_req_common.c
+++ b/library/spdm_requester_lib/libspdm_req_common.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -101,14 +101,6 @@ void libspdm_build_opaque_data_supported_version_data(libspdm_context_t *spdm_co
     libspdm_zero_mem(end, (size_t)data_out + final_data_size - (size_t)end);
 }
 
-/**
- * Process opaque data version selection.
- *
- * This function should be called in KEY_EXCHANGE/PSK_EXCHANGE response parsing in requester.
- *
- * @param  data_in_size                   size in bytes of the data_in.
- * @param  data_in                       A pointer to the buffer to store the opaque data version selection.
- **/
 libspdm_return_t libspdm_process_opaque_data_version_selection_data(
     libspdm_context_t *spdm_context, size_t data_in_size, void *data_in,
     spdm_version_number_t *secured_message_version)

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -7,13 +7,6 @@
 #include "internal/libspdm_responder_lib.h"
 #include "internal/libspdm_secured_message_lib.h"
 
-/**
- * Return the GET_SPDM_RESPONSE function via request code.
- *
- * @param  request_code                  The SPDM request code.
- *
- * @return GET_SPDM_RESPONSE function according to the request code.
- **/
 libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_t request_code)
 {
     size_t index;
@@ -135,19 +128,6 @@ static libspdm_get_spdm_response_func libspdm_get_response_func_via_last_request
     return libspdm_get_response_func_via_request_code(spdm_request->request_response_code);
 }
 
-/**
- * Process a SPDM request from a device.
- *
- * @param  spdm_context                  The SPDM context for the device.
- * @param  session_id                    Indicate if the request is a secured message.
- *                                     If session_id is NULL, it is a normal message.
- *                                     If session_id is NOT NULL, it is a secured message.
- * @param  is_app_message                 Indicates if it is an APP message or SPDM message.
- * @param  request_size                  size in bytes of the request data buffer.
- * @param  request                      A pointer to a destination buffer to store the request.
- *                                     The caller is responsible for having
- *                                     either implicit or explicit ownership of the buffer.
- **/
 libspdm_return_t libspdm_process_request(void *spdm_context, uint32_t **session_id,
                                          bool *is_app_message,
                                          size_t request_size, void *request)
@@ -340,13 +320,6 @@ static void libspdm_trigger_session_state_callback(libspdm_context_t *spdm_conte
     }
 }
 
-/**
- * Set session_state to an SPDM secured message context and trigger callback.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    Indicate the SPDM session ID.
- * @param  session_state                 Indicate the SPDM session state.
- */
 void libspdm_set_session_state(libspdm_context_t *spdm_context,
                                uint32_t session_id,
                                libspdm_session_state_t session_state)
@@ -370,16 +343,6 @@ void libspdm_set_session_state(libspdm_context_t *spdm_context,
     }
 }
 
-/**
- * This function allows the consumer to terminate a session.
- * For example, it can be used when the heartbeat period is over.
- *
- * @param  spdm_context                 A pointer to the SPDM context.
- * @param  session_id                   session_id of the session to be terminated.
- *
- * @retval LIBSPDM_STATUS_SUCCESS Success
- * @retval LIBSPDM_STATUS_INVALID_PARAMETER session_id is invalid.
- **/
 libspdm_return_t libspdm_terminate_session(
     void *spdm_context, uint32_t session_id)
 {
@@ -411,12 +374,6 @@ static void libspdm_trigger_connection_state_callback(libspdm_context_t *spdm_co
     }
 }
 
-/**
- * Set connection_state to an SPDM context and trigger callback.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  connection_state              Indicate the SPDM connection state.
- */
 void libspdm_set_connection_state(libspdm_context_t *spdm_context,
                                   libspdm_connection_state_t connection_state)
 {

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -1,28 +1,16 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_secured_message_lib.h"
 
-/**
- * Return the size in bytes of a single SPDM secured message context.
- *
- * @return the size in bytes of a single SPDM secured message context.
- **/
 size_t libspdm_secured_message_get_context_size(void)
 {
     return sizeof(libspdm_secured_message_context_t);
 }
 
-/**
- * Initialize an SPDM secured message context.
- *
- * The size in bytes of the spdm_secured_message_context can be returned by libspdm_secured_message_get_context_size.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- */
 void libspdm_secured_message_init_context(void *spdm_secured_message_context)
 {
     libspdm_secured_message_context_t *secured_message_context;
@@ -31,12 +19,6 @@ void libspdm_secured_message_init_context(void *spdm_secured_message_context)
     libspdm_zero_mem(secured_message_context, sizeof(libspdm_secured_message_context_t));
 }
 
-/**
- * Set use_psk to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  use_psk                       Indicate if the SPDM session use PSK.
- */
 void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context, bool use_psk)
 {
     libspdm_secured_message_context_t *secured_message_context;
@@ -45,12 +27,6 @@ void libspdm_secured_message_set_use_psk(void *spdm_secured_message_context, boo
     secured_message_context->use_psk = use_psk;
 }
 
-/**
- * Set session_state to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  session_state                 Indicate the SPDM session state.
- */
 void libspdm_secured_message_set_session_state(
     void *spdm_secured_message_context,
     libspdm_session_state_t session_state)
@@ -67,13 +43,6 @@ void libspdm_secured_message_set_session_state(
     }
 }
 
-/**
- * Return session_state of an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @return the SPDM session state.
- */
 libspdm_session_state_t
 libspdm_secured_message_get_session_state(void *spdm_secured_message_context)
 {
@@ -83,12 +52,6 @@ libspdm_secured_message_get_session_state(void *spdm_secured_message_context)
     return secured_message_context->session_state;
 }
 
-/**
- * Set session_type to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  session_type                  Indicate the SPDM session type.
- */
 void libspdm_secured_message_set_session_type(void *spdm_secured_message_context,
                                               libspdm_session_type_t session_type)
 {
@@ -98,15 +61,6 @@ void libspdm_secured_message_set_session_type(void *spdm_secured_message_context
     secured_message_context->session_type = session_type;
 }
 
-/**
- * Set algorithm to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  base_hash_algo                 Indicate the negotiated base_hash_algo for the SPDM session.
- * @param  dhe_named_group                Indicate the negotiated dhe_named_group for the SPDM session.
- * @param  aead_cipher_suite              Indicate the negotiated aead_cipher_suite for the SPDM session.
- * @param  key_schedule                  Indicate the negotiated key_schedule for the SPDM session.
- */
 void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
                                             const spdm_version_number_t version,
                                             const spdm_version_number_t secured_message_version,
@@ -162,12 +116,6 @@ void libspdm_secured_message_set_psk_hint(void *spdm_secured_message_context,
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_PSK_CAP */
 
-/**
- * Set the maximum sequence_number to an SPDM secured message context.
- *
- * @param  spdm_secured_message_context      A pointer to the SPDM secured message context.
- * @param  max_spdm_session_sequence_number  Indicate the maximum sequence_number in SPDM session.
- */
 void libspdm_secured_message_set_max_spdm_session_sequence_number(
     void *spdm_secured_message_context,
     uint64_t max_spdm_session_sequence_number)
@@ -356,12 +304,6 @@ bool libspdm_secured_message_import_session_keys(void *spdm_secured_message_cont
     return true;
 }
 
-/**
- * Get the last SPDM error struct of an SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  last_spdm_error                Last SPDM error struct of an SPDM context.
- */
 void libspdm_secured_message_get_last_spdm_error_struct(
     void *spdm_secured_message_context,
     libspdm_error_struct_t *last_spdm_error)
@@ -374,12 +316,6 @@ void libspdm_secured_message_get_last_spdm_error_struct(
                      sizeof(libspdm_error_struct_t));
 }
 
-/**
- * Set the last SPDM error struct of an SPDM context.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  last_spdm_error                Last SPDM error struct of an SPDM context.
- */
 void libspdm_secured_message_set_last_spdm_error_struct(
     void *spdm_secured_message_context,
     const libspdm_error_struct_t *last_spdm_error)

--- a/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_key_exchange.c
@@ -1,59 +1,22 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_secured_message_lib.h"
 
-/**
- * Allocates and Initializes one Diffie-Hellman Ephemeral (DHE) context for subsequent use,
- * based upon negotiated DHE algorithm.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  is_initiator                   if the caller is initiator.
- *                                       true: initiator
- *                                       false: not an initiator
- *
- * @return  Pointer to the Diffie-Hellman context that has been initialized.
- **/
 void *libspdm_secured_message_dhe_new(spdm_version_number_t spdm_version,
                                       uint16_t dhe_named_group, bool is_initiator)
 {
     return libspdm_dhe_new(spdm_version, dhe_named_group, is_initiator);
 }
 
-/**
- * Release the specified DHE context,
- * based upon negotiated DHE algorithm.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context to be released.
- **/
 void libspdm_secured_message_dhe_free(uint16_t dhe_named_group, void *dhe_context)
 {
     libspdm_dhe_free(dhe_named_group, dhe_context);
 }
 
-/**
- * Generates DHE public key,
- * based upon negotiated DHE algorithm.
- *
- * This function generates random secret exponent, and computes the public key, which is
- * returned via parameter public_key and public_key_size. DH context is updated accordingly.
- * If the public_key buffer is too small to hold the public key, false is returned and
- * public_key_size is set to the required buffer size to obtain the public key.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context.
- * @param  public_key                    Pointer to the buffer to receive generated public key.
- * @param  public_key_size                On input, the size of public_key buffer in bytes.
- *                                     On output, the size of data returned in public_key buffer in bytes.
- *
- * @retval true   DHE public key generation succeeded.
- * @retval false  DHE public key generation failed.
- * @retval false  public_key_size is not large enough.
- **/
 bool libspdm_secured_message_dhe_generate_key(uint16_t dhe_named_group,
                                               void *dhe_context,
                                               uint8_t *public_key,
@@ -62,24 +25,6 @@ bool libspdm_secured_message_dhe_generate_key(uint16_t dhe_named_group,
     return libspdm_dhe_generate_key(dhe_named_group, dhe_context, public_key, public_key_size);
 }
 
-/**
- * Computes exchanged common key,
- * based upon negotiated DHE algorithm.
- *
- * Given peer's public key, this function computes the exchanged common key, based on its own
- * context including value of prime modulus and random secret exponent.
- *
- * @param  dhe_named_group                SPDM dhe_named_group
- * @param  dhe_context                   Pointer to the DHE context.
- * @param  peer_public_key                Pointer to the peer's public key.
- * @param  peer_public_key_size            size of peer's public key in bytes.
- * @param  key                          Pointer to the buffer to receive generated key.
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true   DHE exchanged key generation succeeded.
- * @retval false  DHE exchanged key generation failed.
- * @retval false  key_size is not large enough.
- **/
 bool libspdm_secured_message_dhe_compute_key(
     uint16_t dhe_named_group, void *dhe_context,
     const uint8_t *peer_public, size_t peer_public_size,

--- a/library/spdm_secured_message_lib/libspdm_secmes_key_exchange_pqc.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_key_exchange_pqc.c
@@ -1,54 +1,22 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_secured_message_lib.h"
 
-/**
- * Allocates and Initializes one KEM context for subsequent use,
- * based upon negotiated KEM algorithm.
- *
- * @param  kem_alg                SPDM kem_alg
- * @param  is_initiator                   if the caller is initiator.
- *                                       true: initiator
- *                                       false: not an initiator
- *
- * @return  Pointer to the KEM context that has been initialized.
- **/
 void *libspdm_secured_message_kem_new(spdm_version_number_t spdm_version,
                                       uint32_t kem_alg, bool is_initiator)
 {
     return libspdm_kem_new(spdm_version, kem_alg, is_initiator);
 }
 
-/**
- * Release the specified KEM context,
- * based upon negotiated KEM algorithm.
- *
- * @param  kem_alg                SPDM kem_alg
- * @param  kem_context                   Pointer to the KEM context to be released.
- **/
 void libspdm_secured_message_kem_free(uint32_t kem_alg, void *kem_context)
 {
     libspdm_kem_free(kem_alg, kem_context);
 }
 
-/**
- * Generates KEM public key,
- * based upon negotiated KEM algorithm.
- *
- * @param  kem_alg                SPDM kem_alg
- * @param  kem_context                 Pointer to the KEM context.
- * @param  encap_key                   Pointer to the buffer to receive generated public key.
- * @param  encap_key_size              On input, the size of public_key buffer in bytes.
- *                                     On output, the size of data returned in public_key buffer in bytes.
- *
- * @retval true   KEM public key generation succeeded.
- * @retval false  KEM public key generation failed.
- * @retval false  public_key_size is not large enough.
- **/
 bool libspdm_secured_message_kem_generate_key(uint32_t kem_alg,
                                               void *kem_context,
                                               uint8_t *encap_key,
@@ -57,23 +25,6 @@ bool libspdm_secured_message_kem_generate_key(uint32_t kem_alg,
     return libspdm_kem_generate_key(kem_alg, kem_context, encap_key, encap_key_size);
 }
 
-/**
- * Computes exchanged common key,
- * based upon negotiated KEM algorithm.
- *
- * @param  kem_alg                SPDM kem_alg
- * @param  kem_context                   Pointer to the kem context.
- * @param  peer_encap_key                Pointer to the peer's public key.
- * @param  peer_encap_key_size           Size of peer's public key in bytes.
- * @param  cipher_text                   Pointer to the buffer to receive generated cipher text.
- * @param  cipher_text_size              On input, the size of cipher text buffer in bytes.
- *                                       On output, the size of data returned in cipher_text buffer in bytes.
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true   DHE exchanged key generation succeeded.
- * @retval false  DHE exchanged key generation failed.
- * @retval false  key_size is not large enough.
- **/
 bool libspdm_secured_message_kem_encapsulate(
     uint32_t kem_alg, void *kem_context,
     const uint8_t *peer_encap_key, size_t peer_encap_key_size,
@@ -103,20 +54,6 @@ bool libspdm_secured_message_kem_encapsulate(
     return true;
 }
 
-/**
- * Computes exchanged common key,
- * based upon negotiated KEM algorithm.
- *
- * @param  kem_alg                SPDM kem_alg
- * @param  kem_context                   Pointer to the kem context.
- * @param  peer_cipher_text              Pointer to the peer's public key.
- * @param  peer_cipher_text_size         Size of peer's public key in bytes.
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @retval true   DHE exchanged key generation succeeded.
- * @retval false  DHE exchanged key generation failed.
- * @retval false  key_size is not large enough.
- **/
 bool libspdm_secured_message_kem_decapsulate(
     uint32_t kem_alg, void *kem_context,
     const uint8_t *peer_cipher_text, size_t peer_cipher_text_size,

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -582,13 +582,6 @@ bool libspdm_activate_update_session_data_key(void *spdm_secured_message_context
     return true;
 }
 
-/**
- * Allocates and initializes one HMAC context for subsequent use, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @return Pointer to the HMAC context that has been initialized.
- **/
 void *libspdm_hmac_new_with_request_finished_key(void *spdm_secured_message_context)
 {
     libspdm_secured_message_context_t *secured_message_context;
@@ -597,12 +590,6 @@ void *libspdm_hmac_new_with_request_finished_key(void *spdm_secured_message_cont
     return libspdm_hmac_new(secured_message_context->base_hash_algo);
 }
 
-/**
- * Release the specified HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx                   Pointer to the HMAC context to be released.
- **/
 void libspdm_hmac_free_with_request_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
@@ -612,16 +599,6 @@ void libspdm_hmac_free_with_request_finished_key(
     libspdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
 }
 
-/**
- * Set request_finished_key for subsequent use. It must be done before any
- * calling to hmac_update().
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx  Pointer to HMAC context.
- *
- * @retval true   The key is set successfully.
- * @retval false  The key is set unsuccessfully.
- **/
 bool libspdm_hmac_init_with_request_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
@@ -634,16 +611,6 @@ bool libspdm_hmac_init_with_request_finished_key(
         secured_message_context->hash_size);
 }
 
-/**
- * Makes a copy of an existing HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  new_hmac_ctx  Pointer to new HMAC context.
- *
- * @retval true   HMAC context copy succeeded.
- * @retval false  HMAC context copy failed.
- **/
 bool libspdm_hmac_duplicate_with_request_finished_key(
     void *spdm_secured_message_context,
     const void *hmac_ctx, void *new_hmac_ctx)
@@ -654,17 +621,6 @@ bool libspdm_hmac_duplicate_with_request_finished_key(
     return libspdm_hmac_duplicate(secured_message_context->base_hash_algo, hmac_ctx, new_hmac_ctx);
 }
 
-/**
- * Digests the input data and updates HMAC context, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  data              Pointer to the buffer containing the data to be digested.
- * @param  data_size          size of data buffer in bytes.
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
 bool libspdm_hmac_update_with_request_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx, const void *data,
@@ -676,16 +632,6 @@ bool libspdm_hmac_update_with_request_finished_key(
     return libspdm_hmac_update(secured_message_context->base_hash_algo, hmac_ctx, data, data_size);
 }
 
-/**
- * Completes computation of the HMAC digest value, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
 bool libspdm_hmac_final_with_request_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx,  uint8_t *hmac_value)
@@ -696,17 +642,6 @@ bool libspdm_hmac_final_with_request_finished_key(
     return libspdm_hmac_final(secured_message_context->base_hash_algo, hmac_ctx, hmac_value);
 }
 
-/**
- * Computes the HMAC of a input data buffer, with request_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  data                         Pointer to the buffer containing the data to be HMACed.
- * @param  data_size                     size of data buffer in bytes.
- * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
- *
- * @retval true   HMAC computation succeeded.
- * @retval false  HMAC computation failed.
- **/
 bool libspdm_hmac_all_with_request_finished_key(void *spdm_secured_message_context,
                                                 const void *data, size_t data_size,
                                                 uint8_t *hmac_value)
@@ -720,13 +655,6 @@ bool libspdm_hmac_all_with_request_finished_key(void *spdm_secured_message_conte
         secured_message_context->hash_size, hmac_value);
 }
 
-/**
- * Allocates and initializes one HMAC context for subsequent use, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- *
- * @return Pointer to the HMAC context that has been initialized.
- **/
 void *libspdm_hmac_new_with_response_finished_key(void *spdm_secured_message_context)
 {
     libspdm_secured_message_context_t *secured_message_context;
@@ -735,12 +663,6 @@ void *libspdm_hmac_new_with_response_finished_key(void *spdm_secured_message_con
     return libspdm_hmac_new(secured_message_context->base_hash_algo);
 }
 
-/**
- * Release the specified HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx                   Pointer to the HMAC context to be released.
- **/
 void libspdm_hmac_free_with_response_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
@@ -750,16 +672,6 @@ void libspdm_hmac_free_with_response_finished_key(
     libspdm_hmac_free(secured_message_context->base_hash_algo, hmac_ctx);
 }
 
-/**
- * Set response_finished_key for subsequent use. It must be done before any
- * calling to hmac_update().
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx  Pointer to HMAC context.
- *
- * @retval true   The key is set successfully.
- * @retval false  The key is set unsuccessfully.
- **/
 bool libspdm_hmac_init_with_response_finished_key(
     void *spdm_secured_message_context, void *hmac_ctx)
 {
@@ -772,16 +684,6 @@ bool libspdm_hmac_init_with_response_finished_key(
         secured_message_context->hash_size);
 }
 
-/**
- * Makes a copy of an existing HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  new_hmac_ctx  Pointer to new HMAC context.
- *
- * @retval true   HMAC context copy succeeded.
- * @retval false  HMAC context copy failed.
- **/
 bool libspdm_hmac_duplicate_with_response_finished_key(
     void *spdm_secured_message_context,
     const void *hmac_ctx, void *new_hmac_ctx)
@@ -792,17 +694,6 @@ bool libspdm_hmac_duplicate_with_response_finished_key(
     return libspdm_hmac_duplicate(secured_message_context->base_hash_algo, hmac_ctx, new_hmac_ctx);
 }
 
-/**
- * Digests the input data and updates HMAC context, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  data              Pointer to the buffer containing the data to be digested.
- * @param  data_size          size of data buffer in bytes.
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
 bool libspdm_hmac_update_with_response_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx, const void *data,
@@ -814,16 +705,6 @@ bool libspdm_hmac_update_with_response_finished_key(
     return libspdm_hmac_update(secured_message_context->base_hash_algo, hmac_ctx, data, data_size);
 }
 
-/**
- * Completes computation of the HMAC digest value, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  hmac_ctx     Pointer to HMAC context being copied.
- * @param  hmac_value          Pointer to a buffer that receives the HMAC digest value
- *
- * @retval true   HMAC data digest succeeded.
- * @retval false  HMAC data digest failed.
- **/
 bool libspdm_hmac_final_with_response_finished_key(
     void *spdm_secured_message_context,
     void *hmac_ctx,  uint8_t *hmac_value)
@@ -834,17 +715,6 @@ bool libspdm_hmac_final_with_response_finished_key(
     return libspdm_hmac_final(secured_message_context->base_hash_algo, hmac_ctx, hmac_value);
 }
 
-/**
- * Computes the HMAC of a input data buffer, with response_finished_key.
- *
- * @param  spdm_secured_message_context    A pointer to the SPDM secured message context.
- * @param  data                         Pointer to the buffer containing the data to be HMACed.
- * @param  data_size                     size of data buffer in bytes.
- * @param  hash_value                    Pointer to a buffer that receives the HMAC value.
- *
- * @retval true   HMAC computation succeeded.
- * @retval false  HMAC computation failed.
- **/
 bool libspdm_hmac_all_with_response_finished_key(
     void *spdm_secured_message_context, const void *data,
     size_t data_size, uint8_t *hmac_value)

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_common.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -44,32 +44,6 @@ libspdm_return_t libspdm_mctp_decode_message(uint32_t **session_id,
                                              size_t *message_size,
                                              void **message);
 
-/**
- * Encode an SPDM or APP message to a transport layer message.
- *
- * For normal SPDM message, it adds the transport layer wrapper.
- * For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
- * For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
- *
- * The APP message is encoded to a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              Indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a source buffer to store the message.
- *                                 For normal message, it shall point to the acquired sender buffer.
- *                                 For secured message, it shall point to the scratch buffer in spdm_context.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a destination buffer to store the transport message.
- *                                 On input, it shall be msg_buf_ptr from sender buffer.
- *                                 On output, it will point to acquired sender buffer.
- **/
 libspdm_return_t libspdm_transport_mctp_encode_message(
     void *spdm_context, const uint32_t *session_id, bool is_app_message,
     bool is_request_message, size_t message_size, void *message,
@@ -164,32 +138,6 @@ libspdm_return_t libspdm_transport_mctp_encode_message(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode an SPDM or APP message from a transport layer message.
- *
- * For normal SPDM message, it removes the transport layer wrapper,
- * For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- * For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- *
- * The APP message is decoded from a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              Indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- *                                 For normal message or secured message, it shall point to acquired receiver buffer.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a destination buffer to store the message.
- *                                 On input, it shall point to the scratch buffer in spdm_context.
- *                                 On output, for normal message, it will point to the original receiver buffer.
- *                                 On output, for secured message, it will point to the scratch buffer in spdm_context.
- **/
 libspdm_return_t libspdm_transport_mctp_decode_message(
     void *spdm_context, uint32_t **session_id,
     bool *is_app_message, bool is_request_message,

--- a/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
+++ b/library/spdm_transport_mctp_lib/libspdm_mctp_mctp.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,19 +10,6 @@
 #include "hal/library/debuglib.h"
 #include "hal/library/memlib.h"
 
-/**
- * Get sequence number in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @param sequence_number        The current sequence number used to encode or decode message.
- * @param sequence_number_buffer  A buffer to hold the sequence number output used in the secured message.
- *                             The size in byte of the output buffer shall be 8.
- *
- * @return size in byte of the sequence_number_buffer.
- *        It shall be no greater than 8.
- *        0 means no sequence number is required.
- **/
 uint8_t libspdm_mctp_get_sequence_number(uint64_t sequence_number,
                                          uint8_t *sequence_number_buffer)
 {
@@ -31,28 +18,11 @@ uint8_t libspdm_mctp_get_sequence_number(uint64_t sequence_number,
     return LIBSPDM_MCTP_SEQUENCE_NUMBER_COUNT;
 }
 
-/**
- * Return max random number count in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @return Max random number count in an SPDM secured message.
- *        0 means no random number is required.
- **/
 uint32_t libspdm_mctp_get_max_random_number_count(void)
 {
     return LIBSPDM_MCTP_MAX_RANDOM_NUMBER_COUNT;
 }
 
-/**
- * This function translates the negotiated secured_message_version to a DSP0277 version.
- *
- * @param  secured_message_version  The version specified in binding specification and
- *                                  negotiated in KEY_EXCHANGE/KEY_EXCHANGE_RSP.
- *
- * @return The DSP0277 version specified in binding specification,
- *         which is bound to secured_message_version.
- */
 spdm_version_number_t libspdm_mctp_get_secured_spdm_version(
     spdm_version_number_t secured_message_version)
 {

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_common.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -41,32 +41,6 @@ libspdm_return_t libspdm_pci_doe_decode_message(uint32_t **session_id,
                                                 size_t *message_size,
                                                 void **message);
 
-/**
- * Encode an SPDM or APP message to a transport layer message.
- *
- * For normal SPDM message, it adds the transport layer wrapper.
- * For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
- * For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
- *
- * The APP message is encoded to a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              Indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a source buffer to store the message.
- *                                 For normal message, it shall point to the acquired sender buffer.
- *                                 For secured message, it shall point to the scratch buffer in spdm_context.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a destination buffer to store the transport message.
- *                                 On input, it shall be msg_buf_ptr from sender buffer.
- *                                 On output, it will point to acquired sender buffer.
- **/
 libspdm_return_t libspdm_transport_pci_doe_encode_message(
     void *spdm_context, const uint32_t *session_id, bool is_app_message,
     bool is_request_message, size_t message_size, void *message,
@@ -138,32 +112,6 @@ libspdm_return_t libspdm_transport_pci_doe_encode_message(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode an SPDM or APP message from a transport layer message.
- *
- * For normal SPDM message, it removes the transport layer wrapper,
- * For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- * For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- *
- * The APP message is decoded from a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              Indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- *                                 For normal message or secured message, it shall point to acquired receiver buffer.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a destination buffer to store the message.
- *                                 On input, it shall point to the scratch buffer in spdm_context.
- *                                 On output, for normal message, it will point to the original receiver buffer.
- *                                 On output, for secured message, it will point to the scratch buffer in spdm_context.
- **/
 libspdm_return_t libspdm_transport_pci_doe_decode_message(
     void *spdm_context, uint32_t **session_id,
     bool *is_app_message, bool is_request_message,

--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -10,19 +10,6 @@
 #include "hal/library/debuglib.h"
 #include "hal/library/memlib.h"
 
-/**
- * Get sequence number in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @param sequence_number        The current sequence number used to encode or decode message.
- * @param sequence_number_buffer  A buffer to hold the sequence number output used in the secured message.
- *                             The size in byte of the output buffer shall be 8.
- *
- * @return size in byte of the sequence_number_buffer.
- *        It shall be no greater than 8.
- *        0 means no sequence number is required.
- **/
 uint8_t libspdm_pci_doe_get_sequence_number(uint64_t sequence_number,
                                             uint8_t *sequence_number_buffer)
 {
@@ -31,28 +18,11 @@ uint8_t libspdm_pci_doe_get_sequence_number(uint64_t sequence_number,
     return LIBSPDM_PCI_DOE_SEQUENCE_NUMBER_COUNT;
 }
 
-/**
- * Return max random number count in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @return Max random number count in an SPDM secured message.
- *        0 means no random number is required.
- **/
 uint32_t libspdm_pci_doe_get_max_random_number_count(void)
 {
     return LIBSPDM_PCI_DOE_MAX_RANDOM_NUMBER_COUNT;
 }
 
-/**
- * This function translates the negotiated secured_message_version to a DSP0277 version.
- *
- * @param  secured_message_version  The version specified in binding specification and
- *                                  negotiated in KEY_EXCHANGE/KEY_EXCHANGE_RSP.
- *
- * @return The DSP0277 version specified in binding specification,
- *         which is bound to secured_message_version.
- */
 spdm_version_number_t libspdm_pci_doe_get_secured_spdm_version(
     spdm_version_number_t secured_message_version)
 {
@@ -295,17 +265,6 @@ libspdm_return_t libspdm_pci_doe_decode_discovery_request(size_t transport_messa
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode a DOE discovery request message to get the DOE Discovery Version field.
- * DOE Discovery Version is introduced in PCIe Spec 6.1 Section 6.30.1.1.
- *
- * @param  transport_message_size               Size in bytes of the transport message data buffer.
- * @param  transport_message                    A pointer to a source buffer to store the transport message.
- * @param  version                              A pointer to a destination to store the DOE Discovery Version.
- *
- * @retval LIBSPDM_STATUS_SUCCESS               The message is encoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_PARAMETER     The message is NULL or the message_size is zero.
- **/
 libspdm_return_t libspdm_pci_doe_decode_discovery_request_version(size_t transport_message_size,
                                                                   const void *transport_message,
                                                                   uint8_t *version)
@@ -399,17 +358,6 @@ libspdm_return_t libspdm_pci_doe_decode_discovery_response(size_t transport_mess
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Return the maximum transport layer message header size.
- *   Transport Message Header Size + sizeof(spdm_secured_message_cipher_header_t))
- *
- *   For MCTP, Transport Message Header Size = sizeof(mctp_message_header_t)
- *   For PCI_DOE, Transport Message Header Size = sizeof(pci_doe_data_object_header_t)
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- *
- * @return size of maximum transport layer message header size
- **/
 uint32_t libspdm_transport_pci_doe_get_header_size(
     void *spdm_context)
 {

--- a/library/spdm_transport_storage_lib/libspdm_storage.c
+++ b/library/spdm_transport_storage_lib/libspdm_storage.c
@@ -238,22 +238,6 @@ static libspdm_return_t libspdm_storage_secured_message_encode(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode an Security Protocol Command message to a normal message or secured message.
- *
- * @param  session_id                  Indicates if it is a secured message protected via SPDM session.
- *                                     If *session_id is NULL, it is a normal message.
- *                                     If *session_id is NOT NULL, it is a secured message.
- * @param  connection_id               Indicates the connection ID of the message.
- * @param  transport_message_size      size in bytes of the transport message data buffer.
- * @param  transport_message           A pointer to a source buffer to store the transport message.
- * @param  message_size                size in bytes of the message data buffer.
- * @param  message                     A pointer to a destination buffer to store the message.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is encoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the transport_message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- **/
 libspdm_return_t libspdm_storage_decode_message(uint32_t **session_id,
                                                 uint8_t *connection_id,
                                                 size_t transport_message_size,
@@ -330,37 +314,6 @@ libspdm_return_t libspdm_storage_decode_message(uint32_t **session_id,
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode an SPDM or APP message from a storage transport layer message.
- *
- * For normal SPDM message, it removes the transport layer wrapper,
- * For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- * For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- *
- * The APP message is decoded from a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- * Take MCTP as example: APP message == MCTP header (MCTP_MESSAGE_TYPE_SPDM) + SPDM message
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              On entry, indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- *                                 For normal message or secured message, it shall point to acquired receiver buffer.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a destination buffer to store the message.
- *                                 On input, it shall point to the scratch buffer in spdm_context.
- *                                 On output, for normal message, it will point to the original receiver buffer.
- *                                 On output, for secured message, it will point to the scratch buffer in spdm_context.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is decoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP      The transport_message is unsupported.
- **/
 libspdm_return_t libspdm_transport_storage_decode_message(
     void *spdm_context, uint32_t **session_id,
     bool *is_app_message, bool is_request_message,
@@ -525,24 +478,6 @@ libspdm_return_t libspdm_transport_storage_decode_message(
     }
 }
 
-/**
- * Encode a normal message or secured message to a storage transport message.
- *
- * @param  session_id                  Indicates if it is a secured message protected via SPDM session.
- *                                     If *session_id is NULL, it is a normal message.
- *                                     If *session_id is NOT NULL, it is a secured message.
- * @param  connection_id               Indicates the connection ID of the message.
- * @param  message_size                size in bytes of the message data buffer.
- * @param  message                     A pointer to a destination buffer to store the message.
- * @param  transport_message_size      Size in bytes of the transport message data buffer.
- *                                     On return, length of the transport message.
- * @param  transport_message           A pointer to a source buffer to store the transport message.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is encoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size/transport_message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL     Insufficient transport buffer size.
- **/
 libspdm_return_t libspdm_storage_encode_message(const uint32_t *session_id,
                                                 uint8_t connection_id,
                                                 size_t message_size, void *message,
@@ -604,29 +539,6 @@ libspdm_return_t libspdm_storage_encode_message(const uint32_t *session_id,
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Encode an SPDM or APP message into a transport layer message.
- *
- * @param  spdm_context            A pointer to the SPDM context.
- * @param  session_id              Indicates if it is a secured message protected via SPDM session.
- *                                 If session_id is NULL, it is a normal message.
- *                                 If session_id is not NULL, it is a secured message.
- * @param  is_app_message          Indicates if it is an APP message or SPDM message.
- * @param  is_request_message      Indicates if it is a request message.
- * @param  message_size            Size in bytes of the message data buffer.
- * @param  message                 A pointer to a destination buffer to store the message.
- *                                 On input, it shall point to the scratch buffer in spdm_context.
- *                                 On output, for normal message, it will point to the original receiver buffer.
- *                                 On output, for secured message, it will point to the scratch buffer in spdm_context.
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- *                                 For normal message or secured message, it shall point to acquired receiver buffer.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is decoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP      The transport_message is unsupported.
- **/
 libspdm_return_t libspdm_transport_storage_encode_message(
     void *spdm_context, const uint32_t *session_id,
     bool is_app_message,
@@ -735,23 +647,6 @@ libspdm_return_t libspdm_transport_storage_encode_message(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Encode a storage transport management command, supports only Discovery and
- * Pending Info.
- *
- * @param  cmd_direction           Specify the direction of the command IF_SEND/RECV
- * @param  transport_operation     Transport operation type, Discovery/Pending Info
- * @param  connection_id           SPDM Connection ID
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- *                                 On return, the length of the encoded message
- * @param  allocation_length       Storage buffer allocation length
- * @param  transport_message       A pointer to a transport message buffer.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is encoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL     Insufficient transport buffer size
- **/
 libspdm_return_t libspdm_transport_storage_encode_management_cmd(
     uint8_t cmd_direction, uint8_t transport_operation,
     uint8_t connection_id, size_t *transport_message_size,
@@ -815,17 +710,6 @@ libspdm_return_t libspdm_transport_storage_encode_management_cmd(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Encode a storage transport discovery response. As defined by the DMTF DSP0286
- *
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- *                                 On return, the size of the response
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is decoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL     @transport_message is too small
- **/
 libspdm_return_t libspdm_transport_storage_encode_discovery_response(
     size_t *transport_message_size,
     void *transport_message)
@@ -859,21 +743,6 @@ libspdm_return_t libspdm_transport_storage_encode_discovery_response(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Encode a storage transport pending response. As defined by the DMTF DSP0286
- *
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- *                                 On return, the size of the response
- * @param  transport_message       A pointer to a source buffer to store the transport message.
- * @param  response_pending        If true, the responder has a pending response
- * @param  pending_response_length Valid only if @response_pending is true,
- *                                 specifies the length of the pending message
- *                                 in bytes.
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is decoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL     @transport_message is too small
- **/
 libspdm_return_t libspdm_transport_storage_encode_pending_info_response(
     size_t *transport_message_size,
     void *transport_message, bool response_pending,
@@ -906,18 +775,6 @@ libspdm_return_t libspdm_transport_storage_encode_pending_info_response(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode a storage transport management command
- *
- * @param  transport_message_size  Size in bytes of the transport message data buffer.
- * @param  transport_message       A pointer to an encoded transport message buffer.
- * @param  transport_command       Storage transport command contained in transport message
- *
- * @retval LIBSPDM_STATUS_SUCCESS              The message is decoded successfully.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE     The message is NULL or the message_size is zero.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD    The message field is incorrect.
- * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP      The transport_message is unsupported.
- **/
 libspdm_return_t libspdm_transport_storage_decode_management_cmd(
     size_t transport_message_size,
     const void *transport_message,

--- a/library/spdm_transport_tcp_lib/libspdm_tcp_common.c
+++ b/library/spdm_transport_tcp_lib/libspdm_tcp_common.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -42,31 +42,6 @@ libspdm_return_t libspdm_tcp_decode_message(uint32_t **session_id,
                                             size_t *message_size,
                                             void **message);
 
-/**
- * Encode an SPDM or APP message to a transport layer message.
- *
- * For normal SPDM message, it adds the transport layer wrapper.
- * For secured SPDM message, it encrypts a secured message then adds the transport layer wrapper.
- * For secured APP message, it encrypts a secured message then adds the transport layer wrapper.
- *
- * The APP message is encoded to a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    Indicates if it is a secured message protected via SPDM session.
- *                                     If session_id is NULL, it is a normal message.
- *                                     If session_id is NOT NULL, it is a secured message.
- * @param  is_app_message                 Indicates if it is an APP message or SPDM message.
- * @param  is_requester                  Indicates if it is a requester message.
- * @param  message_size                  size in bytes of the message data buffer.
- * @param  message                      A pointer to a source buffer to store the message.
- *                                      For normal message, it shall point to the acquired sender buffer.
- *                                      For secured message, it shall point to the scratch buffer in spdm_context.
- * @param  transport_message_size         size in bytes of the transport message data buffer.
- * @param  transport_message             A pointer to a destination buffer to store the transport message.
- *                                      On input, it shall be msg_buf_ptr from sender buffer.
- *                                      On output, it will point to acquired sender buffer.
- **/
 libspdm_return_t libspdm_transport_tcp_encode_message(
     void *spdm_context, const uint32_t *session_id, bool is_app_message,
     bool is_requester, size_t message_size, void *message,
@@ -156,31 +131,6 @@ libspdm_return_t libspdm_transport_tcp_encode_message(
     return LIBSPDM_STATUS_SUCCESS;
 }
 
-/**
- * Decode an SPDM or APP message from a transport layer message.
- *
- * For normal SPDM message, it removes the transport layer wrapper,
- * For secured SPDM message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- * For secured APP message, it removes the transport layer wrapper, then decrypts and verifies a secured message.
- *
- * The APP message is decoded from a secured message directly in SPDM session.
- * The APP message format is defined by the transport layer.
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- * @param  session_id                    Indicates if it is a secured message protected via SPDM session.
- *                                     If *session_id is NULL, it is a normal message.
- *                                     If *session_id is NOT NULL, it is a secured message.
- * @param  is_app_message                 Indicates if it is an APP message or SPDM message.
- * @param  is_requester                  Indicates if it is a requester message.
- * @param  transport_message_size         size in bytes of the transport message data buffer.
- * @param  transport_message             A pointer to a source buffer to store the transport message.
- *                                      For normal message or secured message, it shall point to acquired receiver buffer.
- * @param  message_size                  size in bytes of the message data buffer.
- * @param  message                      A pointer to a destination buffer to store the message.
- *                                      On input, it shall point to the scratch buffer in spdm_context.
- *                                      On output, for normal message, it will point to the original receiver buffer.
- *                                      On output, for secured message, it will point to the scratch buffer in spdm_context.
- **/
 libspdm_return_t libspdm_transport_tcp_decode_message(
     void *spdm_context, uint32_t **session_id,
     bool *is_app_message, bool is_requester,

--- a/library/spdm_transport_tcp_lib/libspdm_tcp_tcp.c
+++ b/library/spdm_transport_tcp_lib/libspdm_tcp_tcp.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -9,47 +9,17 @@
 #include "hal/library/memlib.h"
 #include "industry_standard/spdm_tcp_binding.h"
 
-/**
- * Get sequence number in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @param sequence_number        The current sequence number used to encode or decode message.
- * @param sequence_number_buffer  A buffer to hold the sequence number output used in the secured message.
- *                             The size in byte of the output buffer shall be 8.
- *
- * @return size in byte of the sequence_number_buffer.
- *        It shall be no greater than 8.
- *        0 means no sequence number is required.
- **/
 uint8_t libspdm_tcp_get_sequence_number(uint64_t sequence_number,
                                         uint8_t *sequence_number_buffer)
 {
     return SPDM_TCP_SEQUENCE_NUMBER_COUNT;
 }
 
-/**
- * Return max random number count in an SPDM secure message.
- *
- * This value is transport layer specific.
- *
- * @return Max random number count in an SPDM secured message.
- *        0 means no randum number is required.
- **/
 uint32_t libspdm_tcp_get_max_random_number_count(void)
 {
     return SPDM_TCP_MAX_RANDOM_NUMBER_COUNT;
 }
 
-/**
- * This function translates the negotiated secured_message_version to a DSP0277 version.
- *
- * @param  secured_message_version  The version specified in binding specification and
- *                                  negotiated in KEY_EXCHANGE/KEY_EXCHANGE_RSP.
- *
- * @return The DSP0277 version specified in binding specification,
- *         which is bound to secured_message_version.
- */
 spdm_version_number_t libspdm_tcp_get_secured_spdm_version(
     spdm_version_number_t secured_message_version)
 {
@@ -160,22 +130,6 @@ libspdm_return_t libspdm_tcp_decode_message(uint32_t **session_id,
 }
 
 
-/**
- * @brief Encode a SPDM-over-TCP message that contains no SPDM payload.
- *
- * This function builds a TCP binding header suitable for Role-Inquiry (0xBF) or
- * any error message (0xC0-0xFF). It does not append any SPDM data after the header.
- *
- * @param[in]      message_type            The message type to encode (e.g., 0xBF, 0xC0...0xFF).
- *                                         Must be SPDM_TCP_MESSAGE_TYPE_ROLE_INQUIRY or an error message type.
- * @param[in,out]  transport_message_size  On input, size of the output buffer. On output, encoded size.
- * @param[in,out]  transport_message       On input, pointer to buffer to write the encoded message.
- *                                         On success, contains the encoded message header.
- *
- * @retval LIBSPDM_STATUS_SUCCESS            Encoding completed successfully.
- * @retval LIBSPDM_STATUS_INVALID_PARAMETER  Unsupported message type for this function.
- * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL   Provided buffer is too small for header.
- **/
 libspdm_return_t libspdm_tcp_encode_discovery_message(uint8_t message_type,
                                                       size_t *transport_message_size,
                                                       void **transport_message)
@@ -202,20 +156,6 @@ libspdm_return_t libspdm_tcp_encode_discovery_message(uint8_t message_type,
 }
 
 
-/**
- * @brief Decode a SPDM-over-TCP discovery or error message (no SPDM payload).
- *
- * Validates header fields including binding version, payload length, and message type.
- *
- * @param[in]  transport_message_size   Size of the incoming buffer.
- * @param[in]  transport_message        Pointer to the incoming buffer.
- * @param[out] message_type             On success, receives the validated message type.
- *
- * @retval LIBSPDM_STATUS_SUCCESS             Decoding successful.
- * @retval LIBSPDM_STATUS_INVALID_MSG_SIZE    Buffer too small for TCP header.
- * @retval LIBSPDM_STATUS_UNSUPPORTED_CAP     Unsupported binding version.
- * @retval LIBSPDM_STATUS_INVALID_MSG_FIELD   Payload length is non-zero or message type invalid.
- **/
 libspdm_return_t libspdm_tcp_decode_discovery_message(size_t transport_message_size,
                                                       const void *transport_message,
                                                       uint8_t *message_type)
@@ -246,17 +186,6 @@ libspdm_return_t libspdm_tcp_decode_discovery_message(size_t transport_message_s
 }
 
 
-/**
- * Return the maximum transport layer message header size.
- *   Transport Message Header Size + sizeof(spdm_secured_message_cipher_header_t))
- *
- *   For TCP, Transport Message Header Size = sizeof(tcp_spdm_binding_header_t)
- *   For PCI_DOE, Transport Message Header Size = sizeof(pci_doe_data_object_header_t)
- *
- * @param  spdm_context                  A pointer to the SPDM context.
- *
- * @return size of maximum transport layer message header size
- **/
 uint32_t libspdm_transport_tcp_get_header_size(
     void *spdm_context)
 {


### PR DESCRIPTION
Fix #1273.