### PR TITLE
spdm_crypt_lib: Split out hardware ID OID finding function

### DIFF
--- a/include/library/spdm_crypt_lib.h
+++ b/include/library/spdm_crypt_lib.h
@@ -1003,6 +1003,21 @@ bool libspdm_x509_set_cert_certificate_check(
     bool is_requester, uint8_t cert_model);
 
 /**
+ * Returns whether the given certificate contains the SPDM hardware identity OID.
+ *
+ * The hardware identity OID is required to be present in the Device
+ * Certificate CA when using the alias certificate model.
+ *
+ * @param[in]  cert       Pointer to the DER-encoded certificate data.
+ * @param[in]  cert_size  The size of the certificate data, in bytes.
+ *
+ * @retval true   The certificate contains the SPDM hardware identity OID.
+ * @retval false  The certificate does not contain the SPDM hardware identity OID
+ *                (or the extensions could not be parsed).
+ **/
+bool libspdm_contains_hardware_id_oid(const uint8_t *cert, size_t cert_size);
+
+/**
  * Return whether given certificate is a root certificate or not.
  *
  * A certificate is considered a root certificate if

--- a/library/spdm_crypt_lib/libspdm_crypt_cert.c
+++ b/library/spdm_crypt_lib/libspdm_crypt_cert.c
@@ -1291,20 +1291,7 @@ static bool libspdm_verify_leaf_cert_spdm_eku(const uint8_t *cert, size_t cert_s
     return true;
 }
 
-/**
- * Verify leaf cert spdm defined extension
- *
- * @param[in]  cert                  Pointer to the DER-encoded certificate data.
- * @param[in]  cert_size             The size of certificate data in bytes.
- * @param[in]  is_requester_cert     Is the function verifying requester or responder cert.
- *
- * @retval  true   verify pass
- * @retval  false  verify fail,two case: 1. Unable to get get or validate extension data.
- *                                       2. hardware_identity_oid is found in AliasCert model;
- **/
-static bool libspdm_verify_leaf_cert_spdm_extension(const uint8_t *cert, size_t cert_size,
-                                                    bool is_requester_cert,
-                                                    uint8_t cert_model)
+bool libspdm_contains_hardware_id_oid(const uint8_t *cert, size_t cert_size)
 {
     bool status;
     bool find_successful;
@@ -1332,7 +1319,7 @@ static bool libspdm_verify_leaf_cert_spdm_extension(const uint8_t *cert, size_t 
     if (!status) {
         return false;
     } else if (len == 0) {
-        return true;
+        return false;
     }
 
     /*find the spdm hardware identity OID*/
@@ -1373,6 +1360,26 @@ static bool libspdm_verify_leaf_cert_spdm_extension(const uint8_t *cert, size_t 
     if (ptr != spdm_extension + len) {
         return false;
     }
+
+    return find_successful;
+}
+
+/**
+ * Verify leaf cert spdm defined extension
+ *
+ * @param[in]  cert                  Pointer to the DER-encoded certificate data.
+ * @param[in]  cert_size             The size of certificate data in bytes.
+ * @param[in]  is_requester_cert     Is the function verifying requester or responder cert.
+ *
+ * @retval  true   verify pass
+ * @retval  false  verify fail,two case: 1. Unable to get get or validate extension data.
+ *                                       2. hardware_identity_oid is found in AliasCert model;
+ **/
+static bool libspdm_verify_leaf_cert_spdm_extension(const uint8_t *cert, size_t cert_size,
+                                                    bool is_requester_cert,
+                                                    uint8_t cert_model)
+{
+    bool find_successful = libspdm_contains_hardware_id_oid(cert, cert_size);
 
     /* Responder does not determine Requester's certificate model */
     if (!is_requester_cert) {


### PR DESCRIPTION
Split the existing libspdm_verify_leaf_cert_spdm_extension() function to include a new libspdm_contains_hardware_id_oid() function that can be used elsewhere.