### PR TITLE
bound application_data_length by cipher header in secured decode

### DIFF
--- a/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_encode_decode.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -532,7 +532,7 @@ libspdm_return_t libspdm_decode_secured_message(
             return LIBSPDM_STATUS_CRYPTO_ERROR;
         }
         plain_text_size = enc_msg_header->application_data_length;
-        if (plain_text_size > cipher_text_size) {
+        if (plain_text_size + sizeof(spdm_secured_message_cipher_header_t) > cipher_text_size) {
             libspdm_secured_message_set_last_spdm_error_struct(
                 spdm_secured_message_context, &spdm_error);
             return LIBSPDM_STATUS_INVALID_MSG_SIZE;

--- a/unit_test/test_spdm_secured_message/encode_decode.c
+++ b/unit_test/test_spdm_secured_message/encode_decode.c
@@ -897,6 +897,65 @@ static void libspdm_test_secured_message_encode_case12(void **state)
                      decode_secured_message_context.application_secret.request_data_sequence_number);
 }
 
+/**
+ * Test 13: A peer-crafted ENC_MAC record whose decrypted application_data_length equals
+ *          cipher_text_size leaves no room for the 2-byte cipher header, so the reported
+ *          payload would run past the decrypted plaintext. Decoding must reject it.
+ **/
+static void libspdm_test_secured_message_encode_case13(void **state)
+{
+    libspdm_return_t status;
+    bool result;
+    size_t app_message_size = sizeof(m_app_message);
+    void *app_message = m_app_message;
+    const uint32_t session_id = 0x00112233;
+    const size_t record_header_size = 4 + PARTIAL_SEQ_NUM_SIZE + 2;
+    const size_t cipher_text_size = 48;
+    const size_t tag_size = 16;
+    uint8_t plain_text[48];
+    uint8_t iv[LIBSPDM_MAX_AEAD_IV_SIZE];
+    size_t cipher_out_size = cipher_text_size;
+
+    initialize_secured_message_context();
+    m_secured_message_context.sequence_number_endian =
+        LIBSPDM_DATA_SESSION_SEQ_NUM_ENC_LITTLE_DEC_LITTLE;
+
+    /* Forge a plaintext whose length field claims the entire ciphertext as payload,
+     * leaving no room for the cipher header. */
+    libspdm_zero_mem(plain_text, sizeof(plain_text));
+    libspdm_write_uint16(plain_text, (uint16_t)cipher_text_size);
+
+    /* Build the record header, which also serves as the AEAD additional data. */
+    libspdm_zero_mem(m_secured_message, sizeof(m_secured_message));
+    libspdm_write_uint32(m_secured_message, session_id);
+    libspdm_write_uint16(m_secured_message + record_header_size - 2,
+                         (uint16_t)(cipher_text_size + tag_size));
+
+    /* Sequence number zero means the IV is just the salt. */
+    libspdm_zero_mem(iv, sizeof(iv));
+    libspdm_copy_mem(iv, sizeof(iv),
+                     m_secured_message_context.application_secret.request_data_salt,
+                     m_secured_message_context.aead_iv_size);
+
+    result = libspdm_aead_encryption(
+        m_secured_message_context.secured_message_version,
+        m_secured_message_context.aead_cipher_suite,
+        m_secured_message_context.application_secret.request_data_encryption_key,
+        m_secured_message_context.aead_key_size, iv,
+        m_secured_message_context.aead_iv_size, m_secured_message, record_header_size,
+        plain_text, cipher_text_size,
+        m_secured_message + record_header_size + cipher_text_size, tag_size,
+        m_secured_message + record_header_size, &cipher_out_size);
+    assert_true(result);
+
+    status = libspdm_decode_secured_message(
+        &m_secured_message_context, session_id, true,
+        record_header_size + cipher_text_size + tag_size, m_secured_message,
+        &app_message_size, &app_message, &m_secured_message_callbacks);
+
+    assert_int_equal(LIBSPDM_STATUS_INVALID_MSG_SIZE, status);
+}
+
 libspdm_test_context_t m_libspdm_common_context_data_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     true,
@@ -919,6 +978,7 @@ int libspdm_secured_message_encode_decode_test_main(void)
         cmocka_unit_test(libspdm_test_secured_message_encode_case10),
         cmocka_unit_test(libspdm_test_secured_message_encode_case11),
         cmocka_unit_test(libspdm_test_secured_message_encode_case12),
+        cmocka_unit_test(libspdm_test_secured_message_encode_case13),
     };
 
     libspdm_setup_test_context(&m_libspdm_common_context_data_test_context);

--- a/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
+++ b/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
@@ -1,8 +1,11 @@
 /**
  *  Copyright Notice:
- *  Copyright 2023 DMTF. All rights reserved.
+ *  Copyright 2023-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
+
+#include "spdm_unit_test.h"
+#include "library/spdm_common_lib.h"
 
 extern int libspdm_secured_message_encode_decode_test_main(void);
 


### PR DESCRIPTION
Repro: a session peer sends an ENC_MAC secured message whose decrypted application_data_length equals cipher_text_size.
Cause: libspdm_decode_secured_message bounds application_data_length against cipher_text_size, but the returned payload starts sizeof(spdm_secured_message_cipher_header_t) bytes into the plaintext, so it can run past the decrypted region, and past the plaintext buffer when the ciphertext fills it.
Fix: require application_data_length plus the cipher header to fit within cipher_text_size before returning the payload.

case13 forges such a record and expects INVALID_MSG_SIZE. The suite main was missing the config include that gates it behind LIBSPDM_AEAD_AES_256_GCM_SUPPORT, so none of these tests were compiling in; added the include so they run.