### PR TITLE
Remove `const` for pass-by-value parameters

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -1227,7 +1227,7 @@ size_t libspdm_get_opaque_data_version_selection_data_size(const libspdm_context
  *
  * @return the SPDMversion of the version number struct.
  **/
-uint8_t libspdm_get_version_from_version_number(const spdm_version_number_t ver);
+uint8_t libspdm_get_version_from_version_number(spdm_version_number_t ver);
 
 /**
  * Sort SPDMversion in descending order.

--- a/include/internal/libspdm_requester_lib.h
+++ b/include/internal/libspdm_requester_lib.h
@@ -650,7 +650,7 @@ bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
  **/
 bool libspdm_verify_key_exchange_rsp_signature(
     libspdm_context_t *spdm_context, libspdm_session_info_t *session_info,
-    const void *sign_data, const size_t sign_data_size);
+    const void *sign_data, size_t sign_data_size);
 
 #if LIBSPDM_ENABLE_CAPABILITY_MEAS_CAP
 /**

--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -932,7 +932,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
 bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
                                          libspdm_session_info_t *session_info,
                                          const void *sign_data,
-                                         const size_t sign_data_size);
+                                         size_t sign_data_size);
 #endif
 
 /**

--- a/include/internal/libspdm_secured_message_lib.h
+++ b/include/internal/libspdm_secured_message_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -133,8 +133,8 @@ void libspdm_secured_message_set_session_type(void *spdm_secured_message_context
  * @param  key_schedule                  Indicate the negotiated key_schedule for the SPDM session.
  */
 void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
-                                            const spdm_version_number_t version,
-                                            const spdm_version_number_t secured_message_version,
+                                            spdm_version_number_t version,
+                                            spdm_version_number_t secured_message_version,
                                             uint32_t base_hash_algo,
                                             uint16_t dhe_named_group,
                                             uint32_t kem_alg,

--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1038,7 +1038,7 @@ bool libspdm_is_root_certificate(const uint8_t *cert, size_t cert_size);
  * @retval false   Get the subjectAltName string failed
  **/
 bool libspdm_get_dmtf_subject_alt_name_from_bytes(
-    uint8_t *buffer, const size_t len, char *name_buffer,
+    uint8_t *buffer, size_t len, char *name_buffer,
     size_t *name_buffer_size, uint8_t *oid,
     size_t *oid_size);
 
@@ -1061,7 +1061,7 @@ bool libspdm_get_dmtf_subject_alt_name_from_bytes(
  * @retval true    Get the subjectAltName string successfully
  * @retval false   Get the subjectAltName string failed
  **/
-bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const size_t cert_size,
+bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, size_t cert_size,
                                        char *name_buffer,
                                        size_t *name_buffer_size,
                                        uint8_t *oid, size_t *oid_size);

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -3062,7 +3062,7 @@ size_t libspdm_get_context_size_without_secured_context(void)
     return size;
 }
 
-uint8_t libspdm_get_version_from_version_number(const spdm_version_number_t ver)
+uint8_t libspdm_get_version_from_version_number(spdm_version_number_t ver)
 {
     return (uint8_t)(ver >> SPDM_VERSION_NUMBER_SHIFT_BIT);
 }

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -1734,7 +1734,7 @@ bool libspdm_is_root_certificate(const uint8_t *cert, size_t cert_size)
 }
 
 bool libspdm_get_dmtf_subject_alt_name_from_bytes(
-    uint8_t *buffer, const size_t len, char *name_buffer,
+    uint8_t *buffer, size_t len, char *name_buffer,
     size_t *name_buffer_size, uint8_t *oid,
     size_t *oid_size)
 {
@@ -1831,7 +1831,7 @@ bool libspdm_get_dmtf_subject_alt_name_from_bytes(
     return false;
 }
 
-bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, const size_t cert_size,
+bool libspdm_get_dmtf_subject_alt_name(const uint8_t *cert, size_t cert_size,
                                        char *name_buffer,
                                        size_t *name_buffer_size,
                                        uint8_t *oid, size_t *oid_size)

--- a/library/spdm_requester_lib/libspdm_req_key_exchange.c
+++ b/library/spdm_requester_lib/libspdm_req_key_exchange.c
@@ -114,7 +114,7 @@ bool libspdm_verify_key_exchange_rsp_hmac(libspdm_context_t *spdm_context,
 
 bool libspdm_verify_key_exchange_rsp_signature(
     libspdm_context_t *spdm_context, libspdm_session_info_t *session_info,
-    const void *sign_data, const size_t sign_data_size)
+    const void *sign_data, size_t sign_data_size)
 {
     bool result;
     void *context;

--- a/library/spdm_responder_lib/libspdm_rsp_finish.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish.c
@@ -108,7 +108,7 @@ bool libspdm_verify_finish_req_hmac(libspdm_context_t *spdm_context,
 bool libspdm_verify_finish_req_signature(libspdm_context_t *spdm_context,
                                          libspdm_session_info_t *session_info,
                                          const void *sign_data,
-                                         const size_t sign_data_size)
+                                         size_t sign_data_size)
 {
     bool result;
     void *context;

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -365,8 +365,7 @@ libspdm_return_t libspdm_terminate_session(
  * @param  connection_state              Indicate the SPDM connection state.
  **/
 static void libspdm_trigger_connection_state_callback(libspdm_context_t *spdm_context,
-                                                      const libspdm_connection_state_t
-                                                      connection_state)
+                                                      libspdm_connection_state_t connection_state)
 {
     if (spdm_context->spdm_connection_state_callback != NULL) {
         ((libspdm_connection_state_callback_func)

--- a/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_context_data.c
@@ -62,8 +62,8 @@ void libspdm_secured_message_set_session_type(void *spdm_secured_message_context
 }
 
 void libspdm_secured_message_set_algorithms(void *spdm_secured_message_context,
-                                            const spdm_version_number_t version,
-                                            const spdm_version_number_t secured_message_version,
+                                            spdm_version_number_t version,
+                                            spdm_version_number_t secured_message_version,
                                             uint32_t base_hash_algo,
                                             uint16_t dhe_named_group,
                                             uint32_t kem_alg,


### PR DESCRIPTION
Fix #3526.