### PR TITLE
free session transcript hash contexts in libspdm_session_info_init

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data_session.c
+++ b/library/spdm_common_lib/libspdm_com_context_data_session.c
@@ -70,6 +70,21 @@ void libspdm_session_info_init(libspdm_context_t *spdm_context,
                            session_info->session_transcript.digest_context_th_backup);
         session_info->session_transcript.digest_context_th_backup = NULL;
     }
+    if (session_info->session_transcript.digest_context_l1l2 != NULL) {
+        libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                           session_info->session_transcript.digest_context_l1l2);
+        session_info->session_transcript.digest_context_l1l2 = NULL;
+    }
+    if (session_info->session_transcript.digest_context_il1il2 != NULL) {
+        libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                           session_info->session_transcript.digest_context_il1il2);
+        session_info->session_transcript.digest_context_il1il2 = NULL;
+    }
+    if (session_info->session_transcript.digest_context_encap_il1il2 != NULL) {
+        libspdm_hash_free (spdm_context->connection_info.algorithm.base_hash_algo,
+                           session_info->session_transcript.digest_context_encap_il1il2);
+        session_info->session_transcript.digest_context_encap_il1il2 = NULL;
+    }
 #endif
 
     libspdm_zero_mem (&(session_info->last_key_update_request), sizeof(spdm_key_update_request_t));


### PR DESCRIPTION
Repro: open a secure session, send an in-session GET_MEASUREMENTS without the GENERATE_SIGNATURE attribute, then end the session. digest_context_l1l2 is allocated by libspdm_append_message_m and is still live at teardown.
Cause: libspdm_session_info_init frees digest_context_th and digest_context_th_backup but not the sibling l1l2/il1il2/encap_il1il2 contexts. The libspdm_zero_mem right after clears session_transcript, nulling those three pointers without freeing them. libspdm_free_session_id reaches session_info_init directly, so reset_message_m/reset_message_e/reset_message_encap_e never run and the contexts are orphaned.
Fix: free the three remaining contexts before the zero_mem, matching the th/th_backup block and the per-transcript frees in reset_message_m/reset_message_e/reset_message_encap_e.
