### PR TITLE
Return `BUFFER_TOO_SMALL` for undersized buffers

### DIFF
--- a/include/library/spdm_requester_lib.h
+++ b/include/library/spdm_requester_lib.h
@@ -95,6 +95,8 @@ libspdm_return_t libspdm_get_digest(void *spdm_context, const uint32_t *session_
  *         The Responder returned a RequestResynch error message.
  * @retval LIBSPDM_STATUS_BUFFER_FULL
  *         The buffer used to store transcripts is exhausted.
+ * @retval LIBSPDM_STATUS_BUFFER_TOO_SMALL
+ *         The cert_chain buffer is too small to hold the certificate chain.
  * @retval LIBSPDM_STATUS_VERIF_FAIL
  *         Verification of the certificate chain failed.
  * @retval LIBSPDM_STATUS_INVALID_CERT

--- a/library/spdm_requester_lib/libspdm_req_get_key_pair_info.c
+++ b/library/spdm_requester_lib/libspdm_req_get_key_pair_info.c
@@ -300,7 +300,7 @@ static libspdm_return_t libspdm_try_get_key_pair_info(libspdm_context_t *spdm_co
     }
 
     if (*public_key_info_len < spdm_response->public_key_info_len) {
-        status = LIBSPDM_STATUS_BUFFER_FULL;
+        status = LIBSPDM_STATUS_BUFFER_TOO_SMALL;
         goto receive_done;
     }
     *public_key_info_len = spdm_response->public_key_info_len;

--- a/library/spdm_requester_lib/libspdm_req_get_measurement_extension_log.c
+++ b/library/spdm_requester_lib/libspdm_req_get_measurement_extension_log.c
@@ -1,6 +1,6 @@
 /**
  *  Copyright Notice:
- *  Copyright 2024-2025 DMTF. All rights reserved.
+ *  Copyright 2024-2026 DMTF. All rights reserved.
  *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
  **/
 
@@ -216,7 +216,7 @@ static libspdm_return_t libspdm_try_get_measurement_extension_log(libspdm_contex
 
         if (mel_size_internal + spdm_response->portion_length > mel_capacity) {
             libspdm_release_receiver_buffer (spdm_context);
-            status = LIBSPDM_STATUS_BUFFER_FULL;
+            status = LIBSPDM_STATUS_BUFFER_TOO_SMALL;
             goto done;
         }
 

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -252,8 +252,8 @@ libspdm_return_t libspdm_process_encap_response_certificate(
                               rsp_msg_portion_length);
 
     if (cert_chain_buffer_size + rsp_msg_portion_length > cert_chain_buffer_max_size) {
-        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "cert_chain_buffer full\n"));
-        return LIBSPDM_STATUS_BUFFER_FULL;
+        LIBSPDM_DEBUG((LIBSPDM_DEBUG_INFO, "cert_chain buffer too small\n"));
+        return LIBSPDM_STATUS_BUFFER_TOO_SMALL;
     }
 
     libspdm_copy_mem(cert_chain_buffer + cert_chain_buffer_size,

--- a/unit_test/test_spdm_requester/get_key_pair_info.c
+++ b/unit_test/test_spdm_requester/get_key_pair_info.c
@@ -30,6 +30,7 @@ static libspdm_return_t send_message(
     case 0x2:
     case 0x3:
     case 0x4:
+    case 0x5:
         return LIBSPDM_STATUS_SUCCESS;
     default:
         return LIBSPDM_STATUS_SEND_FAIL;
@@ -43,7 +44,8 @@ static libspdm_return_t receive_message(
 
     spdm_test_context = libspdm_get_test_context();
     switch (spdm_test_context->case_id) {
-    case 0x1: {
+    case 0x1:
+    case 0x5: {
         spdm_key_pair_info_response_t *spdm_response;
         size_t spdm_response_size;
         size_t transport_header_size;
@@ -806,6 +808,59 @@ static void req_get_key_pair_info_case4(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_SIZE);
 }
 
+/**
+ * Test 5: The Requester's PublicKeyInfo buffer is smaller than the KEY_PAIR_INFO response's
+ * PublicKeyInfoLen.
+ * Expected Behavior: get a LIBSPDM_STATUS_BUFFER_TOO_SMALL return code
+ **/
+static void req_get_key_pair_info_case5(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+
+    uint8_t key_pair_id;
+    uint8_t associated_slot_id;
+    uint8_t total_key_pairs;
+    uint16_t capabilities;
+    uint16_t key_usage_capabilities;
+    uint16_t current_key_usage;
+    uint32_t asym_algo_capabilities;
+    uint32_t current_asym_algo;
+    uint32_t pqc_asym_algo_capabilities;
+    uint32_t current_pqc_asym_algo;
+    uint16_t public_key_info_len;
+    uint8_t assoc_cert_slot_mask;
+    uint8_t public_key_info[SPDM_MAX_PUBLIC_KEY_INFO_LEN];
+
+    key_pair_id = 1;
+    associated_slot_id = 1;
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x5;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_GET_KEY_PAIR_INFO_CAP |
+        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_KEY_PAIR_INFO_CAP;
+
+    spdm_context->connection_info.peer_key_pair_id[associated_slot_id] = key_pair_id;
+
+    /* Case 0x5 responds with the same 15-byte RSA 2048 PublicKeyInfo as case 0x1. */
+    public_key_info_len = 14;
+
+    status = libspdm_get_key_pair_info(spdm_context, NULL, key_pair_id, &total_key_pairs,
+                                       &capabilities, &key_usage_capabilities, &current_key_usage,
+                                       &asym_algo_capabilities, &current_asym_algo,
+                                       &pqc_asym_algo_capabilities, &current_pqc_asym_algo,
+                                       &assoc_cert_slot_mask, &public_key_info_len,
+                                       public_key_info);
+
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_TOO_SMALL);
+}
+
 int libspdm_req_get_key_pair_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -817,6 +872,8 @@ int libspdm_req_get_key_pair_info_test(void)
         cmocka_unit_test(req_get_key_pair_info_case3),
         /* Header-only response is rejected before reading the body fields */
         cmocka_unit_test(req_get_key_pair_info_case4),
+        /* The Requester's PublicKeyInfo buffer is too small */
+        cmocka_unit_test(req_get_key_pair_info_case5),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_requester/get_measurement_extension_log.c
+++ b/unit_test/test_spdm_requester/get_measurement_extension_log.c
@@ -169,6 +169,7 @@ static libspdm_return_t send_message(
     case 0x7:
     case 0x8:
     case 0x9:
+    case 0xA:
         return LIBSPDM_STATUS_SUCCESS;
     default:
         return LIBSPDM_STATUS_SEND_FAIL;
@@ -650,6 +651,41 @@ static libspdm_return_t receive_message(
     }
         return LIBSPDM_STATUS_SUCCESS;
 
+    case 0xA:
+    {
+        spdm_measurement_extension_log_response_t *spdm_response;
+        size_t spdm_response_size;
+        size_t transport_header_size;
+        spdm_measurement_extension_log_dmtf_t *spdm_mel;
+
+        spdm_mel = (spdm_measurement_extension_log_dmtf_t *)m_libspdm_mel_test;
+
+        transport_header_size = LIBSPDM_TEST_TRANSPORT_HEADER_SIZE;
+        spdm_response = (void *)((uint8_t *)*response + transport_header_size);
+
+        spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+        spdm_response->header.request_response_code = SPDM_MEASUREMENT_EXTENSION_LOG;
+        spdm_response->header.param1 = 0;
+        spdm_response->header.param2 = 0;
+        /* The entire MEL is delivered in a single response. */
+        spdm_response->portion_length = LIBSPDM_MAX_MEL_BLOCK_LEN;
+        spdm_response->remainder_length = 0;
+
+        libspdm_copy_mem(spdm_response + 1,
+                         (size_t)(*response) + *response_size - (size_t)(spdm_response + 1),
+                         (uint8_t *)spdm_mel,
+                         LIBSPDM_MAX_MEL_BLOCK_LEN);
+
+        spdm_response_size = sizeof(spdm_measurement_extension_log_response_t) +
+                             LIBSPDM_MAX_MEL_BLOCK_LEN;
+
+        libspdm_transport_test_encode_message(spdm_context, NULL, false,
+                                              false, spdm_response_size,
+                                              spdm_response, response_size,
+                                              response);
+    }
+        return LIBSPDM_STATUS_SUCCESS;
+
     default:
         return LIBSPDM_STATUS_RECEIVE_FAIL;
     }
@@ -997,6 +1033,44 @@ static void req_get_measurement_extension_log_case9(void **state)
     assert_int_equal(status, LIBSPDM_STATUS_INVALID_MSG_FIELD);
 }
 
+/**
+ * Test 10: The Requester's MEL buffer is smaller than the MEASUREMENT_EXTENSION_LOG response's
+ * PortionLength.
+ * Expected Behavior: get a LIBSPDM_STATUS_BUFFER_TOO_SMALL return code
+ **/
+static void req_get_measurement_extension_log_case10(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    size_t spdm_mel_size;
+    uint8_t spdm_mel[LIBSPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE];
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0xA;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_AUTHENTICATED;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEL_CAP;
+
+    libspdm_reset_message_b(spdm_context);
+    libspdm_zero_mem(spdm_mel, sizeof(spdm_mel));
+
+    spdm_context->connection_info.algorithm.measurement_spec = m_libspdm_use_measurement_spec;
+    spdm_context->connection_info.algorithm.measurement_hash_algo =
+        m_libspdm_use_measurement_hash_algo;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.base_asym_algo = m_libspdm_use_asym_algo;
+    spdm_context->local_context.algorithm.measurement_spec = SPDM_MEASUREMENT_SPECIFICATION_DMTF;
+
+    /* Case 0xA responds with a PortionLength of LIBSPDM_MAX_MEL_BLOCK_LEN. */
+    spdm_mel_size = LIBSPDM_MAX_MEL_BLOCK_LEN - 1;
+
+    status = libspdm_get_measurement_extension_log(spdm_context, NULL, &spdm_mel_size, spdm_mel);
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_TOO_SMALL);
+}
+
 int libspdm_req_get_measurement_extension_log_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -1018,7 +1092,8 @@ int libspdm_req_get_measurement_extension_log_test(void)
         cmocka_unit_test(req_get_measurement_extension_log_case8),
         /* Failed response , The total MEL length is larger than SPDM_MAX_MEASUREMENT_EXTENSION_LOG_SIZE*/
         cmocka_unit_test(req_get_measurement_extension_log_case9),
-
+        /* Failed response , The caller's MEL buffer is smaller than the portion length*/
+        cmocka_unit_test(req_get_measurement_extension_log_case10),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_certificate.c
+++ b/unit_test/test_spdm_responder/encap_get_certificate.c
@@ -580,6 +580,93 @@ static void rsp_encap_get_certificate_case5(void **state)
     m_libspdm_local_certificate_chain_size = 0;
 }
 
+/**
+ * Test 6: The Responder's Integrator registered, through libspdm_register_cert_chain_buffer(),
+ * a certificate chain buffer that is smaller than the CERTIFICATE response's PortionLength.
+ * Expected Behavior: returns a status of LIBSPDM_STATUS_BUFFER_TOO_SMALL and the buffer is left
+ *                    untouched.
+ **/
+static void rsp_encap_get_certificate_case6(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    bool need_continue;
+    spdm_certificate_response_t *spdm_response;
+    uint8_t temp_buf[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t temp_buf_size;
+    uint8_t cert_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
+    uint16_t portion_length;
+    uint16_t remainder_length;
+    size_t spdm_response_size;
+    void *saved_cert_chain_buffer;
+    size_t saved_cert_chain_buffer_max_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x6;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP;
+    spdm_context->connection_info.algorithm.base_hash_algo = m_libspdm_use_hash_algo;
+    spdm_context->connection_info.algorithm.req_base_asym_alg = m_libspdm_use_req_asym_algo;
+
+    if (!libspdm_read_responder_public_certificate_chain(
+            m_libspdm_use_hash_algo, m_libspdm_use_asym_algo,
+            &m_libspdm_local_certificate_chain,
+            &m_libspdm_local_certificate_chain_size, NULL, NULL)) {
+        assert(false);
+    }
+
+    portion_length = LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN;
+    remainder_length =
+        (uint16_t)(m_libspdm_local_certificate_chain_size - LIBSPDM_MAX_CERT_CHAIN_BLOCK_LEN);
+
+    temp_buf_size = sizeof(spdm_certificate_response_t) + portion_length;
+    spdm_response_size = temp_buf_size;
+    spdm_response = (void *)temp_buf;
+
+    spdm_response->header.spdm_version = SPDM_MESSAGE_VERSION_13;
+    spdm_response->header.request_response_code = SPDM_CERTIFICATE;
+    spdm_response->header.param1 = 0;
+    spdm_response->header.param2 = SPDM_CERTIFICATE_INFO_CERT_MODEL_NONE;
+    spdm_response->portion_length = portion_length;
+    spdm_response->remainder_length = remainder_length;
+    libspdm_copy_mem(spdm_response + 1,
+                     sizeof(temp_buf) - sizeof(*spdm_response),
+                     (uint8_t *)m_libspdm_local_certificate_chain,
+                     portion_length);
+
+    /* This is the configuration of rsp_encap_get_certificate_case5 Sub Case 6, which succeeds,
+     * except that the registered buffer cannot hold the first portion. */
+    spdm_context->connection_info.multi_key_conn_req = false;
+    spdm_context->encap_context.req_slot_id = 0;
+    spdm_context->connection_info.peer_cert_info[0] = 0;
+    libspdm_reset_message_mut_b(spdm_context);
+    libspdm_zero_mem(cert_chain, sizeof(cert_chain));
+
+    saved_cert_chain_buffer = spdm_context->mut_auth_cert_chain_buffer;
+    saved_cert_chain_buffer_max_size = spdm_context->mut_auth_cert_chain_buffer_max_size;
+    spdm_context->mut_auth_cert_chain_buffer = cert_chain;
+    spdm_context->mut_auth_cert_chain_buffer_max_size = portion_length - 1;
+    spdm_context->mut_auth_cert_chain_buffer_size = 0;
+
+    status = libspdm_process_encap_response_certificate(spdm_context, spdm_response_size,
+                                                        spdm_response,
+                                                        &need_continue);
+
+    assert_int_equal(status, LIBSPDM_STATUS_BUFFER_TOO_SMALL);
+    assert_int_equal(spdm_context->mut_auth_cert_chain_buffer_size, 0);
+
+    spdm_context->mut_auth_cert_chain_buffer = saved_cert_chain_buffer;
+    spdm_context->mut_auth_cert_chain_buffer_max_size = saved_cert_chain_buffer_max_size;
+
+    free(m_libspdm_local_certificate_chain);
+    m_libspdm_local_certificate_chain = NULL;
+    m_libspdm_local_certificate_chain_size = 0;
+}
+
 int libspdm_rsp_encap_get_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -596,6 +683,8 @@ int libspdm_rsp_encap_get_certificate_test(void)
         cmocka_unit_test(rsp_encap_get_certificate_case4),
         /* check request attributes and response attributes*/
         cmocka_unit_test(rsp_encap_get_certificate_case5),
+        /* The Integrator's certificate chain buffer is too small*/
+        cmocka_unit_test(rsp_encap_get_certificate_case6),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
Fix #3795.