### PR TITLE
validate size before reading storage secured message fields

### DIFF
--- a/library/spdm_transport_storage_lib/libspdm_storage.c
+++ b/library/spdm_transport_storage_lib/libspdm_storage.c
@@ -91,7 +91,16 @@ static libspdm_return_t libspdm_storage_secured_message_decode(
     libspdm_error_struct_t spdm_error;
     uint32_t spdm_msg_offset;
     spdm_storage_secured_message_descriptor *descriptor;
-    uint8_t num_descriptors = ((uint8_t *)(*message))[0];
+    uint8_t num_descriptors;
+
+    /* The num descriptors byte and the single supported descriptor are read
+     * below, so the decrypted message must be at least that large before any
+     * field is dereferenced. */
+    if (*message_size < LIBSPDM_STORAGE_SECURED_MESSAGE_DESCRIPTOR_MIN_SIZE) {
+        return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+    }
+
+    num_descriptors = ((uint8_t *)(*message))[0];
 
     /* Check for invalid message with no descriptors (DSP0286 Table 8) */
     if (num_descriptors == 0) {
@@ -365,6 +374,10 @@ libspdm_return_t libspdm_transport_storage_decode_message(
          */
         /* Expecting a secured message */
         if (*session_id != NULL) {
+            if (transport_message_size <
+                LIBSPDM_STORAGE_SECURED_MESSAGE_HEADER_RESERVED_BYTES + sizeof(uint32_t)) {
+                return LIBSPDM_STATUS_INVALID_MSG_SIZE;
+            }
             **session_id =
                 *((uint32_t *)(((uint8_t *)transport_message) +
                                LIBSPDM_STORAGE_SECURED_MESSAGE_HEADER_RESERVED_BYTES));


### PR DESCRIPTION
Repro: a peer storage device returns a secured-message response shorter than the 4 reserved bytes plus the 4-byte session id (a 0-7 byte reply); with ASAN this is a heap-buffer-overflow READ of size 4 at libspdm_storage.c:369.

Cause: the response branch of libspdm_transport_storage_decode_message reads the session id at transport_message+4 and then derives the ciphertext length as transport_message_size - LIBSPDM_STORAGE_SECURED_MESSAGE_HEADER_RESERVED_BYTES with no size guard, so the read runs past the buffer and the subtraction underflows into the length handed to libspdm_decode_secured_message. The request path (libspdm_storage_decode_message) already validates this. The same shape exists in libspdm_storage_secured_message_decode, which reads num_descriptors and the 16-byte descriptor from the decrypted message before checking *message_size.

Fix: guard both reads with the minimum-size checks the request path already performs, before any field is dereferenced.