### PR TITLE
spdm_responder_lib: Sync slot context after SET_KEY_PAIR_INFO

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_set_key_pair_info_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_set_key_pair_info_ack.c
@@ -394,6 +394,38 @@ libspdm_return_t libspdm_get_response_set_key_pair_info_ack(libspdm_context_t *s
                                                SPDM_ERROR_CODE_RESET_REQUIRED, 0,
                                                response_size, response);
     } else {
+        /* Update context with new key pair information if a reset is not needed. Re-read the key
+         * pair info so the authoritative post-write association and key usage are used (the device
+         * may normalize or apply defaults on a successful write). */
+        uint8_t new_assoc_cert_slot_mask = 0;
+        uint16_t new_current_key_usage = 0;
+        uint8_t slot_index;
+
+        result = libspdm_read_key_pair_info(
+            spdm_context, key_pair_id, &total_key_pairs, &capabilities, &key_usage_capabilities,
+            &new_current_key_usage, &asym_algo_capabilities, &current_asym_algo,
+            &pqc_asym_algo_capabilities, &current_pqc_asym_algo, &new_assoc_cert_slot_mask,
+            NULL, NULL);
+        if (!result) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_UNSPECIFIED, 0,
+                                                   response_size, response);
+        }
+
+        for (slot_index = 0; slot_index < SPDM_MAX_SLOT_COUNT; slot_index++) {
+            if ((new_assoc_cert_slot_mask & (1 << slot_index)) != 0) {
+                /* Slot is (still) associated with this KeyPairID. */
+                spdm_context->local_context.local_key_pair_id[slot_index] = key_pair_id;
+                spdm_context->local_context.local_key_usage_bit_mask[slot_index] =
+                    new_current_key_usage;
+            } else if (spdm_context->local_context.local_key_pair_id[slot_index] == key_pair_id) {
+                /* Context still points at this KeyPairID but the slot is no longer in the
+                 * authoritative mask (removed or stale); clear it. */
+                spdm_context->local_context.local_key_pair_id[slot_index] = 0;
+                spdm_context->local_context.local_key_usage_bit_mask[slot_index] = 0;
+            }
+        }
+
         spdm_response->header.spdm_version = spdm_request->header.spdm_version;
         spdm_response->header.request_response_code = SPDM_SET_KEY_PAIR_INFO_ACK;
         spdm_response->header.param1 = 0;

--- a/unit_test/test_spdm_responder/set_key_pair_info_ack.c
+++ b/unit_test/test_spdm_responder/set_key_pair_info_ack.c
@@ -788,6 +788,133 @@ static void rsp_set_key_pair_info_ack_case7(void **state)
     free(set_key_pair_info_request);
 }
 
