### PR TITLE
Reject secured messages with invalid descriptor count

### DIFF
--- a/library/spdm_transport_storage_lib/libspdm_storage.c
+++ b/library/spdm_transport_storage_lib/libspdm_storage.c
@@ -93,6 +93,14 @@ static libspdm_return_t libspdm_storage_secured_message_decode(
     spdm_storage_secured_message_descriptor *descriptor;
     uint8_t num_descriptors = ((uint8_t *)(*message))[0];
 
+    /* Check for invalid message with no descriptors (DSP0286 Table 8) */
+    if (num_descriptors == 0) {
+        spdm_error.session_id = session_id;
+        spdm_error.error_code = SPDM_STORAGE_SECURED_MSG_ENCAPSULATED_STATUS_INVALID_CMD;
+        libspdm_set_last_spdm_error_struct(spdm_context, &spdm_error);
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
+
     /* Currently support handling only a single SPDM descriptor */
     if (num_descriptors > 1) {
         spdm_error.session_id = session_id;


### PR DESCRIPTION
## Summary

In `libspdm_storage_secured_message_decode()`, the guard on `num_descriptors` only rejected values greater than 1 but allowed 0. When `num_descriptors` is 0, the for-loop never executes, leaving `spdm_msg_offset` uninitialized. This uninitialized value is then used as a pointer offset to compute `*message` - undefined behavior on malformed input.

Defense-in-depth hardening fix by changing `if (num_descriptors > 1)` to `if (num_descriptors != 1)`, which matches the existing code comments and the encode side (always writes `num_descriptors = 1`).

Detected using cppcheck with `--check-level=exhaustive` flagged `uninitvar` on `spdm_msg_offset`

## Test plan

- [x] cppcheck `uninitvar` warning eliminated after fix
- [x] Existing CI tests pass