### PR TITLE
Fix CHUNK_SEND error overwritten by UNSUPPORTED_REQUEST

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -241,6 +241,10 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
             &chunk_response_size, chunk_response);
 
         *response_size = response_header_size + chunk_response_size;
+
+        /* Return success so that libspdm_build_response() does not overwrite
+         * the CHUNK_ACK with EarlyErrorDetected with a generic error. */
+        status = LIBSPDM_STATUS_SUCCESS;
 
         send_info->chunk_in_use = false;
         send_info->chunk_handle = 0;

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -852,7 +852,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case8(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -931,7 +931,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case9(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1009,7 +1009,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case10(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1085,7 +1085,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case11(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1163,7 +1163,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case12(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1252,7 +1252,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case13(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1329,7 +1329,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case14(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1408,7 +1408,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case15(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1485,7 +1485,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case16(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1562,7 +1562,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case17(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1639,7 +1639,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case18(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1719,7 +1719,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case19(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1800,7 +1800,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case20(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 
@@ -1878,7 +1878,7 @@ void libspdm_test_responder_chunk_send_ack_rsp_case21(void** state)
         request_size, request,
         &response_size, response);
 
-    assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
     assert_true(response_size == sizeof(spdm_chunk_send_ack_response_t)
                 + sizeof(spdm_error_response_t));
 


### PR DESCRIPTION
When CHUNK_SEND has an error (wrong handle, bad sequence number, etc.), the responder correctly builds a CHUNK_ACK response with EarlyErrorDetected attribute and an embedded ERROR response. However, libspdm_get_response_chunk_send() returns LIBSPDM_STATUS_INVALID_MSG_FIELD, which causes libspdm_build_response() to overwrite the properly formed CHUNK_ACK with an UNSUPPORTED_REQUEST error.

Fix: Set status to LIBSPDM_STATUS_SUCCESS after constructing the CHUNK_ACK+EarlyErrorDetected response so the caller does not overwrite it.

Update corresponding unit tests to expect LIBSPDM_STATUS_SUCCESS return value.

Fix https://github.com/DMTF/libspdm/issues/3573