### PR TITLE
Fix large_message_capacity unset on chunked GET path

### DIFF
--- a/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -609,6 +609,7 @@ static libspdm_return_t libspdm_handle_large_request(
         send_info->chunk_bytes_transferred = 0;
         send_info->large_message = NULL;
         send_info->large_message_size = 0;
+        send_info->large_message_capacity = 0;
     }
 
     return status;

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_response.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_response.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2021-2025 DMTF. All rights reserved.
+ *  Copyright 2021-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -214,6 +214,7 @@ libspdm_return_t libspdm_get_response_chunk_get(
         get_info->chunk_seq_no = 0;
         get_info->large_message = NULL;
         get_info->large_message_size = 0;
+        get_info->large_message_capacity = 0;
         get_info->chunk_bytes_transferred = 0;
 
         spdm_response->header.param1 |= SPDM_CHUNK_GET_RESPONSE_ATTRIBUTE_LAST_CHUNK;

--- a/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_chunk_send_ack.c
@@ -246,12 +246,17 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
          * the CHUNK_ACK with EarlyErrorDetected with a generic error. */
         status = LIBSPDM_STATUS_SUCCESS;
 
+        if (send_info->large_message != NULL) {
+            libspdm_zero_mem(send_info->large_message, send_info->large_message_capacity);
+        }
+
         send_info->chunk_in_use = false;
         send_info->chunk_handle = 0;
         send_info->chunk_seq_no = 0;
         send_info->chunk_bytes_transferred = 0;
         send_info->large_message = NULL;
         send_info->large_message_size = 0;
+        send_info->large_message_capacity = 0;
     } else if (send_info->chunk_bytes_transferred == send_info->large_message_size) {
         uint8_t opcode;
 
@@ -276,8 +281,12 @@ libspdm_return_t libspdm_get_response_chunk_send(libspdm_context_t *spdm_context
         send_info->chunk_handle = 0;
         send_info->chunk_seq_no = 0;
         send_info->chunk_bytes_transferred = 0;
+        if (send_info->large_message != NULL) {
+            libspdm_zero_mem(send_info->large_message, send_info->large_message_capacity);
+        }
         send_info->large_message = NULL;
         send_info->large_message_size = 0;
+        send_info->large_message_capacity = 0;
 
         *response_size = response_header_size + chunk_response_size;
     } else {

--- a/library/spdm_responder_lib/libspdm_rsp_receive_send.c
+++ b/library/spdm_responder_lib/libspdm_rsp_receive_send.c
@@ -555,11 +555,16 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
             if (get_response_func == libspdm_get_response_version) {
                 /* GET_VERSION is allowed to interrupt chunk transfer.
                  * Reset chunk get context and proceed normally. */
+                if (context->chunk_context.get.large_message != NULL) {
+                    libspdm_zero_mem(context->chunk_context.get.large_message,
+                                     context->chunk_context.get.large_message_capacity);
+                }
                 context->chunk_context.get.chunk_in_use = false;
                 context->chunk_context.get.chunk_handle++;
                 context->chunk_context.get.chunk_seq_no = 0;
                 context->chunk_context.get.large_message = NULL;
                 context->chunk_context.get.large_message_size = 0;
+                context->chunk_context.get.large_message_capacity = 0;
                 context->chunk_context.get.chunk_bytes_transferred = 0;
             } else {
                 /* Reject with UnexpectedRequest without terminating
@@ -576,11 +581,16 @@ libspdm_return_t libspdm_build_response(void *spdm_context, const uint32_t *sess
             if (get_response_func == libspdm_get_response_version) {
                 /* GET_VERSION is allowed to interrupt chunk transfer.
                  * Reset chunk send context and proceed normally. */
+                if (context->chunk_context.send.large_message != NULL) {
+                    libspdm_zero_mem(context->chunk_context.send.large_message,
+                                     context->chunk_context.send.large_message_capacity);
+                }
                 context->chunk_context.send.chunk_in_use = false;
                 context->chunk_context.send.chunk_handle = 0;
                 context->chunk_context.send.chunk_seq_no = 0;
                 context->chunk_context.send.large_message = NULL;
                 context->chunk_context.send.large_message_size = 0;
+                context->chunk_context.send.large_message_capacity = 0;
                 context->chunk_context.send.chunk_bytes_transferred = 0;
             } else {
                 /* Reject with UnexpectedRequest without terminating
@@ -670,6 +680,7 @@ response_dispatched:
             get_info->chunk_handle++;
             get_info->chunk_seq_no = 0;
             get_info->chunk_bytes_transferred = 0;
+            get_info->large_message_capacity = large_buffer_size;
 
             libspdm_zero_mem(large_buffer, large_buffer_size);
 

--- a/unit_test/test_spdm_requester/chunk_send.c
+++ b/unit_test/test_spdm_requester/chunk_send.c
@@ -653,8 +653,31 @@ static void req_chunk_send_case3(void** state)
 static void req_chunk_send_case4(void** state)
 {
     libspdm_return_t status;
+    libspdm_test_context_t* spdm_test_context;
+    libspdm_context_t* spdm_context;
+    void* scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t* large_message;
+    uint32_t large_message_capacity;
+    size_t index;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 4);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_false(spdm_context->chunk_context.send.chunk_in_use);
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t*)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    for (index = 0; index < large_message_capacity; index++) {
+        assert_int_equal(large_message[index], 0);
+    }
 }
 
 static void req_chunk_send_case5(void** state)
@@ -688,8 +711,31 @@ static void req_chunk_send_case8(void** state)
 static void req_chunk_send_case9(void** state)
 {
     libspdm_return_t status;
+    libspdm_test_context_t* spdm_test_context;
+    libspdm_context_t* spdm_context;
+    void* scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t* large_message;
+    uint32_t large_message_capacity;
+    size_t index;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
     status = libspdm_test_requester_chunk_send_generic_test_case(state, 9);
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
+    assert_false(spdm_context->chunk_context.send.chunk_in_use);
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t*)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    for (index = 0; index < large_message_capacity; index++) {
+        assert_int_equal(large_message[index], 0);
+    }
 }
 
 static void req_chunk_send_case10(void** state)

--- a/unit_test/test_spdm_responder/chunk_response.c
+++ b/unit_test/test_spdm_responder/chunk_response.c
@@ -805,6 +805,7 @@ static void rsp_chunk_response_case12(void** state)
     spdm_context->chunk_context.get.chunk_seq_no = chunk_seq_no;
     spdm_context->chunk_context.get.large_message = scratch_buffer;
     spdm_context->chunk_context.get.large_message_size = total_chunk_size;
+    spdm_context->chunk_context.get.large_message_capacity = scratch_buffer_size;
     spdm_context->chunk_context.get.chunk_bytes_transferred = first_chunk_size + second_chunk_size;
 
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
@@ -835,6 +836,18 @@ static void rsp_chunk_response_case12(void** state)
     chunk_ptr = (uint8_t*) (spdm_response + 1);
     for (i = 0; i < spdm_response->chunk_size; i++) {
         assert_int_equal(chunk_ptr[i], 3);
+    }
+
+    assert_false(spdm_context->chunk_context.get.chunk_in_use);
+    assert_int_equal(spdm_context->chunk_context.get.chunk_handle,
+                     (uint8_t)(chunk_handle + 1));
+    assert_int_equal(spdm_context->chunk_context.get.chunk_seq_no, 0);
+    assert_int_equal(spdm_context->chunk_context.get.chunk_bytes_transferred, 0);
+    assert_null(spdm_context->chunk_context.get.large_message);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_capacity, 0);
+    for (i = 0; i < total_chunk_size; i++) {
+        assert_int_equal(((uint8_t*)scratch_buffer)[i], 0);
     }
 }
 

--- a/unit_test/test_spdm_responder/chunk_send_ack.c
+++ b/unit_test/test_spdm_responder/chunk_send_ack.c
@@ -169,6 +169,12 @@ static void rsp_chunk_send_ack_case0(void** state)
     uint32_t bytes_sent;
     uint32_t bytes_total;
 
+    void *scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t *large_message;
+    size_t large_message_capacity;
+    size_t i;
+
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 0;
@@ -255,6 +261,21 @@ static void rsp_chunk_send_ack_case0(void** state)
     assert_int_equal(algorithms_response->header.spdm_version, SPDM_MESSAGE_VERSION_12);
     assert_int_equal(algorithms_response->header.request_response_code, SPDM_ALGORITHMS);
     assert_int_equal(algorithms_response->header.param1, 4);
+
+    /* Verify the completion cleanup fully reset large_message state and
+     * scrubbed the scratch buffer, so the consumed large request does not linger. */
+    assert_false(spdm_context->chunk_context.send.chunk_in_use);
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t *)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    for (i = 0; i < large_message_capacity; i++) {
+        assert_int_equal(large_message[i], 0);
+    }
 }
 
 /**
@@ -1189,6 +1210,7 @@ void libspdm_test_responder_chunk_send_ack_reset_send_state(libspdm_context_t* s
     send_info->chunk_bytes_transferred = 0;
     send_info->large_message = NULL;
     send_info->large_message_size = 0;
+    send_info->large_message_capacity = 0;
 }
 
 /**
@@ -1214,14 +1236,31 @@ static void rsp_chunk_send_ack_case13(void** state)
     const uint8_t* chunk_src;
     uint8_t* chunk_dst;
 
+    void *scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t *large_message;
+    size_t large_message_capacity;
+    size_t i;
+
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 13;
 
     libspdm_test_responder_chunk_send_ack_setup_algo_state(spdm_context);
+
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t *)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    libspdm_set_mem(large_message, large_message_capacity, 0xa5);
+
     spdm_context->chunk_context.send.chunk_in_use = true;
     spdm_context->chunk_context.send.chunk_handle = (uint8_t) spdm_test_context->case_id;
     spdm_context->chunk_context.send.chunk_seq_no = 0;
+    spdm_context->chunk_context.send.large_message = large_message;
+    spdm_context->chunk_context.send.large_message_capacity = large_message_capacity;
+    spdm_context->chunk_context.send.large_message_size = large_message_capacity;
+    spdm_context->chunk_context.send.chunk_bytes_transferred = large_message_capacity;
 
     chunk_src = (const uint8_t*) &m_libspdm_chunk_send_negotiate_algorithm_request1;
 
@@ -1265,6 +1304,13 @@ static void rsp_chunk_send_ack_case13(void** state)
     assert_int_equal(error_response->header.request_response_code, SPDM_ERROR);
     assert_int_equal(error_response->header.param1, SPDM_ERROR_CODE_INVALID_REQUEST);
     assert_int_equal(error_response->header.param2, 0);
+
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+    for (i = 0; i < large_message_capacity; i++) {
+        assert_int_equal(large_message[i], 0);
+    }
 
     libspdm_test_responder_chunk_send_ack_reset_send_state(spdm_context);
 }
@@ -1921,6 +1967,12 @@ static void rsp_chunk_send_ack_case22(void** state)
     uint32_t bytes_sent;
     uint32_t bytes_total;
 
+    void *scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t *large_message;
+    size_t large_message_capacity;
+    size_t i;
+
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
     spdm_test_context->case_id = 22;
@@ -2014,6 +2066,19 @@ static void rsp_chunk_send_ack_case22(void** state)
     assert_int_equal(algorithms_response->header.spdm_version, SPDM_MESSAGE_VERSION_14);
     assert_int_equal(algorithms_response->header.request_response_code, SPDM_ALGORITHMS);
     assert_int_equal(algorithms_response->header.param1, 4);
+
+    assert_false(spdm_context->chunk_context.send.chunk_in_use);
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t *)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    for (i = 0; i < large_message_capacity; i++) {
+        assert_int_equal(large_message[i], 0);
+    }
 }
 
 int libspdm_rsp_chunk_send_ack_test(void)

--- a/unit_test/test_spdm_responder/receive_send.c
+++ b/unit_test/test_spdm_responder/receive_send.c
@@ -165,6 +165,8 @@ static void libspdm_test_responder_receive_send_rsp_case1(void** state)
     chunk_handle = *(uint8_t*)(spdm_response + 1);
     assert_int_equal(chunk_handle, spdm_context->chunk_context.get.chunk_handle);
     assert_int_equal(spdm_context->chunk_context.get.chunk_in_use, true);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_capacity,
+                     spdm_context->local_context.capability.max_spdm_msg_size);
     libspdm_release_sender_buffer(spdm_context);
 
     free(data);
@@ -250,6 +252,8 @@ static void libspdm_test_responder_receive_send_rsp_case2(void** state)
     chunk_handle = *(uint8_t*)(spdm_response + 1);
     assert_int_equal(chunk_handle, spdm_context->chunk_context.get.chunk_handle);
     assert_int_equal(spdm_context->chunk_context.get.chunk_in_use, true);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_capacity,
+                     spdm_context->local_context.capability.max_spdm_msg_size);
     libspdm_release_sender_buffer(spdm_context);
 }
 
@@ -328,6 +332,8 @@ static void libspdm_test_responder_receive_send_rsp_case3(void** state)
     chunk_handle = *(uint8_t*)(spdm_response + 1);
     assert_int_equal(chunk_handle, spdm_context->chunk_context.get.chunk_handle);
     assert_int_equal(spdm_context->chunk_context.get.chunk_in_use, true);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_capacity,
+                     spdm_context->local_context.capability.max_spdm_msg_size);
     libspdm_release_sender_buffer(spdm_context);
 }
 #endif /* LIBSPDM_ENABLE_VENDOR_DEFINED_MESSAGES */
@@ -558,6 +564,11 @@ static void libspdm_test_responder_receive_send_rsp_case6(void** state)
     void *message;
     size_t message_size;
     uint32_t transport_header_size;
+    void *scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t *large_message;
+    size_t large_message_capacity;
+    size_t i;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -576,9 +587,18 @@ static void libspdm_test_responder_receive_send_rsp_case6(void** state)
         LIBSPDM_MAX_SPDM_MSG_SIZE;
 
     /* Simulate an active chunk GET transfer. */
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t *)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    libspdm_set_mem(large_message, large_message_capacity, 0xa5);
+
     spdm_context->chunk_context.get.chunk_in_use = true;
     spdm_context->chunk_context.get.chunk_handle = 1;
     spdm_context->chunk_context.get.chunk_seq_no = 2;
