### PR TITLE
Expose `SEND_EVENT_ACK` to Responder dispatch

### DIFF
--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -658,7 +658,7 @@ libspdm_return_t libspdm_process_encap_response_event_ack(
 #endif /* LIBSPDM_ENABLE_CAPABILITY_ENCAP_CAP */
 
 #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
-libspdm_return_t libspdm_get_response_send_event(
+libspdm_return_t libspdm_get_response_event_ack(
     libspdm_context_t *spdm_context, size_t request_size, const void *request,
     size_t *response_size, void *response);
 #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */

--- a/library/spdm_responder_lib/libspdm_rsp_event_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_event_ack.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2025-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -9,11 +9,11 @@
 
 #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
 
-libspdm_return_t libspdm_get_response_send_event(libspdm_context_t *spdm_context,
-                                                 size_t request_size,
-                                                 const void *request,
-                                                 size_t *response_size,
-                                                 void *response)
+libspdm_return_t libspdm_get_response_event_ack(libspdm_context_t *spdm_context,
+                                                size_t request_size,
+                                                const void *request,
+                                                size_t *response_size,
+                                                void *response)
 {
     const spdm_send_event_request_t *spdm_request;
     spdm_event_ack_response_t *spdm_response;

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -99,6 +99,10 @@ libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_
         { SPDM_SUBSCRIBE_EVENT_TYPES, libspdm_get_response_subscribe_event_types_ack },
         #endif /* LIBSPDM_ENABLE_CAPABILITY_EVENT_CAP */
 
+        #if LIBSPDM_EVENT_RECIPIENT_SUPPORT
+        { SPDM_SEND_EVENT, libspdm_get_response_event_ack },
+        #endif /* LIBSPDM_EVENT_RECIPIENT_SUPPORT */
+
         #if LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES
         { SPDM_VENDOR_DEFINED_REQUEST, libspdm_get_vendor_defined_response },
         #endif /*LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES*/

--- a/unit_test/test_spdm_responder/error_test/event_ack_err.c
+++ b/unit_test/test_spdm_responder/error_test/event_ack_err.c
@@ -154,7 +154,7 @@ static void rsp_event_ack_err_case1(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size;
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -232,7 +232,7 @@ static void rsp_event_ack_err_case2(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -290,7 +290,7 @@ static void rsp_event_ack_err_case3(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size;
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -348,7 +348,7 @@ static void rsp_event_ack_err_case4(void **state)
     /* request_size is not exact (+ 1). */
     request_size = sizeof(spdm_send_event_request_t) + event_data_size + 1;
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -400,7 +400,7 @@ static void rsp_event_ack_err_case5(void **state)
 
     request_size = sizeof(spdm_send_event_request_t);
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -453,7 +453,7 @@ static void rsp_event_ack_err_case6(void **state)
 
     request_size = sizeof(spdm_send_event_request_t);
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -505,7 +505,7 @@ static void rsp_event_ack_err_case7(void **state)
 
     request_size = sizeof(spdm_send_event_request_t);
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -565,7 +565,7 @@ static void rsp_event_ack_err_case8(void **state)
     /* Induce error in process_request. */
     m_process_event_error = true;
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 

--- a/unit_test/test_spdm_responder/event_ack.c
+++ b/unit_test/test_spdm_responder/event_ack.c
@@ -154,7 +154,7 @@ static void rsp_event_ack_case1(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size;
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -237,7 +237,7 @@ static void rsp_event_ack_case2(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -320,7 +320,7 @@ static void rsp_event_ack_case3(void **state)
 
     request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1];
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 
@@ -435,7 +435,7 @@ static void rsp_event_ack_case4(void **state)
     request_size = sizeof(spdm_send_event_request_t) + event_data_size[0] + event_data_size[1] +
                    event_data_size[2] + event_data_size[3];
 
-    status = libspdm_get_response_send_event(
+    status = libspdm_get_response_event_ack(
         spdm_context, request_size, m_spdm_request_buffer,
         &response_size, m_spdm_response_buffer);
 


### PR DESCRIPTION
Fix #3589.

This pull request also renames the function to the correct name.