+/**
+ * Test 6: After a successful no-reset SET_KEY_PAIR_INFO that changes a key pair's certificate slot
+ * association, the connection-level context (local_key_pair_id and local_key_usage_bit_mask, which
+ * DIGESTS reports per slot) shall be kept coherent with the new association: a newly associated
+ * slot shall reflect this KeyPairID and its current key usage, and a slot removed from the
+ * association shall be cleared.
+ * Expected Behavior: local_key_pair_id[slot] and local_key_usage_bit_mask[slot] track the change.
+ **/
+static void rsp_set_key_pair_info_ack_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    spdm_set_key_pair_info_ack_response_t *spdm_response;
+
+    uint8_t key_pair_id;
+    uint8_t slot_id;
+    size_t set_key_pair_info_request_size;
+    spdm_set_key_pair_info_request_t *set_key_pair_info_request;
+    uint8_t *ptr;
+    uint16_t desired_key_usage;
+    uint32_t desired_asym_algo;
+    uint8_t desired_assoc_cert_slot_mask;
+
+    set_key_pair_info_request = malloc(sizeof(spdm_set_key_pair_info_request_t) +
+                                       sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint32_t) +
+                                       sizeof(uint8_t));
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x6;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_KEY_PAIR_INFO_CAP;
+
+    key_pair_id = 4;
+    /* Slot 2 is never provisioned in the sample (only slots 0/1 for primary key pairs and slot 4
+     * for the secondaries), so associating it never collides with a same-algorithm key pair. This
+     * keeps the case independent of which algorithm key_pair_id 4 maps to in the build. */
+    slot_id = 2;
+
+    /* Seed the per-slot context with sentinels that differ from what a coherent sync must write,
+     * so the assertions below are meaningful. */
+    spdm_context->local_context.local_key_pair_id[slot_id] = 0xEE;
+    spdm_context->local_context.local_key_usage_bit_mask[slot_id] = 0;
+
+    response_size = sizeof(response);
+
+    /* Step 1: ParameterChange associating the slot with key_pair_id 4 and KeyExUse. Do not change
+     * the algorithm (DesiredAsymAlgo = 0). This is a no-reset flow (SPDM 1.3), so it applies at
+     * once. */
+    desired_key_usage = SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    desired_asym_algo = 0;
+    desired_assoc_cert_slot_mask = (uint8_t)(1 << slot_id);
+    set_key_pair_info_request_size =
+        sizeof(spdm_set_key_pair_info_request_t) +
+        sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint8_t);
+
+    libspdm_zero_mem(set_key_pair_info_request, set_key_pair_info_request_size);
+    set_key_pair_info_request->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    set_key_pair_info_request->header.request_response_code = SPDM_SET_KEY_PAIR_INFO;
+    set_key_pair_info_request->header.param1 = SPDM_SET_KEY_PAIR_INFO_CHANGE_OPERATION;
+    set_key_pair_info_request->header.param2 = 0;
+    set_key_pair_info_request->key_pair_id = key_pair_id;
+
+    ptr = (uint8_t*)(set_key_pair_info_request + 1);
+    ptr += sizeof(uint8_t);
+    libspdm_write_uint16(ptr, desired_key_usage);
+    ptr += sizeof(uint16_t);
+    libspdm_write_uint32(ptr, desired_asym_algo);
+    ptr += sizeof(uint32_t);
+    *ptr = desired_assoc_cert_slot_mask;
+
+    status = libspdm_get_response_set_key_pair_info_ack(
+        spdm_context, set_key_pair_info_request_size,
+        set_key_pair_info_request, &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_set_key_pair_info_ack_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_SET_KEY_PAIR_INFO_ACK);
+
+    /* The newly associated slot must now report this KeyPairID and its current key usage. */
+    assert_int_equal(spdm_context->local_context.local_key_pair_id[slot_id], key_pair_id);
+    assert_int_equal(spdm_context->local_context.local_key_usage_bit_mask[slot_id],
+                     SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE);
+
+    /* Step 2: ParameterChange removing the slot association (empty mask). */
+    desired_key_usage = 0;
+    desired_asym_algo = 0;
+    desired_assoc_cert_slot_mask = 0x00;
+
+    libspdm_zero_mem(set_key_pair_info_request, set_key_pair_info_request_size);
+    set_key_pair_info_request->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    set_key_pair_info_request->header.request_response_code = SPDM_SET_KEY_PAIR_INFO;
+    set_key_pair_info_request->header.param1 = SPDM_SET_KEY_PAIR_INFO_CHANGE_OPERATION;
+    set_key_pair_info_request->header.param2 = 0;
+    set_key_pair_info_request->key_pair_id = key_pair_id;
+
+    ptr = (uint8_t*)(set_key_pair_info_request + 1);
+    ptr += sizeof(uint8_t);
+    libspdm_write_uint16(ptr, desired_key_usage);
+    ptr += sizeof(uint16_t);
+    libspdm_write_uint32(ptr, desired_asym_algo);
+    ptr += sizeof(uint32_t);
+    *ptr = desired_assoc_cert_slot_mask;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_set_key_pair_info_ack(
+        spdm_context, set_key_pair_info_request_size,
+        set_key_pair_info_request, &response_size, response);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(response_size, sizeof(spdm_set_key_pair_info_ack_response_t));
+    spdm_response = (void *)response;
+    assert_int_equal(spdm_response->header.request_response_code, SPDM_SET_KEY_PAIR_INFO_ACK);
+
+    /* The removed slot must be cleared, since this KeyPairID owned it in the context. */
+    assert_int_equal(spdm_context->local_context.local_key_pair_id[slot_id], 0);
+    assert_int_equal(spdm_context->local_context.local_key_usage_bit_mask[slot_id], 0);
+
+    free(set_key_pair_info_request);
+}
+
 int libspdm_rsp_set_key_pair_info_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -803,6 +930,8 @@ int libspdm_rsp_set_key_pair_info_ack_test(void)
         cmocka_unit_test(rsp_set_key_pair_info_ack_case5),
         /* Reject same-algorithm slot collision across KeyPairIDs*/
         cmocka_unit_test(rsp_set_key_pair_info_ack_case7),
+        /* Context (DIGESTS) coherence after a no-reset association change*/
+        cmocka_unit_test(rsp_set_key_pair_info_ack_case6),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
Fix https://github.com/DMTF/libspdm/issues/3673

DIGESTS reports exactly one KeyPairID and one KeyUsageMask per certificate slot (DSP0274 Table 42), sourced from local_context.local_key_pair_id[] and local_context.local_key_usage_bit_mask[]. A successful no-reset SET_KEY_PAIR_INFO changes a key pair's certificate slot association inside the device (via the libspdm_write_key_pair_info HAL), but the responder never updated these connection-level arrays. As a result a later DIGESTS could report a stale KeyPairID / KeyUsageMask for a slot whose association had changed, disagreeing with the key pair actually used for signing.

After a successful no-reset SET_KEY_PAIR_INFO, the responder re-reads the key pair info (libspdm_read_key_pair_info) and syncs the per-slot context from the authoritative post-write AssocCertSlotMask and CurrentKeyUsage. Re-reading (rather than inferring the new state from the request inputs) keeps the context correct even when the device normalizes the request or applies defaults on a successful write. The pre-write mask is kept only to identify slots this KeyPairID no longer owns, which are then cleared.

- libspdm_rsp_set_key_pair_info_ack.c: re-read key pair info and sync local_key_pair_id[] and local_key_usage_bit_mask[] for the affected slots in the no-reset success path.
- test_spdm_responder/set_key_pair_info_ack.c: add case 6, which seeds a sentinel KeyPairID in the slot context, performs a no-reset association change, and asserts the context reflects the new association (and is cleared when the association is removed).

Assisted-by: Claude Code:claude-opus-4-8
