### PR TITLE
transport/tcp: expose transport haeder and tail sizes

### DIFF
--- a/include/library/spdm_transport_tcp_lib.h
+++ b/include/library/spdm_transport_tcp_lib.h
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2025 DMTF. All rights reserved.
+ *  Copyright 2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 

--- a/include/library/spdm_transport_tcp_lib.h
+++ b/include/library/spdm_transport_tcp_lib.h
@@ -19,6 +19,9 @@
  *
  */
 
+#define LIBSPDM_TCP_TRANSPORT_HEADER_SIZE  (4 + 4 + 2 + 2)
+#define LIBSPDM_TCP_TRANSPORT_TAIL_SIZE    (16 + 3 + 31)
+
 /*
  * Encode an SPDM or APP message to a transport layer message.
  *


### PR DESCRIPTION
Currently the TCP trasnport header does not expose the transport header and tail size unlike the other transports. So expose it.