### PR TITLE
Validate per-slot `DIGESTS` consistency

### DIFF
--- a/include/internal/libspdm_responder_lib.h
+++ b/include/internal/libspdm_responder_lib.h
@@ -147,6 +147,30 @@ libspdm_return_t libspdm_get_response_algorithms(libspdm_context_t *spdm_context
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
 /**
+ * Verify that the integrator-provisioned SupportedSlotMask is consistent with the populated
+ * certificate slots: every populated slot shall be indicated in SupportedSlotMask.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS             The provisioned SupportedSlotMask is consistent.
+ * @retval LIBSPDM_STATUS_INVALID_STATE_LOCAL The provisioned SupportedSlotMask is inconsistent.
+ **/
+libspdm_return_t libspdm_validate_supported_slot_mask(libspdm_context_t *spdm_context);
+
+/**
+ * Verify that the integrator-provisioned per-slot CertificateInfo, KeyUsageMask and KeyPairID
+ * values are internally consistent and (when KEY_PAIR_INFO is supported) consistent with the
+ * associated key pair. These per-slot fields are only emitted for a multi-key connection; the
+ * caller is responsible for skipping this check when a multi-key connection is not in use.
+ *
+ * @param  spdm_context                  A pointer to the SPDM context.
+ *
+ * @retval LIBSPDM_STATUS_SUCCESS             The provisioned per-slot values are consistent.
+ * @retval LIBSPDM_STATUS_INVALID_STATE_LOCAL The provisioned per-slot values are inconsistent.
+ **/
+libspdm_return_t libspdm_validate_multi_key_slot_info(libspdm_context_t *spdm_context);
+
+/**
  * Process the SPDM GET_DIGESTS request and return the response.
  *
  * @param  spdm_context                  A pointer to the SPDM context.

--- a/library/spdm_responder_lib/libspdm_rsp_digests.c
+++ b/library/spdm_responder_lib/libspdm_rsp_digests.c
@@ -1,12 +1,188 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2024 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
 #include "internal/libspdm_responder_lib.h"
 
 #if LIBSPDM_ENABLE_CAPABILITY_CERT_CAP
+
+libspdm_return_t libspdm_validate_supported_slot_mask(libspdm_context_t *spdm_context)
+{
+    uint8_t index;
+    uint8_t supported_slot_mask;
+    bool support_slot_mask_version;
+
+    /* SupportedSlotMask is only emitted for SPDM 1.3 and later. If the responder is not
+     * provisioned to support any such version there is nothing to validate. */
+    support_slot_mask_version = false;
+    for (index = 0; index < spdm_context->local_context.version.spdm_version_count; index++) {
+        if (libspdm_get_version_from_version_number(
+                spdm_context->local_context.version.spdm_version[index]) >=
+            SPDM_MESSAGE_VERSION_13) {
+            support_slot_mask_version = true;
+            break;
+        }
+    }
+    if (!support_slot_mask_version) {
+        return LIBSPDM_STATUS_SUCCESS;
+    }
+
+    supported_slot_mask = spdm_context->local_context.local_supported_slot_mask;
+
+    for (index = 0; index < SPDM_MAX_SLOT_COUNT; index++) {
+        if (spdm_context->local_context.local_cert_chain_provision[index] == NULL) {
+            continue;
+        }
+        /* A populated slot must be indicated as supported (SupportedSlotMask covers
+         * ProvisionedSlotMask). */
+        if ((supported_slot_mask & (1 << index)) == 0) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_supported_slot_mask - slot %d populated but not in "
+                           "SupportedSlotMask 0x%02x\n", index, supported_slot_mask));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+libspdm_return_t libspdm_validate_multi_key_slot_info(libspdm_context_t *spdm_context)
+{
+    uint8_t index;
+    spdm_certificate_info_t cert_info;
+    spdm_key_usage_bit_mask_t key_usage_bit_mask;
+
+    for (index = 0; index < SPDM_MAX_SLOT_COUNT; index++) {
+        if (spdm_context->local_context.local_cert_chain_provision[index] == NULL) {
+            continue;
+        }
+        cert_info = spdm_context->local_context.local_cert_info[index];
+        key_usage_bit_mask = spdm_context->local_context.local_key_usage_bit_mask[index];
+
+        /* CertModel validity (Table 42). CertificateInfo reserved bits shall be zero. */
+        if ((cert_info & (uint8_t)(~SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK)) != 0) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot %d CertificateInfo 0x%02x "
+                           "has reserved bits set\n", index, cert_info));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* CertModel value shall be a defined model (not a reserved value). */
+        if ((cert_info & SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK) >
+            SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot %d CertModel %d is "
+                           "reserved\n", index, cert_info & SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* A populated slot in a multi-key connection is in the "exists with key and cert" state,
+         * so its CertModel shall be non-zero. */
+        if ((cert_info & SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK) ==
+            SPDM_CERTIFICATE_INFO_CERT_MODEL_NONE) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot %d populated but CertModel "
+                           "is zero\n", index));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* The GenericCert model applies only to slots greater than 0. */
+        if (((cert_info & SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK) ==
+             SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT) && (index == 0)) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot 0 must not use the "
+                           "GenericCert model\n"));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* The AliasCert model is forbidden unless ALIAS_CERT_CAP is set (Table 15). */
+        if (((cert_info & SPDM_CERTIFICATE_INFO_CERT_MODEL_MASK) ==
+             SPDM_CERTIFICATE_INFO_CERT_MODEL_ALIAS_CERT) &&
+            !libspdm_is_capabilities_flag_supported(
+                spdm_context, false, 0,
+                SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP)) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot %d uses the AliasCert "
+                           "model but ALIAS_CERT_CAP is not set\n", index));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* KeyUsageMask validity (Table 43). Reserved bits shall be zero. */
+        if ((key_usage_bit_mask & (uint16_t)(~SPDM_KEY_USAGE_BIT_MASK)) != 0) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot %d KeyUsageMask 0x%04x has "
+                           "reserved bits set\n", index, key_usage_bit_mask));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+        /* Slot 0 shall set at least one of KeyExUse, ChallengeUse, MeasurementUse, or
+         * EndpointInfoUse. */
+        if ((index == 0) &&
+            ((key_usage_bit_mask &
+              (SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE |
+               SPDM_KEY_USAGE_BIT_MASK_CHALLENGE_USE |
+               SPDM_KEY_USAGE_BIT_MASK_MEASUREMENT_USE |
+               SPDM_KEY_USAGE_BIT_MASK_ENDPOINT_INFO_USE)) == 0)) {
+            LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                           "libspdm_validate_multi_key_slot_info - slot 0 KeyUsageMask 0x%04x sets "
+                           "none of KeyEx/Challenge/Measurement/EndpointInfo use\n",
+                           key_usage_bit_mask));
+            return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+        }
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
+        /* Cross-check the reported per-slot values against KEY_PAIR_INFO: the slot's key pair must
+         * claim this slot in its AssocCertSlotMask, the reported KeyUsageMask must match the key
+         * pair's CurrentKeyUsage, and CurrentKeyUsage shall be within KeyUsageCapabilities. */
+        if (spdm_context->local_context.local_key_pair_id[index] != 0) {
+            uint8_t key_pair_id;
+            uint8_t total_key_pairs;
+            uint16_t capabilities;
+            uint16_t key_usage_capabilities;
+            uint16_t current_key_usage;
+            uint32_t asym_algo_capabilities;
+            uint32_t current_asym_algo;
+            uint32_t pqc_asym_algo_capabilities;
+            uint32_t current_pqc_asym_algo;
+            uint8_t assoc_cert_slot_mask;
+            bool kp_result;
+
+            key_pair_id = spdm_context->local_context.local_key_pair_id[index];
+            kp_result = libspdm_read_key_pair_info(
+                spdm_context, key_pair_id, &total_key_pairs, &capabilities,
+                &key_usage_capabilities, &current_key_usage, &asym_algo_capabilities,
+                &current_asym_algo, &pqc_asym_algo_capabilities, &current_pqc_asym_algo,
+                &assoc_cert_slot_mask, NULL, NULL);
+            if (!kp_result) {
+                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                               "libspdm_validate_multi_key_slot_info - slot %d KeyPairID %d read "
+                               "failed\n", index, key_pair_id));
+                return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+            }
+            if ((assoc_cert_slot_mask & (1 << index)) == 0) {
+                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                               "libspdm_validate_multi_key_slot_info - slot %d KeyPairID %d does "
+                               "not claim this slot in AssocCertSlotMask 0x%02x\n",
+                               index, key_pair_id, assoc_cert_slot_mask));
+                return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+            }
+            if (key_usage_bit_mask != current_key_usage) {
+                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                               "libspdm_validate_multi_key_slot_info - slot %d KeyUsageMask 0x%04x "
+                               "does not match KeyPairID %d CurrentKeyUsage 0x%04x\n",
+                               index, key_usage_bit_mask, key_pair_id, current_key_usage));
+                return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+            }
+            /* CurrentKeyUsage shall be a subset of KeyUsageCapabilities (Table 111). */
+            if ((current_key_usage & (uint16_t)(~key_usage_capabilities)) != 0) {
+                LIBSPDM_DEBUG((LIBSPDM_DEBUG_ERROR,
+                               "libspdm_validate_multi_key_slot_info - slot %d KeyUsageMask 0x%04x "
+                               "exceeds KeyPairID %d KeyUsageCapabilities 0x%04x\n",
+                               index, key_usage_bit_mask, key_pair_id, key_usage_capabilities));
+                return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
+            }
+        }
+#endif /* LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP */
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
 
 libspdm_return_t libspdm_get_response_digests(libspdm_context_t *spdm_context, size_t request_size,
                                               const void *request,
@@ -108,6 +284,25 @@ libspdm_return_t libspdm_get_response_digests(libspdm_context_t *spdm_context, s
         return libspdm_generate_error_response(
             spdm_context, SPDM_ERROR_CODE_UNSPECIFIED,
             0, response_size, response);
+    }
+
+    /* The reported per-slot values are provisioned by the integrator; verify they are internally
+     * consistent before emitting them. A failure here is a local misconfiguration. */
+    status = libspdm_validate_supported_slot_mask(spdm_context);
+    LIBSPDM_ASSERT(!LIBSPDM_STATUS_IS_ERROR(status));
+    if (LIBSPDM_STATUS_IS_ERROR(status)) {
+        return libspdm_generate_error_response(
+            spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0, response_size, response);
+    }
+    /* The per-slot KeyPairID, CertificateInfo and KeyUsageMask fields are only emitted for a
+     * multi-key connection, so there is nothing to validate otherwise. */
+    if (spdm_context->connection_info.multi_key_conn_rsp) {
+        status = libspdm_validate_multi_key_slot_info(spdm_context);
+        LIBSPDM_ASSERT(!LIBSPDM_STATUS_IS_ERROR(status));
+        if (LIBSPDM_STATUS_IS_ERROR(status)) {
+            return libspdm_generate_error_response(
+                spdm_context, SPDM_ERROR_CODE_UNSPECIFIED, 0, response_size, response);
+        }
     }
 
     hash_size = libspdm_get_hash_size(

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_digests/digests.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2024 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -37,6 +37,8 @@ void libspdm_test_responder_digests_case1(void **State)
         m_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_local_certificate_chain, sizeof(m_local_certificate_chain),
                     (uint8_t)(0xFF));
 

--- a/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
+++ b/unit_test/fuzzing/test_responder/test_spdm_responder_if_ready/respond_if_ready.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2022 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -53,6 +53,8 @@ void libspdm_test_responder_respond_if_ready(void **State)
         local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(local_certificate_chain, sizeof(local_certificate_chain),
                     (uint8_t)(0xFF));
 
@@ -110,6 +112,8 @@ void libspdm_test_responder_respond_if_ready_case2(void **State)
         local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(local_certificate_chain, sizeof(local_certificate_chain),
                     (uint8_t)(0xFF));
 
@@ -167,6 +171,8 @@ void libspdm_test_responder_respond_if_ready_case3(void **State)
         local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(local_certificate_chain, sizeof(local_certificate_chain),
                     (uint8_t)(0xFF));
 

--- a/unit_test/test_spdm_responder/digests.c
+++ b/unit_test/test_spdm_responder/digests.c
@@ -51,6 +51,8 @@ static void rsp_digests_case1(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -111,6 +113,8 @@ static void rsp_digests_case3(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -154,6 +158,8 @@ static void rsp_digests_case4(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -199,6 +205,8 @@ static void rsp_digests_case5(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -248,6 +256,8 @@ static void rsp_digests_case6(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -398,6 +408,8 @@ static void rsp_digests_case9(void **state)
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
                     (uint8_t)(0xFF));
@@ -407,6 +419,12 @@ static void rsp_digests_case9(void **state)
         spdm_context->transcript.message_m.max_buffer_size;
 #endif
     /* Sub Case 1: Set multi_key_conn_rsp to true*/
+    /* A populated multi-key slot shall report a non-zero CertModel, and slot 0 shall set at
+     * least one usage bit. */
+    spdm_context->local_context.local_cert_info[0] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->local_context.local_key_usage_bit_mask[0] =
+        SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
     spdm_context->connection_info.multi_key_conn_rsp = true;
     libspdm_reset_message_d(spdm_context);
 
@@ -491,7 +509,15 @@ static void rsp_digests_case10(void **state)
         spdm_context->local_context.local_cert_chain_provision[index] =
             &m_libspdm_local_certificate_chain[hash_size *index];
         spdm_context->local_context.local_cert_chain_provision_size[index] = hash_size;
+        /* A populated multi-key slot shall report a non-zero CertModel. */
+        spdm_context->local_context.local_cert_info[index] =
+            SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+        /* SupportedSlotMask shall cover every populated slot. */
+        spdm_context->local_context.local_supported_slot_mask |= (uint8_t)(1 << index);
     }
+    /* Slot 0 shall set at least one usage bit. */
+    spdm_context->local_context.local_key_usage_bit_mask[0] =
+        SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
 
     libspdm_set_mem(m_libspdm_local_certificate_chain,
                     sizeof(m_libspdm_local_certificate_chain),
@@ -584,6 +610,333 @@ static void rsp_digests_case11(void **state)
     assert_int_equal(spdm_response->header.param2, 0);
 }
 
+/* Group setup runs once per group, so clear any per-slot state a prior case populated. */
+static void rsp_digests_reset_slot_context(libspdm_context_t *spdm_context)
+{
+    uint8_t index;
+    for (index = 0; index < SPDM_MAX_SLOT_COUNT; index++) {
+        spdm_context->local_context.local_cert_chain_provision[index] = NULL;
+        spdm_context->local_context.local_cert_chain_provision_size[index] = 0;
+        spdm_context->local_context.local_key_pair_id[index] = 0;
+        spdm_context->local_context.local_key_usage_bit_mask[index] = 0;
+        spdm_context->local_context.local_cert_info[index] = 0;
+    }
+    spdm_context->local_context.local_supported_slot_mask = 0;
+    spdm_context->local_context.cert_slot_reset_mask = 0;
+}
+
+/* Provision a populated slot with a cert chain and mark it supported. */
+static void rsp_digests_provision_slot(libspdm_context_t *spdm_context, uint8_t index)
+{
+    spdm_context->local_context.local_cert_chain_provision[index] =
+        m_libspdm_local_certificate_chain;
+    spdm_context->local_context.local_cert_chain_provision_size[index] =
+        sizeof(m_libspdm_local_certificate_chain);
+    libspdm_set_mem(m_libspdm_local_certificate_chain,
+                    sizeof(m_libspdm_local_certificate_chain), (uint8_t)(0xFF));
+    spdm_context->local_context.local_supported_slot_mask |= (uint8_t)(1 << index);
+}
+
+/**
+ * Test 12: multi-key connection with per-slot values that are all consistent with KEY_PAIR_INFO:
+ * slot 0 uses key pair 1 (whose AssocCertSlotMask includes slot 0), the reported KeyUsageMask
+ * matches the key pair CurrentKeyUsage, and slot 0 is in SupportedSlotMask.
+ * Expected Behavior: both checkers report success.
+ **/
+static void rsp_digests_case12(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x0C;
+    rsp_digests_reset_slot_context(spdm_context);
+    /* Key pair 1 (mask 0x03) claims slots 0 and 1; its CurrentKeyUsage is KEY_EX_USE. Provision
+     * both claimed slots so the mapping is consistent in both directions. */
+    rsp_digests_provision_slot(spdm_context, 0);
+    rsp_digests_provision_slot(spdm_context, 1);
+    spdm_context->local_context.local_key_pair_id[0] = 1;
+    spdm_context->local_context.local_key_pair_id[1] = 1;
+    spdm_context->local_context.local_key_usage_bit_mask[0] = SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    spdm_context->local_context.local_key_usage_bit_mask[1] = SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    spdm_context->local_context.local_cert_info[0] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->local_context.local_cert_info[1] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    assert_int_equal(libspdm_validate_supported_slot_mask(spdm_context),
+                     LIBSPDM_STATUS_SUCCESS);
+    assert_int_equal(libspdm_validate_multi_key_slot_info(spdm_context),
+                     LIBSPDM_STATUS_SUCCESS);
+}
+
+/**
+ * Test 13: a populated slot is not indicated in SupportedSlotMask.
+ * Expected Behavior: the supported-slot-mask checker reports an error.
+ **/
+static void rsp_digests_case13(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x0D;
+    rsp_digests_reset_slot_context(spdm_context);
+    spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
+    spdm_context->local_context.local_cert_chain_provision_size[0] =
+        sizeof(m_libspdm_local_certificate_chain);
+    /* Slot 0 is populated but only slot 1 is marked supported. */
+    spdm_context->local_context.local_supported_slot_mask = 0x02;
+
+    assert_true(LIBSPDM_STATUS_IS_ERROR(libspdm_validate_supported_slot_mask(spdm_context)));
+}
+
+#if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
+/**
+ * Test 14: the KeyPairID reported for a slot does not claim that slot in its AssocCertSlotMask.
+ * Expected Behavior: the multi-key slot-info checker reports an error.
+ **/
+static void rsp_digests_case14(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x0E;
+    rsp_digests_reset_slot_context(spdm_context);
+    /* Populate slot 2, which key pair 1 (mask 0x03) does not claim. */
+    rsp_digests_provision_slot(spdm_context, 2);
+    spdm_context->local_context.local_key_pair_id[2] = 1;
+    spdm_context->local_context.local_cert_info[2] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    assert_true(LIBSPDM_STATUS_IS_ERROR(libspdm_validate_multi_key_slot_info(spdm_context)));
+}
+
+/**
+ * Test 15: the KeyUsageMask reported for a slot does not match the key pair CurrentKeyUsage.
+ * Expected Behavior: the multi-key slot-info checker reports an error.
+ **/
+static void rsp_digests_case15(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x0F;
+    rsp_digests_reset_slot_context(spdm_context);
+    /* Key pair 1 (mask 0x03) claims slots 0 and 1 with CurrentKeyUsage KEY_EX_USE. Provision both
+     * consistently except slot 0's KeyUsageMask, so only the usage mismatch is exercised. */
+    rsp_digests_provision_slot(spdm_context, 0);
+    rsp_digests_provision_slot(spdm_context, 1);
+    spdm_context->local_context.local_key_pair_id[0] = 1;
+    spdm_context->local_context.local_key_pair_id[1] = 1;
+    spdm_context->local_context.local_key_usage_bit_mask[0] =
+        SPDM_KEY_USAGE_BIT_MASK_CHALLENGE_USE;
+    spdm_context->local_context.local_key_usage_bit_mask[1] =
+        SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    spdm_context->local_context.local_cert_info[0] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->local_context.local_cert_info[1] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    assert_true(LIBSPDM_STATUS_IS_ERROR(libspdm_validate_multi_key_slot_info(spdm_context)));
+}
+#endif /* LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP */
+
+/* Provision a single populated slot for a multi-key connection with the given CertificateInfo,
+ * then run the multi-key slot-info checker and return its status. */
+static libspdm_return_t rsp_digests_run_cert_info_case(void **state, uint8_t case_id,
+                                                       uint8_t index, uint8_t cert_info)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = case_id;
+    rsp_digests_reset_slot_context(spdm_context);
+    rsp_digests_provision_slot(spdm_context, index);
+    /* Leave local_key_pair_id at 0 so the CertificateInfo check is exercised in isolation. */
+    spdm_context->local_context.local_cert_info[index] = cert_info;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    return libspdm_validate_multi_key_slot_info(spdm_context);
+}
+
+/* Provision a single populated slot for a multi-key connection with a valid CertModel and the
+ * given KeyUsageMask, then run the multi-key slot-info checker and return its status. */
+static libspdm_return_t rsp_digests_run_key_usage_case(void **state, uint8_t case_id,
+                                                       uint8_t index,
+                                                       spdm_key_usage_bit_mask_t key_usage)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = case_id;
+    rsp_digests_reset_slot_context(spdm_context);
+    rsp_digests_provision_slot(spdm_context, index);
+    /* Leave local_key_pair_id at 0 so the KeyUsageMask check is exercised in isolation. */
+    spdm_context->local_context.local_cert_info[index] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT;
+    spdm_context->local_context.local_key_usage_bit_mask[index] = key_usage;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    return libspdm_validate_multi_key_slot_info(spdm_context);
+}
+
+/**
+ * Test 16: a populated multi-key slot reports CertModel zero.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case16(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_cert_info_case(
+                                            state, 0x10, 0,
+                                            SPDM_CERTIFICATE_INFO_CERT_MODEL_NONE)));
+}
+
+/**
+ * Test 17: CertificateInfo has reserved bits set.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case17(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_cert_info_case(
+                                            state, 0x11, 0,
+                                            (uint8_t)(SPDM_CERTIFICATE_INFO_CERT_MODEL_DEVICE_CERT |
+                                                      0x08))));
+}
+
+/**
+ * Test 18: CertModel is a reserved value (greater than GenericCert).
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case18(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_cert_info_case(
+                                            state, 0x12, 0,
+                                            (uint8_t)(SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT +
+                                                      1))));
+}
+
+/**
+ * Test 19: slot 0 uses the GenericCert model, which is only valid for slots greater than 0.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case19(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_cert_info_case(
+                                            state, 0x13, 0,
+                                            SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT)));
+}
+
+/**
+ * Test 20: GenericCert model in a slot greater than 0 is accepted.
+ * Expected Behavior: the checker reports success.
+ **/
+static void rsp_digests_case20(void **state)
+{
+    assert_int_equal(rsp_digests_run_cert_info_case(
+                         state, 0x14, 1, SPDM_CERTIFICATE_INFO_CERT_MODEL_GENERIC_CERT),
+                     LIBSPDM_STATUS_SUCCESS);
+}
+
+/**
+ * Test 21: KeyUsageMask has reserved bits set.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case21(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_key_usage_case(
+                                            state, 0x15, 0,
+                                            (spdm_key_usage_bit_mask_t)(
+                                                SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE | 0x0010))));
+}
+
+/**
+ * Test 22: slot 0 KeyUsageMask sets none of KeyEx/Challenge/Measurement/EndpointInfo use.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case22(void **state)
+{
+    assert_true(LIBSPDM_STATUS_IS_ERROR(rsp_digests_run_key_usage_case(
+                                            state, 0x16, 0,
+                                            SPDM_KEY_USAGE_BIT_MASK_VENDOR_KEY_USE)));
+}
+
+/**
+ * Test 23: slot greater than 0 may set only VendorKeyUse (the slot-0 usage rule does not apply).
+ * Expected Behavior: the checker reports success.
+ **/
+static void rsp_digests_case23(void **state)
+{
+    assert_int_equal(rsp_digests_run_key_usage_case(
+                         state, 0x17, 1, SPDM_KEY_USAGE_BIT_MASK_VENDOR_KEY_USE),
+                     LIBSPDM_STATUS_SUCCESS);
+}
+
+/**
+ * Test 24: a slot uses the AliasCert model but the Responder does not set ALIAS_CERT_CAP.
+ * Expected Behavior: the checker reports an error.
+ **/
+static void rsp_digests_case24(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x18;
+    rsp_digests_reset_slot_context(spdm_context);
+    rsp_digests_provision_slot(spdm_context, 0);
+    /* ALIAS_CERT_CAP is not set, so an AliasCert slot is a misconfiguration. */
+    spdm_context->local_context.capability.flags &=
+        ~SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP;
+    spdm_context->local_context.local_cert_info[0] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_ALIAS_CERT;
+    spdm_context->local_context.local_key_usage_bit_mask[0] =
+        SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    assert_true(LIBSPDM_STATUS_IS_ERROR(libspdm_validate_multi_key_slot_info(spdm_context)));
+}
+
+/**
+ * Test 25: a slot uses the AliasCert model and the Responder sets ALIAS_CERT_CAP.
+ * Expected Behavior: the checker reports success.
+ **/
+static void rsp_digests_case25(void **state)
+{
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x19;
+    rsp_digests_reset_slot_context(spdm_context);
+    rsp_digests_provision_slot(spdm_context, 0);
+    spdm_context->local_context.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP;
+    spdm_context->local_context.local_cert_info[0] =
+        SPDM_CERTIFICATE_INFO_CERT_MODEL_ALIAS_CERT;
+    spdm_context->local_context.local_key_usage_bit_mask[0] =
+        SPDM_KEY_USAGE_BIT_MASK_KEY_EX_USE;
+    spdm_context->connection_info.multi_key_conn_rsp = true;
+
+    assert_int_equal(libspdm_validate_multi_key_slot_info(spdm_context),
+                     LIBSPDM_STATUS_SUCCESS);
+}
+
 int libspdm_rsp_digests_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -610,6 +963,36 @@ int libspdm_rsp_digests_test(void)
         /* Check KeyPairID CertificateInfo and KeyUsageMask*/
         cmocka_unit_test(rsp_digests_case10),
         cmocka_unit_test(rsp_digests_case11),
+        /* Multi-key: all per-slot values consistent with KEY_PAIR_INFO */
+        cmocka_unit_test(rsp_digests_case12),
+        /* Populated slot missing from SupportedSlotMask */
+        cmocka_unit_test(rsp_digests_case13),
+#if LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP
+        /* KeyPairID does not claim the slot in AssocCertSlotMask */
+        cmocka_unit_test(rsp_digests_case14),
+        /* KeyUsageMask does not match key pair CurrentKeyUsage */
+        cmocka_unit_test(rsp_digests_case15),
+#endif /* LIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP */
+        /* Populated multi-key slot reports CertModel zero */
+        cmocka_unit_test(rsp_digests_case16),
+        /* CertificateInfo reserved bits set */
+        cmocka_unit_test(rsp_digests_case17),
+        /* CertModel is a reserved value */
+        cmocka_unit_test(rsp_digests_case18),
+        /* Slot 0 uses the GenericCert model */
+        cmocka_unit_test(rsp_digests_case19),
+        /* GenericCert model in a slot greater than 0 is accepted */
+        cmocka_unit_test(rsp_digests_case20),
+        /* KeyUsageMask reserved bits set */
+        cmocka_unit_test(rsp_digests_case21),
+        /* Slot 0 KeyUsageMask sets no applicable usage bit */
+        cmocka_unit_test(rsp_digests_case22),
+        /* Slot greater than 0 may set only VendorKeyUse */
+        cmocka_unit_test(rsp_digests_case23),
+        /* AliasCert model without ALIAS_CERT_CAP */
+        cmocka_unit_test(rsp_digests_case24),
+        /* AliasCert model with ALIAS_CERT_CAP */
+        cmocka_unit_test(rsp_digests_case25),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/respond_if_ready.c
+++ b/unit_test/test_spdm_responder/respond_if_ready.c
@@ -309,6 +309,8 @@ static void rsp_respond_if_ready_case1(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1084,6 +1086,8 @@ static void rsp_respond_if_ready_case10(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1151,6 +1155,8 @@ static void rsp_respond_if_ready_case11(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1220,6 +1226,8 @@ static void rsp_respond_if_ready_case12(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1292,6 +1300,8 @@ static void rsp_respond_if_ready_case13(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1357,6 +1367,8 @@ static void rsp_respond_if_ready_case14(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 
@@ -1418,6 +1430,8 @@ static void rsp_respond_if_ready_case15(void **state) {
     spdm_context->local_context.local_cert_chain_provision[0] = m_libspdm_local_certificate_chain;
     spdm_context->local_context.local_cert_chain_provision_size[0] =
         sizeof(m_libspdm_local_certificate_chain);
+    /* SupportedSlotMask shall cover the populated slot. */
+    spdm_context->local_context.local_supported_slot_mask = 0x01;
     libspdm_set_mem (m_libspdm_local_certificate_chain, sizeof(m_libspdm_local_certificate_chain),
                      (uint8_t)(0xFF));
 


### PR DESCRIPTION
The per-slot SupportedSlotMask, KeyPairID, CertificateInfo and KeyUsageMask in DIGESTS are integrator-provisioned. Verify them in the DIGESTS path via libspdm_validate_supported_slot_mask and libspdm_validate_multi_key_slot_info before emitting.


Assisted-by: Claude Code:claude-opus-4-8

Ref: https://github.com/DMTF/libspdm/issues/3638