### PR TITLE
fix unaligned reads of vendor-defined response payload length

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_vendor_defined_request.c
+++ b/library/spdm_requester_lib/libspdm_req_vendor_defined_request.c
@@ -263,7 +263,7 @@ static libspdm_return_t libspdm_try_vendor_send_request_receive_response(
     response_ptr = spdm_response->vendor_plus_request + spdm_response->vendor_id_len;
     if (use_large_payload) {
         response_ptr += sizeof(uint16_t);
-        response_size = *((uint32_t*)response_ptr);
+        response_size = libspdm_read_uint32(response_ptr);
         if (spdm_response_size < response_size +
             sizeof(spdm_vendor_defined_response_msg_t) +
             spdm_response->vendor_id_len + sizeof(uint16_t) + sizeof(uint32_t)) {
@@ -272,7 +272,7 @@ static libspdm_return_t libspdm_try_vendor_send_request_receive_response(
         }
         response_ptr += sizeof(uint32_t);
     } else {
-        response_size = *((uint16_t*)response_ptr);
+        response_size = libspdm_read_uint16(response_ptr);
 
         if (spdm_response_size < response_size +
             sizeof(spdm_vendor_defined_response_msg_t) +


### PR DESCRIPTION
The requester-side vendor-defined response parser reads the payload-length
field through raw type-punned pointer casts (`*((uint32_t*)ptr)` /
`*((uint16_t*)ptr)`).  Because the preceding VendorID is variable-length
the field can land at a non-naturally-aligned offset.

**Repro:** a responder sends a VENDOR_DEFINED_RESPONSE whose VendorID
length causes the payload-length field to sit at a non-naturally-aligned
offset (e.g. `vendor_id_len == 2` puts the `uint16_t` at byte offset 9).

**Cause:** direct type-punned dereferences instead of the library's
alignment- and endian-safe `libspdm_read_uint32` / `libspdm_read_uint16`.

**Fix:** replace with `libspdm_read_uint32` / `libspdm_read_uint16`,
matching what the responder side already does after PR #3197.

On strict-alignment targets (ARM Cortex-M, RISC-V without misaligned-load
support) the original code triggers a CPU load fault when parsing a
legitimate or crafted vendor-defined response — giving a remote peer a
trivial denial-of-service vector.  On big-endian targets the value is
additionally byte-swapped, corrupting the subsequent bounds check and
potentially enabling an out-of-bounds read.

Signed-off-by: Nayyar <nayyar@bugqore.com>