### PR TITLE
fix: correct typos in chunk processing and challenge logic

### DIFF
--- a/unit_test/test_spdm_requester/challenge.c
+++ b/unit_test/test_spdm_requester/challenge.c
@@ -470,7 +470,7 @@ static libspdm_return_t receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
-    case 0x8: { /*correct ERROR message (response net ready)*/
+    case 0x8: { /*correct ERROR message (response not ready)*/
         spdm_error_response_data_response_not_ready_t *spdm_response;
         size_t spdm_response_size;
         size_t transport_header_size;

--- a/unit_test/test_spdm_requester/chunk_get.c
+++ b/unit_test/test_spdm_requester/chunk_get.c
@@ -1199,7 +1199,7 @@ int libspdm_req_chunk_get_test(void)
         /* Request Vendor Specific Response and chunk seq no wrapped */
         cmocka_unit_test(req_chunk_get_case6),
         /* Request Vendor Specific Response
-         * and recieve error code RequestResync */
+         * and receive error code RequestResync */
         cmocka_unit_test(req_chunk_get_case7),
 #endif
 #if LIBSPDM_SEND_GET_CERTIFICATE_SUPPORT

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -803,7 +803,7 @@ int libspdm_req_chunk_send_test(void)
         /* Request size exceed max chunks */
         cmocka_unit_test(req_chunk_send_case13),
 #endif
-        /* Recieved and error message indicating RequestResynch */
+        /* Received and error message indicating RequestResynch */
         cmocka_unit_test(req_chunk_send_case14),
         /* Request Algorithms successfully sent in chunks, with SPDM 1.4 */
         cmocka_unit_test(req_chunk_send_case15),


### PR DESCRIPTION
- Fix spelling of "receive" and "received" in chunk_get.c and chunk_send.c.
- Fix typo "net" to "not" in challenge.c to clarify conditional logic.