### PR TITLE
avoid oob read of struct_table->alg_type when param1 is 0

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
+++ b/library/spdm_requester_lib/libspdm_req_negotiate_algorithms.c
@@ -355,7 +355,7 @@ static libspdm_return_t libspdm_try_negotiate_algorithms(libspdm_context_t *spdm
                  sizeof(uint32_t) * spdm_response->ext_asym_sel_count +
                  sizeof(uint32_t) * spdm_response->ext_hash_sel_count);
     if (spdm_response->header.spdm_version >= SPDM_MESSAGE_VERSION_11) {
-        alg_type_pre = struct_table->alg_type;
+        alg_type_pre = 0;
         /* header.param1 is implicitly checked through spdm_response_size. */
         for (index = 0; index < spdm_response->header.param1; index++) {
             if ((size_t)spdm_response + spdm_response_size < (size_t)struct_table) {

--- a/library/spdm_responder_lib/libspdm_rsp_algorithms.c
+++ b/library/spdm_responder_lib/libspdm_rsp_algorithms.c
@@ -428,7 +428,7 @@ libspdm_return_t libspdm_get_response_algorithms(libspdm_context_t *spdm_context
                             sizeof(uint32_t) * spdm_request->ext_asym_count +
                             sizeof(uint32_t) * spdm_request->ext_hash_count);
     if (spdm_request->header.spdm_version >= SPDM_MESSAGE_VERSION_11) {
-        alg_type_pre = struct_table->alg_type;
+        alg_type_pre = 0;
         for (index = 0; index < spdm_request->header.param1; index++) {
             if ((size_t)spdm_request + request_size < (size_t)struct_table) {
                 return libspdm_generate_error_response(


### PR DESCRIPTION
Repro: send a NEGOTIATE_ALGORITHMS request (responder) or ALGORITHMS response (requester) with param1 == 0 and no extended algorithms, sized to exactly the fixed header. ASAN reports a heap-buffer-overflow read of size 1 at offset request_size/spdm_response_size, at libspdm_rsp_algorithms.c:431 and libspdm_req_negotiate_algorithms.c:358.
Cause: both parsers seed alg_type_pre from struct_table->alg_type before the per-entry loop. With zero algorithm-structure tables struct_table lands one past the message end, so that seed read runs off the buffer. In the loop every struct_table access is already bounds-checked; only this pre-loop seed skips the guard. The seed is dead anyway: alg_type_pre is compared only when index != 0 and is reassigned at index 0.
Fix: seed alg_type_pre to 0 instead of dereferencing struct_table. Same change on the requester side.