### PR TITLE
Fix CHUNK_SEND_ACK to return UNSUPPORTED_REQUEST

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -45,7 +45,7 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
             SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP)) {
         return libspdm_generate_error_response(
             spdm_context,
-            SPDM_ERROR_CODE_UNEXPECTED_REQUEST, 0,
+            SPDM_ERROR_CODE_UNSUPPORTED_REQUEST, SPDM_CHUNK_SEND,
             response_size, response);
     }
 

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -330,8 +330,8 @@ void libspdm_test_responder_chunk_send_ack_rsp_case1(void** state)
     error_response = (spdm_error_response_t*) response;
     assert_int_equal(error_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
     assert_int_equal(error_response->header.request_response_code, SPDM_ERROR);
-    assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_UNEXPECTED_REQUEST);
-    assert_int_equal(error_response->header.param2, 0);
+    assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_UNSUPPORTED_REQUEST);
+    assert_int_equal(error_response->header.param2, SPDM_CHUNK_SEND);
 }
 
 /**


### PR DESCRIPTION
When CHUNK_CAP capability is not negotiated, CHUNK_SEND_ACK should return SPDM_ERROR_CODE_UNSUPPORTED_REQUEST instead of SPDM_ERROR_CODE_UNEXPECTED_REQUEST.

Fixes #3711