+    spdm_context->chunk_context.get.large_message = large_message;
+    spdm_context->chunk_context.get.large_message_size = large_message_capacity;
+    spdm_context->chunk_context.get.large_message_capacity = large_message_capacity;
 
     /* Send a GET_VERSION request. */
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
@@ -609,6 +629,13 @@ static void libspdm_test_responder_receive_send_rsp_case6(void** state)
     /* Verify chunk transfer was terminated. */
     assert_false(spdm_context->chunk_context.get.chunk_in_use);
     assert_int_equal(spdm_context->chunk_context.get.chunk_seq_no, 0);
+
+    assert_null(spdm_context->chunk_context.get.large_message);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.get.large_message_capacity, 0);
+    for (i = 0; i < large_message_capacity; i++) {
+        assert_int_equal(large_message[i], 0);
+    }
 
     libspdm_release_sender_buffer(spdm_context);
 }
@@ -708,6 +735,11 @@ static void libspdm_test_responder_receive_send_rsp_case8(void** state)
     void *message;
     size_t message_size;
     uint32_t transport_header_size;
+    void *scratch_buffer;
+    size_t scratch_buffer_size;
+    uint8_t *large_message;
+    size_t large_message_capacity;
+    size_t i;
 
     spdm_test_context = *state;
     spdm_context = spdm_test_context->spdm_context;
