### PR TITLE
Align key_pair_info HAL with KEY_PAIR_INFO response format

### DIFF
--- a/include/hal/library/responder/key_pair_info.h
+++ b/include/hal/library/responder/key_pair_info.h
@@ -14,19 +14,18 @@
 #if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
 
 /**
- * return the total key pairs number.
- * It is a fixed number per SPDM connection.
- *
- * @return the total key pairs number.
- */
-extern uint8_t libspdm_read_total_key_pairs (void *spdm_context);
-
-/**
  * read the key pair info of the key_pair_id.
  *
  * @param  spdm_context               A pointer to the SPDM context.
  * @param  key_pair_id                Indicate which key pair ID's information to retrieve.
  *
+ * @param  total_key_pairs            Indicate the total number of key pairs on the Responder.
+ *                                    It is a fixed number per SPDM connection. This aligns with the
+ *                                    TotalKeyPairs field of the KEY_PAIR_INFO response.
+ *                                    This output shall ALWAYS be set, including on the failure path
+ *                                    (set it before any other validation), because the responder
+ *                                    uses it to range-check key_pair_id. A device with no key pairs
+ *                                    shall set it to 0.
  * @param  capabilities               Indicate the capabilities of the requested key pairs.
  * @param  key_usage_capabilities     Indicate the key usages the responder allows.
  * @param  current_key_usage          Indicate the currently configured key usage for the requested key pairs ID.
@@ -40,11 +39,14 @@ extern uint8_t libspdm_read_total_key_pairs (void *spdm_context);
  *                                    It can be NULL, if public_key_info is not required.
  *
  * @retval true  get key pair info successfully.
- * @retval false get key pair info failed.
+ * @retval false get key pair info failed. total_key_pairs shall still be set on this path so the
+ *               caller can distinguish an invalid key_pair_id (0 or > total_key_pairs ->
+ *               INVALID_REQUEST) from another read failure (-> UNSPECIFIED).
  **/
 extern bool libspdm_read_key_pair_info(
     void *spdm_context,
     uint8_t key_pair_id,
+    uint8_t *total_key_pairs,
     uint16_t *capabilities,
     uint16_t *key_usage_capabilities,
     uint16_t *current_key_usage,

--- a/library/spdm_responder_lib/libspdm_rsp_key_pair_info.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_pair_info.c
@@ -101,22 +101,21 @@ libspdm_return_t libspdm_get_response_key_pair_info(libspdm_context_t *spdm_cont
             SPDM_GET_KEY_PAIR_INFO, response_size, response);
     }
 
-    total_key_pairs = libspdm_read_total_key_pairs(spdm_context);
     key_pair_id = spdm_request->key_pair_id;
-    if ((key_pair_id == 0) || (key_pair_id > total_key_pairs)) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
-                                               response_size, response);
-    }
 
     LIBSPDM_ASSERT(*response_size >= sizeof(spdm_key_pair_info_response_t));
     public_key_info_len = (uint16_t)(*response_size - sizeof(spdm_key_pair_info_response_t));
     libspdm_zero_mem(response, *response_size);
 
