### PR TITLE
unit_test/test_crypt: Guard EdDSA tests per-algorithm

### DIFF
--- a/unit_test/test_crypt/ecd_verify.c
+++ b/unit_test/test_crypt/ecd_verify.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -17,77 +17,87 @@
  **/
 bool libspdm_validate_crypt_ecd(void)
 {
-    void *ecd1;
-    void *ecd2;
     uint8_t message[] = "EdDsaTest";
-    uint8_t context[] = "EdDsaTestContext";
-    uint8_t signature1[32 * 2];
-    uint8_t signature2[57 * 2];
-    size_t sig1_size;
-    size_t sig2_size;
     bool status;
 
     libspdm_my_print("\nCrypto Ed-DSA Signing Verification Testing:\n");
 
-    libspdm_my_print("- Context1 ... ");
-    ecd1 = libspdm_ecd_new_by_nid(LIBSPDM_CRYPTO_NID_EDDSA_ED25519);
-    if (ecd1 == NULL) {
-        libspdm_my_print("[Fail]");
-        return false;
-    }
+#if LIBSPDM_EDDSA_ED25519_SUPPORT
+    {
+        void *ecd1;
+        uint8_t signature1[32 * 2];
+        size_t sig1_size;
 
-    /* Verify Ed-DSA*/
-    sig1_size = sizeof(signature1);
-    libspdm_my_print("\n- Ed-DSA Signing ... ");
-    status = libspdm_eddsa_sign(ecd1, LIBSPDM_CRYPTO_NID_NULL, NULL, 0, message, sizeof(message),
-                                signature1, &sig1_size);
-    if (!status) {
-        libspdm_my_print("[Fail]");
+        libspdm_my_print("- Context1 ... ");
+        ecd1 = libspdm_ecd_new_by_nid(LIBSPDM_CRYPTO_NID_EDDSA_ED25519);
+        if (ecd1 == NULL) {
+            libspdm_my_print("[Fail]");
+            return false;
+        }
+
+        /* Verify Ed-DSA*/
+        sig1_size = sizeof(signature1);
+        libspdm_my_print("\n- Ed-DSA Signing ... ");
+        status = libspdm_eddsa_sign(ecd1, LIBSPDM_CRYPTO_NID_NULL, NULL, 0, message,
+                                    sizeof(message), signature1, &sig1_size);
+        if (!status) {
+            libspdm_my_print("[Fail]");
+            libspdm_ecd_free(ecd1);
+            return false;
+        }
+
+        libspdm_my_print("Ed-DSA Verification ... ");
+        status = libspdm_eddsa_verify(ecd1, LIBSPDM_CRYPTO_NID_NULL, NULL, 0, message,
+                                      sizeof(message), signature1, sig1_size);
+        if (!status) {
+            libspdm_my_print("[Fail]");
+            libspdm_ecd_free(ecd1);
+            return false;
+        } else {
+            libspdm_my_print("[Pass]\n");
+        }
         libspdm_ecd_free(ecd1);
-        return false;
     }
+#endif /* LIBSPDM_EDDSA_ED25519_SUPPORT */
 
-    libspdm_my_print("Ed-DSA Verification ... ");
-    status = libspdm_eddsa_verify(ecd1, LIBSPDM_CRYPTO_NID_NULL, NULL, 0, message, sizeof(message),
-                                  signature1, sig1_size);
-    if (!status) {
-        libspdm_my_print("[Fail]");
-        libspdm_ecd_free(ecd1);
-        return false;
-    } else {
-        libspdm_my_print("[Pass]\n");
-    }
-    libspdm_ecd_free(ecd1);
+#if LIBSPDM_EDDSA_ED448_SUPPORT
+    {
+        void *ecd2;
+        uint8_t context[] = "EdDsaTestContext";
+        uint8_t signature2[57 * 2];
+        size_t sig2_size;
 
-    libspdm_my_print("Context2 ... ");
-    ecd2 = libspdm_ecd_new_by_nid(LIBSPDM_CRYPTO_NID_EDDSA_ED448);
-    if (ecd2 == NULL) {
-        libspdm_my_print("[Fail]");
-        return false;
-    }
+        libspdm_my_print("Context2 ... ");
+        ecd2 = libspdm_ecd_new_by_nid(LIBSPDM_CRYPTO_NID_EDDSA_ED448);
+        if (ecd2 == NULL) {
+            libspdm_my_print("[Fail]");
+            return false;
+        }
 
-    sig2_size = sizeof(signature2);
-    libspdm_my_print("\n- Ed-DSA Signing ... ");
-    status = libspdm_eddsa_sign(ecd2, LIBSPDM_CRYPTO_NID_NULL, context, sizeof(context) - 1,
-                                message, sizeof(message), signature2, &sig2_size);
-    if (!status) {
-        libspdm_my_print("[Fail]");
+        sig2_size = sizeof(signature2);
+        libspdm_my_print("\n- Ed-DSA Signing ... ");
+        status = libspdm_eddsa_sign(ecd2, LIBSPDM_CRYPTO_NID_NULL, context, sizeof(context) - 1,
+                                    message, sizeof(message), signature2, &sig2_size);
+        if (!status) {
+            libspdm_my_print("[Fail]");
+            libspdm_ecd_free(ecd2);
+            return false;
+        }
+
+        libspdm_my_print("Ed-DSA Verification ... ");
+        status = libspdm_eddsa_verify(ecd2, LIBSPDM_CRYPTO_NID_NULL, context, sizeof(context) - 1,
+                                      message, sizeof(message), signature2, sig2_size);
+        if (!status) {
+            libspdm_my_print("[Fail]");
+            libspdm_ecd_free(ecd2);
+            return false;
+        } else {
+            libspdm_my_print("[Pass]\n");
+        }
+
         libspdm_ecd_free(ecd2);
-        return false;
     }
-
-    libspdm_my_print("Ed-DSA Verification ... ");
-    status = libspdm_eddsa_verify(ecd2, LIBSPDM_CRYPTO_NID_NULL, context, sizeof(context) - 1,
-                                  message, sizeof(message), signature2, sig2_size);
-    if (!status) {
-        libspdm_my_print("[Fail]");
-        libspdm_ecd_free(ecd2);
-        return false;
-    } else {
-        libspdm_my_print("[Pass]\n");
-    }
-
-    libspdm_ecd_free(ecd2);
+#endif /* LIBSPDM_EDDSA_ED448_SUPPORT */
 
     return true;
 }

--- a/unit_test/test_crypt/test_crypt.c
+++ b/unit_test/test_crypt/test_crypt.c
@@ -93,16 +93,18 @@ bool libspdm_cryptest_main(void)
         return status;
     }
 
-    #if LIBSPDM_EDDSA_SUPPORT
+    #if LIBSPDM_EDDSA_ED25519_SUPPORT
     status = libspdm_validate_crypt_x509("ed25519", sizeof("ed25519"));
     if (!status) {
         return status;
     }
+    #endif /* LIBSPDM_EDDSA_ED25519_SUPPORT */
 
+    #if LIBSPDM_EDDSA_ED448_SUPPORT
     status = libspdm_validate_crypt_x509("ed448", sizeof("ed448"));
     if (!status) {
     }
-    #endif /* LIBSPDM_EDDSA_SUPPORT */
+    #endif /* LIBSPDM_EDDSA_ED448_SUPPORT */
 
     #if LIBSPDM_SM2_DSA_SUPPORT
     status = libspdm_validate_crypt_x509("sm2", sizeof("sm2"));


### PR DESCRIPTION
The Ed-DSA signing test and the EdDSA X.509 test were guarded by the combined (LIBSPDM_EDDSA_ED25519_SUPPORT || LIBSPDM_EDDSA_ED448_SUPPORT) condition but then exercised both Ed25519 and Ed448 unconditionally. A backend that supports only one curve would therefore fail on the unsupported curve.

Guard each curve by its own LIBSPDM_EDDSA_ED25519_SUPPORT / LIBSPDM_EDDSA_ED448_SUPPORT macro so the test runs whichever curve(s) the crypto backend actually supports.