### PR TITLE
cmake: cryptlib_openssl: link missing TSS2 dependencies

### DIFF
--- a/os_stub/cryptlib_openssl/CMakeLists.txt
+++ b/os_stub/cryptlib_openssl/CMakeLists.txt
@@ -58,5 +58,5 @@ if (LIBSPDM_TPM_SUPPORT)
     target_sources(cryptlib_openssl
         PRIVATE
             tpm/tpm.c)
-    target_link_libraries(cryptlib_openssl PUBLIC tss2-esys tss2-tctildr tss2-rc)
+    target_link_libraries(cryptlib_openssl PUBLIC tss2-esys tss2-sys tss2-mu tss2-tctildr tss2-rc)
 endif ()


### PR DESCRIPTION
The tss2-esys library depends on tss2-sys and tss2-mu, but these dependencies are not always propagated automatically in certain build environments (e.g. Yocto). This results in unresolved symbols during linking.

Explicitly linking these libraries ensures successful builds when building libspdm with TPM support enabled.