### PR TITLE
free pqc key context in libspdm_verify_endpoint_info_signature

### DIFF
--- a/library/spdm_common_lib/libspdm_com_crypto_service.c
+++ b/library/spdm_common_lib/libspdm_com_crypto_service.c
@@ -1459,7 +1459,7 @@ bool libspdm_verify_endpoint_info_signature(libspdm_context_t *spdm_context,
                 spdm_context->connection_info.algorithm.pqc_asym_algo,
                 spdm_context->connection_info.algorithm.base_hash_algo,
                 context, il1il2_hash, il1il2_hash_size, sign_data, sign_data_size);
-            if (slot_id == 0xFF) {
+            if (slot_id == 0xF) {
                 libspdm_pqc_asym_free(
                     spdm_context->connection_info.algorithm.pqc_asym_algo, context);
             }
@@ -1504,7 +1504,7 @@ bool libspdm_verify_endpoint_info_signature(libspdm_context_t *spdm_context,
                 spdm_context->connection_info.algorithm.req_pqc_asym_alg,
                 spdm_context->connection_info.algorithm.base_hash_algo,
                 context, il1il2_hash, il1il2_hash_size, sign_data, sign_data_size);
-            if (slot_id == 0xFF) {
+            if (slot_id == 0xF) {
                 libspdm_req_pqc_asym_free(
                     spdm_context->connection_info.algorithm.req_pqc_asym_alg, context);
             }


### PR DESCRIPTION
Repro: verify a peer GET_ENDPOINT_INFO signature against a provisioned public key (slot 0xF) on a connection that negotiated a PQC signature algorithm.
Cause: the two PQC context frees in libspdm_verify_endpoint_info_signature guard on slot_id == 0xFF, but ENDPOINT_INFO carries a 4-bit slot id (SPDM_GET_ENDPOINT_INFO_REQUEST_SLOT_ID_MASK is 0xF), so slot_id is never 0xFF and the context allocated at the slot_id == 0xF branch is never released. The base_asym/req_base_asym frees in the same function already use 0xF; 0xFF was carried over from libspdm_verify_challenge_auth_signature, whose slot id is a full byte.
Fix: gate both PQC frees on slot_id == 0xF, matching the allocation and the classical-asym frees in this function.
