### PR TITLE
library/spdm_responder_lib: Mark array of functions static

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -16,7 +16,7 @@ libspdm_get_spdm_response_func libspdm_get_response_func_via_request_code(uint8_
         libspdm_get_spdm_response_func get_response_func;
     } libspdm_get_response_struct_t;
 
-    libspdm_get_response_struct_t get_response_struct[] = {
+    static const libspdm_get_response_struct_t get_response_struct[] = {
         { SPDM_GET_VERSION, libspdm_get_response_version },
         { SPDM_GET_CAPABILITIES, libspdm_get_response_capabilities },
         { SPDM_NEGOTIATE_ALGORITHMS, libspdm_get_response_algorithms },


### PR DESCRIPTION
The C standard requires memcpy to be avaliable [1], [2], but it insn't in the case of some libspdm tests (test_size_of_spdm_responder) as libc isn't used and memcpy isn't provided.

This results in build failures like this (depending on compiler versions as it doesn't happen in the CI).

```
[100%] Linking C executable ../../../bin/test_size_of_spdm_responder
/usr/bin/ld.bfd: /tmp/cc9WR1GI.ltrans0.ltrans.o: in function `libspdm_get_response_func_via_request_code':
/scratch/alistair/software/tier4/SPDM-Utils/third-party/libspdm/library/spdm_responder_lib/libspdm_rsp_receive_send.c:19:(.text+0x7ae): undefined reference to `memcpy'
collect2: error: ld returned 1 exit status
make[2]: *** [unit_test/test_size/test_size_of_spdm_responder/CMakeFiles/test_size_of_spdm_responder.dir/build.make:145: bin/test_size_of_spdm_responder] Error 1
make[1]: *** [CMakeFiles/Makefile2:7358: unit_test/test_size/test_size_of_spdm_responder/CMakeFiles/test_size_of_spdm_responder.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

We can avoid the memcpy() when creating the get_response_struct array by marking it static. It's also constant, so we can also mark it const.

This fixes build failures seem on Linux when using GCC 16.1.1.

1: https://gcc.gnu.org/pipermail/gcc-help/2025-May/144229.html
2: https://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Standards.html#C-Language