### PR TITLE
[issue-3597] Add explicit SPDM_MAX_OPAQUE_DATA_SIZE check in responder FINISH and PSK_FINISH parsers

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_finish_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish_rsp.c
@@ -537,6 +537,11 @@ libspdm_return_t libspdm_get_response_finish(libspdm_context_t *spdm_context, si
         req_opaque_data_size = libspdm_read_uint16((const uint8_t *)request +
                                                    sizeof(spdm_finish_request_t));
         ptr += sizeof(uint16_t);
+        if (req_opaque_data_size > SPDM_MAX_OPAQUE_DATA_SIZE) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                                   response_size, response);
+        }
         if (request_size < sizeof(spdm_finish_request_t) +
             sizeof(uint16_t) + req_opaque_data_size) {
             return libspdm_generate_error_response(spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish_rsp.c
@@ -172,6 +172,11 @@ libspdm_return_t libspdm_get_response_psk_finish(libspdm_context_t *spdm_context
         req_opaque_data_size = libspdm_read_uint16((const uint8_t *)request +
                                                    sizeof(spdm_psk_finish_request_t));
         ptr += sizeof(uint16_t);
+        if (req_opaque_data_size > SPDM_MAX_OPAQUE_DATA_SIZE) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                                   response_size, response);
+        }
         if (request_size < sizeof(spdm_psk_finish_request_t) +
             sizeof(uint16_t) + req_opaque_data_size) {
             return libspdm_generate_error_response(spdm_context,


### PR DESCRIPTION
Fixes #3597

Mirror the explicit opaque-length max-bound check that already exists in the requester-side parsers to the corresponding responder-side parsers.

**Existing pattern (requester side):**
- `libspdm_req_finish.c` line 600: `if (opaque_data_size > SPDM_MAX_OPAQUE_DATA_SIZE)` → reject
- `libspdm_req_psk_finish.c` line 292: same check

**Added (responder side):**
- `libspdm_rsp_finish_rsp.c`: add `if (req_opaque_data_size > SPDM_MAX_OPAQUE_DATA_SIZE)` before the size-consistency check
- `libspdm_rsp_psk_finish_rsp.c`: same check

Both reject with `SPDM_ERROR_CODE_INVALID_REQUEST`, consistent with the existing error-response pattern in those functions.

This makes opaque-length validation symmetric across all four FINISH/PSK_FINISH request and response parsing paths.

Signed-off-by: Cezary Zwolak <cezary.zwolak@intel.com>