### PR TITLE
library/spdm_lib_config: Ensure crypto support is defined early

### DIFF
--- a/include/library/spdm_lib_config.h
+++ b/include/library/spdm_lib_config.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -213,47 +213,6 @@
 #define LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT 0
 #endif
 
-#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
-
-/* This value specifies the maximum size, in bytes, of a certificate chain that can be stored in a
- * libspdm context. */
-#ifndef LIBSPDM_MAX_CERT_CHAIN_SIZE
-/* MLDSA - 0x8000, SLHDSA - 0x28000 */
-#if ((LIBSPDM_SLH_DSA_SHA2_128S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_128S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHA2_128F_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_128F_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHA2_192S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_192S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHA2_192F_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_192F_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHA2_256S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_256S_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHA2_256F_SUPPORT) || \
-    (LIBSPDM_SLH_DSA_SHAKE_256F_SUPPORT))
-#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x28000
-#elif ((LIBSPDM_ML_DSA_44_SUPPORT) || \
-    (LIBSPDM_ML_DSA_65_SUPPORT) || \
-    (LIBSPDM_ML_DSA_87_SUPPORT))
-#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x8000
-#else
-#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x1000
-#endif
-#endif /* LIBSPDM_MAX_CERT_CHAIN_SIZE */
-
-/* This value specifies the maximum size, in bytes, of the MEASUREMENTS.MeasurementRecord field. */
-#ifndef LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE
-#define LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE 0x1000
-#endif
-
-/* This value specifies the maximum size, in bytes, of a endpoint info that can be stored in a
- * libspdm context. */
-#ifndef LIBSPDM_MAX_ENDPOINT_INFO_LENGTH
-#define LIBSPDM_MAX_ENDPOINT_INFO_LENGTH 1024
-#endif
-
-#endif /* LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT */
-
 /* Cryptography Configuration
  * In each category, at least one should be selected.
  * NOTE: Not all combination can be supported. E.g. Don't mix NIST algo with SMx.*/
@@ -433,6 +392,47 @@
 #ifndef LIBSPDM_ML_KEM_1024_SUPPORT
 #define LIBSPDM_ML_KEM_1024_SUPPORT 1
 #endif
+
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+
+/* This value specifies the maximum size, in bytes, of a certificate chain that can be stored in a
+ * libspdm context. */
+#ifndef LIBSPDM_MAX_CERT_CHAIN_SIZE
+/* MLDSA - 0x8000, SLHDSA - 0x28000 */
+#if ((LIBSPDM_SLH_DSA_SHA2_128S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_128S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHA2_128F_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_128F_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHA2_192S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_192S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHA2_192F_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_192F_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHA2_256S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_256S_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHA2_256F_SUPPORT) || \
+    (LIBSPDM_SLH_DSA_SHAKE_256F_SUPPORT))
+#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x28000
+#elif ((LIBSPDM_ML_DSA_44_SUPPORT) || \
+    (LIBSPDM_ML_DSA_65_SUPPORT) || \
+    (LIBSPDM_ML_DSA_87_SUPPORT))
+#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x8000
+#else
+#define LIBSPDM_MAX_CERT_CHAIN_SIZE 0x1000
+#endif
+#endif /* LIBSPDM_MAX_CERT_CHAIN_SIZE */
+
+/* This value specifies the maximum size, in bytes, of the MEASUREMENTS.MeasurementRecord field. */
+#ifndef LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE
+#define LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE 0x1000
+#endif
+
+/* This value specifies the maximum size, in bytes, of a endpoint info that can be stored in a
+ * libspdm context. */
+#ifndef LIBSPDM_MAX_ENDPOINT_INFO_LENGTH
+#define LIBSPDM_MAX_ENDPOINT_INFO_LENGTH 1024
+#endif
+
+#endif /* LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT */
 
 /* If 1 then endpoint supports parsing X.509 certificate chains. */
 #ifndef LIBSPDM_CERT_PARSE_SUPPORT


### PR DESCRIPTION
We need to ensure the crypto macros like
`LIBSPDM_SLH_DSA_SHA2_128S_SUPPORT` and `LIBSPDM_ML_DSA_44_SUPPORT` are defined before the `LIBSPDM_MAX_CERT_CHAIN_SIZE` is defined. Otherwise `LIBSPDM_MAX_CERT_CHAIN_SIZE` will use the incorrect values resulting in a small `LIBSPDM_MAX_CERT_CHAIN_SIZE`.