### PR TITLE
libspdm_rsp_algorithms: Add a callback on successfull negotiation

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -564,6 +564,8 @@ typedef struct {
     libspdm_transport_encode_message_func transport_encode_message;
     libspdm_transport_decode_message_func transport_decode_message;
 
+    libspdm_device_algs_negotiated_func algs_negotiated;
+
     /* Cached plain text command
      * If the command is cipher text, decrypt then cache it. */
     void *last_spdm_request;

--- a/include/library/spdm_common_lib.h
+++ b/include/library/spdm_common_lib.h
@@ -528,6 +528,21 @@ typedef libspdm_return_t (*libspdm_device_receive_message_func)(void *spdm_conte
                                                                 uint64_t timeout);
 
 /**
+ * A callback function that is called after a ALGORITHMS have been sucessfully
+ * negotiated by the responder.
+ *
+ * This can be used by implementions to support the SPDM Banked Architecture as
+ * described in section 10.32.1. The idea is that implementations can change
+ * the certificate banks once the algorithm is negotiated.
+ *
+ * @param  spdm_context  A pointer to the SPDM context.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS   The bank was successfully updated.
+ * @retval LIBSPDM_STATUS_INVALID_STATE_LOCAL Unable to update the bank.
+ **/
+typedef libspdm_return_t (*libspdm_device_algs_negotiated_func)(void *spdm_context);
+
+/**
  * Register SPDM device input/output functions.
  *
  * This function must be called after libspdm_init_context, and before any SPDM communication.
@@ -539,6 +554,23 @@ typedef libspdm_return_t (*libspdm_device_receive_message_func)(void *spdm_conte
 void libspdm_register_device_io_func(
     void *spdm_context, libspdm_device_send_message_func send_message,
     libspdm_device_receive_message_func receive_message);
+
+
+/**
+ * Register SPDM responder ALGORITHMS negotiated callback.
+ *
+ * Sets an optional callback function that is called after ALGORITHMS
+ * have been sucessfully negotiated by the responder.
+ *
+ * This can be used by implementions to support the SPDM Banked Architecture as
+ * described in section 10.32.1. The idea is that implementations can change
+ * the certificate banks once the algorithm is negotiated.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ * @param  algs_negotiated               The function callback to be called.
+ **/
+void libspdm_register_rsp_alg_func(
+    void *spdm_context, libspdm_device_algs_negotiated_func algs_negotiated);
 
 /**
  * Acquire a device sender buffer for transport layer message.

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2499,6 +2499,15 @@ void libspdm_register_device_io_func(
     context->receive_message = receive_message;
 }
 
+void libspdm_register_rsp_alg_func(
+    void *spdm_context, libspdm_device_algs_negotiated_func algs_negotiated)
+{
+    libspdm_context_t *context;
+
+    context = spdm_context;
+    context->algs_negotiated = algs_negotiated;
+}
+
 void libspdm_register_device_buffer_func(
     void *spdm_context,
     uint32_t sender_buffer_size,

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -1135,5 +1135,13 @@ libspdm_return_t libspdm_get_response_algorithms(libspdm_context_t *spdm_context
     /* -=[Update State Phase]=- */
     libspdm_set_connection_state(spdm_context, LIBSPDM_CONNECTION_STATE_NEGOTIATED);
 
+    if (spdm_context->algs_negotiated) {
+        if (spdm_context->algs_negotiated(spdm_context) != LIBSPDM_STATUS_SUCCESS) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                                                   response_size, response);
+        }
+    }
+
     return LIBSPDM_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Add a new optional callback that is called when ALGORITHMS are sucessfully negotiated. The idea is that once algorithms are set libspdm can trigger a callback, this allows the main implementation to update the banked certificate chains.

This allows us to support banking, without requiring all of the possible combinations to be set in libspdm arrays.

Note that this doesn't support `SLOT_MGMT_CAP=1`, but that can be added in the future, where the implementer of libspdm can then handle the requests.