### PR TITLE
Fix out-of-bounds read in libspdm_process_general_opaque_data_check

### DIFF
--- a/library/spdm_common_lib/libspdm_com_opaque_data.c
+++ b/library/spdm_common_lib/libspdm_com_opaque_data.c
@@ -308,6 +308,14 @@ bool libspdm_process_general_opaque_data_check(libspdm_context_t *spdm_context,
                     return false;
                 }
 
+                /*ensure the vendor_id and opaque_element_data_len field are within the buffer*/
+                if (total_element_len + sizeof(opaque_element_table_header_t) +
+                    opaque_element_table_header->vendor_len +
+                    sizeof(opaque_element_data_len) >
+                    data_element_size) {
+                    return false;
+                }
+
                 opaque_element_data_len = libspdm_read_uint16(
                     (const uint8_t *)(opaque_element_table_header + 1) +
                     opaque_element_table_header->vendor_len);
@@ -316,6 +324,12 @@ bool libspdm_process_general_opaque_data_check(libspdm_context_t *spdm_context,
                                       opaque_element_table_header->vendor_len +
                                       sizeof(opaque_element_data_len) +
                                       opaque_element_data_len;
+
+                /*ensure the element with padding is within the buffer before reading it*/
+                if (total_element_len + ((current_element_len + 3) & ~3) >
+                    data_element_size) {
+                    return false;
+                }
 
                 if ((current_element_len & 3) != 0) {
                     if (!libspdm_consttime_is_mem_equal(zero_padding,
@@ -330,10 +344,6 @@ bool libspdm_process_general_opaque_data_check(libspdm_context_t *spdm_context,
                 current_element_len = (current_element_len + 3) & ~3;
 
                 total_element_len += current_element_len;
-
-                if (total_element_len > data_element_size) {
-                    return false;
-                }
 
                 /*move to next element*/
                 opaque_element_table_header =


### PR DESCRIPTION
Repro: a 1.2+ peer sends format-1 opaque data (in KEY_EXCHANGE/PSK_EXCHANGE/MEASUREMENTS/CHALLENGE/CSR) with a single element whose vendor_len is non-zero, or whose opaque_element_data_len runs past the element table.
Cause: the per-element loop reads opaque_element_data_len at header+vendor_len, then compares the alignment-padding bytes, before either offset is checked against data_element_size. The sibling libspdm_get_element_from_opaque_data_with_element_id already guards both reads; this path only checked header + length-field.
Fix: validate vendor_len plus the length field, and the padded element length, against the remaining buffer before the reads.