### PR TITLE
Rename libspdm_debug_print() to LIBSPDM_DEBUG()

### DIFF
--- a/os_stub/spdm_device_secret_lib_tpm/read_pub_cert.c
+++ b/os_stub/spdm_device_secret_lib_tpm/read_pub_cert.c
@@ -222,8 +222,8 @@ bool libspdm_read_responder_public_certificate_chain_alias_cert_till_dev_cert_ca
     uint32_t base_hash_algo, uint32_t base_asym_algo, void **data,
     size_t *size, void **hash, size_t *hash_size)
 {
-    libspdm_debug_print(LIBSPDM_DEBUG_ERROR,
-                        "libspdm_read_responder_public_certificate_chain_alias_cert_till_dev_cert_ca not yet implemented\n");
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                   "libspdm_read_responder_public_certificate_chain_alias_cert_till_dev_cert_ca not yet implemented\n"));
     return false;
 }
 
@@ -232,7 +232,7 @@ bool libspdm_read_responder_public_certificate_chain_alias_cert(
     uint32_t base_hash_algo, uint32_t base_asym_algo, void **data,
     size_t *size, void **hash, size_t *hash_size)
 {
-    libspdm_debug_print(LIBSPDM_DEBUG_ERROR,
-                        "libspdm_read_responder_public_certificate_chain_alias_cert not yet implemented\n");
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                   "libspdm_read_responder_public_certificate_chain_alias_cert not yet implemented\n"));
     return false;
 }

--- a/os_stub/spdm_device_secret_lib_tpm/sign.c
+++ b/os_stub/spdm_device_secret_lib_tpm/sign.c
@@ -34,11 +34,11 @@ bool libspdm_requester_data_sign(
     void *context = NULL;
     bool result = false;
 
-    libspdm_debug_print(LIBSPDM_DEBUG_INFO, "Loading TPM device");
+    LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "Loading TPM device"));
     libspdm_tpm_device_init();
     result = libspdm_tpm_get_pvt_key_handle(TPM_REQU_HANDLE, &context);
     if (!result){
-        libspdm_debug_print(LIBSPDM_DEBUG_ERROR, "Failed to load requester handle");
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "Failed to load requester handle"));
         return false;
     }
 
@@ -72,7 +72,7 @@ bool libspdm_responder_data_sign(
     libspdm_tpm_device_init();
     result = libspdm_tpm_get_pvt_key_handle(TPM_RESP_HANDLE, &context);
     if (!result){
-        libspdm_debug_print(LIBSPDM_DEBUG_ERROR, "Failed to load responder handle");
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR, "Failed to load responder handle"));
         return false;
     }
 


### PR DESCRIPTION
This fixes compilation errors on Yocto when TPM support is enabled.