### PR TITLE
Add a update local cert chain callback

### DIFF
--- a/include/hal/library/responder/setcertlib.h
+++ b/include/hal/library/responder/setcertlib.h
@@ -23,33 +23,6 @@
 extern bool libspdm_is_in_trusted_environment(void *spdm_context);
 
 /**
- * Stores or erase a certificate chain in non-volatile memory.
- * If the cert_chain is NULL and cert_chain_size is 0,
- * the feature is to erase the certificate chain.
- *
- * @param[in]  spdm_context     A pointer to the SPDM context.
- * @param[in]  slot_id          The number of slot for the certificate chain.
- * @param[in]  cert_chain       The pointer for the certificate chain to set.
- * @param[in]  cert_chain_size  The size of the certificate chain to set.
- * @param[in]  base_hash_algo   Indicates the negotiated hash algorithm.
- * @param[in]  base_asym_algo   Indicates the negotiated signing algorithms.
- * @param[in,out] need_reset    On input, indicates the value of CERT_INSTALL_RESET_CAP.
- *                              On output, indicates whether the device needs to be reset (true) for
- *                              the SET_CERTIFICATE operation to complete.
- * @param[out]  is_busy         If true, indicates that the certificate chain cannot be written at
- *                              this time, but it may be successful in a later call. The function's
- *                              return value must be false if this parameter is true.
- * @retval true   The certificate chain was successfully written to non-volatile memory.
- * @retval false  Unable to write certificate chain to non-volatile memory.
- **/
-extern bool libspdm_write_certificate_to_nvm(
-    void *spdm_context,
-    uint8_t slot_id, const void * cert_chain,
-    size_t cert_chain_size,
-    uint32_t base_hash_algo, uint32_t base_asym_algo, uint32_t pqc_asym_algo,
-    bool *need_reset, bool *is_busy);
-
-/**
  * Get the size of storage space for a certificate chain in a specific slot.
  *
  * @param[in]  spdm_context  A pointer to the SPDM context.
@@ -60,6 +33,88 @@ extern bool libspdm_write_certificate_to_nvm(
 uint32_t libspdm_get_cert_chain_slot_storage_size(
     void *spdm_context,
     uint8_t slot_id);
+
+/**
+ * Refresh the spdm_context local certificate after a successful
+ * SET_CERTIFICATE.
+ *
+ * After a successful SET_CERTIFICATE this callback is called.
+ * The new and old certificates are supplied as arguments.
+ *
+ * This function should store the new certificate chain in
+ * non-volatile memory.
+ * If the cert_chain is NULL and cert_chain_size is 0,
+ * the feature is to erase the certificate chain.
+ *
+ * If a reset isn't required, then it is the implementations
+ * responsability to allocate memory to store the new certificate
+ * chain and update `LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN` to
+ * use the new chain in libspdm.
+ *
+ * After which the old certificate chain can be freed. Unfortunately we can't
+ * handle this in libspdm as it might require allocation, which is why the
+ * HAL must handle this.
+ *
+ * For DEVICE_CERT and GENERIC_CERT this is a simple. All that needs to be done
+ * is memory allocated, thenew certificate copied and the old certificate freed.
+ *
+ * The ALIAS_CERT is similar, but required combining the new updated certificates
+ * with the existing ones that aren't changed.
+ *
+ * @param[in,out]  spdm_context     A pointer to the SPDM context.
+ * @param[in]      slot_id          The slot id of the certificate chain.
+ * @param[in]      base_hash_algo   The negotiated base hash algorithm
+ *                                  (SPDM_ALGORITHMS_BASE_HASH_ALGO_*). May be
+ *                                  used by the HAL when (re)computing root
+ *                                  certificate hashes or other digests.
+ * @param[in]      base_asym_algo   Indicates the negotiated signing algorithms.
+ * @param[in]      pqc_asym_algo    Indicates the negotiated PQC signing algorithms.
+ * @param[in]      hash_size        Size in bytes of the negotiated base hash
+ *                                  (used to locate the certificates inside the
+ *                                  spdm_cert_chain_t buffer).
+ * @param[in]      old_cert_chain   Pointer to the currently installed SPDM
+ *                                  certificate chain (including the
+ *                                  spdm_cert_chain_t header), or NULL if no
+ *                                  chain has been installed yet.
+ * @param[in]      old_cert_chain_size  Size in bytes of old_cert_chain. Must be
+ *                                  zero when old_cert_chain is NULL.
+ * @param[in]      cert_chain       The new SPDM certificate chain (including
+ *                                  the spdm_cert_chain_t header and root hash).
+ * @param[in,out]  cert_chain_size  Size of the new SPDM certificate chain, in
+ *                                  bytes. This needs be updated with the final
+ *                                  size.
+ * @param[in]      cert_model       The certificate model (one of
+ *                                  SPDM_CERTIFICATE_INFO_CERT_MODEL_*) that
+ *                                  applies to the certificate chain being
+ *                                  written.
+ * @param[in,out]  need_reset       On input, indicates the value of CERT_INSTALL_RESET_CAP.
+ *                                  On output, indicates whether the device needs to be reset (true) for
+ *                                  the SET_CERTIFICATE operation to complete.
+ * @param[out]     is_busy          If true, indicates that the certificate chain cannot be written at
+ *                                  this time, but it may be successful in a later call. The function's
+ *                                  return value must be false if this parameter is true.
+ *
+ * @retval true   The certificate chain was successfully written to non-volatile memory.
+ *                If a reset is required then the `need_reset` bool was set
+ *                If a reset is not required the local certificate chain was
+ *                successfully updated.
+ * @retval false  Failed to update the local certificate chain or store the new chain.
+ *                The new chain is not commited and not in use.
+ **/
+extern bool libspdm_update_local_cert_chain(
+    void *spdm_context,
+    uint8_t slot_id,
+    uint32_t base_hash_algo,
+    uint32_t base_asym_algo,
+    uint32_t pqc_asym_algo,
+    size_t hash_size,
+    const void *old_cert_chain,
+    size_t old_cert_chain_size,
+    const void *cert_chain,
+    size_t *cert_chain_size,
+    uint8_t cert_model,
+    bool *need_reset,
+    bool *is_busy);
 #endif /* LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP */
 
 #endif /* RESPONDER_SETCERTLIB_H */

