### PR TITLE
[issue-3590] Allow SlotSizeRequested for an empty certificate slot

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_certificate.c
@@ -24,6 +24,7 @@ libspdm_return_t libspdm_get_response_certificate(libspdm_context_t *spdm_contex
     libspdm_session_info_t *session_info;
     libspdm_session_state_t session_state;
     bool use_large_cert_chain;
+    bool slot_size_requested;
     uint32_t req_msg_header_size;
     uint32_t rsp_msg_header_size;
     size_t cert_chain_size;
@@ -121,13 +122,28 @@ libspdm_return_t libspdm_get_response_certificate(libspdm_context_t *spdm_contex
                                                response_size, response);
     }
 
-    if (spdm_context->local_context.local_cert_chain_provision[slot_id] == NULL) {
+    /* The SlotSizeRequested attribute is only defined for SPDM 1.3 and later; in earlier
+     * versions the param2 bit is reserved and must be ignored. */
+    if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_13) {
+        slot_size_requested =
+            ((spdm_request->header.param2 &
+              SPDM_GET_CERTIFICATE_REQUEST_ATTRIBUTES_SLOT_SIZE_REQUESTED) != 0);
+    } else {
+        slot_size_requested = false;
+    }
+
+    if (!slot_size_requested &&
+        (spdm_context->local_context.local_cert_chain_provision[slot_id] == NULL)) {
         return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_INVALID_REQUEST,
             0, response_size, response);
     }
 
