### PR TITLE
 [issue-3185] When SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG is negotiated,

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -633,7 +633,10 @@ static libspdm_return_t libspdm_try_negotiate_algorithms(libspdm_context_t *spdm
         if (libspdm_is_capabilities_flag_supported(
                 spdm_context, true,
                 SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP,
-                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP)) {
+                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP) ||
+            libspdm_is_capabilities_flag_supported(
+                spdm_context, true,
+                SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG, 0)) {
             algo_size = libspdm_get_req_asym_signature_size(
                 spdm_context->connection_info.algorithm.req_base_asym_alg);
             if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_14) {

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -1038,7 +1038,10 @@ libspdm_return_t libspdm_get_response_algorithms(libspdm_context_t *spdm_context
         if (libspdm_is_capabilities_flag_supported(
                 spdm_context, false,
                 SPDM_GET_CAPABILITIES_REQUEST_FLAGS_MUT_AUTH_CAP,
-                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP)) {
+                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP) ||
+            libspdm_is_capabilities_flag_supported(
+                spdm_context, false,
+                SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG, 0)) {
             algo_size = libspdm_get_req_asym_signature_size(
                 spdm_context->connection_info.algorithm.req_base_asym_alg);
             pqc_algo_size = libspdm_get_req_pqc_asym_signature_size(

--- a/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
+++ b/unit_test/test_spdm_requester/error_test/negotiate_algorithms_err.c
@@ -129,6 +129,8 @@ static libspdm_return_t send_message(
         return LIBSPDM_STATUS_SUCCESS;
     case 0x2C:
         return LIBSPDM_STATUS_SUCCESS;
+    case 0x2D:
+        return LIBSPDM_STATUS_SUCCESS;
     default:
         return LIBSPDM_STATUS_SEND_FAIL;
     }
@@ -1646,6 +1648,51 @@ static libspdm_return_t receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
+    case 0x2D: {
+        /* EP_INFO_CAP_SIG negotiated: responder returns req_base_asym_alg = 0 */
+        libspdm_algorithms_response_spdm11_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(libspdm_algorithms_response_spdm11_t);
+        transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_ALGORITHMS;
+        spdm_response->header.param1 = 4;
+        spdm_response->header.param2 = 0;
+        spdm_response->length = sizeof(libspdm_algorithms_response_spdm11_t);
+        spdm_response->measurement_specification_sel = SPDM_MEASUREMENT_SPECIFICATION_DMTF;
+        spdm_response->measurement_hash_algo = m_libspdm_use_measurement_hash_algo;
+        spdm_response->base_asym_sel = m_libspdm_use_asym_algo;
+        spdm_response->base_hash_sel = m_libspdm_use_hash_algo;
+        spdm_response->ext_asym_sel_count = 0;
+        spdm_response->ext_hash_sel_count = 0;
+        spdm_response->struct_table[0].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE;
+        spdm_response->struct_table[0].alg_count = 0x20;
+        spdm_response->struct_table[0].alg_supported = m_libspdm_use_dhe_algo;
+        spdm_response->struct_table[1].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD;
+        spdm_response->struct_table[1].alg_count = 0x20;
+        spdm_response->struct_table[1].alg_supported = m_libspdm_use_aead_algo;
+        spdm_response->struct_table[2].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG;
+        spdm_response->struct_table[2].alg_count = 0x20;
+        spdm_response->struct_table[2].alg_supported = 0; /* req_base_asym_alg = 0 */
+        spdm_response->struct_table[3].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEY_SCHEDULE;
+        spdm_response->struct_table[3].alg_count = 0x20;
+        spdm_response->struct_table[3].alg_supported = m_libspdm_use_key_schedule_algo;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false, false,
+                                              spdm_response_size,
+                                              spdm_response, response_size, response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
     default:
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
@@ -3046,6 +3093,40 @@ static void libspdm_test_requester_negotiate_algorithms_error_case43(void** stat
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
+/**
+ * Test 44: EP_INFO_CAP_SIG is negotiated but req_base_asym_alg in the ALGORITHMS response is 0.
+ * Expected behavior: returns with status LIBSPDM_STATUS_NEGOTIATION_FAIL.
+ **/
+static void libspdm_test_requester_negotiate_algorithms_error_case44(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x2D;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+
+    status = libspdm_negotiate_algorithms(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_NEGOTIATION_FAIL);
+}
+
 int libspdm_req_negotiate_algorithms_error_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -3095,6 +3176,7 @@ int libspdm_req_negotiate_algorithms_error_test(void)
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case41),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case42),
         cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case43),
+        cmocka_unit_test(libspdm_test_requester_negotiate_algorithms_error_case44),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/negotiate_algorithms.c
+++ b/unit_test/test_spdm_requester/negotiate_algorithms.c
@@ -126,6 +126,7 @@ static libspdm_return_t send_message(
     case 0x22:
     case 0x23:
     case 0x24:
+    case 0x25:
         return LIBSPDM_STATUS_SUCCESS;
     default:
         return LIBSPDM_STATUS_SEND_FAIL;
@@ -1372,6 +1373,50 @@ static libspdm_return_t receive_message(
 
     }
         return LIBSPDM_STATUS_SUCCESS;
+    case 0x25: {
+        /* EP_INFO_CAP_SIG negotiated: responder returns valid req_base_asym_alg */
+        libspdm_algorithms_response_spdm11_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+
+        spdm_response_size = sizeof(libspdm_algorithms_response_spdm11_t);
+        transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        libspdm_zero_mem(spdm_response, spdm_response_size);
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_11;
+        spdm_response->header.request_response_code = SPDM_ALGORITHMS;
+        spdm_response->header.param1 = 4;
+        spdm_response->header.param2 = 0;
+        spdm_response->length = sizeof(libspdm_algorithms_response_spdm11_t);
+        spdm_response->measurement_specification_sel = SPDM_MEASUREMENT_SPECIFICATION_DMTF;
+        spdm_response->measurement_hash_algo = m_libspdm_use_measurement_hash_algo;
+        spdm_response->base_asym_sel = m_libspdm_use_asym_algo;
+        spdm_response->base_hash_sel = m_libspdm_use_hash_algo;
+        spdm_response->ext_asym_sel_count = 0;
+        spdm_response->ext_hash_sel_count = 0;
+        spdm_response->struct_table[0].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_DHE;
+        spdm_response->struct_table[0].alg_count = 0x20;
+        spdm_response->struct_table[0].alg_supported = m_libspdm_use_dhe_algo;
+        spdm_response->struct_table[1].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_AEAD;
+        spdm_response->struct_table[1].alg_count = 0x20;
+        spdm_response->struct_table[1].alg_supported = m_libspdm_use_aead_algo;
+        spdm_response->struct_table[2].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_REQ_BASE_ASYM_ALG;
+        spdm_response->struct_table[2].alg_count = 0x20;
+        spdm_response->struct_table[2].alg_supported = m_libspdm_use_req_asym_algo;
+        spdm_response->struct_table[3].alg_type =
+            SPDM_NEGOTIATE_ALGORITHMS_STRUCT_TABLE_ALG_TYPE_KEY_SCHEDULE;
+        spdm_response->struct_table[3].alg_count = 0x20;
+        spdm_response->struct_table[3].alg_supported = m_libspdm_use_key_schedule_algo;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false, false,
+                                              spdm_response_size,
+                                              spdm_response, response_size, response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
     default:
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
@@ -2124,6 +2169,40 @@ static void req_negotiate_algorithms_case36(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
 }
 
+/**
+ * Test 37: EP_INFO_CAP_SIG is negotiated and req_base_asym_alg in the ALGORITHMS response is valid.
+ * Expected behavior: returns with status LIBSPDM_STATUS_SUCCESS.
+ **/
+static void req_negotiate_algorithms_case37(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x25;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+    spdm_context->local_context.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+    libspdm_reset_message_a(spdm_context);
+
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+
+    status = libspdm_negotiate_algorithms(spdm_context);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+}
+
 int libspdm_req_negotiate_algorithms_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -2163,6 +2242,7 @@ int libspdm_req_negotiate_algorithms_test(void)
         cmocka_unit_test(req_negotiate_algorithms_case34),
         cmocka_unit_test(req_negotiate_algorithms_case35),
         cmocka_unit_test(req_negotiate_algorithms_case36),
+        cmocka_unit_test(req_negotiate_algorithms_case37),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/algorithms.c
+++ b/unit_test/test_spdm_responder/algorithms.c
@@ -2887,6 +2887,101 @@ static void rsp_algorithms_case32(void **state)
     assert_int_equal(spdm_context->connection_info.algorithm.measurement_spec, 0);
 }
 
+/**
+ * Test 33: EP_INFO_CAP_SIG is negotiated but req_base_asym_alg negotiation results in 0.
+ * Expected behavior: returns SPDM_ERROR_CODE_INVALID_REQUEST.
+ **/
+static void rsp_algorithms_case33(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_algorithms_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x20;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+
+    libspdm_reset_message_a(spdm_context);
+
+    /* EP_INFO_CAP_SIG on requester side; no MUT_AUTH_CAP */
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+
+    /* request8 has req_base_asym_alg = ECDSA_ECC_NIST_P521; local has RSASSA_2048 → intersection = 0 */
+    response_size = sizeof(response);
+    status = libspdm_get_response_algorithms(
+        spdm_context,
+        m_libspdm_negotiate_algorithm_request8_size,
+        &m_libspdm_negotiate_algorithm_request8,
+        &response_size,
+        response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal(spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
+    assert_int_equal(spdm_response->header.param2, 0);
+}
+
+/**
+ * Test 34: EP_INFO_CAP_SIG is negotiated and req_base_asym_alg intersection is non-zero.
+ * Expected behavior: returns SPDM_ALGORITHMS (success).
+ **/
+static void rsp_algorithms_case34(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_algorithms_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x21;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.dhe_named_group = m_libspdm_use_dhe_algo;
+    spdm_context->local_context.algorithm.aead_cipher_suite = m_libspdm_use_aead_algo;
+    spdm_context->local_context.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+    spdm_context->local_context.algorithm.key_schedule = m_libspdm_use_key_schedule_algo;
+
+    libspdm_reset_message_a(spdm_context);
+
+    /* EP_INFO_CAP_SIG on requester side; no MUT_AUTH_CAP */
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+
+    /* request7 has req_base_asym_alg = RSASSA_2048 = m_libspdm_use_req_asym_algo → intersection != 0 */
+    response_size = sizeof(response);
+    status = libspdm_get_response_algorithms(
+        spdm_context,
+        m_libspdm_negotiate_algorithm_request7_size,
+        &m_libspdm_negotiate_algorithm_request7,
+        &response_size,
+        response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_ALGORITHMS);
+}
+
 int libspdm_rsp_algorithms_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -2952,6 +3047,10 @@ int libspdm_rsp_algorithms_test(void)
         cmocka_unit_test(rsp_algorithms_case31),
         /* Success Case , set MeasurementSpecification*/
         cmocka_unit_test(rsp_algorithms_case32),
+        /* EP_INFO_CAP_SIG negotiated, req_base_asym_alg intersection = 0 */
+        cmocka_unit_test(rsp_algorithms_case33),
+        /* EP_INFO_CAP_SIG negotiated, req_base_asym_alg intersection != 0, success */
+        cmocka_unit_test(rsp_algorithms_case34),
     };
 
     m_libspdm_negotiate_algorithms_request1.base_asym_algo = m_libspdm_use_asym_algo;


### PR DESCRIPTION
## Problem

When `SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG` is negotiated, the encap `GET_ENDPOINT_INFO` flow requires the requester to sign its response using `req_base_asym_alg`. If `NEGOTIATE_ALGORITHMS` results in `req_base_asym_alg == 0` (empty intersection between requester andresponder algorithm sets), the downstream signing path silently computes a zero-length signature, violating the protocol.

The root cause is that `NEGOTIATE_ALGORITHMS` validation already enforces `req_base_asym_alg != 0` for `MUT_AUTH_CAP`, but had no equivalent guard for `EP_INFO_CAP_SIG`.

## Details

`libspdm_rsp_encap_get_endpoint_info.c` uses `req_base_asym_alg` directly to compute `signature_size`. If `req_base_asym_alg == 0`, then `signature_size == 0`, which is a protocol violation
```c
/* libspdm_rsp_encap_get_endpoint_info.c:185 */
signature_size = libspdm_get_req_asym_signature_size(
    spdm_context->connection_info.algorithm.req_base_asym_alg);
/* if req_base_asym_alg == 0 → signature_size == 0 → protocol violation */
```

## Fix

- Extend the existing `req_base_asym_alg` validation block in both the requester (`libspdm_req_negotiate_algorithms.c`) and the responder to also trigger when `EP_INFO_CAP_SIG` is active, mirroring the existing `MUT_AUTH_CAP` treatment.

- `resp_flag` is kept at `0` because `EP_INFO_CAP_SIG` is a requester-only capability. This is consistent with its usage throughout the encap code path (`libspdm_rsp_encap_get_endpoint_info.c` lines 74 and 178).


## Unit Tests

| File | Case | Scenario | Expected |
|------|------|----------|----------|
| `test_spdm_requester/.../negotiate_algorithms_err.c` | 44 | EP_INFO_CAP_SIG set; ALGORITHMS response has `req_base_asym_alg == 0` | `LIBSPDM_STATUS_NEGOTIATION_FAIL` |
| `test_spdm_requester/.../negotiate_algorithms_err.c` | 45 | EP_INFO_CAP_SIG set; ALGORITHMS response has valid `req_base_asym_alg` | `LIBSPDM_STATUS_SUCCESS` |
| `unit_test/test_spdm_responder/algorithms.c` | 33 | EP_INFO_CAP_SIG set; `req_base_asym_alg` intersection with local is 0 | `SPDM_ERROR_CODE_INVALID_REQUEST` |
| `unit_test/test_spdm_responder/algorithms.c` | 34 | EP_INFO_CAP_SIG set; `req_base_asym_alg` intersection with local is non-zero | `SPDM_ALGORITHMS` (success) |
```
Fixes #3185