### PR TITLE
null digest_context_th after free in libspdm_append_message_k

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -1948,6 +1948,7 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
             if (!result) {
                 libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                    spdm_session_info->session_transcript.digest_context_th);
+                spdm_session_info->session_transcript.digest_context_th = NULL;
                 return LIBSPDM_STATUS_CRYPTO_ERROR;
             }
             result = libspdm_hash_update (spdm_context->connection_info.algorithm.base_hash_algo,
@@ -1959,6 +1960,7 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
             if (!result) {
                 libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                    spdm_session_info->session_transcript.digest_context_th);
+                spdm_session_info->session_transcript.digest_context_th = NULL;
                 return LIBSPDM_STATUS_CRYPTO_ERROR;
             }
             if (!spdm_session_info->use_psk) {
@@ -1971,6 +1973,7 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
                     if (!result) {
                         libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                            spdm_session_info->session_transcript.digest_context_th);
+                        spdm_session_info->session_transcript.digest_context_th = NULL;
                         return LIBSPDM_STATUS_CRYPTO_ERROR;
                     }
                 }
@@ -1982,6 +1985,7 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
                 if (!result) {
                     libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                        spdm_session_info->session_transcript.digest_context_th);
+                    spdm_session_info->session_transcript.digest_context_th = NULL;
                     return LIBSPDM_STATUS_CRYPTO_ERROR;
                 }
             }
@@ -1993,6 +1997,7 @@ libspdm_return_t libspdm_append_message_k(libspdm_context_t *spdm_context,
         if (!result) {
             libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
                                spdm_session_info->session_transcript.digest_context_th);
+            spdm_session_info->session_transcript.digest_context_th = NULL;
             return LIBSPDM_STATUS_CRYPTO_ERROR;
         }
         return LIBSPDM_STATUS_SUCCESS;


### PR DESCRIPTION
Repro: on the responder, a KEY_EXCHANGE whose transcript hashing hits a crypto HAL failure. libspdm_append_message_k frees session_transcript.digest_context_th on the error path, the caller (libspdm_rsp_key_exchange.c) then tears the session down through libspdm_free_session_id, and libspdm_session_info_init frees the same context again.
Cause: the five hash-failure paths in append_message_k free digest_context_th but leave the dangling pointer in the session struct. The sibling transcript builders append_message_f/_m/_e all null it after freeing; only this one does not.
Fix: null digest_context_th after each free, matching the siblings.