### PR TITLE
Fix key update rollback for Specula cluster A.1 and A.3

### DIFF
--- a/library/spdm_responder_lib/libspdm_rsp_key_update_ack.c
+++ b/library/spdm_responder_lib/libspdm_rsp_key_update_ack.c
@@ -127,6 +127,9 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
             session_info->secured_message_context,
             LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
         if (!result) {
+            libspdm_activate_update_session_data_key(
+                session_info->secured_message_context,
+                LIBSPDM_KEY_UPDATE_ACTION_REQUESTER, false);
             return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         }
         libspdm_trigger_key_update_callback(
@@ -153,6 +156,9 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
             session_info->secured_message_context,
             LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
         if (!result) {
+            libspdm_activate_update_session_data_key(
+                session_info->secured_message_context,
+                LIBSPDM_KEY_UPDATE_ACTION_REQUESTER, false);
             return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         }
         libspdm_trigger_key_update_callback(
@@ -166,6 +172,9 @@ libspdm_return_t libspdm_get_response_key_update(libspdm_context_t *spdm_context
             session_info->secured_message_context,
             LIBSPDM_KEY_UPDATE_ACTION_RESPONDER);
         if (!result) {
+            libspdm_activate_update_session_data_key(
+                session_info->secured_message_context,
+                LIBSPDM_KEY_UPDATE_ACTION_REQUESTER, false);
             return LIBSPDM_STATUS_UNSUPPORTED_CAP;
         }
         libspdm_trigger_key_update_callback(

--- a/library/spdm_secured_message_lib/libspdm_secmes_session.c
+++ b/library/spdm_secured_message_lib/libspdm_secmes_session.c
@@ -380,6 +380,11 @@ bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
         .request_data_sequence_number =
             secured_message_context->application_secret.request_data_sequence_number;
 
+        /* The backup now holds a complete snapshot of the old keys, so mark it valid before
+         * deriving the new ones. If a derivation below fails the caller can still roll back
+         * via libspdm_activate_update_session_data_key(..., use_new_key = false). */
+        secured_message_context->requester_backup_valid = true;
+
         status = libspdm_hkdf_expand(
             secured_message_context->base_hash_algo,
             secured_message_context->application_secret.request_data_secret,
@@ -403,8 +408,6 @@ bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
             return status;
         }
         secured_message_context->application_secret.request_data_sequence_number = 0;
-
-        secured_message_context->requester_backup_valid = true;
     } else if (action == LIBSPDM_KEY_UPDATE_ACTION_RESPONDER) {
         libspdm_copy_mem(&secured_message_context->application_secret_backup
                          .response_data_secret,
@@ -431,6 +434,11 @@ bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
         .response_data_sequence_number =
             secured_message_context->application_secret.response_data_sequence_number;
 
+        /* The backup now holds a complete snapshot of the old keys, so mark it valid before
+         * deriving the new ones. If a derivation below fails the caller can still roll back
+         * via libspdm_activate_update_session_data_key(..., use_new_key = false). */
+        secured_message_context->responder_backup_valid = true;
+
         status = libspdm_hkdf_expand(
             secured_message_context->base_hash_algo,
             secured_message_context->application_secret.response_data_secret,
@@ -455,8 +463,6 @@ bool libspdm_create_update_session_data_key(void *spdm_secured_message_context,
             return status;
         }
         secured_message_context->application_secret.response_data_sequence_number = 0;
-
-        secured_message_context->responder_backup_valid = true;
     } else {
         return false;
     }

--- a/unit_test/test_spdm_responder/key_update_ack.c
+++ b/unit_test/test_spdm_responder/key_update_ack.c
@@ -2056,6 +2056,74 @@ static void rsp_key_update_ack_case27(void **state)
                         m_rsp_secret_buffer, secured_message_context->hash_size);
 }
 
+/**
+ * Test 28: UPDATE_ALL_KEYS must not leave one direction updated while the other
+ * is not.
+ * Expected Behavior: when the key update cannot be completed for both
+ * directions the responder reports an error and leaves both directions on the
+ * old keys, with no backup left pending for a later commit.
+ **/
+static void rsp_key_update_ack_case28(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t            *spdm_test_context;
+    libspdm_context_t                 *spdm_context;
+    uint32_t session_id;
+    libspdm_session_info_t            *session_info;
+    libspdm_secured_message_context_t *secured_message_context;
+
+    size_t response_size;
+    uint8_t response[LIBSPDM_MAX_SPDM_MSG_SIZE];
+
+    uint8_t m_req_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
+    uint8_t m_rsp_secret_buffer[LIBSPDM_MAX_HASH_SIZE];
+    size_t original_aead_key_size;
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_test_context->case_id = 0x1C;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+
+    libspdm_set_standard_key_update_test_state( spdm_context, &session_id);
+
+    session_info = &spdm_context->session_info[0];
+    secured_message_context = session_info->secured_message_context;
+
+    libspdm_set_standard_key_update_test_secrets(
+        session_info->secured_message_context,
+        m_rsp_secret_buffer, (uint8_t)(0xFF),
+        m_req_secret_buffer, (uint8_t)(0xEE));
+
+    /* Make the AEAD key derivation fail: HKDF-Expand rejects an output longer
+     * than 255 * hash_size per RFC 5869 Section 2.3, and rejects it on the
+     * requested length alone, before writing to the output buffer. */
+    original_aead_key_size = secured_message_context->aead_key_size;
+    secured_message_context->aead_key_size = 255 * secured_message_context->hash_size + 1;
+
+    response_size = sizeof(response);
+    status = libspdm_get_response_key_update(spdm_context,
+                                             m_libspdm_key_update_request3_size,
+                                             &m_libspdm_key_update_request3,
+                                             &response_size, response);
+
+    secured_message_context->aead_key_size = original_aead_key_size;
+
+    assert_int_equal(status, LIBSPDM_STATUS_UNSUPPORTED_CAP);
+
+    /* Both directions must still hold the pre-update secrets. */
+    assert_memory_equal(secured_message_context
+                        ->application_secret.request_data_secret,
+                        m_req_secret_buffer, secured_message_context->hash_size);
+    assert_memory_equal(secured_message_context
+                        ->application_secret.response_data_secret,
+                        m_rsp_secret_buffer, secured_message_context->hash_size);
+
+    /* No half-finished update may be left pending for a later commit. */
+    assert_false(secured_message_context->requester_backup_valid);
+    assert_false(secured_message_context->responder_backup_valid);
+}
+
 int libspdm_rsp_key_update_ack_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -2115,6 +2183,8 @@ int libspdm_rsp_key_update_ack_test(void)
         cmocka_unit_test(rsp_key_update_ack_case26),
         /* Invalid operation,other key_update operation: failed*/
         cmocka_unit_test(rsp_key_update_ack_case27),
+        /* UpdateAllKeys: a failed update leaves neither direction updated*/
+        cmocka_unit_test(rsp_key_update_ack_case28),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_secured_message/CMakeLists.txt
+++ b/unit_test/test_spdm_secured_message/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT ((TOOLCHAIN STREQUAL "KLEE") OR (TOOLCHAIN STREQUAL "CBMC")))
         PRIVATE
             test_spdm_secured_message.c
             encode_decode.c
+            key_update.c
             ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/common.c
             ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/algo.c
             ${LIBSPDM_DIR}/unit_test/spdm_unit_test_common/support.c

--- a/unit_test/test_spdm_secured_message/key_update.c
+++ b/unit_test/test_spdm_secured_message/key_update.c
@@ -1,0 +1,215 @@
+/**
+ *  Copyright Notice:
+ *  Copyright 2026 DMTF. All rights reserved.
+ *  License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/libspdm/blob/main/LICENSE.md
+ **/
+
+#include "spdm_unit_test.h"
+#include "internal/libspdm_secured_message_lib.h"
+
+#if LIBSPDM_AEAD_AES_256_GCM_SUPPORT
+
+static libspdm_secured_message_context_t m_secured_message_context;
+
+#define OLD_SECRET_BYTE 0xAA
+#define OLD_KEY_BYTE    0xBB
+#define OLD_SALT_BYTE   0xCC
+#define OLD_SEQ_NUMBER  0x42
+
+/* An okm_len above 255 * hash_size is rejected by HKDF-Expand per RFC 5869
+ * Section 2.3. The check is on the requested length alone, so the derivation
+ * fails before anything is written to the output buffer. */
+#define OVERSIZED_AEAD_KEY_SIZE (255 * LIBSPDM_SHA256_DIGEST_SIZE + 1)
+
+static void initialize_key_update_context(libspdm_key_update_action_t action)
+{
+    libspdm_zero_mem(&m_secured_message_context, sizeof(m_secured_message_context));
+
+    m_secured_message_context.secured_message_version =
+        SECURED_SPDM_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    m_secured_message_context.version = SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    m_secured_message_context.base_hash_algo = SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_256;
+    m_secured_message_context.aead_cipher_suite = SPDM_ALGORITHMS_AEAD_CIPHER_SUITE_AES_256_GCM;
+    m_secured_message_context.session_type = LIBSPDM_SESSION_TYPE_ENC_MAC;
+    m_secured_message_context.session_state = LIBSPDM_SESSION_STATE_ESTABLISHED;
+    m_secured_message_context.hash_size = LIBSPDM_SHA256_DIGEST_SIZE;
+    m_secured_message_context.aead_key_size = 32;
+    m_secured_message_context.aead_iv_size = 12;
+
+    /* Populate the live keys with a recognizable pattern so a successful
+     * rollback can be distinguished from a partially-updated state. */
+    if (action == LIBSPDM_KEY_UPDATE_ACTION_REQUESTER) {
+        libspdm_set_mem(m_secured_message_context.application_secret.request_data_secret,
+                        LIBSPDM_SHA256_DIGEST_SIZE, OLD_SECRET_BYTE);
+        libspdm_set_mem(m_secured_message_context.application_secret.request_data_encryption_key,
+                        m_secured_message_context.aead_key_size, OLD_KEY_BYTE);
+        libspdm_set_mem(m_secured_message_context.application_secret.request_data_salt,
+                        m_secured_message_context.aead_iv_size, OLD_SALT_BYTE);
+        m_secured_message_context.application_secret.request_data_sequence_number =
+            OLD_SEQ_NUMBER;
+    } else {
+        libspdm_set_mem(m_secured_message_context.application_secret.response_data_secret,
+                        LIBSPDM_SHA256_DIGEST_SIZE, OLD_SECRET_BYTE);
+        libspdm_set_mem(m_secured_message_context.application_secret.response_data_encryption_key,
+                        m_secured_message_context.aead_key_size, OLD_KEY_BYTE);
+        libspdm_set_mem(m_secured_message_context.application_secret.response_data_salt,
+                        m_secured_message_context.aead_iv_size, OLD_SALT_BYTE);
+        m_secured_message_context.application_secret.response_data_sequence_number =
+            OLD_SEQ_NUMBER;
+    }
+}
+
+/**
+ * Assert that the live keys for the given direction still hold the pre-update
+ * pattern, i.e. that a rollback fully restored them.
+ **/
+static void assert_old_keys_restored(libspdm_key_update_action_t action)
+{
+    const libspdm_session_info_struct_application_secret_t *secret =
+        &m_secured_message_context.application_secret;
+    const uint8_t *data_secret;
+    const uint8_t *encryption_key;
+    const uint8_t *salt;
+    uint64_t sequence_number;
+    size_t index;
+
+    if (action == LIBSPDM_KEY_UPDATE_ACTION_REQUESTER) {
+        data_secret = secret->request_data_secret;
+        encryption_key = secret->request_data_encryption_key;
+        salt = secret->request_data_salt;
+        sequence_number = secret->request_data_sequence_number;
+    } else {
+        data_secret = secret->response_data_secret;
+        encryption_key = secret->response_data_encryption_key;
+        salt = secret->response_data_salt;
+        sequence_number = secret->response_data_sequence_number;
+    }
+
+    for (index = 0; index < LIBSPDM_SHA256_DIGEST_SIZE; index++) {
+        assert_int_equal(data_secret[index], OLD_SECRET_BYTE);
+    }
+    for (index = 0; index < 32; index++) {
+        assert_int_equal(encryption_key[index], OLD_KEY_BYTE);
+    }
+    for (index = 0; index < 12; index++) {
+        assert_int_equal(salt[index], OLD_SALT_BYTE);
+    }
+    assert_int_equal(sequence_number, OLD_SEQ_NUMBER);
+}
+
+/**
+ * Test 1: A failure while deriving the new Requester keys leaves the backup
+ * recoverable, so a rollback restores the original keys.
+ *
+ * libspdm_create_update_session_data_key() snapshots the old keys into the
+ * backup slot and then derives the new ones. If a derivation fails after the
+ * snapshot was taken, the backup must already be marked valid, otherwise
+ * libspdm_activate_update_session_data_key(..., use_new_key = false) has
+ * nothing to roll back to and the old keys are lost for good.
+ **/
+static void libspdm_test_key_update_rollback_after_derive_failure_case1(void **state)
+{
+    bool result;
+
+    initialize_key_update_context(LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
+
+    /* Force the AEAD key derivation, which runs after the data-secret update,
+     * to fail. The data-secret update itself is sized by hash_size and still
+     * succeeds, so this reproduces a failure part-way through the update. */
+    m_secured_message_context.aead_key_size = OVERSIZED_AEAD_KEY_SIZE;
+
+    result = libspdm_create_update_session_data_key(&m_secured_message_context,
+                                                    LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
+    assert_false(result);
+
+    /* The backup holds a complete snapshot of the old keys and must be usable. */
+    assert_true(m_secured_message_context.requester_backup_valid);
+
+    /* Restore aead_key_size so the rollback copies the real key length. */
+    m_secured_message_context.aead_key_size = 32;
+
+    result = libspdm_activate_update_session_data_key(&m_secured_message_context,
+                                                      LIBSPDM_KEY_UPDATE_ACTION_REQUESTER,
+                                                      false);
+    assert_true(result);
+
+    assert_old_keys_restored(LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
+
+    /* The backup is consumed by the rollback. */
+    assert_false(m_secured_message_context.requester_backup_valid);
+}
+
+/**
+ * Test 2: The same property for the Responder direction.
+ **/
+static void libspdm_test_key_update_rollback_after_derive_failure_case2(void **state)
+{
+    bool result;
+
+    initialize_key_update_context(LIBSPDM_KEY_UPDATE_ACTION_RESPONDER);
+
+    m_secured_message_context.aead_key_size = OVERSIZED_AEAD_KEY_SIZE;
+
+    result = libspdm_create_update_session_data_key(&m_secured_message_context,
+                                                    LIBSPDM_KEY_UPDATE_ACTION_RESPONDER);
+    assert_false(result);
+
+    assert_true(m_secured_message_context.responder_backup_valid);
+
+    m_secured_message_context.aead_key_size = 32;
+
+    result = libspdm_activate_update_session_data_key(&m_secured_message_context,
+                                                      LIBSPDM_KEY_UPDATE_ACTION_RESPONDER,
+                                                      false);
+    assert_true(result);
+
+    assert_old_keys_restored(LIBSPDM_KEY_UPDATE_ACTION_RESPONDER);
+
+    assert_false(m_secured_message_context.responder_backup_valid);
+}
+
+/**
+ * Test 3: A successful key update still marks the backup valid and commits the
+ * new keys, so the fix does not regress the success path.
+ **/
+static void libspdm_test_key_update_success_path_case3(void **state)
+{
+    bool result;
+
+    initialize_key_update_context(LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
+
+    result = libspdm_create_update_session_data_key(&m_secured_message_context,
+                                                    LIBSPDM_KEY_UPDATE_ACTION_REQUESTER);
+    assert_true(result);
+    assert_true(m_secured_message_context.requester_backup_valid);
+
+    /* The live secret has been replaced by the derived one. */
+    assert_memory_not_equal(m_secured_message_context.application_secret.request_data_secret,
+                            m_secured_message_context.application_secret_backup
+                            .request_data_secret,
+                            LIBSPDM_SHA256_DIGEST_SIZE);
+    assert_int_equal(m_secured_message_context.application_secret.request_data_sequence_number, 0);
+
+    /* Committing the new keys discards the backup. */
+    result = libspdm_activate_update_session_data_key(&m_secured_message_context,
+                                                      LIBSPDM_KEY_UPDATE_ACTION_REQUESTER,
+                                                      true);
+    assert_true(result);
+    assert_false(m_secured_message_context.requester_backup_valid);
+}
+
+int libspdm_secured_message_key_update_test_main(void)
+{
+    const struct CMUnitTest test_cases[] = {
+        /* Requester: rollback works after a mid-update derivation failure */
+        cmocka_unit_test(libspdm_test_key_update_rollback_after_derive_failure_case1),
+        /* Responder: rollback works after a mid-update derivation failure */
+        cmocka_unit_test(libspdm_test_key_update_rollback_after_derive_failure_case2),
+        /* Success path is unaffected */
+        cmocka_unit_test(libspdm_test_key_update_success_path_case3),
+    };
+
+    return cmocka_run_group_tests(test_cases, NULL, NULL);
+}
+
+#endif /* LIBSPDM_AEAD_AES_256_GCM_SUPPORT */

--- a/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
+++ b/unit_test/test_spdm_secured_message/test_spdm_secured_message.c
@@ -8,6 +8,7 @@
 #include "library/spdm_common_lib.h"
 
 extern int libspdm_secured_message_encode_decode_test_main(void);
+extern int libspdm_secured_message_key_update_test_main(void);
 
 int main(void)
 {
@@ -15,6 +16,9 @@ int main(void)
 
 #if LIBSPDM_AEAD_AES_256_GCM_SUPPORT
     if (libspdm_secured_message_encode_decode_test_main() != 0) {
+        return_value = 1;
+    }
+    if (libspdm_secured_message_key_update_test_main() != 0) {
         return_value = 1;
     }
 #endif


### PR DESCRIPTION
Fixes two of the Specula cluster A findings from #3733: A.1 (backup not marked
valid before HKDF can fail) and A.3 (no rollback between the two
`create_update` calls).

The two commits are ordered, and A.3 depends on A.1: without the flag ordering
fixed, every rollback added in the second commit is a silent no-op.

## A.1 — mark the backup valid before deriving

`libspdm_create_update_session_data_key()` snapshots the current keys into the
backup slot and then derives the new ones, but only set
`requester_backup_valid` / `responder_backup_valid` after both
`libspdm_hkdf_expand()` and `libspdm_generate_aead_key_and_iv()` had
succeeded.

If either derivation fails, the function returns `false` with the backup slot
already holding a complete copy of the old keys, yet the valid flag still
clear. `libspdm_activate_update_session_data_key()` gates its restore path on
that flag, so a rollback with `use_new_key = false` silently does nothing and
the old keys are unrecoverable.

The fix moves the assignment to immediately after the snapshot completes,
before any derivation runs. At that point the backup is a full,
self-consistent copy of the pre-update keys, which is exactly what a rollback
needs. The success path is unchanged.

## A.3 — roll back a failed update instead of leaving keys half applied

`libspdm_create_update_session_data_key()` derives the new data secret **in
place**: `request_data_secret` is passed as both the PRK and the output buffer
of `libspdm_hkdf_expand()`. So by the time the function can fail, the live
secret has already been replaced. Any failure arm that returns without a
rollback leaves the session holding a key the peer never derived, and the peer
cannot detect it because it never receives the ACK. Nothing later reverts it:
the pending backup is only consumed by a subsequent `KEY_UPDATE`, which can no
longer be decrypted.

This makes it three sites in `libspdm_get_response_key_update()`, where #3733
describes one:

1. `UPDATE_KEY`, when the request-direction create fails.
2. `UPDATE_ALL_KEYS`, when the request-direction create fails — the first of
   the two calls; the report covers only the second.
3. `UPDATE_ALL_KEYS`, when the response-direction create fails. This is the
   one in the report, and it rolls back the request direction created just
   before it.

Sites 1 and 2 are single-direction, so they do not produce the "request side
committed and response side not" desynchronization the report describes. They
are still wrong for the reason above, so they are fixed the same way.

The failed response-direction *commit* arm is deliberately left alone.
`libspdm_activate_update_session_data_key()` cannot currently return false, so
a rollback there would be unreachable and untestable. Happy to add it if you
would rather the arm be defensively complete.

I kept these as minimal per-site fixes rather than the single transactional
rewrite suggested in #3733, so each is reviewable on its own. Glad to redo it
as a rewrite if you prefer, though that wants a clear owner for the
commit/rollback boundary and is a larger API discussion.

## Testing

x64 / GCC / Debug / mbedtls.

- Three new tests in `test_spdm_secured_message` (`key_update.c`) for A.1:
  rollback after a mid-update derivation failure in each direction, plus the
  success path.
- `rsp_key_update_ack_case28` in `test_spdm_responder` for A.3: a failed
  `UPDATE_ALL_KEYS` must leave both directions on the pre-update secrets with
  no backup pending.
- Each test was checked against its own bug: reverting a fix and re-running
  makes the corresponding tests fail, and they pass with the fix applied.
- No regressions — `test_spdm_responder` (527), `test_spdm_requester` (742),
  `test_spdm_common` (35), `test_spdm_secured_message` (20), `test_spdm_crypt`
  (11).
- Both changed source files are clean under `uncrustify 0.78` via
  `.uncrustify.cfg`.

To force a derivation failure without mocking the crypto layer, the tests set
`aead_key_size` above `255 * hash_size`, which HKDF-Expand rejects per
RFC 5869 Section 2.3. The check is on the requested length alone, so it fails
before anything is written to the output buffer. An invalid `base_hash_algo`
is not usable for this — that path is `LIBSPDM_ASSERT(false)` and aborts the
run.