--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -162,7 +162,7 @@ libspdm_return_t libspdm_set_data(void *spdm_context, libspdm_data_type_t data_t
     size_t cert_buffer_size;
 #endif
 
-    if (spdm_context == NULL || data == NULL || data_type >= LIBSPDM_DATA_MAX) {
+    if (spdm_context == NULL || data_type >= LIBSPDM_DATA_MAX) {
         return LIBSPDM_STATUS_INVALID_PARAMETER;
     }
 

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate_rsp.c
@@ -73,11 +73,17 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
     const spdm_cert_chain_t *cert_chain_header;
     size_t cert_chain_size;
     const void * cert_chain;
+    const void *full_cert_chain;
+    size_t full_cert_chain_size;
+    const void *old_local_cert_chain;
+    size_t old_local_cert_chain_size;
 
     libspdm_session_info_t *session_info;
     libspdm_session_state_t session_state;
 
     spdm_request = request;
+    full_cert_chain = NULL;
+    full_cert_chain_size = 0;
 
     /* -=[Check Parameters Phase]=- */
     LIBSPDM_ASSERT(spdm_request->header.request_response_code == SPDM_SET_CERTIFICATE);
@@ -156,6 +162,11 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
     root_cert_hash_size = libspdm_get_hash_size(
         spdm_context->connection_info.algorithm.base_hash_algo);
 
+    old_local_cert_chain =
+        spdm_context->local_context.local_cert_chain_provision[slot_id];
+    old_local_cert_chain_size =
+        spdm_context->local_context.local_cert_chain_provision_size[slot_id];
+
     if (spdm_version >= SPDM_MESSAGE_VERSION_13) {
         const uint8_t key_pair_id = spdm_request->header.param2;
 
@@ -217,9 +228,13 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
         }
 
         /* erase slot_id cert_chain*/
-        result = libspdm_write_certificate_to_nvm(
+        result = libspdm_update_local_cert_chain(
             spdm_context,
-            slot_id, NULL, 0, 0, 0, 0,
+            slot_id, 0, 0, 0, 0,
+            old_local_cert_chain,
+            old_local_cert_chain_size,
+            NULL, 0,
+            set_cert_model,
             &need_reset, &is_busy);
         if (!result) {
             if (is_busy) {
@@ -243,6 +258,8 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
         /*point to full SPDM certificate chain*/
         cert_chain = (const void*)(spdm_request + 1);
         cert_chain_header = cert_chain;
+        full_cert_chain = cert_chain;
+        full_cert_chain_size = cert_chain_header->length;
 
         if (cert_chain_header->length < sizeof(spdm_cert_chain_t) + root_cert_hash_size) {
             return libspdm_generate_error_response(spdm_context,
@@ -286,15 +303,19 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
                                                    response_size, response);
         }
 #endif /*LIBSPDM_CERT_PARSE_SUPPORT*/
-
         /* set certificate to NV*/
-        result = libspdm_write_certificate_to_nvm(
+        result = libspdm_update_local_cert_chain(
             spdm_context,
-            slot_id, cert_chain,
-            cert_chain_size,
+            slot_id,
             spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_context->connection_info.algorithm.base_asym_algo,
             spdm_context->connection_info.algorithm.pqc_asym_algo,
+            root_cert_hash_size,
+            old_local_cert_chain,
+            old_local_cert_chain_size,
+            full_cert_chain,
+            &full_cert_chain_size,
+            set_cert_model,
             &need_reset, &is_busy);
 
         if (!result) {

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -250,20 +250,28 @@ bool libspdm_is_in_trusted_environment(void *spdm_context)
     return false;
 }
 
-bool libspdm_write_certificate_to_nvm(
-    void *spdm_context,
-    uint8_t slot_id, const void * cert_chain,
-    size_t cert_chain_size,
-    uint32_t base_hash_algo, uint32_t base_asym_algo, uint32_t pqc_asym_algo,
-    bool *need_reset, bool *is_busy)
-{
-    return false;
-}
-
 uint32_t libspdm_get_cert_chain_slot_storage_size(
     void *spdm_context, uint8_t slot_id)
 {
     return 0;
+}
+
+bool libspdm_update_local_cert_chain(
+    void *spdm_context,
+    uint8_t slot_id,
+    uint32_t base_hash_algo,
+    uint32_t base_asym_algo,
+    uint32_t pqc_asym_algo,
+    size_t hash_size,
+    const void *old_cert_chain,
+    size_t old_cert_chain_size,
+    const void *cert_chain,
+    size_t *cert_chain_size,
+    uint8_t cert_model,
+    bool *need_reset,
+    bool *is_busy)
+{
+    return false;
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP */
 

--- a/os_stub/spdm_device_secret_lib_sample/set_cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/set_cert.c
@@ -34,7 +34,7 @@ bool libspdm_is_in_trusted_environment(void *spdm_context)
     return g_in_trusted_environment;
 }
 
-bool libspdm_write_certificate_to_nvm(
+static bool libspdm_write_certificate_to_nvm(
     void *spdm_context,
     uint8_t slot_id, const void * cert_chain,
     size_t cert_chain_size,
@@ -108,5 +108,194 @@ uint32_t libspdm_get_cert_chain_slot_storage_size(
     void *spdm_context, uint8_t slot_id)
 {
     return SPDM_MAX_CERTIFICATE_CHAIN_SIZE_14;
+}
+
+bool libspdm_update_local_cert_chain(
+    void *spdm_context,
+    uint8_t slot_id,
+    uint32_t base_hash_algo,
+    uint32_t base_asym_algo,
+    uint32_t pqc_asym_algo,
+    size_t hash_size,
+    const void *old_cert_chain,
+    size_t old_cert_chain_size,
+    const void *cert_chain,
+    size_t *cert_chain_size,
+    uint8_t cert_model,
+    bool *need_reset,
+    bool *is_busy)
+{
+    libspdm_data_parameter_t parameter;
+    libspdm_return_t status;
+    size_t header_size;
+    uint8_t *new_buffer;
+    bool result;
+    const uint8_t *new_chain_bytes;
+
+    if (slot_id >= SPDM_MAX_SLOT_COUNT) {
+        return false;
+    }
+
+    if (cert_chain != NULL) {
+        result = libspdm_write_certificate_to_nvm(
+            spdm_context,
+            slot_id,
+            (const uint8_t *)cert_chain + sizeof(spdm_cert_chain_t) + hash_size,
+            *cert_chain_size - (sizeof(spdm_cert_chain_t) + hash_size),
+            base_hash_algo,
+            base_asym_algo,
+            pqc_asym_algo,
+            need_reset,
+            is_busy);
+    } else {
+        result = libspdm_write_certificate_to_nvm(
+            spdm_context,
+            slot_id,
+            NULL,
+            0,
+            base_hash_algo,
+            base_asym_algo,
+            pqc_asym_algo,
+            need_reset,
+            is_busy);
+    }
+
+    if (!result) {
+        return result;
+    }
+
+    if (cert_chain == NULL || cert_chain_size == NULL || *cert_chain_size == 0) {
+        new_buffer = NULL;
+        goto set_cert;
+    }
+
+    header_size = sizeof(spdm_cert_chain_t) + hash_size;
+    if (*cert_chain_size < header_size) {
+        return false;
+    }
+
+    new_chain_bytes = (const uint8_t *)cert_chain;
+
+    if (cert_model == SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT ||
+        cert_model == SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT) {
+        /* Device/generic certificate model: replace the entire local chain.*/
+
+        new_buffer = (uint8_t *)malloc(*cert_chain_size);
+        if (new_buffer == NULL) {
+            return false;
+        }
+
+        libspdm_copy_mem(new_buffer, *cert_chain_size,
+                         new_chain_bytes, *cert_chain_size);
+    } else if (cert_model == SPDM_CERTIFICATE_INFO_CERT_MODEL_ALIAS_CERT) {
+        /* Alias Cert Model, the new `cert_chain` shall contain a partial
+         * certificate chain from the root CA to the Device Certificate CA.
+         *
+         * We need to update the old root CA to the Device Certificate CA
+         * and leave the other certs as they are. Then update the hash and
+         * the size.
+         */
+        const uint8_t *new_certs = new_chain_bytes + header_size;
+        size_t new_certs_size = *cert_chain_size - header_size;
+        const uint8_t *old_certs = (const uint8_t *)old_cert_chain + header_size;
+        size_t old_certs_size = old_cert_chain_size - header_size;
+        size_t old_offset = 0;
+        int32_t cert_index = 0;
+        size_t mutable_cert_offset = 0;
+        spdm_cert_chain_t *new_cert_chain;
+        const uint8_t *root_cert;
+        size_t root_cert_len;
+
+        /* First, find the offset of the Device Certificate CA in the old
+         * certs. This should contain the Hardware identity OID.
+         */
+        while (old_offset < old_certs_size) {
+            const uint8_t *cert = NULL;
+            size_t cert_size = 0;
+
+            if (!libspdm_x509_get_cert_from_cert_chain(
+                    old_certs, old_certs_size, cert_index,
+                    &cert, &cert_size)) {
+                return false;
+            }
+
+            mutable_cert_offset += cert_size;
+
+            if (libspdm_contains_hardware_id_oid(cert, cert_size)) {
+                /* We found the Device Certificate CA */
+                break;
+            }
+
+            cert_index++;
+        }
+
+        /* Now Allocate enough memory for the new cert chain and the old
+         * mutable certs
+         */
+        size_t new_cert_chain_size = (old_certs_size - mutable_cert_offset) + *cert_chain_size;
+        new_buffer = (uint8_t *)malloc(new_cert_chain_size);
+        if (new_buffer == NULL) {
+            return false;
+        }
+
+
+        /* Copy the new immutable certificates */
+        libspdm_copy_mem(new_buffer + header_size, new_cert_chain_size - header_size,
+                         new_certs, new_certs_size);
+
+        /* Copy the old mutable certificates */
+        libspdm_copy_mem(new_buffer + header_size + new_certs_size, new_cert_chain_size - header_size - new_certs_size,
+                         old_certs + mutable_cert_offset, old_certs_size - mutable_cert_offset);
+
+        /* Update the size */
+        *cert_chain_size = new_cert_chain_size;
+
+        new_cert_chain = (spdm_cert_chain_t*)new_buffer;
+        new_cert_chain->length = (uint32_t)new_cert_chain_size;
+
+        /* Get Root Certificate*/
+        status = libspdm_x509_get_cert_from_cert_chain(new_buffer + header_size, new_cert_chain_size - header_size, 0,
+                                                       &root_cert,
+                                                       &root_cert_len);
+        if (!status) {
+            free(new_buffer);
+            return false;
+        }
+
+        /* Update the certificate hash */
+        libspdm_hash_all(
+            base_hash_algo,
+            root_cert,
+            root_cert_len,
+            new_buffer + 4);
+    } else {
+        return false;
+    }
+
+set_cert:
+
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+    parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
+    parameter.additional_data[0] = slot_id;
+    if (cert_chain_size == NULL) {
+        status = libspdm_set_data(spdm_context, LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN,
+                                  &parameter, new_buffer, 0);
+    } else {
+        status = libspdm_set_data(spdm_context, LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN,
+                                  &parameter, new_buffer, *cert_chain_size);
+    }
+    if (status != LIBSPDM_STATUS_SUCCESS) {
+        free(new_buffer);
+        return false;
+    }
+
+    /* `old_cert_chain` can be freed at this point. We can't
+     * free() the const version supplied to this function and
+     * stored in libspdm, so implementations need to keep track
+     * of the buffer manually, probably by storing it in
+     * `app_context_data_ptr`.
+     */
+
+    return true;
 }
 #endif /* LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP */

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1072,6 +1072,186 @@ static void rsp_set_certificate_rsp_case13(void **state)
     free(m_libspdm_set_certificate_request);
 }
 
+/**
+ * Test 14: directly exercises libspdm_update_local_cert_chain to verify the
+ * HAL replaces the in-memory local cert chain for both DEVICE_CERT and
+ * ALIAS_CERT models.
+ **/
+static void rsp_set_certificate_rsp_case14(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t hash_size;
+
+    void *cert_chain_a;
+    size_t cert_chain_a_size, tmp_cert_size;
+    void *cert_chain_b;
+    size_t cert_chain_b_size;
+    void *alias_chain;
+    size_t alias_chain_size;
+
+    const void *installed_chain;
+    size_t installed_chain_size;
+    void *orig_alias_chain;
+    size_t orig_alias_chain_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xe;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+
+    hash_size = libspdm_get_hash_size(m_libspdm_use_hash_algo);
+
+    spdm_context->local_context.local_cert_chain_provision[0] = NULL;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = 0;
+
+    if (!libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                         m_libspdm_use_asym_algo,
+                                                         &cert_chain_a, &cert_chain_a_size,
+                                                         NULL, NULL)) {
+        return;
+    }
+    if (!libspdm_read_responder_public_certificate_chain_per_slot(1, m_libspdm_use_hash_algo,
+                                                                  m_libspdm_use_asym_algo,
+                                                                  &cert_chain_b,
+                                                                  &cert_chain_b_size,
+                                                                  NULL, NULL)) {
+        free(cert_chain_a);
+        return;
+    }
+
+    /* Out-of-range slot id. */
+    tmp_cert_size = cert_chain_a_size;
+    assert_false(libspdm_update_local_cert_chain(spdm_context, SPDM_MAX_SLOT_COUNT,
+                                                 m_libspdm_use_hash_algo,
+                                                 m_libspdm_use_asym_algo,
+                                                 0,
+                                                 hash_size,
+                                                 NULL, 0,
+                                                 cert_chain_a, &tmp_cert_size,
+                                                 SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT,
+                                                 NULL, NULL));
+    /* cert_chain_size smaller than the spdm_cert_chain_t header + root hash. */
+    tmp_cert_size = sizeof(spdm_cert_chain_t) + hash_size - 1;
+    assert_false(libspdm_update_local_cert_chain(spdm_context, 0,
+                                                 m_libspdm_use_hash_algo,
+                                                 m_libspdm_use_asym_algo,
+                                                 0,
+                                                 hash_size,
+                                                 NULL, 0,
+                                                 cert_chain_a,
+                                                 &tmp_cert_size,
+                                                 SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT,
+                                                 NULL, NULL));
+    /* Unsupported cert_model. */
+    tmp_cert_size = cert_chain_a_size;
+    assert_false(libspdm_update_local_cert_chain(spdm_context, 0,
+                                                 m_libspdm_use_hash_algo,
+                                                 m_libspdm_use_asym_algo,
+                                                 0,
+                                                 hash_size,
+                                                 NULL, 0,
+                                                 cert_chain_a, &tmp_cert_size,
+                                                 SPDM_CERTIFICATE_INFO_CERT_MODEL_NONE,
+                                                 NULL, NULL));
+    assert_null(spdm_context->local_context.local_cert_chain_provision[0]);
+    assert_int_equal(spdm_context->local_context.local_cert_chain_provision_size[0], 0);
+
+    /* Device Cert, empty slot*/
+    tmp_cert_size = cert_chain_a_size;
+    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+                                                m_libspdm_use_hash_algo,
+                                                m_libspdm_use_asym_algo,
+                                                0,
+                                                hash_size,
+                                                NULL, 0,
+                                                cert_chain_a, &tmp_cert_size,
+                                                SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT,
+                                                NULL, NULL));
+
+    installed_chain = spdm_context->local_context.local_cert_chain_provision[0];
+    installed_chain_size = spdm_context->local_context.local_cert_chain_provision_size[0];
+    assert_non_null(installed_chain);
+    /* Assert it's an allocated buffer */
+    assert_ptr_not_equal(installed_chain, cert_chain_a);
+    /* These should be a blind copy */
+    assert_int_equal(installed_chain_size, cert_chain_a_size);
+    assert_memory_equal(installed_chain, cert_chain_a, cert_chain_a_size);
+
+    /* Device Cert, replace chain*/
+    tmp_cert_size = cert_chain_b_size;
+    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+                                                m_libspdm_use_hash_algo,
+                                                m_libspdm_use_asym_algo,
+                                                0,
+                                                hash_size,
+                                                installed_chain, installed_chain_size,
+                                                cert_chain_b, &tmp_cert_size,
+                                                SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT,
+                                                NULL, NULL));
+    free((void *)(uintptr_t)installed_chain);
+
+    installed_chain = spdm_context->local_context.local_cert_chain_provision[0];
+    installed_chain_size = spdm_context->local_context.local_cert_chain_provision_size[0];
+    assert_non_null(installed_chain);
+    /* Ensure it's a newly alloced buffer */
+    assert_ptr_not_equal(installed_chain, cert_chain_b);
+    /* Again a blind copy */
+    assert_memory_equal(installed_chain, cert_chain_b, cert_chain_b_size);
+
+    /* Alias Cert, existing slot*/
+    free((void *)(uintptr_t)installed_chain);
+
+    /* Read in the entire chain */
+    assert_true(libspdm_read_responder_public_certificate_chain_alias_cert(
+                    m_libspdm_use_hash_algo, m_libspdm_use_asym_algo,
+                    &orig_alias_chain, &orig_alias_chain_size, NULL, NULL));
+
+    /* Read in the new SET_CERTIFICATE chain */
+    assert_true(libspdm_read_responder_public_certificate_chain_alias_cert_till_dev_cert_ca(
+                    m_libspdm_use_hash_algo, m_libspdm_use_asym_algo,
+                    &alias_chain, &alias_chain_size, NULL, NULL));
+
+    tmp_cert_size = alias_chain_size;
+    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+                                                m_libspdm_use_hash_algo,
+                                                m_libspdm_use_asym_algo,
+                                                0,
+                                                hash_size,
+                                                orig_alias_chain, orig_alias_chain_size,
+                                                alias_chain, &tmp_cert_size,
+                                                SPDM_CERTIFICATE_INFO_CERT_MODEL_ALIAS_CERT,
+                                                NULL, NULL));
+
+    installed_chain = spdm_context->local_context.local_cert_chain_provision[0];
+    installed_chain_size = spdm_context->local_context.local_cert_chain_provision_size[0];
+    assert_non_null(installed_chain);
+    /* Ensure it's a newly alloced buffer */
+    assert_ptr_not_equal(installed_chain, orig_alias_chain);
+    assert_ptr_not_equal(installed_chain, alias_chain);
+    /* At this point we loaded the alias chain over the installed chain.
+     * For this test we `SET_CERTIFICATE` the same immutable chain, so the new
+     * buffer should be the same as the original one.
+     */
+    assert_memory_equal(installed_chain, orig_alias_chain, orig_alias_chain_size);
+
+    free(alias_chain);
+
+    free((void *)(uintptr_t)installed_chain);
+    free((void *)(uintptr_t)orig_alias_chain);
+    spdm_context->local_context.local_cert_chain_provision[0] = NULL;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = 0;
+
+    free(cert_chain_a);
+    free(cert_chain_b);
+}
+
 int libspdm_rsp_set_certificate_rsp_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -1099,6 +1279,7 @@ int libspdm_rsp_set_certificate_rsp_test(void)
         cmocka_unit_test(rsp_set_certificate_rsp_case11),
         cmocka_unit_test(rsp_set_certificate_rsp_case12),
         cmocka_unit_test(rsp_set_certificate_rsp_case13),
+        cmocka_unit_test(rsp_set_certificate_rsp_case14),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
After a successful SET_CERTIFICATE (that doesn't require a reset) this
new callback is called. It's the implementations responsibility to
allocate memory to store the new certificate chain and update
`LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN` to use the new chain.

After which the old certificate chain can be freed. Unfortunately we can't
handle this all in libspdm as it requires allocation, which is why the
HAL must handle this.

For DEVICE_CERT and GENERIC_CERT this is a simple. All that needs to be done
is memory allocated, the new certificate copied and the old certificate freed.

The ALIAS_CERT is similar, but required combining the new updated certificates
with the existing ones that aren't changed.

While we are at it we need to fix a bug with the current `AliasCert` certificate chains.
The SPDM spec states that in the AliasCert model "the Device Certificate
CA should contain the Hardware identity OID." This was previously
missing, let's ensure it's included and update the certificates to
include it.

Resolves: https://github.com/DMTF/libspdm/issues/873