### PR TITLE
HAL/setcertlib: Add bank_id parameter to libspdm_update_local_cert_chain

### DIFF
--- a/include/hal/library/responder/setcertlib.h
+++ b/include/hal/library/responder/setcertlib.h
@@ -62,6 +62,13 @@ uint32_t libspdm_get_cert_chain_slot_storage_size(
  * with the existing ones that aren't changed.
  *
  * @param[in,out]  spdm_context     A pointer to the SPDM context.
+ * @param[in]      bank_id          When invoked via the SLOT_MANAGEMENT SetCertificate SubCode,
+ *                                  points to the Bank for the certificate chain. NULL for the
+ *                                  legacy SET_CERTIFICATE flow, which has no Bank concept. The
+ *                                  in-memory local_cert_chain_provision (used by GET_CERTIFICATE,
+ *                                  GET_DIGESTS, and CHALLENGE) is only refreshed when bank_id is
+ *                                  NULL or points to the currently selected Bank, since that is
+ *                                  the chain those commands serve.
  * @param[in]      slot_id          The slot id of the certificate chain.
  * @param[in]      base_hash_algo   The negotiated base hash algorithm
  *                                  (SPDM_ALGORITHMS_BASE_HASH_ALGO_*). May be
@@ -103,6 +110,7 @@ uint32_t libspdm_get_cert_chain_slot_storage_size(
  **/
 extern bool libspdm_update_local_cert_chain(
     void *spdm_context,
+    const uint8_t *bank_id,
     uint8_t slot_id,
     uint32_t base_hash_algo,
     uint32_t base_asym_algo,

--- a/library/spdm_responder_lib/libspdm_rsp_set_certificate_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_certificate_rsp.c
@@ -230,6 +230,7 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
         /* erase slot_id cert_chain*/
         result = libspdm_update_local_cert_chain(
             spdm_context,
+            NULL,
             slot_id, 0, 0, 0, 0,
             old_local_cert_chain,
             old_local_cert_chain_size,
@@ -306,6 +307,7 @@ libspdm_return_t libspdm_get_response_set_certificate(libspdm_context_t *spdm_co
         /* set certificate to NV*/
         result = libspdm_update_local_cert_chain(
             spdm_context,
+            NULL,
             slot_id,
             spdm_context->connection_info.algorithm.base_hash_algo,
             spdm_context->connection_info.algorithm.base_asym_algo,

--- a/os_stub/spdm_device_secret_lib_null/lib.c
+++ b/os_stub/spdm_device_secret_lib_null/lib.c
@@ -258,6 +258,7 @@ uint32_t libspdm_get_cert_chain_slot_storage_size(
 
 bool libspdm_update_local_cert_chain(
     void *spdm_context,
+    const uint8_t *bank_id,
     uint8_t slot_id,
     uint32_t base_hash_algo,
     uint32_t base_asym_algo,

--- a/os_stub/spdm_device_secret_lib_sample/set_cert.c
+++ b/os_stub/spdm_device_secret_lib_sample/set_cert.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2024 DMTF. All rights reserved.
+ *  Copyright 2024-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -112,6 +112,7 @@ uint32_t libspdm_get_cert_chain_slot_storage_size(
 
 bool libspdm_update_local_cert_chain(
     void *spdm_context,
+    const uint8_t *bank_id,
     uint8_t slot_id,
     uint32_t base_hash_algo,
     uint32_t base_asym_algo,
@@ -131,6 +132,10 @@ bool libspdm_update_local_cert_chain(
     uint8_t *new_buffer;
     bool result;
     const uint8_t *new_chain_bytes;
+
+    /* This sample has no Bank-addressed certificate store; bank_id is ignored and the chain is
+     * stored as in the legacy SET_CERTIFICATE flow. */
+    (void)bank_id;
 
     if (slot_id >= SPDM_MAX_SLOT_COUNT) {
         return false;

--- a/unit_test/test_spdm_responder/set_certificate_rsp.c
+++ b/unit_test/test_spdm_responder/set_certificate_rsp.c
@@ -1128,7 +1128,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
 
     /* Out-of-range slot id. */
     tmp_cert_size = cert_chain_a_size;
-    assert_false(libspdm_update_local_cert_chain(spdm_context, SPDM_MAX_SLOT_COUNT,
+    assert_false(libspdm_update_local_cert_chain(spdm_context, NULL, SPDM_MAX_SLOT_COUNT,
                                                  m_libspdm_use_hash_algo,
                                                  m_libspdm_use_asym_algo,
                                                  0,
@@ -1139,7 +1139,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
                                                  NULL, NULL));
     /* cert_chain_size smaller than the spdm_cert_chain_t header + root hash. */
     tmp_cert_size = sizeof(spdm_cert_chain_t) + hash_size - 1;
-    assert_false(libspdm_update_local_cert_chain(spdm_context, 0,
+    assert_false(libspdm_update_local_cert_chain(spdm_context, NULL, 0,
                                                  m_libspdm_use_hash_algo,
                                                  m_libspdm_use_asym_algo,
                                                  0,
@@ -1151,7 +1151,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
                                                  NULL, NULL));
     /* Unsupported cert_model. */
     tmp_cert_size = cert_chain_a_size;
-    assert_false(libspdm_update_local_cert_chain(spdm_context, 0,
+    assert_false(libspdm_update_local_cert_chain(spdm_context, NULL, 0,
                                                  m_libspdm_use_hash_algo,
                                                  m_libspdm_use_asym_algo,
                                                  0,
@@ -1165,7 +1165,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
 
     /* Device Cert, empty slot*/
     tmp_cert_size = cert_chain_a_size;
-    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+    assert_true(libspdm_update_local_cert_chain(spdm_context, NULL, 0,
                                                 m_libspdm_use_hash_algo,
                                                 m_libspdm_use_asym_algo,
                                                 0,
@@ -1186,7 +1186,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
 
     /* Device Cert, replace chain*/
     tmp_cert_size = cert_chain_b_size;
-    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+    assert_true(libspdm_update_local_cert_chain(spdm_context, NULL, 0,
                                                 m_libspdm_use_hash_algo,
                                                 m_libspdm_use_asym_algo,
                                                 0,
@@ -1219,7 +1219,7 @@ static void rsp_set_certificate_rsp_case14(void **state)
                     &alias_chain, &alias_chain_size, NULL, NULL));
 
     tmp_cert_size = alias_chain_size;
-    assert_true(libspdm_update_local_cert_chain(spdm_context, 0,
+    assert_true(libspdm_update_local_cert_chain(spdm_context, NULL, 0,
                                                 m_libspdm_use_hash_algo,
                                                 m_libspdm_use_asym_algo,
                                                 0,


### PR DESCRIPTION
Add a const uint8_t *bank_id parameter to the libspdm_update_local_cert_chain HAL API. This is the API plumbing needed by the SLOT_MANAGEMENT SetCertificate SubCode, which addresses a certificate chain by Bank, while the legacy SET_CERTIFICATE flow has no Bank concept.

bank_id == NULL preserves the existing SET_CERTIFICATE behavior: the certificate chain is stored and the in-memory local_cert_chain_provision (served by GET_CERTIFICATE, GET_DIGESTS, and CHALLENGE) is refreshed. A non-NULL bank_id is reserved for the Bank-addressed SLOT_MANAGEMENT flow.

- setcertlib.h: add the bank_id parameter and document it.
- libspdm_rsp_set_certificate_rsp.c: the two SET_CERTIFICATE call sites pass NULL (no Bank).
- spdm_device_secret_lib_null: update the stub definition.
- spdm_device_secret_lib_sample: update the definition; this sample has no Bank-addressed store, so bank_id is ignored and the chain is stored as in the legacy flow.
- test_spdm_responder/set_certificate_rsp.c: update the direct API call sites to pass NULL.


Assisted-by: Claude Code:claude-opus-4-8