### PR TITLE
spdm_device_secret_lib_sample: Fix build when GET_KEY_PAIR_INFO_CAP is disabled

### DIFF
--- a/os_stub/spdm_device_secret_lib_sample/read_priv_key_pem.c
+++ b/os_stub/spdm_device_secret_lib_sample/read_priv_key_pem.c
@@ -67,6 +67,7 @@ bool libspdm_read_responder_private_key(uint32_t base_asym_algo,
 bool libspdm_read_responder_private_key_ex(uint32_t base_asym_algo, uint8_t key_pair_id,
                                            void **data, size_t *size)
 {
+#if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
     bool res;
     char *file;
 
@@ -114,6 +115,9 @@ bool libspdm_read_responder_private_key_ex(uint32_t base_asym_algo, uint8_t key_
     }
     res = libspdm_read_input_file(file, data, size);
     return res;
+#else
+    return libspdm_read_responder_private_key(base_asym_algo, data, size);
+#endif
 }
 #endif
 

--- a/os_stub/spdm_device_secret_lib_sample/read_priv_key_pem_pqc.c
+++ b/os_stub/spdm_device_secret_lib_sample/read_priv_key_pem_pqc.c
@@ -82,6 +82,7 @@ bool libspdm_read_responder_pqc_private_key(uint32_t pqc_asym_algo,
 bool libspdm_read_responder_pqc_private_key_ex(uint32_t pqc_asym_algo, uint8_t key_pair_id,
                                                void **data, size_t *size)
 {
+#if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
     bool res;
     char *file;
 
@@ -144,6 +145,9 @@ bool libspdm_read_responder_pqc_private_key_ex(uint32_t pqc_asym_algo, uint8_t k
     }
     res = libspdm_read_input_file(file, data, size);
     return res;
+#else
+    return libspdm_read_responder_pqc_private_key(pqc_asym_algo, data, size);
+#endif
 }
 #endif
 


### PR DESCRIPTION
Commit 1e16c60f6d30 broke builds when
LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP is not enabled as libspdm_get_key_pair_id_by_slot() isn't defined. Fix the build by guarding calls of libspdm_get_key_pair_id_by_slot().

Fixes: 1e16c60f6d30 ("Add slot 4 multi-key example with a distinct responder leaf key")