@@ -726,9 +758,18 @@ static void libspdm_test_responder_receive_send_rsp_case8(void** state)
         LIBSPDM_MAX_SPDM_MSG_SIZE;
 
     /* Simulate an active chunk SEND transfer. */
+    libspdm_get_scratch_buffer(spdm_context, &scratch_buffer, &scratch_buffer_size);
+    large_message = (uint8_t *)scratch_buffer +
+                    libspdm_get_scratch_buffer_large_message_offset(spdm_context);
+    large_message_capacity = libspdm_get_scratch_buffer_large_message_capacity(spdm_context);
+    libspdm_set_mem(large_message, large_message_capacity, 0xa5);
+
     spdm_context->chunk_context.send.chunk_in_use = true;
     spdm_context->chunk_context.send.chunk_handle = 1;
     spdm_context->chunk_context.send.chunk_seq_no = 3;
+    spdm_context->chunk_context.send.large_message = large_message;
+    spdm_context->chunk_context.send.large_message_size = large_message_capacity;
+    spdm_context->chunk_context.send.large_message_capacity = large_message_capacity;
 
     /* Send a GET_VERSION request. */
     libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
@@ -759,6 +800,13 @@ static void libspdm_test_responder_receive_send_rsp_case8(void** state)
     /* Verify chunk send transfer was terminated. */
     assert_false(spdm_context->chunk_context.send.chunk_in_use);
     assert_int_equal(spdm_context->chunk_context.send.chunk_seq_no, 0);
+
+    assert_null(spdm_context->chunk_context.send.large_message);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_size, 0);
+    assert_int_equal(spdm_context->chunk_context.send.large_message_capacity, 0);
+    for (i = 0; i < large_message_capacity; i++) {
+        assert_int_equal(large_message[i], 0);
+    }
 
     libspdm_release_sender_buffer(spdm_context);
 }


### PR DESCRIPTION
Fixed #3731 as described in the issue and added assertions in original tests.

The CHUNK process is complicated for me. So I requested Claude Sonnet 5 for reviewing my fix and visualing the lifecycle of scratch buffer during CHUNK_GET as the figure below. 

<img width="2445" height="2187" alt="chunk_get_sequence" src="https://github.com/user-attachments/assets/4b9d6d64-5bf3-4662-8fcc-844d9abfd5b8" />

Probably the sequence diagram helps a lot into realizing the problem statement.

Assisted-by: GitHub Copilot CLI 1.0.79:Claude Sonnet 5