### PR TITLE
Fixed Coverity 912688 RESOURCE_LEAK in libspdm_gen_csr

### DIFF
--- a/os_stub/spdm_device_secret_lib_sample/csr.c
+++ b/os_stub/spdm_device_secret_lib_sample/csr.c
@@ -352,6 +352,7 @@ bool libspdm_gen_csr(
         if (*req_csr_tracking_tag == 0) {
             if (available_csr_tracking_tag == 0) {
                 /*no available tracking tag*/
+                free(cached_last_csr_request);
                 *is_busy = true;
                 return false;
             } else {
@@ -363,6 +364,7 @@ bool libspdm_gen_csr(
                 flag = true;
             } else {
                 /*unexpected*/
+                free(cached_last_csr_request);
                 return false;
             }
         }


### PR DESCRIPTION
Fixed #3745.

I found there are some checking NULL on pointers before free them.
Please let me know if any concern.