### PR TITLE
Remove `os_stub` from core library build files

### DIFF
--- a/library/spdm_crypt_lib/CMakeLists.txt
+++ b/library/spdm_crypt_lib/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(spdm_crypt_lib STATIC "")
 target_include_directories(spdm_crypt_lib
     PRIVATE
         ${LIBSPDM_DIR}/include
-        ${LIBSPDM_DIR}/os_stub
 )
 
 target_sources(spdm_crypt_lib

--- a/library/spdm_responder_lib/CMakeLists.txt
+++ b/library/spdm_responder_lib/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(spdm_responder_lib STATIC "")
 target_include_directories(spdm_responder_lib
     PRIVATE
         ${LIBSPDM_DIR}/include
-        ${LIBSPDM_DIR}/os_stub
 )
 
 target_sources(spdm_responder_lib


### PR DESCRIPTION
Fix #3547.