+    /* libspdm_read_key_pair_info() always reports total_key_pairs (even on failure), so read first
+     * and then validate the range -- identical to the SET_KEY_PAIR_INFO_ACK handler. An invalid
+     * key_pair_id (0 or > total_key_pairs) is INVALID_REQUEST; any other read failure is UNSPECIFIED. */
+    total_key_pairs = 0;
     public_key_info = (uint8_t*)response + sizeof(spdm_key_pair_info_response_t);
     result = libspdm_read_key_pair_info(
         spdm_context,
         key_pair_id,
+        &total_key_pairs,
         &capabilities,
         &key_usage_capabilities,
         &current_key_usage,
@@ -127,9 +126,14 @@ libspdm_return_t libspdm_get_response_key_pair_info(libspdm_context_t *spdm_cont
         &assoc_cert_slot_mask,
         &public_key_info_len,
         public_key_info);
-    if (!result) {
+    if ((key_pair_id == 0) || (key_pair_id > total_key_pairs)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+    if (!result) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNSPECIFIED, 0,
                                                response_size, response);
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_set_key_pair_info_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_key_pair_info_ack.c
@@ -107,21 +107,16 @@ libspdm_return_t libspdm_get_response_set_key_pair_info_ack(libspdm_context_t *s
             SPDM_SET_KEY_PAIR_INFO, response_size, response);
     }
 
-    total_key_pairs = libspdm_read_total_key_pairs(spdm_context);
-    key_pair_id = spdm_request->key_pair_id;
-    if ((key_pair_id == 0) || (key_pair_id > total_key_pairs)) {
-        return libspdm_generate_error_response(spdm_context,
-                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
-                                               response_size, response);
-    }
-
     LIBSPDM_ASSERT(*response_size >= sizeof(spdm_set_key_pair_info_ack_response_t));
 
     libspdm_zero_mem(response, *response_size);
 
+    total_key_pairs = 0;
+    key_pair_id = spdm_request->key_pair_id;
     result = libspdm_read_key_pair_info(
         spdm_context,
         key_pair_id,
+        &total_key_pairs,
         &capabilities,
         &key_usage_capabilities,
         &current_key_usage,
@@ -131,6 +126,11 @@ libspdm_return_t libspdm_get_response_set_key_pair_info_ack(libspdm_context_t *s
         &current_pqc_asym_algo,
         &assoc_cert_slot_mask,
         NULL, NULL);
+    if ((key_pair_id == 0) || (key_pair_id > total_key_pairs)) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
     if (!result) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_UNSPECIFIED, 0,

--- a/os_stub/include/internal/libspdm_device_secret_lib.h
+++ b/os_stub/include/internal/libspdm_device_secret_lib.h
@@ -233,8 +233,6 @@ bool libspdm_get_requester_pqc_private_key_from_raw_data(uint32_t req_pqc_asym_a
 
 /* key pairs */
 #if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
-uint8_t libspdm_read_total_key_pairs(void *spdm_context);
-
 /* Resolve the device-global KeyPairID (1..TotalKeyPairs) that backs slot_id under the connection's
  * negotiated algorithm (pqc_asym_algo if non-zero, otherwise base_asym_algo). Slots 0/1 map to the
  * algorithm's primary key pair, slot 4 to its secondary (the multi-key example). Returns 0 if none

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -332,17 +332,13 @@ bool libspdm_generate_event_list(
 
 #if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
 
-uint8_t libspdm_read_total_key_pairs (void *spdm_context)
-{
-    return 0;
-}
-
 /**
  * read the key pair info of the key_pair_id.
  *
  * @param  spdm_context               A pointer to the SPDM context.
  * @param  key_pair_id                Indicate which key pair ID's information to retrieve.
  *
+ * @param  total_key_pairs            Indicate the total number of key pairs on the Responder.
  * @param  capabilities               Indicate the capabilities of the requested key pairs.
  * @param  key_usage_capabilities     Indicate the key usages the responder allows.
  * @param  current_key_usage          Indicate the currently configured key usage for the requested key pairs ID.
@@ -361,6 +357,7 @@ uint8_t libspdm_read_total_key_pairs (void *spdm_context)
 bool libspdm_read_key_pair_info(
     void *spdm_context,
     uint8_t key_pair_id,
+    uint8_t *total_key_pairs,
     uint16_t *capabilities,
     uint16_t *key_usage_capabilities,
     uint16_t *current_key_usage,
@@ -372,6 +369,7 @@ bool libspdm_read_key_pair_info(
     uint16_t *public_key_info_len,
     uint8_t *public_key_info)
 {
+    *total_key_pairs = 0;
     return false;
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP */

--- a/os_stub/spdm_device_secret_lib_sample/key_pair.c
+++ b/os_stub/spdm_device_secret_lib_sample/key_pair.c
@@ -315,7 +315,7 @@ void libspdm_init_key_pair_info() {
     m_total_key_pair_count = index;
 }
 
-uint8_t libspdm_read_total_key_pairs (void *spdm_context)
+static uint8_t libspdm_get_total_key_pairs (void)
 {
     if (m_total_key_pair_count == 0) {
         libspdm_init_key_pair_info();
@@ -398,6 +398,7 @@ uint8_t libspdm_get_key_pair_id_by_slot(uint32_t base_asym_algo, uint32_t pqc_as
  * @param  spdm_context               A pointer to the SPDM context.
  * @param  key_pair_id                Indicate which key pair ID's information to retrieve.
  *
+ * @param  total_key_pairs            Indicate the total number of key pairs on the Responder.
  * @param  capabilities               Indicate the capabilities of the requested key pairs.
  * @param  key_usage_capabilities     Indicate the key usages the responder allows.
  * @param  current_key_usage          Indicate the currently configured key usage for the requested key pairs ID.
@@ -416,6 +417,7 @@ uint8_t libspdm_get_key_pair_id_by_slot(uint32_t base_asym_algo, uint32_t pqc_as
 bool libspdm_read_key_pair_info(
     void *spdm_context,
     uint8_t key_pair_id,
+    uint8_t *total_key_pairs,
     uint16_t *capabilities,
     uint16_t *key_usage_capabilities,
     uint16_t *current_key_usage,
@@ -427,8 +429,10 @@ bool libspdm_read_key_pair_info(
     uint16_t *public_key_info_len,
     uint8_t *public_key_info)
 {
+    *total_key_pairs = libspdm_get_total_key_pairs();
+
     /*check: KeyPairID is 1-based and indexes m_key_pair_info[key_pair_id - 1]*/
-    if ((key_pair_id == 0) || (key_pair_id > libspdm_read_total_key_pairs(spdm_context))) {
+    if ((key_pair_id == 0) || (key_pair_id > *total_key_pairs)) {
         return false;
     }
 
@@ -517,7 +521,7 @@ bool libspdm_write_key_pair_info(
     size_t cached_key_pair_info_len;
 
     /*check: KeyPairID is 1-based and indexes m_key_pair_info[key_pair_id - 1]*/
-    if ((key_pair_id == 0) || (key_pair_id > libspdm_read_total_key_pairs(spdm_context))) {
+    if ((key_pair_id == 0) || (key_pair_id > libspdm_get_total_key_pairs())) {
         return false;
     }
 

--- a/unit_test/test_spdm_responder/key_pair_info.c
+++ b/unit_test/test_spdm_responder/key_pair_info.c
@@ -124,8 +124,8 @@ static void rsp_key_pair_info_case3(void **state)
     spdm_context->local_context.capability.flags |=
         SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_GET_KEY_PAIR_INFO_CAP;
 
-    /* key_pair_id > total_key_pairs*/
-    key_pair_id = libspdm_read_total_key_pairs(spdm_context) + 1;
+    /* key_pair_id > total_key_pairs (0xFF exceeds any possible TotalKeyPairs) */
+    key_pair_id = 0xFF;
     m_libspdm_get_key_pair_info_request1.key_pair_id = key_pair_id;
 
     response_size = sizeof(response);

--- a/unit_test/test_spdm_responder/set_key_pair_info_ack.c
+++ b/unit_test/test_spdm_responder/set_key_pair_info_ack.c
@@ -570,6 +570,7 @@ static void rsp_set_key_pair_info_ack_case5(void **state)
     uint8_t key_pair_id;
     bool need_reset;
     bool result;
+    uint8_t total_key_pairs;
     uint16_t capabilities;
     uint16_t key_usage_capabilities;
     uint16_t current_key_usage;
@@ -618,9 +619,9 @@ static void rsp_set_key_pair_info_ack_case5(void **state)
 
     /* The applied PQC algorithm shall be ML-DSA-65 (the replayed value), not ML-DSA-44. */
     assert_true(libspdm_read_key_pair_info(
-                    spdm_context, key_pair_id, &capabilities, &key_usage_capabilities,
-                    &current_key_usage, &asym_algo_capabilities, &current_asym_algo,
-                    &pqc_asym_algo_capabilities, &current_pqc_asym_algo,
+                    spdm_context, key_pair_id, &total_key_pairs, &capabilities,
+                    &key_usage_capabilities, &current_key_usage, &asym_algo_capabilities,
+                    &current_asym_algo, &pqc_asym_algo_capabilities, &current_pqc_asym_algo,
                     &assoc_cert_slot_mask, NULL, NULL));
     assert_int_equal(current_pqc_asym_algo, SPDM_KEY_PAIR_PQC_ASYM_ALGO_CAP_ML_DSA_65);
 }


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/3153

The KEY_PAIR_INFO response (DSP0274 Table 111) carries TotalKeyPairs (byte 4) in the same response as the per-key-pair fields, so the HAL should surface both together rather than via a separate query.

- Remove libspdm_read_total_key_pairs() from the responder HAL.
- Add a total_key_pairs output parameter to libspdm_read_key_pair_info().
- GET/SET-ack responders obtain total_key_pairs from the read; the existing error semantics are preserved (INVALID_REQUEST for key_pair_id 0 or out of range; UNSPECIFIED for other SET read failures).
- The sample keeps an internal file-static helper for its lazy init/count and write-path range check; the null stub sets total_key_pairs to 0.
- Update the responder unit test (use 0xFF as the out-of-range key_pair_id).

