### PR TITLE
Update copyright check for fuzzing tests

### DIFF
--- a/script/check_copyright_date.sh
+++ b/script/check_copyright_date.sh
@@ -20,7 +20,9 @@ echo
 for file in $modified_files
 do
     # Only examine C files for now.
-    if [[ $file == "include/"* ]] || [[ $file == "library/"* ]] || [[ $file == "unit_test/test_"* ]]; then
+    if [[ $file == "include/"* ]] || [[ $file == "library/"* ]] ||
+       [[ $file == "unit_test/test_"* ]] || [[ $file == "unit_test/fuzzing/test_"* ]] ||
+       [[ $file == "unit_test/fuzzing/spdm_unit_fuzzing_common/"* ]]; then
         if [[ $file == *".h" ]] || [[ $file == *".c" ]]; then
             # Assume that the copyright is located at the third line of the file.
             if [[ $(sed -n '3p' $file) != *$current_year* ]]; then


### PR DESCRIPTION
Expand the copyright-year validation to cover fuzzing test sources and shared fuzzing helpers so they are checked alongside the existing C headers and unit tests.