### PR TITLE
free peer leaf cert public key contexts in libspdm_reset_context

### DIFF
--- a/library/spdm_common_lib/libspdm_com_context_data.c
+++ b/library/spdm_common_lib/libspdm_com_context_data.c
@@ -2935,8 +2935,16 @@ void libspdm_reset_context(void *spdm_context)
 {
     libspdm_context_t *context;
     size_t index;
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+    void *pubkey_context;
+    bool is_requester;
+    uint8_t slot_index;
+#endif
 
     context = spdm_context;
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+    is_requester = context->local_context.is_requester;
+#endif
 
     /* Clear all information about previous connection. Local context information is preserved. */
 
@@ -2960,6 +2968,39 @@ void libspdm_reset_context(void *spdm_context)
     libspdm_reset_message_m(spdm_context, NULL);
     libspdm_reset_message_e(spdm_context, NULL);
     libspdm_reset_message_encap_e(spdm_context, NULL);
+
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+    /* Free the peer leaf certificate public key contexts while the negotiated
+     * algorithm they were parsed under is still known; that algorithm is cleared
+     * below, and these contexts are otherwise only released in
+     * libspdm_deinit_context, so they leak across every re-connection. */
+    for (slot_index = 0; slot_index < SPDM_MAX_SLOT_COUNT; slot_index++) {
+        pubkey_context = context->connection_info.peer_used_cert_chain[slot_index].
+                         leaf_cert_public_key;
+
+        if (pubkey_context != NULL) {
+            if (is_requester) {
+                if (context->connection_info.algorithm.pqc_asym_algo != 0) {
+                    libspdm_pqc_asym_free(
+                        context->connection_info.algorithm.pqc_asym_algo, pubkey_context);
+                } else {
+                    libspdm_asym_free(
+                        context->connection_info.algorithm.base_asym_algo, pubkey_context);
+                }
+            } else {
+                if (context->connection_info.algorithm.req_pqc_asym_alg != 0) {
+                    libspdm_req_pqc_asym_free(
+                        context->connection_info.algorithm.req_pqc_asym_alg, pubkey_context);
+                } else {
+                    libspdm_req_asym_free(
+                        context->connection_info.algorithm.req_base_asym_alg, pubkey_context);
+                }
+            }
+
+            context->connection_info.peer_used_cert_chain[slot_index].leaf_cert_public_key = NULL;
+        }
+    }
+#endif
 
     context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NOT_STARTED;
     libspdm_zero_mem(&context->connection_info.version, sizeof(spdm_version_number_t));

--- a/unit_test/test_spdm_common/context_data.c
+++ b/unit_test/test_spdm_common/context_data.c
@@ -1715,6 +1715,51 @@ static void libspdm_test_process_opaque_data_case22(void **state)
     assert_int_equal (status, true);
 }
 
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+/**
+ * Test 23: libspdm_reset_context releases the peer leaf certificate public key.
+ * Expected Behavior: after a parsed leaf public key is stored for a slot,
+ * reset_context frees it and clears the slot, so it is not orphaned when the
+ * connection is re-established (reset_context runs on every GET_VERSION).
+ **/
+static void libspdm_test_reset_context_leaf_key_case23(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    void *data;
+    size_t data_size;
+    void *hash;
+    size_t hash_size;
+    bool result;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x17;
+
+    spdm_context->local_context.is_requester = true;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+
+    if (!libspdm_read_responder_public_certificate_chain(m_libspdm_use_hash_algo,
+                                                         m_libspdm_use_asym_algo, &data,
+                                                         &data_size, &hash, &hash_size)) {
+        assert(false);
+    }
+
+    result = libspdm_get_leaf_cert_public_key_from_cert_chain(
+        m_libspdm_use_hash_algo, m_libspdm_use_asym_algo, data, data_size,
+        &spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+    assert_true(result);
+    assert_non_null(spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+
+    libspdm_reset_context(spdm_context);
+
+    assert_null(spdm_context->connection_info.peer_used_cert_chain[0].leaf_cert_public_key);
+
+    free(data);
+}
+#endif /* !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT) */
+
 static libspdm_test_context_t m_libspdm_common_context_data_test_context = {
     LIBSPDM_TEST_CONTEXT_VERSION,
     true,
@@ -1766,6 +1811,11 @@ int libspdm_common_context_data_test_main(void)
 
         /* Successful response V1.2 for multi element */
         cmocka_unit_test(libspdm_test_process_opaque_data_case22),
+
+#if !(LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT)
+        /* reset_context frees the stored peer leaf certificate public key */
+        cmocka_unit_test(libspdm_test_reset_context_leaf_key_case23),
+#endif
     };
 
     libspdm_setup_test_context(&m_libspdm_common_context_data_test_context);


### PR DESCRIPTION
Repro: reuse an SPDM context for a second connection. GET_VERSION runs libspdm_reset_context after a slot certificate was retrieved, so a leaf public key context is live.
Cause: reset_context clears connection_info.algorithm but never frees peer_used_cert_chain[].leaf_cert_public_key. Those contexts are released only in libspdm_deinit_context, whose free path selects the algorithm reset just zeroed, so each re-init orphans them.
Fix: free the per-slot leaf public key contexts before the algorithm is cleared, matching the deinit_context path, then null the slots. A regression test asserts the slot is cleared after reset.