### PR TITLE
spdm_requester_lib: allow chunked CAPABILITIES response (SupportedAlgorithms)

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -243,12 +243,19 @@ libspdm_return_t libspdm_handle_error_large_response(
         return LIBSPDM_STATUS_UNSUPPORTED_CAP;
     }
 
-    /* Fail if requester or responder does not support chunk cap */
-    if (!libspdm_is_capabilities_flag_supported(
-            spdm_context, true,
-            SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP,
-            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
-        return LIBSPDM_STATUS_ERROR_PEER;
+    /* Fail if requester or responder does not support chunk cap. The Responder's negotiated
+     * capability flags are only known once the CAPABILITIES response has been processed
+     * (connection state AFTER_CAPABILITIES). A CAPABILITIES response that carries the Supported
+     * Algorithms Block can itself be chunked, in which case this handler runs while the state is
+     * still AFTER_VERSION; skip the check then, since the Responder returning
+     * ERROR_LARGE_RESPONSE already implies it supports chunking. */
+    if (spdm_context->connection_info.connection_state >= LIBSPDM_CONNECTION_STATE_AFTER_CAPABILITIES) {
+        if (!libspdm_is_capabilities_flag_supported(
+                spdm_context, true,
+                SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP,
+                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
+            return LIBSPDM_STATUS_ERROR_PEER;
+        }
     }
 
     if (*inout_response_size < sizeof(spdm_error_response_t) +
@@ -286,6 +293,12 @@ libspdm_return_t libspdm_handle_error_large_response(
     large_response_size = 0;
     large_response_size_so_far = 0;
     chunk_seq_no = 0;
+
+    /* Mark that a CHUNK_GET transfer is in progress so that the response to a CHUNK_GET is not
+     * itself dispatched back into this handler by libspdm_receive_spdm_response. Per spec the
+     * response to CHUNK_GET must be CHUNK_RESPONSE; a nested ERROR_LARGE_RESPONSE would otherwise
+     * cause unbounded recursion. */
+    spdm_context->chunk_context.get.chunk_in_use = true;
 
     do {
         LIBSPDM_ASSERT(message_size >= transport_header_size);
@@ -475,6 +488,8 @@ libspdm_return_t libspdm_handle_error_large_response(
             libspdm_zero_mem(large_response, large_response_size);
         }
     }
+
+    spdm_context->chunk_context.get.chunk_in_use = false;
 
     return status;
 }

--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -788,7 +788,8 @@ libspdm_return_t libspdm_receive_spdm_response(libspdm_context_t *spdm_context,
     }
 
     if (spdm_response->request_response_code == SPDM_ERROR
-        && spdm_response->param1 == SPDM_ERROR_CODE_LARGE_RESPONSE) {
+        && spdm_response->param1 == SPDM_ERROR_CODE_LARGE_RESPONSE
+        && !spdm_context->chunk_context.get.chunk_in_use) {
         status = libspdm_handle_error_large_response(
             spdm_context, session_id,
             response_size, (void *)spdm_response, response_capacity, response_from_chunk);


### PR DESCRIPTION
A CAPABILITIES response that carries the Supported Algorithms Block (DSP0274 1.3+, requested via GET_CAPABILITIES Param1[0]) can exceed DataTransferSize and be transferred via the Large SPDM message mechanism. libspdm_get_capabilities receives the response through libspdm_receive_spdm_response, which already permits a chunked CAPABILITIES, but libspdm_handle_error_large_response rejected it: it verifies the Responder's negotiated CHUNK_CAP via libspdm_is_capabilities_flag_supported, and during the CAPABILITIES exchange the Responder's capability flags are not yet known (connection state is still AFTER_VERSION), so the check failed with LIBSPDM_STATUS_ERROR_PEER.

Skip the negotiated-flag check while the connection state is below AFTER_CAPABILITIES; the Responder returning ERROR_LARGE_RESPONSE already implies it supports chunking. Once capabilities are negotiated, the check is unchanged.


Assisted-by: Claude Code:claude-opus-4-8

Related PR: https://github.com/DMTF/spdm-emu/pull/505