### PR TITLE
bound opaque_length against response size before opaque check

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_challenge.c
+++ b/library/spdm_requester_lib/libspdm_req_challenge.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -288,6 +288,12 @@ static libspdm_return_t libspdm_try_challenge(libspdm_context_t *spdm_context,
         }
     }
     ptr += sizeof(uint16_t);
+    if (spdm_response_size <
+        sizeof(spdm_challenge_auth_response_t) + hash_size + SPDM_NONCE_SIZE +
+        measurement_summary_hash_size + sizeof(uint16_t) + opaque_length) {
+        status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
+        goto receive_done;
+    }
     if (opaque_length != 0) {
         result = libspdm_process_general_opaque_data_check(spdm_context, opaque_length, ptr);
         if (!result) {

--- a/library/spdm_requester_lib/libspdm_req_get_measurements.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurements.c
@@ -461,6 +461,12 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
             }
         }
         ptr += sizeof(uint16_t);
+        if (spdm_response_size <
+            sizeof(spdm_measurements_response_t) + measurement_record_data_length +
+            SPDM_NONCE_SIZE + sizeof(uint16_t) + opaque_length) {
+            status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
+            goto receive_done;
+        }
         if (opaque_length != 0) {
             result = libspdm_process_general_opaque_data_check(spdm_context, opaque_length, ptr);
             if (!result) {
@@ -545,7 +551,7 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
     } else {
         if (spdm_response_size <
             sizeof(spdm_measurements_response_t) +
-            measurement_record_data_length + sizeof(uint16_t)) {
+            measurement_record_data_length + SPDM_NONCE_SIZE + sizeof(uint16_t)) {
             status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
             goto receive_done;
         }
@@ -566,6 +572,12 @@ static libspdm_return_t libspdm_try_get_measurement(libspdm_context_t *spdm_cont
             goto receive_done;
         }
         ptr += sizeof(uint16_t);
+        if (spdm_response_size <
+            sizeof(spdm_measurements_response_t) + measurement_record_data_length +
+            SPDM_NONCE_SIZE + sizeof(uint16_t) + opaque_length) {
+            status = LIBSPDM_STATUS_INVALID_MSG_SIZE;
+            goto receive_done;
+        }
         if (opaque_length != 0) {
             result = libspdm_process_general_opaque_data_check(spdm_context, opaque_length, ptr);
             if (!result) {


### PR DESCRIPTION
Repro: a responder returns a short CHALLENGE_AUTH or MEASUREMENTS response whose opaque_length field is set near SPDM_MAX_OPAQUE_DATA_SIZE while the actual trailing bytes are truncated.
Cause: libspdm_try_challenge and both branches of libspdm_try_get_measurement pass opaque_length into libspdm_process_general_opaque_data_check before validating it against spdm_response_size. The helper treats data_in_size as the buffer length and dereferences up to that many bytes, so the peer-declared length drives an out-of-bounds read of up to ~1KB past the received message. The unsigned MEASUREMENTS branch also left SPDM_NONCE_SIZE out of its size check, so the nonce and length fields were read past the buffer as well.
Fix: check opaque_length against the remaining response size before the opaque parse, the same guard the sibling key_exchange and psk_exchange parsers already apply, and add the missing nonce term to the unsigned MEASUREMENTS check.