### PR TITLE
spdm_responder_lib: Enforce RESPOND_IF_READY session context

### DIFF
--- a/include/internal/libspdm_common_lib.h
+++ b/include/internal/libspdm_common_lib.h
@@ -627,6 +627,12 @@ typedef struct {
 #if LIBSPDM_RESPOND_IF_READY_SUPPORT
     void *cache_spdm_request;
     size_t cache_spdm_request_size;
+    /* Session context of the original request that triggered the ResponseNotReady flow. The validity
+     * of the RESPOND_IF_READY request is defined by that original request, so the RESPOND_IF_READY
+     * must arrive in the same session context (same in-session/out-of-session, and if in a session
+     * the same session_id). */
+    bool cache_spdm_request_session_id_valid;
+    uint32_t cache_spdm_request_session_id;
 #endif
     uint8_t current_token;
 

--- a/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
+++ b/library/spdm_responder_lib/libspdm_rsp_handle_response_state.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -31,13 +31,29 @@ libspdm_return_t libspdm_responder_handle_response_state(libspdm_context_t *spdm
         return LIBSPDM_STATUS_SUCCESS;
     #if LIBSPDM_RESPOND_IF_READY_SUPPORT
     case LIBSPDM_RESPONSE_STATE_NOT_READY:
-        /*do not update ErrorData if a previous request has not been completed*/
+        /* Do not update ErrorData if a previous request has not been completed.
+         *
+         * Only one deferred (ResponseNotReady) request is tracked per connection. A Requester shall
+         * not have multiple outstanding requests to the same Responder within a connection (the only
+         * exceptions are GET_VERSION and the large-message / CHUNK_SEND pair). A request awaiting its
+         * RESPOND_IF_READY completion is still outstanding, so a conformant Requester will not issue
+         * another request - in another session or otherwise - until this one completes. A Responder
+         * is not required to process more than one request message at a time, even across
+         * connections, so a single context-wide cache is sufficient and conformant. */
         if (request_code != SPDM_RESPOND_IF_READY) {
             spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
             libspdm_copy_mem(spdm_context->cache_spdm_request,
                              libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                              spdm_context->last_spdm_request,
                              spdm_context->last_spdm_request_size);
+            /* Record the session context of the original request. The validity of the
+             * RESPOND_IF_READY request is defined by the original request that caused the
+             * RESPOND_IF_READY flow, so the matching RESPOND_IF_READY must arrive in the same
+             * session context. */
+            spdm_context->cache_spdm_request_session_id_valid =
+                spdm_context->last_spdm_request_session_id_valid;
+            spdm_context->cache_spdm_request_session_id =
+                spdm_context->last_spdm_request_session_id;
             spdm_context->error_data.rd_exponent = 1;
             spdm_context->error_data.rd_tm = 1;
             spdm_context->error_data.request_code = request_code;

--- a/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
+++ b/library/spdm_responder_lib/libspdm_rsp_respond_if_ready.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -38,6 +38,24 @@ libspdm_return_t libspdm_get_response_respond_if_ready(libspdm_context_t *spdm_c
     if (request_size < sizeof(spdm_message_header_t)) {
         return libspdm_generate_error_response(spdm_context,
                                                SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                               response_size, response);
+    }
+
+    /* The validity of the RESPOND_IF_READY request is defined by the original request that caused
+     * the RESPOND_IF_READY flow (the last request to which the Responder sent an ERROR message of
+     * ErrorCode=ResponseNotReady). The RESPOND_IF_READY shall therefore arrive in the same session
+     * context as that original request: the same in-session / out-of-session state, and, when in a
+     * session, the same session_id. Otherwise the cached response would be returned outside the
+     * context it belongs to. (Only one deferred request is tracked per connection; a conformant
+     * Requester does not have multiple outstanding requests to the same Responder within a
+     * connection.) */
+    if ((spdm_context->last_spdm_request_session_id_valid !=
+         spdm_context->cache_spdm_request_session_id_valid) ||
+        (spdm_context->cache_spdm_request_session_id_valid &&
+         (spdm_context->last_spdm_request_session_id !=
+          spdm_context->cache_spdm_request_session_id))) {
+        return libspdm_generate_error_response(spdm_context,
+                                               SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
                                                response_size, response);
     }
 

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -1010,6 +1010,9 @@ static void rsp_respond_if_ready_case8(void **state) {
     libspdm_copy_mem(spdm_context->cache_spdm_request,
                      libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
                      spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
+    /* The original PSK_FINISH was in a session; the RESPOND_IF_READY arrives in that same session. */
+    spdm_context->cache_spdm_request_session_id_valid = true;
+    spdm_context->cache_spdm_request_session_id = session_id;
     spdm_context->error_data.rd_exponent = 1;
     spdm_context->error_data.rd_tm        = 1;
     spdm_context->error_data.request_code = SPDM_PSK_FINISH;
@@ -1060,6 +1063,10 @@ static void rsp_respond_if_ready_case10(void **state) {
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xA;
+    /* Connection (non-session) original request and RESPOND_IF_READY: both contexts are
+     * out-of-session. Set explicitly so the test does not depend on prior cases' state. */
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_BUSY;
 
     /*state for the the original request (GET_DIGESTS)*/
@@ -1123,6 +1130,10 @@ static void rsp_respond_if_ready_case11(void **state) {
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xB;
+    /* Connection (non-session) original request and RESPOND_IF_READY: both contexts are
+     * out-of-session. Set explicitly so the test does not depend on prior cases' state. */
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NEED_RESYNC;
 
     /*state for the the original request (GET_DIGESTS)*/
@@ -1188,6 +1199,10 @@ static void rsp_respond_if_ready_case12(void **state) {
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xC;
+    /* Connection (non-session) original request and RESPOND_IF_READY: both contexts are
+     * out-of-session. Set explicitly so the test does not depend on prior cases' state. */
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NOT_READY;
 
     /*state for the the original request (GET_DIGESTS)*/
@@ -1256,6 +1271,10 @@ static void rsp_respond_if_ready_case13(void **state) {
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xD;
+    /* Connection (non-session) original request and RESPOND_IF_READY: both contexts are
+     * out-of-session. Set explicitly so the test does not depend on prior cases' state. */
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
 
     /*state for the the original request (GET_DIGESTS)*/
@@ -1317,6 +1336,10 @@ static void rsp_respond_if_ready_case14(void **state) {
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0xE;
+    /* Connection (non-session) original request and RESPOND_IF_READY: both contexts are
+     * out-of-session. Set explicitly so the test does not depend on prior cases' state. */
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->last_spdm_request_session_id_valid = false;
     spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
 
     /*state for the the original request (GET_DIGESTS)*/
@@ -1358,6 +1381,75 @@ static void rsp_respond_if_ready_case14(void **state) {
     assert_int_equal (spdm_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
     assert_int_equal (spdm_response->header.param2, 0);
 }
+
+/**
+ * Test 15: receiving a RESPOND_IF_READY with the correct original request code and token, but in a
+ * DIFFERENT session context than the original request. Here the original request (GET_DIGESTS) was
+ * received outside of a session, but the RESPOND_IF_READY arrives inside a session.
+ * Expected behavior: per DSP0274 the validity of RESPOND_IF_READY is defined by the original
+ * request, so a context mismatch is refused with ERROR(UnexpectedRequest); the cached response is
+ * NOT returned.
+ **/
+static void rsp_respond_if_ready_case15(void **state) {
+    libspdm_return_t status;
+    libspdm_test_context_t    *spdm_test_context;
+    libspdm_context_t  *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_error_response_t *spdm_response;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xF;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
+
+    /*state for the the original request (GET_DIGESTS)*/
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->local_context.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.local_cert_chain_provision_size[0] =
+        sizeof(m_libspdm_local_certificate_chain);
+    libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
+                     (uint8_t)(0xFF));
+
+    spdm_context->last_spdm_request_size = m_libspdm_get_digest_request_size;
+    libspdm_copy_mem(spdm_context->last_spdm_request,
+                     libspdm_get_scratch_buffer_last_spdm_request_capacity(spdm_context),
+                     &m_libspdm_get_digest_request, m_libspdm_get_digest_request_size);
+
+    /*RESPOND_IF_READY specific data: the original GET_DIGESTS was received OUTSIDE a session.*/
+    spdm_context->cache_spdm_request_size = spdm_context->last_spdm_request_size;
+    libspdm_copy_mem(spdm_context->cache_spdm_request,
+                     libspdm_get_scratch_buffer_cache_spdm_request_capacity(spdm_context),
+                     spdm_context->last_spdm_request, spdm_context->last_spdm_request_size);
+    spdm_context->cache_spdm_request_session_id_valid = false;
+    spdm_context->error_data.rd_exponent = 1;
+    spdm_context->error_data.rd_tm        = 1;
+    spdm_context->error_data.request_code = SPDM_GET_DIGESTS;
+    spdm_context->error_data.token       = LIBSPDM_MY_TEST_TOKEN;
+
+    /* But the RESPOND_IF_READY arrives INSIDE a session -- a context mismatch. */
+    spdm_context->last_spdm_request_session_id_valid = true;
+    spdm_context->last_spdm_request_session_id = 0xFFFFFFFF;
+
+    /*check ERROR response*/
+    response_size = sizeof(response);
+    status = libspdm_get_response_respond_if_ready(spdm_context,
+                                                   m_libspdm_respond_if_ready_request1_size,
+                                                   &m_libspdm_respond_if_ready_request1,
+                                                   &response_size,
+                                                   response);
+    assert_int_equal (status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal (response_size, sizeof(spdm_error_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal (spdm_response->header.request_response_code, SPDM_ERROR);
+    assert_int_equal (spdm_response->header.param1, SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
+    assert_int_equal (spdm_response->header.param2, 0);
+
+    /* restore for subsequent cases */
+    spdm_context->last_spdm_request_session_id_valid = false;
+}
 #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
 int libspdm_rsp_respond_if_ready_test(void) {
@@ -1393,6 +1485,7 @@ int libspdm_rsp_respond_if_ready_test(void) {
         cmocka_unit_test(rsp_respond_if_ready_case12),
         cmocka_unit_test(rsp_respond_if_ready_case13),
         cmocka_unit_test(rsp_respond_if_ready_case14),
+        cmocka_unit_test(rsp_respond_if_ready_case15),
     #endif /* LIBSPDM_ENABLE_CAPABILITY_CERT_CAP*/
 
     };


### PR DESCRIPTION
Fix: https://github.com/DMTF/libspdm/issues/3664

Per DSP0274 (RESPOND_IF_READY request message format), "the validity of the RESPOND_IF_READY request ... is defined by the original request that caused the RESPOND_IF_READY flow." The responder must therefore only honor a RESPOND_IF_READY that arrives in the same session context as the original deferred request; otherwise the cached response would be returned outside the context it belongs to.

The handler previously validated only the SPDM version, the original request code, and the token -- not the session context -- so a RESPOND_IF_READY sent in a different session (or in a session when the original was on the connection, or vice versa) was wrongly accepted and the cached response replayed.

Capture the original request's session context when the ResponseNotReady flow is entered (libspdm_responder_handle_response_state), and reject a RESPOND_IF_READY whose session context does not exactly match -- same in-session / out-of-session state, and the same session_id when in a session -- with ERROR(UnexpectedRequest), before replaying the cached request.

- libspdm_common_lib.h: add cache_spdm_request_session_id_valid / cache_spdm_request_session_id to the context (RESPOND_IF_READY support).
- libspdm_rsp_handle_response_state.c: record the original request's session context alongside the cached request.
- libspdm_rsp_respond_if_ready.c: reject a session-context mismatch with UnexpectedRequest.
- test_spdm_responder/respond_if_ready.c: add case 15 (original on the connection, RESPOND_IF_READY in a session -> UnexpectedRequest); seed the new cache session fields in the existing session/connection cases so they do not depend on cross-case state.


Assisted-by: Claude Code:claude-opus-4-8