### PR TITLE
Fix out-of-bounds read in libspdm_pci_doe_decode_discovery_response

### DIFF
--- a/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
+++ b/library/spdm_transport_pcidoe_lib/libspdm_doe_pcidoe.c
@@ -326,6 +326,10 @@ libspdm_return_t libspdm_pci_doe_decode_discovery_response(size_t transport_mess
          * of the PCIe DOE spec. DOE discovery is mandatory for all
          * implementations.
          */
+        if (transport_message_size <
+            sizeof(pci_doe_data_object_header_t) + sizeof(pci_doe_discovery_response_t)) {
+            return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        }
         message = (uint8_t *)transport_message + sizeof(pci_doe_data_object_header_t);
         if (vendor_id != NULL) {
             *vendor_id = *message;


### PR DESCRIPTION
Repro: a peer returns a DOE discovery response of 9 to 11 bytes (8-byte header plus 1 to 3 payload bytes); it clears the size > header guard.
Cause: the discovery case reads protocol at header+2 and next_index at header+3 before the length == transport_message_size check at the tail of the function, so the 4-byte payload is dereferenced with only a one-byte-past-header guarantee.
Fix: reject a short discovery response before the field reads, the way the request decoder is already bounded.