### PR TITLE
check request_size before reading finish opaque_length

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_finish_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_finish_rsp.c
@@ -534,6 +534,11 @@ libspdm_return_t libspdm_get_response_finish(libspdm_context_t *spdm_context, si
 
     ptr = (uint8_t *)(size_t)spdm_request + sizeof(spdm_finish_request_t);
     if (libspdm_get_connection_version(spdm_context) >= SPDM_MESSAGE_VERSION_14) {
+        if (request_size < sizeof(spdm_finish_request_t) + sizeof(uint16_t)) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                                   response_size, response);
+        }
         req_opaque_data_size = libspdm_read_uint16((const uint8_t *)request +
                                                    sizeof(spdm_finish_request_t));
         ptr += sizeof(uint16_t);

--- a/library/spdm_responder_lib/libspdm_rsp_psk_finish_rsp.c
+++ b/library/spdm_responder_lib/libspdm_rsp_psk_finish_rsp.c
@@ -169,6 +169,11 @@ libspdm_return_t libspdm_get_response_psk_finish(libspdm_context_t *spdm_context
 
     ptr = (uint8_t *)(size_t)spdm_request + sizeof(spdm_psk_finish_request_t);
     if (libspdm_get_connection_version(spdm_context) >= SPDM_MESSAGE_VERSION_14) {
+        if (request_size < sizeof(spdm_psk_finish_request_t) + sizeof(uint16_t)) {
+            return libspdm_generate_error_response(spdm_context,
+                                                   SPDM_ERROR_CODE_INVALID_REQUEST, 0,
+                                                   response_size, response);
+        }
         req_opaque_data_size = libspdm_read_uint16((const uint8_t *)request +
                                                    sizeof(spdm_psk_finish_request_t));
         ptr += sizeof(uint16_t);


### PR DESCRIPTION
Repro: a v1.4 responder receives a FINISH or PSK_FINISH carrying only the request header (request_size == sizeof(request_t)).
Cause: libspdm_get_response_finish / libspdm_get_response_psk_finish read the 2-byte opaque_length via libspdm_read_uint16 at request+sizeof(request_t) before any request_size guard covers those bytes; the size check runs afterward.
Fix: add the request_size >= header + sizeof(uint16_t) check before the read, matching what key_exchange and set_key_pair_info already do for their length fields.