### PR TITLE
Add SPDM v1.4 error codes RequestSessionTerminated and InvalidState

### DIFF
--- a/include/industry_standard/spdm.h
+++ b/include/industry_standard/spdm.h
@@ -1005,6 +1005,8 @@ typedef struct {
 
 /* SPDM error code (1.4) */
 #define SPDM_ERROR_CODE_DATA_TOO_LARGE 0x12
+#define SPDM_ERROR_CODE_REQUEST_SESSION_TERMINATED 0x46
+#define SPDM_ERROR_CODE_INVALID_STATE 0x47
 
 /* SPDM ResponseNotReady extended data */
 typedef struct {


### PR DESCRIPTION
Add the missing SPDM v1.4 error code definitions from DSP0274 Table 65:
- RequestSessionTerminated (0x46)
- InvalidState (0x47)

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>