-    cert_chain_size = spdm_context->local_context.local_cert_chain_provision_size[slot_id];
+    if (spdm_context->local_context.local_cert_chain_provision[slot_id] == NULL) {
+        cert_chain_size = 0;
+    } else {
+        cert_chain_size = spdm_context->local_context.local_cert_chain_provision_size[slot_id];
+    }
 
     if ((spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_14) &&
         (!use_large_cert_chain) && (cert_chain_size > SPDM_MAX_CERTIFICATE_CHAIN_SIZE)) {
@@ -146,15 +162,12 @@ libspdm_return_t libspdm_get_response_certificate(libspdm_context_t *spdm_contex
         length = spdm_request->length;
     }
 
-    if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_13) {
-        if (spdm_request->header.param2 &
-            SPDM_GET_CERTIFICATE_REQUEST_ATTRIBUTES_SLOT_SIZE_REQUESTED) {
-            offset = 0;
-            length = 0;
-        }
+    if (slot_size_requested) {
+        offset = 0;
+        length = 0;
     }
 
-    if (offset >= cert_chain_size) {
+    if (!slot_size_requested && (offset >= cert_chain_size)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
                                                response_size, response);
@@ -216,10 +229,14 @@ libspdm_return_t libspdm_get_response_certificate(libspdm_context_t *spdm_contex
         spdm_response->remainder_length = (uint16_t)remainder_length;
     }
 
-    libspdm_copy_mem((uint8_t *)spdm_response + rsp_msg_header_size,
-                     response_capacity - rsp_msg_header_size,
-                     (const uint8_t *)spdm_context->local_context
-                     .local_cert_chain_provision[slot_id] + offset, length);
+    /* A SlotSizeRequested query carries no certificate data (length == 0), and the slot may be
+     * empty (provision == NULL), so skip the copy to avoid dereferencing a NULL source. */
+    if (length != 0) {
+        libspdm_copy_mem((uint8_t *)spdm_response + rsp_msg_header_size,
+                         response_capacity - rsp_msg_header_size,
+                         (const uint8_t *)spdm_context->local_context
+                         .local_cert_chain_provision[slot_id] + offset, length);
+    }
 
     if (session_info == NULL) {
         /* Log to transcript. */

--- a/unit_test/test_spdm_responder/certificate.c
+++ b/unit_test/test_spdm_responder/certificate.c
@@ -1282,6 +1282,62 @@ static void rsp_certificate_case19(void **state)
     free(data);
 }
 
+/**
+ * Test 20: SlotSizeRequested query against an empty slot (no certificate chain provisioned).
+ * A SlotSizeRequested query returns only a size and is independent of whether the slot holds a
+ * certificate chain, so it must not be rejected for an empty slot.
+ * Expected Behavior: SUCCESS with portion_length 0 and a remainder_length equal to the slot
+ * storage size: the maximum provisioning size when SET_CERT_CAP is supported (case 1), otherwise
+ * 0 because the slot is empty (case 3).
+ **/
+static void rsp_certificate_case20(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_certificate_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 20;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AFTER_DIGESTS;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+
+    /* Empty slot: no certificate chain is provisioned. */
+    spdm_context->local_context.cert_slot_reset_mask = 0;
+    spdm_context->local_context.local_cert_chain_provision[0] = NULL;
+    spdm_context->local_context.local_cert_chain_provision_size[0] = 0;
+
+    m_libspdm_get_certificate_request5.header.param1 = 0;
+    m_libspdm_get_certificate_request5.header.param2 =
+        SPDM_GET_CERTIFICATE_REQUEST_ATTRIBUTES_SLOT_SIZE_REQUESTED;
+    m_libspdm_get_certificate_request5.length = LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN;
+    m_libspdm_get_certificate_request5.offset = 0xFF;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_certificate(
+        spdm_context, m_libspdm_get_certificate_request5_size,
+        &m_libspdm_get_certificate_request5, &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_certificate_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_CERTIFICATE);
+    assert_int_equal(spdm_response->header.param1, 0);
+    assert_int_equal(spdm_response->portion_length, 0);
+#if LIBSPDM_ENABLE_CAPABILITY_SET_CERT_CAP
+    /* Case 1: SET_CERT_CAP supported -> maximum provisioning size for the slot. */
+    assert_int_equal(spdm_response->remainder_length, SPDM_MAX_CERTIFICATE_CHAIN_SIZE);
+#else
+    /* Case 3: no SET_CERT_CAP and the slot is empty -> size 0. */
+    assert_int_equal(spdm_response->remainder_length, 0);
+#endif
+}
+
 int libspdm_rsp_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -1323,6 +1379,8 @@ int libspdm_rsp_certificate_test(void)
         /* check request attributes and response attributes*/
         cmocka_unit_test(rsp_certificate_case18),
         cmocka_unit_test(rsp_certificate_case19),
+        /* SlotSizeRequested against an empty slot */
+        cmocka_unit_test(rsp_certificate_case20),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
## Summary

A `GET_CERTIFICATE` request with the `SlotSizeRequested` attribute asks only for the slot size. Per the SPDM-WG discussion behind DSP0274, this result is **independent** of whether the slot currently holds a certificate chain:

| Condition                                | Returned size              |
| ---------------------------------------- | -------------------------- |
| `SET_CERTIFICATE` supported              | maximum provisionable size |
| no `SET_CERTIFICATE`, slot **has** chain | size of the chain          |
| no `SET_CERTIFICATE`, slot **empty**     | 0                          |

The responder previously made the "empty slot" outcomes unreachable.

## Problem

`libspdm_get_response_certificate()` rejected an empty slot **before** ever reaching the size logic:

1. The `local_cert_chain_provision[slot_id] == NULL` check returned `InvalidRequest`.
2. A later `offset >= cert_chain_size` check rejected the same case again. As a result, both the **"empty slot → 0"** outcome and the **"empty slot under SET_CERT_CAP → maximum size"** outcome could never be produced, even though a `SlotSizeRequested` query is valid against an empty slot.

## Changes

- Compute a `slot_size_requested` flag (SPDM 1.3+ and the `SLOT_SIZE_REQUESTED` attribute set).
- Bypass the `NULL` rejection when `slot_size_requested` is set.
- Treat a `NULL` provision as `cert_chain_size = 0`.
- Skip the certificate copy when the portion length is 0 (the source pointer may be `NULL` for an empty slot), avoiding a NULL dereference.

The size still flows through the existing response path, so the `SET_CERT_CAP` HAL override, transcript logging, and connection-state update are unchanged. Non-`SlotSizeRequested` requests behave exactly as before.

## Testing

- Added responder unit test **case 20**: a `SlotSizeRequested` query against an empty slot returns `SUCCESS` with `portion_length == 0` and `remainder_length` equal to the slot storage size — the maximum size with `SET_CERT_CAP`, otherwise 0.
- The existing **case 18** already covers the non-empty slot.

## Related

Fixes #3590