### PR TITLE
Document error unit test conventions

### DIFF
--- a/doc/internal/unit_test_template.md
+++ b/doc/internal/unit_test_template.md
@@ -26,6 +26,21 @@ test_spdm_requester/encap_challenge_auth.c
 test_spdm_responder/encap_challenge.c
 ```
 
+#### Error Tests
+
+Test file names for error tests take the form *message_name*\_err.c or encap_*message_name*_err.c.
+
+```
+// Error unit test file names for CHALLENGE request and CHALLENGE_AUTH response.
+test_spdm_requester/error_test/challenge_err.c
+test_spdm_responder/error_test/challenge_auth_err.c
+
+// Error unit test file names for encapsulated CHALLENGE_AUTH response and encapsulated CHALLENGE
+// request.
+test_spdm_requester/error_test/encap_challenge_auth_err.c
+test_spdm_responder/error_test/encap_challenge_err.c
+```
+
 ## Test Layout
 
 Variables with external linkage (global variables) use the `g_` prefix. Variables at file scope use
@@ -139,4 +154,55 @@ following differences:
 For example
 ```C
 int libspdm_rsp_encap_message_name_test(void)
+```
+
+### Error Tests
+
+Naming patterns are the same as the non-error tests with the following differences:
+- the name of the entry function takes the form `*_error_test`
+- the name of test cases take the form `*_err_case*`
+
+For example
+```C
+/**
+ * Test 1: describe the test case.
+ * Expected behavior: describe the expected behavior of the unit under test.
+ **/
+static void rsp_message_name_err_case1(void **state)
+{
+}
+
+int libspdm_rsp_message_name_error_test(void)
+{
+    const struct CMUnitTest test_cases[] = {
+        cmocka_unit_test(rsp_message_name_err_case1),
+    };
+
+    libspdm_test_context_t test_context = {
+        LIBSPDM_TEST_CONTEXT_VERSION,
+        false,
+    };
+
+    libspdm_setup_test_context(&test_context);
+
+    return cmocka_run_group_tests(test_cases,
+                                  libspdm_unit_test_group_setup,
+                                  libspdm_unit_test_group_teardown);
+}
+```
+
+When an error condition is injected, a comment should also accompany the error condition. The
+comment should begin with the `{ERROR}` token.
+
+For example
+```C
+set_standard_state(spdm_context);
+
+/* {ERROR} Responder is not an event notifier. */
+spdm_context->local_context.capability.flags &= ~SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_EVENT_CAP;
+
+spdm_request.header.spdm_version = SPDM_MESSAGE_VERSION_13;
+spdm_request.header.request_response_code = SPDM_GET_SUPPORTED_EVENT_TYPES;
+spdm_request.header.param1 = 0;
+spdm_request.header.param2 = 0;
 ```


### PR DESCRIPTION
Add guidance for naming and structuring error unit tests in the internal template. This includes the filename patterns for error tests, expected entry function and case naming conventions, and the required `{ERROR}` annotation for injected error conditions to clarify test intent.