### PR TITLE
Fix TCP transport to use negotiated secured message version

### DIFF
--- a/library/spdm_transport_tcp_lib/libspdm_tcp_tcp.c
+++ b/library/spdm_transport_tcp_lib/libspdm_tcp_tcp.c
@@ -23,7 +23,7 @@ uint32_t libspdm_tcp_get_max_random_number_count(void)
 spdm_version_number_t libspdm_tcp_get_secured_spdm_version(
     spdm_version_number_t secured_message_version)
 {
-    return SECURED_SPDM_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    return secured_message_version;
 }
 
 /**


### PR DESCRIPTION
libspdm_tcp_get_secured_spdm_version returned a hardcoded SECURED_SPDM_VERSION_12, ignoring the negotiated version. Return the negotiated secured_message_version, matching mctp/pcidoe/storage.


Assisted-by: Claude Code:claude-opus-4-8

Fix https://github.com/DMTF/libspdm/issues/3708